### PR TITLE
"ui-state-error" problem on Multiple AutoComplete when entering an invalid value

### DIFF
--- a/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -324,6 +324,7 @@ public class AutoCompleteRenderer extends InputRenderer {
         String styleClass = ac.getStyleClass();
         styleClass = styleClass == null ? AutoComplete.MULTIPLE_STYLE_CLASS : AutoComplete.MULTIPLE_STYLE_CLASS + " " + styleClass;
         String listClass = disabled ? AutoComplete.MULTIPLE_CONTAINER_CLASS + " ui-state-disabled" : AutoComplete.MULTIPLE_CONTAINER_CLASS;
+        listClass = ac.isValid() ? listClass : listClass + " ui-state-error";
         
         writer.startElement("div", null);
         writer.writeAttribute("id", clientId, null);


### PR DESCRIPTION
When entering an invalid value,  Multiple Autocomplete with required='true' doesn't add the 'ui-state-error' class.
