### PR TITLE
Multiple autocomplete is deleting on submit all entries with the same label if one of it was previously deleted

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -661,10 +661,11 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
 
     removeItem: function(event, item) {
         var itemValue = item.attr('data-token-value'),
+        itemIndex = this.multiItemContainer.children('li.ui-autocomplete-token').index(item),
         $this = this;
 
         //remove from options
-        this.hinput.children('option').filter('[value="' + itemValue + '"]').remove();
+        this.hinput.children('option').eq(itemIndex).remove();
 
         //remove from items
         item.fadeOut('fast', function() {


### PR DESCRIPTION
Steps to reproduce the Error on Multiple AutoComplete (Showcase):
1. Type 'a' and complete to 'Afterdark'
2. add another entry by typing 'a' and completing to 'Afterdark'
3. delete one entry
4. add another entry by typing 'b' and completing to 'Blitzer'
5. push the submit Button
Now instead of having two entries ('Afterdark' and 'Blitzer') the autocomplete just shows the entry 'Blitzer'.
