### PR TITLE
Added attribute "viewFormat" to schedule. 

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -193,6 +193,11 @@ public class ScheduleRenderer extends CoreRenderer {
             wb.attr("columnFormat", columnFormat, null);
         }
             
+        String viewFormat = schedule.getViewFormat();
+        if(viewFormat != null) {
+            wb.attr("viewFormat", viewFormat, null);
+        }
+
         encodeClientBehaviors(context, schedule);
 
         wb.finish();	

--- a/src/main/resources-maven-jsf/ui/schedule.xml
+++ b/src/main/resources-maven-jsf/ui/schedule.xml
@@ -211,6 +211,13 @@
             <defaultValue>false</defaultValue>
             <description>Displays description of events on a tooltip, default value is false.</description>
         </attribute>
+        <attribute>
+           <name>viewFormat</name>
+           <required>false</required>
+           <type>java.lang.String</type>
+           <description>Complete view format configuration as JSON Object, see http://fullcalendar.io/docs/views/View-Specific-Options/ 
+ WARNING!! The JSON object text given here must be parseable with jQuery.parseJSON(). Remember to enclose all property names in double quotes!</description>
+        </attribute>
 	</attributes>
 	<resources>
         <resource>

--- a/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
@@ -9810,6 +9810,14 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
             this.cfg.defaultDate = moment(this.cfg.defaultDate);
         }
         
+        if (this.cfg.viewFormat) {
+            try {
+                this.cfg["views"] = $.parseJSON(this.cfg.viewFormat);
+            } catch (e) {
+                console.log("Cannot parse viewFormat: " + e.message);
+            }
+        }
+
         this.setupEventSource();
         
         this.configureLocale();


### PR DESCRIPTION
Configuration as in http://fullcalendar.io/docs/views/View-Specific-Options/
i.E. &lt;p:schedule viewFormat="{ \"week\":{ \"columnFormat\":\"ddd, DD.MM\" }}" ...&gt;
(Remember: Object attribute names must be enclosed in double quotes like "week" or jQuery.parseJSON won't be able to parse it.)
