### PR TITLE
fixed #690

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/mobile/widgets/forms.js
+++ b/src/main/resources/META-INF/resources/primefaces/mobile/widgets/forms.js
@@ -235,8 +235,6 @@ PrimeFaces.widget.SelectBooleanCheckbox = PrimeFaces.widget.BaseWidget.extend({
             this.uncheck();
         else
             this.check();
-        
-        this.input.trigger('change');
     },
     
     check: function() {


### PR DESCRIPTION
An checkbox input element will fire 'change' event by itself, so it not need to trigger 'change' event in the  toggle method. fixed #690 
