### PR TITLE
Display inplace as blocked

### DIFF
--- a/src/main/java/org/primefaces/component/inplace/InplaceRenderer.java
+++ b/src/main/java/org/primefaces/component/inplace/InplaceRenderer.java
@@ -51,9 +51,15 @@ public class InplaceRenderer extends CoreRenderer {
         String styleClass = userStyleClass == null ? Inplace.CONTAINER_CLASS : Inplace.CONTAINER_CLASS + " " + userStyleClass;
         boolean disabled = inplace.isDisabled();
         String displayClass = disabled ? Inplace.DISABLED_DISPLAY_CLASS : Inplace.DISPLAY_CLASS;
+        String width = inplace.getWidth();
         
         boolean validationFailed = context.isValidationFailed() && !inplace.isValid();
-        String displayStyle = validationFailed ? "none" : "inline";
+        String displayStyle;
+		if (width == null)
+			displayStyle = validationFailed ? "none" : "inline";
+		else
+			displayStyle = validationFailed ? "none" : "block";
+
         String contentStyle = validationFailed ? "inline" : "none";
         
         UIComponent outputFacet = inplace.getFacet("output");
@@ -73,6 +79,11 @@ public class InplaceRenderer extends CoreRenderer {
 		writer.startElement("span", null);
 		writer.writeAttribute("id", clientId + "_display", "id");
 		writer.writeAttribute("class", displayClass, null);
+
+        if(width != null) {
+			String unit = width.endsWith("%") ? "" : "px";
+			displayStyle += ";width:" + width + unit;
+		}
         writer.writeAttribute("style", "display:" + displayStyle, null);
         
         if(outputFacet != null)

--- a/src/main/resources-maven-jsf/ui/inplace.xml
+++ b/src/main/resources-maven-jsf/ui/inplace.xml
@@ -62,6 +62,12 @@
             <description>Prevents hidden content to be shown.</description>
 		</attribute>
         <attribute>
+            <name>width</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <description>Width of the closed inplace in pixels or percentage.</description>
+        </attribute>
+        <attribute>
 			<name>style</name>
 			<required>false</required>
 			<type>java.lang.String</type>


### PR DESCRIPTION
Option to set inplace width in pixels or percents like in p:column.
It is great option if you have inputtext in p:inplace and input text is 1 letter length and you want to have editable area to be 50px width or 75% of parent element.

Example:
no width set: http://i.imgur.com/NyH4KpT.jpg
width set to 90%: http://i.imgur.com/Btp2qr3.jpg
http://i.imgur.com/MHNk7XS.jpg

Minor changes in code.
Proposed on code.google.com Jul 11, 2013 and later updated with needed code.
