### PR TITLE
Fix for p:editor -> "paste" with mouse right-click

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/editor/editor.js
+++ b/src/main/resources/META-INF/resources/primefaces/editor/editor.js
@@ -946,6 +946,12 @@
             .bind("keyup mouseup", function () {
                 refreshButtons(editor);
                 updateTextArea(editor, true);
+            })
+            .bind("paste", function() {
+                setTimeout(function() {
+                    refreshButtons(editor);
+                    updateTextArea(editor, true);
+                }, 0)
             });
 
         // Show the textarea for iPhone/iTouch/iPad or


### PR DESCRIPTION
Steps to reproduce:
1. Open http://www.primefaces.org/showcase/ui/input/editor.xhtml
2. Copy something into a buffer, e.g. component description from this page 
3. Right click on input area and select "paste". It's important -- right click, not left!
4. Click submit button

Expected: popup window with copied text
Actual: popup window with no copied text 

Pull request for issue #1186 
