### PR TITLE
extender attribute for schedule

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -192,6 +192,11 @@ public class ScheduleRenderer extends CoreRenderer {
         if(columnFormat != null) {
             wb.attr("columnFormat", columnFormat, null);
         }
+
+        String extender = schedule.getExtender();
+        if(extender != null) {
+            wb.attr("extender", extender, null);
+        }
             
         encodeClientBehaviors(context, schedule);
 

--- a/src/main/resources-maven-jsf/ui/schedule.xml
+++ b/src/main/resources-maven-jsf/ui/schedule.xml
@@ -211,6 +211,12 @@
             <defaultValue>false</defaultValue>
             <description>Displays description of events on a tooltip, default value is false.</description>
         </attribute>
+        <attribute>
+            <name>extender</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <description>Name of a javascript function to extend the options of the schedule.</description>
+        </attribute>
 	</attributes>
 	<resources>
         <resource>

--- a/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
@@ -9820,6 +9820,14 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
 
         this.setupEventHandlers();
 
+        if (this.cfg.extender) {
+            if ($.type(this.cfg.extender) == "string") {
+                window[this.cfg.extender].call(this);
+            } else if ($.type(this.cfg.extender) == "function") {
+                this.cfg.extender.call(this);
+            }
+        }
+
         this.renderDeferred();
     },
     


### PR DESCRIPTION
Issue https://github.com/primefaces/primefaces/issues/190. Extender attribute allows to alter the this.cfg structure of the schedule via a javascript function with the name set there, therefore allowing complete access to all options as described in http://fullcalendar.io/docs/views/View-Specific-Options/. 

Example for this issue:

``` javascript
<p:schedule extender="ext" ...>

<script type="text/javascript">
function ext()
{
    this.cfg.displayEventEnd=true;
}
</script>
```

or view specific

``` javascript
<p:schedule extender="ext" ...>

<script type="text/javascript">
function ext()
{
    this.cfg = $.extend(true, this.cfg, { 
        views: { 
            month: { displayEventEnd: false }, 
            week: { displayEventEnd: true },
            day: { displayEventEnd: true }
        }
    });
}
</script>
```
