### PR TITLE
Fix Issue #651

### DIFF
--- a/src/main/java/org/primefaces/validate/DoubleRangeValidator.java
+++ b/src/main/java/org/primefaces/validate/DoubleRangeValidator.java
@@ -22,19 +22,17 @@ import org.primefaces.util.HTML;
 public class DoubleRangeValidator extends javax.faces.validator.DoubleRangeValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
-    private boolean minimumSet;
-    private boolean maximumSet;
+    private Double minimum;
+    private Double maximum;
     
     public Map<String, Object> getMetadata() {
         metadata = new HashMap<String, Object>();
-        double min = this.getMinimum();
-        double max = this.getMaximum();
         
-        if(minimumSet)
-            metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, min);
+        if(minimum != null)
+            metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, minimum);
             
-        if(maximumSet)
-            metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, max);
+        if(maximum != null)
+            metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, maximum);
         
         return metadata;
     }
@@ -45,12 +43,12 @@ public class DoubleRangeValidator extends javax.faces.validator.DoubleRangeValid
     
     public void setMaximum(double maximum) {
         super.setMaximum(maximum);
-        maximumSet=true;
+        this.maximum=maximum;
     }
     
     public void setMinimum(double minimum) {
         super.setMinimum(minimum);
-        minimumSet=true;
+        this.minimum=minimum;
     }
 
 }

--- a/src/main/java/org/primefaces/validate/DoubleRangeValidator.java
+++ b/src/main/java/org/primefaces/validate/DoubleRangeValidator.java
@@ -22,16 +22,18 @@ import org.primefaces.util.HTML;
 public class DoubleRangeValidator extends javax.faces.validator.DoubleRangeValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
+    private boolean minimumSet;
+    private boolean maximumSet;
     
     public Map<String, Object> getMetadata() {
         metadata = new HashMap<String, Object>();
         double min = this.getMinimum();
         double max = this.getMaximum();
         
-        if(min != 0)
+        if(minimumSet)
             metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, min);
             
-        if(max != 0)
+        if(maximumSet)
             metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, max);
         
         return metadata;
@@ -40,4 +42,15 @@ public class DoubleRangeValidator extends javax.faces.validator.DoubleRangeValid
     public String getValidatorId() {
         return DoubleRangeValidator.VALIDATOR_ID;
     }
+    
+    public void setMaximum(double maximum) {
+        super.setMaximum(maximum);
+        maximumSet=true;
+    }
+    
+    public void setMinimum(double minimum) {
+        super.setMinimum(minimum);
+        minimumSet=true;
+    }
+
 }

--- a/src/main/java/org/primefaces/validate/LengthValidator.java
+++ b/src/main/java/org/primefaces/validate/LengthValidator.java
@@ -22,21 +22,18 @@ import org.primefaces.util.HTML;
 public class LengthValidator extends javax.faces.validator.LengthValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
-    private boolean maximumSet;
-    private boolean minimumSet;
+    private Integer maximum;
+    private Integer minimum;
     
     public Map<String, Object> getMetadata() {
-        int min = this.getMinimum();
-        int max = this.getMaximum();
-        
         if(metadata == null) {
             metadata = new HashMap<String, Object>();
             
-            if(minimumSet)
-                metadata.put(HTML.VALIDATION_METADATA.MIN_LENGTH, min);
+            if(minimum!=null)
+                metadata.put(HTML.VALIDATION_METADATA.MIN_LENGTH, minimum);
             
-            if(maximumSet)
-                metadata.put(HTML.VALIDATION_METADATA.MAX_LENGTH, max);
+            if(maximum!=null)
+                metadata.put(HTML.VALIDATION_METADATA.MAX_LENGTH, maximum);
         }
         
         return metadata;
@@ -48,12 +45,12 @@ public class LengthValidator extends javax.faces.validator.LengthValidator imple
     
     public void setMaximum(int maximum) {
         super.setMaximum(maximum);
-        maximumSet=true;
+        this.maximum = maximum;
     }
     
     public void setMinimum(int minimum) {
         super.setMinimum(minimum);
-        minimumSet=true;
+        this.minimum = minimum;
     }
 
 }

