### PR TITLE
Correct way to calculate the time with DST across the whole schedule. Di...

### DIFF
--- a/src/main/java-templates/org/primefaces/component/schedule/ScheduleTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/schedule/ScheduleTemplate.java
@@ -76,10 +76,8 @@ import org.primefaces.model.ScheduleEvent;
 
             if(eventName.equals("dateSelect")) {
                 Long milliseconds = Long.valueOf(params.get(clientId + "_selectedDate"));
-                Calendar calendar = Calendar.getInstance();
-                calendar.setTimeInMillis(milliseconds);
-                calendar.add(Calendar.MILLISECOND, -tz.getOffset(milliseconds));
-                calendar.setTimeZone(tz);
+                Calendar calendar = Calendar.getInstance(tz);
+                calendar.setTimeInMillis(milliseconds - tz.getOffset(milliseconds));
                 Date selectedDate = calendar.getTime();
                 SelectEvent selectEvent = new SelectEvent(this, behaviorEvent.getBehavior(), selectedDate);
                 selectEvent.setPhaseId(behaviorEvent.getPhaseId());

--- a/src/main/java-templates/org/primefaces/component/schedule/ScheduleTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/schedule/ScheduleTemplate.java
@@ -75,8 +75,10 @@ import org.primefaces.model.ScheduleEvent;
             FacesEvent wrapperEvent = null;
 
             if(eventName.equals("dateSelect")) {
+                Long milliseconds = Long.valueOf(params.get(clientId + "_selectedDate"));
                 Calendar calendar = Calendar.getInstance();
-                calendar.setTimeInMillis(Long.valueOf(params.get(clientId + "_selectedDate")));
+                calendar.setTimeInMillis(milliseconds);
+                calendar.add(Calendar.MILLISECOND, -tz.getOffset(milliseconds));
                 calendar.setTimeZone(tz);
                 Date selectedDate = calendar.getTime();
                 SelectEvent selectEvent = new SelectEvent(this, behaviorEvent.getBehavior(), selectedDate);

--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -131,7 +131,7 @@ public class ScheduleRenderer extends CoreRenderer {
         wb.initWithDomReady("Schedule", schedule.resolveWidgetVar(), clientId, "schedule")
             .attr("defaultView", schedule.getView())
             .attr("locale", schedule.calculateLocale(context).toString())
-            .attr("offset", schedule.calculateTimeZone().getRawOffset())
+            .attr("offset", 0)
             .attr("tooltip", schedule.isTooltip(), false)
             .attr("eventLimit", ((ScheduleModel) schedule.getValue()).isEventLimit(), false);
         


### PR DESCRIPTION
Correct way to calculate the time with DST across the whole schedule. Disregard the offset in "ScheduleRenderer.java" - it's no use if you select a date across a DST border. Calculate the right offset inside queueEvent from UTC instead, because now you have the date from the schedule to correctly calculate the offset.
