### PR TITLE
groupId and artifactId itext change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.primefaces</groupId>
     <artifactId>primefaces</artifactId>
     <packaging>jar</packaging>
-    <version>4.0</version>
+    <version>4.1</version>
     <name>primefaces</name>
     <url>http://www.primefaces.org</url>
     
@@ -29,6 +29,12 @@
         <developerConnection>scm:svn:https://primefaces.googlecode.com/svn/primefaces/trunk</developerConnection>
         <url>http://primefaces.googlecode.com/svn/primefaces/trunk</url>
     </scm>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>primeFaces_repository</id>
+            <url>http://repository.primefaces.org/</url>
+        </pluginRepository>
+    </pluginRepositories>
     
     <developers>
         <developer>
@@ -92,9 +98,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.lowagie</groupId>
-            <artifactId>itext</artifactId>
-            <version>2.1.7</version>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.5.6</version>
             <scope>provided</scope>
         </dependency>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.primefaces</groupId>
     <artifactId>primefaces</artifactId>
     <packaging>jar</packaging>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.0</version>
     <name>primefaces</name>
     <url>http://www.primefaces.org</url>
     

--- a/src/main/java/org/primefaces/component/export/PDFExporter.java
+++ b/src/main/java/org/primefaces/component/export/PDFExporter.java
@@ -28,13 +28,13 @@ import javax.faces.context.FacesContext;
 
 import org.primefaces.component.datatable.DataTable;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
-import com.lowagie.text.Font;
-import com.lowagie.text.FontFactory;
-import com.lowagie.text.Paragraph;
-import com.lowagie.text.pdf.PdfPTable;
-import com.lowagie.text.pdf.PdfWriter;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.FontFactory;
+import com.itextpdf.text.Paragraph;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.column.Column;

--- a/src/test/java/org/primefaces/util/CollectingResponseWriter.java
+++ b/src/test/java/org/primefaces/util/CollectingResponseWriter.java
@@ -6,8 +6,6 @@ import java.io.Writer;
 import javax.faces.component.UIComponent;
 import javax.faces.context.ResponseWriter;
 
-import org.bouncycastle.crypto.RuntimeCryptoException;
-
 public class CollectingResponseWriter extends ResponseWriter {
 
 	private StringBuilder builder = new StringBuilder();


### PR DESCRIPTION
This PR was done by forking tag 4.0 (sha1 c3f2f46). This change can also be reported to other version as well.
itext dep changed its groupId/artifactId even for older versions so this change is required in order to keep PDF export working.
