### PR TITLE
adding PROTECTEDx attribut to selectBooleanCheckbox

### DIFF
--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -132,6 +132,19 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         styleClass = !checkbox.isValid() ? styleClass + " ui-state-error" : styleClass;
         styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
 
+        //2016-01-14:BS: new attribute PROTECTED
+        
+        //<REMOVE>
+        //styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
+        //</REMOVE>
+        
+        //<ADD>
+        if (disabled && !checkbox.isProtectedx())
+            {
+            styleClass += " ui-state-disabled";
+            }
+        //</ADD>
+
         String iconClass = checked ? HTML.CHECKBOX_CHECKED_ICON_CLASS : HTML.CHECKBOX_UNCHECKED_ICON_CLASS;
 
         writer.startElement("div", null);

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -133,11 +133,41 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("for", id, null);
         if(disabled)
             writer.writeAttribute("class", "ui-state-disabled", null);
+
+        //2015.12.10:BS: height of empty item(line) in ListBox is not correct !
+        // The square of empty item is overriden by the square of next item.
+        // For this correction, I fill the empty line with a &nb; character 
+        // I have seen this solution in your code for another correction :-)
         
+        //<REMOVE>
+        /*
         if(escaped)
             writer.writeText(option.getLabel(),null);
         else
             writer.write(option.getLabel());
+        */    
+        //</REMOVE> 
+
+        //<UPDATE> 
+        String sLabel = option.getLabel();
+        if(escaped)
+            {
+            if (sLabel.isEmpty())
+                {
+                if (sLabel.isEmpty()) sLabel = "&nbsp;";
+                writer.write(sLabel);
+                }
+            else
+                {
+                writer.writeText(sLabel,null);
+                }
+            }
+        else
+            {
+            if (sLabel.isEmpty()) sLabel = "&nbsp;";
+            writer.write(sLabel);
+            }
+        //</UPDATE> 
         
         writer.endElement("label");
     }

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -134,7 +134,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         if(disabled)
             writer.writeAttribute("class", "ui-state-disabled", null);
 
-        //2015.12.10:BS: height of empty item(line) in ListBox is not correct !
+        //2015.12.10:BS: height of empty item(line) in ListBox is not correctly displayed !
         // The square of empty item is overriden by the square of next item.
         // For this correction, I fill the empty line with a &nb; character 
         // I have seen this solution in your code for another correction :-)

--- a/src/main/resources-maven-jsf/ui/selectBooleanCheckbox.xml
+++ b/src/main/resources-maven-jsf/ui/selectBooleanCheckbox.xml
@@ -31,6 +31,19 @@
             <type>boolean</type>
             <ignoreInComponent>true</ignoreInComponent>
         </attribute>
+        <!--2016-01-14:BS: new attribute PROTECTED
+        -->
+        <!-- ADD -->
+        <attribute>
+            <name>protectedx</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <ignoreInComponent>false</ignoreInComponent>
+            <defaultValue>false</defaultValue>
+            <description>Protects the component (input prohibited).</description>
+        </attribute>
+        <!-- /ADD -->
+
         <attribute>
             <name>label</name>
             <required></required>

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.js
@@ -2661,7 +2661,19 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             $this.check($(this).children('.ui-chkbox').children('.ui-chkbox-box'));
         });
 
+        //2015.12.10:BS: add true to allow immediate refresh of filtered data
+        // when user click on ALL Button in Header of ListBox
+        // to select all items in SelectManyheckBox
+
+        //<UPDATE>
+        this.check(this.togglerBox, true);
+	//</UPDATE>
+	
+	//<REMOVE>
+	/*
         this.check(this.togglerBox);
+        */
+	//</REMOVE>
         
         if(!this.togglerBox.hasClass('ui-state-disabled')) {
             this.togglerBox.prev().children('input').trigger('focus.selectCheckboxMenu');
@@ -2680,7 +2692,20 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             $this.uncheck($(this).children('.ui-chkbox').children('.ui-chkbox-box'));
         });
 
+        //2015.12.10:BS: add true to allow immediate refresh of filtered data
+        // when user click on ALL Button in Header of ListBox
+        // to unselect all items in SelectManyheckBox
+
+        //<UPDATE>
+        this.uncheck(this.togglerBox, true);
+	//</UPDATE>
+	
+	//<REMOVE>
+	/*
         this.uncheck(this.togglerBox);
+        */
+	//</REMOVE>
+
 
         if(!this.togglerBox.hasClass('ui-state-disabled')) {
             this.togglerBox.prev().children('input').trigger('focus.selectCheckboxMenu');


### PR DESCRIPTION
DISABLE attribute on selectBooleanCheckBox locks the widget but also changes the display of widget.

I need a solution more readable for user that locks(protects) the widget but doesn't change the display attributes.

To do that, I lock only the input field linked to this widget.

Attention: the real attribute is "protectedx" with x at end.
I cannot define an attribute "protected" because this name is defined by ENUM and protected is a key for java language.

I think that this problem can be resolved (not by me) in correcting maven-jsf application so that it work with "protected" name like it already work with "for" name in CheckBox.xml file.
