### PR TITLE
Fix doRedirect for IE and onbeforeunload alerts

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -702,7 +702,11 @@ PrimeFaces.ajax = {
     ResponseProcessor: {
 
         doRedirect : function(node) {
-            window.location = node.getAttribute('url');
+            try {
+        		window.location.assign(node.getAttribute('url'));
+        	} catch (error) {
+        		console.warn('Error redirecting to URL');
+        	}
         },
 
         doUpdate : function(node, xhr, updateHandler) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -705,7 +705,7 @@ PrimeFaces.ajax = {
             try {
         		window.location.assign(node.getAttribute('url'));
         	} catch (error) {
-        		console.warn('Error redirecting to URL');
+        		PrimeFaces.warn('Error redirecting to URL');
         	}
         },
 


### PR DESCRIPTION
IE behaves very strange when a redirect is triggered and an onbeforeunload function is defined to show an alert (e.g. window.onbeforeunload = function () {return 'You will lose your changes...'};).
If the user declines the redirect and stays on the current page, IE's window.location will throw an error that will kill the JS execution for that page.

Secondly, for whatever reason, IE will try to unload the current page two times when a user declines the redirect and window.location is used (two alerts are shown from window.onbeforeunload). After that it will throw the error mentioned above. Using window.location.assign() will avoid the multiple attempts at unloading the page.

Tested in IE 11 and Chrome 48.
