### PR TITLE
Fixed #70

### DIFF
--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -120,7 +120,7 @@ public abstract class InputRenderer extends CoreRenderer {
 
         String itemLabel = itemLabelValue == null ? String.valueOf(value) : String.valueOf(itemLabelValue);
         boolean disabled = itemDisabled == null ? false : Boolean.valueOf(itemDisabled.toString());
-        boolean escaped = itemEscaped == null ? false : Boolean.valueOf(itemEscaped.toString());
+        boolean escaped = itemEscaped == null ? true : Boolean.valueOf(itemEscaped.toString());
         boolean noSelectionOption = noSelection == null ? false : Boolean.valueOf(noSelection.toString());
         
         if(var != null) {


### PR DESCRIPTION
the default value for escaped should be true instead of false

this will escape the label when writing

```
    <p:selectOneMenu value="#{testBean.selectedPk}">
        <f:selectItems value="#{testBean.items}" var="item" itemLabel="#{item.name}" itemValue="#{item.pk}"/>
    </p:selectOneMenu>
```

which is the same behavior as when you write

```
    <h:selectOneMenu value="#{testBean.selectedPk}">
        <f:selectItems value="#{testBean.items}" var="item" itemLabel="#{item.name}" itemValue="#{item.pk}"/>
    </h:selectOneMenu>
```
