### PR TITLE
p:captcha callback support

### DIFF
--- a/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
+++ b/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
@@ -76,9 +76,7 @@ public class CaptchaRenderer extends CoreRenderer {
         wb.attr("sitekey", publicKey)
             .attr("theme", captcha.getTheme(), "light")
             .attr("language", captcha.getLanguage(), "en")
-            .attr("tabindex", captcha.getTabindex(), 0)
-            .attr("callback", captcha.getCallback(), null)
-            .attr("expired", captcha.getExpired(), null);
+            .attr("tabindex", captcha.getTabindex(), 0);
         
         wb.finish();
     }

--- a/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
+++ b/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
@@ -76,7 +76,9 @@ public class CaptchaRenderer extends CoreRenderer {
         wb.attr("sitekey", publicKey)
             .attr("theme", captcha.getTheme(), "light")
             .attr("language", captcha.getLanguage(), "en")
-            .attr("tabindex", captcha.getTabindex(), 0);
+            .attr("tabindex", captcha.getTabindex(), 0)
+            .attr("callback", captcha.getCallback(), null)
+            .attr("expired", captcha.getExpired(), null);
         
         wb.finish();
     }

--- a/src/main/resources-maven-jsf/ui/captcha.xml
+++ b/src/main/resources-maven-jsf/ui/captcha.xml
@@ -49,6 +49,18 @@
 			<type>java.lang.String</type>
             <description>A localized user presentable name.</description>
 		</attribute>
+            <attribute>
+                    <name>callback</name>
+                    <required>false</required>
+                    <type>java.lang.String</type>
+        <description>Callback executed when the user submits a successful captcha response.</description>
+            </attribute>
+            <attribute>
+                    <name>expired</name>
+                    <required>false</required>
+                    <type>java.lang.String</type>
+        <description>Callback executed when the captcha response expires and the user needs to solve a new captcha.</description>
+            </attribute>
 	</attributes>
     <resources>
 		<resource>

--- a/src/main/resources-maven-jsf/ui/captcha.xml
+++ b/src/main/resources-maven-jsf/ui/captcha.xml
@@ -49,6 +49,18 @@
 			<type>java.lang.String</type>
             <description>A localized user presentable name.</description>
 		</attribute>
+            <attribute>
+			<name>callback</name>
+			<required>false</required>
+			<type>java.lang.String</type>
+            <description>Callback executed when the user submits a successful captcha response.</description>
+		</attribute>
+            <attribute>
+			<name>expired</name>
+			<required>false</required>
+			<type>java.lang.String</type>
+            <description>Callback executed when the captcha response expires and the user needs to solve a new captcha.</description>
+		</attribute>
 	</attributes>
     <resources>
 		<resource>

--- a/src/main/resources-maven-jsf/ui/captcha.xml
+++ b/src/main/resources-maven-jsf/ui/captcha.xml
@@ -49,18 +49,6 @@
 			<type>java.lang.String</type>
             <description>A localized user presentable name.</description>
 		</attribute>
-            <attribute>
-			<name>callback</name>
-			<required>false</required>
-			<type>java.lang.String</type>
-            <description>Callback executed when the user submits a successful captcha response.</description>
-		</attribute>
-            <attribute>
-			<name>expired</name>
-			<required>false</required>
-			<type>java.lang.String</type>
-            <description>Callback executed when the captcha response expires and the user needs to solve a new captcha.</description>
-		</attribute>
 	</attributes>
     <resources>
 		<resource>

--- a/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
+++ b/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
@@ -17,12 +17,15 @@ PrimeFaces.widget.Captcha = PrimeFaces.widget.BaseWidget.extend({
     },
     
     render: function() {
+        $this = this;
         grecaptcha.render(this.jq.get(0), {
             'sitekey' : this.cfg.sitekey,
             'tabindex': this.cfg.tabindex,
-            'theme': this.cfg.theme
+            'theme': this.cfg.theme,
+            'callback': new Function($this.cfg.callback),
+            'expired-callback': new Function($this.cfg.expired)   
         });
-        
+
         window[this.cfg.widgetVar + '_initCallback'] = undefined;
     }
     

--- a/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
+++ b/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
@@ -17,15 +17,12 @@ PrimeFaces.widget.Captcha = PrimeFaces.widget.BaseWidget.extend({
     },
     
     render: function() {
-        $this = this;
         grecaptcha.render(this.jq.get(0), {
             'sitekey' : this.cfg.sitekey,
             'tabindex': this.cfg.tabindex,
-            'theme': this.cfg.theme,
-            'callback': new Function($this.cfg.callback),
-            'expired-callback': new Function($this.cfg.expired)   
+            'theme': this.cfg.theme
         });
-
+        
         window[this.cfg.widgetVar + '_initCallback'] = undefined;
     }
     

--- a/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
+++ b/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
@@ -17,10 +17,13 @@ PrimeFaces.widget.Captcha = PrimeFaces.widget.BaseWidget.extend({
     },
     
     render: function() {
+        $this = this;
         grecaptcha.render(this.jq.get(0), {
             'sitekey' : this.cfg.sitekey,
             'tabindex': this.cfg.tabindex,
-            'theme': this.cfg.theme
+            'theme': this.cfg.theme,
+            'callback': new Function($this.cfg.callback),
+            'expired-callback': new Function($this.cfg.expired) 
         });
         
         window[this.cfg.widgetVar + '_initCallback'] = undefined;


### PR DESCRIPTION
Fixes #1241 callback and callback-expired from reCaptcha v2 were not supported by p:captcha.
With this patch captcha provide two attributes for javascript callbacks:
- callback (executed when the user submits a successful captcha response)
- expired (executed when the recaptcha response expires and the user needs to solve a new captcha).
