### PR TITLE
Added attribute "showWeekNumbers" to schedule.

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -186,7 +186,8 @@ public class ScheduleRenderer extends CoreRenderer {
             .attr("eventStartEditable", schedule.isDraggable(), true)
             .attr("eventDurationEditable", schedule.isResizable(), true)    
             .attr("axisFormat", schedule.getAxisFormat(), null)
-            .attr("timeFormat", schedule.getTimeFormat(), null);
+            .attr("timeFormat", schedule.getTimeFormat(), null)
+            .attr("weekNumbers", schedule.isShowWeekNumbers(), false);
                 
         String columnFormat = schedule.getColumnFormat();
         if(columnFormat != null) {

--- a/src/main/resources-maven-jsf/ui/schedule.xml
+++ b/src/main/resources-maven-jsf/ui/schedule.xml
@@ -211,6 +211,13 @@
             <defaultValue>false</defaultValue>
             <description>Displays description of events on a tooltip, default value is false.</description>
         </attribute>
+        <attribute>
+            <name>showWeekNumbers</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <defaultValue>false</defaultValue>
+            <description>Display week numbers in schedule.</description>
+        </attribute>
 	</attributes>
 	<resources>
         <resource>


### PR DESCRIPTION
Activate the attribute weekNumbers in fullCalendar.io to display the current week of the year in the schedule.
