### PR TITLE
Fix global contextMenu overlays component specific ones

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.js
@@ -1021,7 +1021,6 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                     .on(event, rowSelector, null, function(e) {
                     	PrimeFaces.widgets[_self.cfg.targetWidgetVar].onRowRightClick(e, $(this));
                         _self.show(e);
-                        e.preventDefault();
                     });
     },
     
@@ -1038,7 +1037,6 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                         if($this.cfg.nodeType === undefined || nodeContent.parent().data('nodetype') === $this.cfg.nodeType) {
                         	PrimeFaces.widgets[$this.cfg.targetWidgetVar].nodeRightClick(e, nodeContent);
                             $this.show(e);
-                            e.preventDefault();
                         }
                     });
                                     
@@ -1046,7 +1044,6 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                     .on(containerEvent, this.jqTargetId, null, function(e) {
                 if(PrimeFaces.widgets[$this.cfg.targetWidgetVar].isEmpty()) {
                     $this.show(e);
-                    e.preventDefault();
                 }
         });
     },
@@ -1121,7 +1118,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
             'top': top,
             'z-index': ++PrimeFaces.zindex
         }).show();
-
+        e.stopPropagation();
         e.preventDefault();
     },
     


### PR DESCRIPTION
The issue was created here #129. Also we removed some unnecessary calls of preventDefault() functions because it is already existed in show() function.
