### PR TITLE
Fix for OverlayPanel contextMenu event should block browser menu

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -61,6 +61,7 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.BaseWidget.extend({
             this.target.off(showEvent + ' ' + hideEvent).on(showEvent, function(e) {
                 if(!$this.isVisible()) {
                     $this.show();
+                    e.preventDefault();
                 }
             })
             .on(hideEvent, function(e) {


### PR DESCRIPTION
The actual issue was created here https://github.com/primefaces/primefaces/issues/128
