### PR TITLE
Syncing pom with maven-jsf-plugin current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
             <plugin>
                 <groupId>org.primefaces</groupId>
                 <artifactId>maven-jsf-plugin</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <id>generate-ui</id>
@@ -714,7 +714,7 @@
                     <plugin>
                         <groupId>org.primefaces</groupId>
                         <artifactId>maven-jsf-plugin</artifactId>
-                        <version>1.3.2</version>
+                        <version>1.3.3-SNAPSHOT</version>
                         <executions>
                             <execution>
                                 <id>css-compressor</id>


### PR DESCRIPTION
In order to make sure that the project would build for new comers
(empty .m2 repo) a necessary update to maven-jsf-plugin version in pom.xml is
recommended. And since the current version of maven-jsf-plugin is 1.3.3-SNAPSHOT the pom file is update accordingly. 
