### PR TITLE
fixed problem with minified version

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1,7 +1,7 @@
 (function(window) {
     
     if(window.PrimeFaces) {
-        PrimeFaces.debug("PrimeFaces already loaded, ignoring duplicate execution.");
+        window.PrimeFaces.debug("PrimeFaces already loaded, ignoring duplicate execution.");
         return;
     }
     


### PR DESCRIPTION
it's now minified to:
    function(a){if(a.PrimeFaces){b.debug("PrimeFaces already loaded, ignoring duplicate execution.");return}

which caused "Cannot read property 'debug' of undefined" JS error when loaded two times on a page - common case in portal environment where portlets use primefaces, see following report:
http://stackoverflow.com/questions/29521708/ajax-file-upload-error-in-jsf-primefaces-cannot-read-property-debug-of-undef
