### PR TITLE
improve orderlist's events to represent what really happend on the ui

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/orderlist/orderlist.js
+++ b/src/main/resources/META-INF/resources/primefaces/orderlist/orderlist.js
@@ -65,7 +65,10 @@ PrimeFaces.widget.OrderList = PrimeFaces.widget.BaseWidget.extend({
 
             if(!metaKey) {
                 element.removeClass('ui-state-hover').addClass('ui-state-highlight')
-                .siblings('.ui-state-highlight').removeClass('ui-state-highlight');
+                .siblings('.ui-state-highlight').each(function() {
+                	$(this).removeClass('ui-state-highlight');
+                	$this.fireItemUnselectEvent($(this));
+                });
         
                 $this.fireItemSelectEvent(element);
             }
@@ -97,6 +100,7 @@ PrimeFaces.widget.OrderList = PrimeFaces.widget.BaseWidget.extend({
         ui.item.removeClass('ui-state-highlight');
         this.saveState();
         this.fireReorderEvent();
+        this.fireItemUnselectEvent(ui.item);
     },
     
     saveState: function() {


### PR DESCRIPTION
Fixes issue #167.

I fixed the events to work as (I think) they are supposed to be:
Every unselect in the UI results in a corresponding unselect event.
According to my former example (see issue #167) that is:
- click on "a" -> select "a" event fired -> "a" is selected
- click on "b" -> unselect "a" event fired -> select "b" event fired -> "b" is selected
- control key + click on "c" -> select event fired -> "b" and "c" are selected

Also after drag and drop the correct unselect event is fired.

(in onDragDrop fireReorderEvent has to be fired before fireItemUnselectEvent, otherwise the object associated with the event on server side is not the dragged (and selected) item but instead the item that was previously displayed at the drop position).
