### PR TITLE
Empty parameter value rendering

### DIFF
--- a/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
+++ b/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
@@ -240,6 +240,11 @@ public class AjaxRequestBuilder {
         for(UIComponent child : component.getChildren()) {
             if(child instanceof UIParameter) {
                 UIParameter parameter = (UIParameter) child;
+                Object paramValue = parameter.getValue();
+
+                if (paramValue == null) {
+                    continue;
+                }
 
                 if(!paramWritten) {
                     paramWritten = true;
@@ -248,7 +253,7 @@ public class AjaxRequestBuilder {
                     buffer.append(",");
                 }
 
-                buffer.append("{name:").append("\"").append(parameter.getName()).append("\",value:\"").append(parameter.getValue()).append("\"}");
+                buffer.append("{name:").append("\"").append(parameter.getName()).append("\",value:\"").append(paramValue).append("\"}");
             }
         }
 
@@ -269,6 +274,9 @@ public class AjaxRequestBuilder {
                 int size = paramValues.size();
                 for(int i = 0; i < size; i++) {
                     String paramValue = paramValues.get(i);
+                    if (paramValue == null) {
+                        paramValue = "";
+                    }
                     buffer.append("{name:").append("\"").append(name).append("\",value:\"").append(paramValue).append("\"}");
                     
                     if(i < (size - 1)) {


### PR DESCRIPTION
Hello. I found problem with empty f:param value rendering. For example, next code will initiate HTTP request with additional form data.

Code:
`<p:commandLink...>
   <f:param name="param" value="#{null}"/>
  </p:commandLink>`

Request data:
`param: null`

But I guess "param" value should be empty at least. I updated AjaxRequestBuilder class for solving it.

Referenced issue: #1424 
