### PR TITLE
Add onTabClose callback

### DIFF
--- a/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -120,7 +120,8 @@ public class AccordionPanelRenderer extends CoreRenderer {
         
         wb.attr("multiple", multiple, false)
         .callback("onTabChange", "function(panel)", acco.getOnTabChange())
-        .callback("onTabShow", "function(panel)", acco.getOnTabShow());
+        .callback("onTabShow", "function(panel)", acco.getOnTabShow())
+        .callback("onTabClose", "function(panel)", acco.getOnTabClose());
         
         if(acco.getTabController() != null) {
             wb.attr("controlled", true);

--- a/src/main/resources-maven-jsf/ui/accordionPanel.xml
+++ b/src/main/resources-maven-jsf/ui/accordionPanel.xml
@@ -62,6 +62,12 @@
             <description>Client side callback to execute when a tab is shown.</description>
         </attribute>
         <attribute>
+            <name>onTabClose</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <description>Client side callback to execute when a tab is closed.</description>
+        </attribute>
+        <attribute>
             <name>dynamic</name>
             <required>false</required>
             <type>java.lang.Boolean</type>

--- a/src/main/resources/META-INF/resources/primefaces/accordion/accordion.js
+++ b/src/main/resources/META-INF/resources/primefaces/accordion/accordion.js
@@ -184,13 +184,17 @@ PrimeFaces.widget.AccordionPanel = PrimeFaces.widget.BaseWidget.extend({
     },
     
     hide: function(index) {
-        var panel = this.panels.eq(index),
+        var $this = this,
+        panel = this.panels.eq(index),
         header = panel.prev();
 
         header.attr('aria-selected', false);
         header.attr('aria-expanded', false).children('.ui-icon').removeClass(this.cfg.expandedIcon).addClass(this.cfg.collapsedIcon);
         header.removeClass('ui-state-active ui-corner-top').addClass('ui-corner-all');
-        panel.attr('aria-hidden', true).slideUp();
+        panel.attr('aria-hidden', true).slideUp(function(){
+            if($this.cfg.onTabClose)
+                $this.cfg.onTabClose.call($this, panel);
+        });
 
         this.removeFromSelection(index);
         this.saveState();

--- a/src/main/resources/META-INF/resources/primefaces/accordion/accordion.js
+++ b/src/main/resources/META-INF/resources/primefaces/accordion/accordion.js
@@ -169,7 +169,11 @@ PrimeFaces.widget.AccordionPanel = PrimeFaces.widget.BaseWidget.extend({
             var oldHeader = this.headers.filter('.ui-state-active');
             oldHeader.children('.ui-icon').removeClass(this.cfg.expandedIcon).addClass(this.cfg.collapsedIcon);
             oldHeader.attr('aria-selected', false);
-            oldHeader.attr('aria-expanded', false).removeClass('ui-state-active ui-corner-top').addClass('ui-corner-all').next().attr('aria-hidden', true).slideUp();
+            oldHeader.attr('aria-expanded', false).removeClass('ui-state-active ui-corner-top').addClass('ui-corner-all')
+                .next().attr('aria-hidden', true).slideUp(function(){
+                    if(_self.cfg.onTabClose)
+                        _self.cfg.onTabClose.call(_self, panel);
+                });
         }
 
         //activate selected
@@ -184,7 +188,7 @@ PrimeFaces.widget.AccordionPanel = PrimeFaces.widget.BaseWidget.extend({
     },
     
     hide: function(index) {
-        var $this = this,
+        var _self = this,
         panel = this.panels.eq(index),
         header = panel.prev();
 
@@ -192,8 +196,8 @@ PrimeFaces.widget.AccordionPanel = PrimeFaces.widget.BaseWidget.extend({
         header.attr('aria-expanded', false).children('.ui-icon').removeClass(this.cfg.expandedIcon).addClass(this.cfg.collapsedIcon);
         header.removeClass('ui-state-active ui-corner-top').addClass('ui-corner-all');
         panel.attr('aria-hidden', true).slideUp(function(){
-            if($this.cfg.onTabClose)
-                $this.cfg.onTabClose.call($this, panel);
+            if(_self.cfg.onTabClose)
+                _self.cfg.onTabClose.call(_self, panel);
         });
 
         this.removeFromSelection(index);


### PR DESCRIPTION
Adds a onTabClose callback to be called as soon as a tab as finished to close (after animation). For client side use and most likely ui related stuff.

Using this personally, thought it won't hurt to add it directly into Primefaces since it has really low impact.
