### PR TITLE
Fixed #387 - DataTable's emptyMessage and colspan

### DIFF
--- a/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
@@ -832,13 +832,13 @@ import org.primefaces.util.SharedStringBuilder;
                         }
                     }
                     else if(kid instanceof Column) {
-                        columnsCount++;
+                        columnsCount += ((Column) kid).getColspan();
                     } 
                     else if(kid instanceof SubTable) {
                         SubTable subTable = (SubTable) kid;
                         for(UIComponent subTableKid : subTable.getChildren()) {
                             if(subTableKid.isRendered() && subTableKid instanceof Column) {
-                                columnsCount++;
+                                columnsCount += ((Column) subTableKid).getColspan();
                             }
                         }
                     }


### PR DESCRIPTION
Before:
![primefaces-before](https://cloud.githubusercontent.com/assets/1197514/7958162/8d69ba56-09e4-11e5-97c0-c599af7200f4.png)

After:
![primefaces-after](https://cloud.githubusercontent.com/assets/1197514/7958167/990598e4-09e4-11e5-95b7-a46d0dd8fb98.png)

Test code:

``` xml
<style>
    body {font-family: sans-serif; padding: 20px;}
    .ui-datatable {margin-bottom: 50px;}
    .ui-datatable .ui-datatable-empty-message td {background: #FFF69E; text-align: center; padding: 20px;}
</style>

<h:body>

    <p>3 columns</p>
    <p:dataTable emptyMessage="should have a colspan='3'">
        <p:column headerText="1" />
        <p:column headerText="2" />
        <p:column headerText="3" />
    </p:dataTable>


    <p>1 column with colspan 2 + 1 column</p>
    <p:dataTable emptyMessage="should have a colspan='3'">
        <p:column headerText="1" colspan="2" />
        <p:column headerText="2" />
    </p:dataTable>


    <p>1 column with colspan 2 + 1 column (using columnGroup)</p>
    <p:dataTable emptyMessage="should have a colspan='3'">
        <p:columnGroup type="header">
            <p:row>
                <p:column headerText="1" />
                <p:column headerText="2" />
                <p:column headerText="3" />
            </p:row>
        </p:columnGroup>
        <p:column colspan="2" />
        <p:column />
    </p:dataTable>


    <p>1 column with colspan 2 + 1 column (using subTable)</p>
    <p:dataTable emptyMessage="should have a colspan='3'">
        <p:columnGroup type="header">
            <p:row>
                <p:column headerText="1" />
                <p:column headerText="2" />
                <p:column headerText="3" />
            </p:row>
        </p:columnGroup>
        <p:subTable>
            <p:column colspan="2" />
            <p:column />
        </p:subTable>
    </p:dataTable>

</h:body>
```
