### PR TITLE
fix npe in DataTableRenderer.isInSameGroup()

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1314,7 +1314,7 @@ public class DataTableRenderer extends DataRenderer {
             return false;
         
         Object nextGroupByData = groupByVE.getValue(eLContext);
-        if(currentGroupByData != null && nextGroupByData.equals(currentGroupByData)) {
+        if(nextGroupByData != null && nextGroupByData.equals(currentGroupByData)) {
             return true;
         }
         


### PR DESCRIPTION
We had a NPE during DataTableRenderer.isInSameGroup() in our
application, and patched it successfully with this change.
