### PR TITLE
Correct square display of empty item + refresh filtered data on global select/unselect 

### DIFF
--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -132,6 +132,19 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         styleClass = !checkbox.isValid() ? styleClass + " ui-state-error" : styleClass;
         styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
 
+        //2016-01-14:BS: new attribute PROTECTED
+        
+        //<REMOVE>
+        //styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
+        //</REMOVE>
+        
+        //<ADD>
+        if (disabled && !checkbox.isProtectedx())
+            {
+            styleClass += " ui-state-disabled";
+            }
+        //</ADD>
+
         String iconClass = checked ? HTML.CHECKBOX_CHECKED_ICON_CLASS : HTML.CHECKBOX_UNCHECKED_ICON_CLASS;
 
         writer.startElement("div", null);

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -133,11 +133,41 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("for", id, null);
         if(disabled)
             writer.writeAttribute("class", "ui-state-disabled", null);
+
+        //2015.12.10:BS: height of empty item(line) in ListBox is not correct !
+        // The square of empty item is overriden by the square of next item.
+        // For this correction, I fill the empty line with a &nb; character 
+        // I have seen this solution in your code for another correction :-)
         
+        //<REMOVE>
+        /*
         if(escaped)
             writer.writeText(option.getLabel(),null);
         else
             writer.write(option.getLabel());
+        */    
+        //</REMOVE> 
+
+        //<UPDATE> 
+        String sLabel = option.getLabel();
+        if(escaped)
+            {
+            if (sLabel.isEmpty())
+                {
+                if (sLabel.isEmpty()) sLabel = "&nbsp;";
+                writer.write(sLabel);
+                }
+            else
+                {
+                writer.writeText(sLabel,null);
+                }
+            }
+        else
+            {
+            if (sLabel.isEmpty()) sLabel = "&nbsp;";
+            writer.write(sLabel);
+            }
+        //</UPDATE> 
         
         writer.endElement("label");
     }

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -134,7 +134,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         if(disabled)
             writer.writeAttribute("class", "ui-state-disabled", null);
 
-        //2015.12.10:BS: height of empty item(line) in ListBox is not correct !
+        //2015.12.10:BS: height of empty item(line) in ListBox is not correctly displayed !
         // The square of empty item is overriden by the square of next item.
         // For this correction, I fill the empty line with a &nb; character 
         // I have seen this solution in your code for another correction :-)

--- a/src/main/resources-maven-jsf/ui/selectBooleanCheckbox.xml
+++ b/src/main/resources-maven-jsf/ui/selectBooleanCheckbox.xml
@@ -31,6 +31,19 @@
             <type>boolean</type>
             <ignoreInComponent>true</ignoreInComponent>
         </attribute>
+        <!--2016-01-14:BS: new attribute PROTECTED
+        -->
+        <!-- ADD -->
+        <attribute>
+            <name>protectedx</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <ignoreInComponent>false</ignoreInComponent>
+            <defaultValue>false</defaultValue>
+            <description>Protects the component (input prohibited).</description>
+        </attribute>
+        <!-- /ADD -->
+
         <attribute>
             <name>label</name>
             <required></required>

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.js
@@ -2661,7 +2661,19 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             $this.check($(this).children('.ui-chkbox').children('.ui-chkbox-box'));
         });
 
+        //2015.12.10:BS: add true to allow immediate refresh of filtered data
+        // when user click on ALL Button in Header of ListBox
+        // to select all items in SelectManyheckBox
+
+        //<UPDATE>
+        this.check(this.togglerBox, true);
+	//</UPDATE>
+	
+	//<REMOVE>
+	/*
         this.check(this.togglerBox);
+        */
+	//</REMOVE>
         
         if(!this.togglerBox.hasClass('ui-state-disabled')) {
             this.togglerBox.prev().children('input').trigger('focus.selectCheckboxMenu');
@@ -2680,7 +2692,20 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             $this.uncheck($(this).children('.ui-chkbox').children('.ui-chkbox-box'));
         });
 
+        //2015.12.10:BS: add true to allow immediate refresh of filtered data
+        // when user click on ALL Button in Header of ListBox
+        // to unselect all items in SelectManyheckBox
+
+        //<UPDATE>
+        this.uncheck(this.togglerBox, true);
+	//</UPDATE>
+	
+	//<REMOVE>
+	/*
         this.uncheck(this.togglerBox);
+        */
+	//</REMOVE>
+
 
         if(!this.togglerBox.hasClass('ui-state-disabled')) {
             this.togglerBox.prev().children('input').trigger('focus.selectCheckboxMenu');


### PR DESCRIPTION
There is 2 corrections in this PullRequest.
1. Correct square display of empty item in ListBox display by a SelectManyCheckBox

The height of empty item(line) in ListBox is not correctly displayed !
The square of empty item is overriden by the square of next item.
For this correction, I fill the empty line with a &nb; character 
I have seen this solution in your code for another correction :-)
1. refresh filtered data on global select/unselect

when clicking on checkbox displayed in header of ListBox linked to a SelectManyCheckBox, the filtered data in DataTable are not refreshed.
But when I click on an item to select or unselect it, that work.
I think that the problem is that the filtering event is not propagated to dataTable.
To correct it, I have only changed 2 lines in adding a second parameter with TRUE value.
That's working on my PC.
