### PR TITLE
Show tooltip with error message instead of title using p:message

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/messages/messages.js
+++ b/src/main/resources/META-INF/resources/primefaces/messages/messages.js
@@ -10,6 +10,7 @@ PrimeFaces.widget.Message = PrimeFaces.widget.BaseWidget.extend({
         
         if(text) {
            $(PrimeFaces.escapeClientId(this.cfg.target)).data('tooltip', text);
+           $(PrimeFaces.escapeClientId(this.cfg.target)).data('tooltipError', true);
         }
     }
 });

--- a/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -53,7 +53,10 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
                 
                         var title = element.attr('title');
                         if(title) {
-                            element.data('tooltip', title).removeAttr('title');
+                            if (!element.data('tooltipError')) {
+                                element.data('tooltip', title);
+                            }
+                            element.removeAttr('title');
                         }
                         
                         if(element.hasClass('ui-state-error')) {


### PR DESCRIPTION
Set data to specify that there is a tooltip with an error message and use it instead of the title attribute

Fixes #1198 

There is another possible solution https://github.com/CSchulz/primefaces/tree/write-error-to-title-attribute