--- a/src/main/java/org/primefaces/validate/LengthValidator.java
+++ b/src/main/java/org/primefaces/validate/LengthValidator.java
@@ -22,6 +22,8 @@ import org.primefaces.util.HTML;
 public class LengthValidator extends javax.faces.validator.LengthValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
+    private boolean maximumSet;
+    private boolean minimumSet;
     
     public Map<String, Object> getMetadata() {
         int min = this.getMinimum();
@@ -30,10 +32,10 @@ public class LengthValidator extends javax.faces.validator.LengthValidator imple
         if(metadata == null) {
             metadata = new HashMap<String, Object>();
             
-            if(min != 0)
+            if(minimumSet)
                 metadata.put(HTML.VALIDATION_METADATA.MIN_LENGTH, min);
             
-            if(max != 0)
+            if(maximumSet)
                 metadata.put(HTML.VALIDATION_METADATA.MAX_LENGTH, max);
         }
         
@@ -43,4 +45,15 @@ public class LengthValidator extends javax.faces.validator.LengthValidator imple
     public String getValidatorId() {
         return LengthValidator.VALIDATOR_ID;
     }
+    
+    public void setMaximum(int maximum) {
+        super.setMaximum(maximum);
+        maximumSet=true;
+    }
+    
+    public void setMinimum(int minimum) {
+        super.setMinimum(minimum);
+        minimumSet=true;
+    }
+
 }

--- a/src/main/java/org/primefaces/validate/LongRangeValidator.java
+++ b/src/main/java/org/primefaces/validate/LongRangeValidator.java
@@ -22,16 +22,18 @@ import org.primefaces.util.HTML;
 public class LongRangeValidator extends javax.faces.validator.LongRangeValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
+    private boolean minimumSet;
+    private boolean maximumSet;
     
     public Map<String, Object> getMetadata() {
         metadata = new HashMap<String, Object>();
         long min = this.getMinimum();
         long max = this.getMaximum();
         
-        if(min != 0)
+        if(minimumSet)
             metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, min);
             
-        if(max != 0)
+        if(maximumSet)
             metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, max);
         
         return metadata;
@@ -39,5 +41,15 @@ public class LongRangeValidator extends javax.faces.validator.LongRangeValidator
 
     public String getValidatorId() {
         return LongRangeValidator.VALIDATOR_ID;
+    }
+    
+    public void setMaximum(long maximum) {
+        super.setMaximum(maximum);
+        maximumSet=true;
+    }
+    
+    public void setMinimum(long minimum) {
+        super.setMinimum(minimum);
+        minimumSet=true;
     }
 }

--- a/src/main/java/org/primefaces/validate/LongRangeValidator.java
+++ b/src/main/java/org/primefaces/validate/LongRangeValidator.java
@@ -22,19 +22,17 @@ import org.primefaces.util.HTML;
 public class LongRangeValidator extends javax.faces.validator.LongRangeValidator implements ClientValidator {
 
     private Map<String,Object> metadata;
-    private boolean minimumSet;
-    private boolean maximumSet;
+    private Long minimum;
+    private Long maximum;
     
     public Map<String, Object> getMetadata() {
         metadata = new HashMap<String, Object>();
-        long min = this.getMinimum();
-        long max = this.getMaximum();
         
-        if(minimumSet)
-            metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, min);
+        if(minimum!=null)
+            metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, minimum);
             
-        if(maximumSet)
-            metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, max);
+        if(maximum!=null)
+            metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, maximum);
         
         return metadata;
     }
@@ -45,11 +43,11 @@ public class LongRangeValidator extends javax.faces.validator.LongRangeValidator
     
     public void setMaximum(long maximum) {
         super.setMaximum(maximum);
-        maximumSet=true;
+        this.maximum=maximum;
     }
     
     public void setMinimum(long minimum) {
         super.setMinimum(minimum);
-        minimumSet=true;
+        this.minimum=minimum;
     }
 }


### PR DESCRIPTION
This changeset fixes issue #651. 

The old implementations only set the meta data if the value is not 0. So a value of 0 was not propagated to and considered by the client side validation. Moreover the value returned by getMinimum() is depending on the implementation of javax.faces.validator.LongRangeValidator. Some implmenations return a 0. Others returns Long.MIN_VALUE. 

The validators now set boolean flags if a minimum or maximum value are set. This flags are considered when building the meta data. The meta data is only set if also the minimum or maximum were set.
