### PR TITLE
Set mime type correctly for XLSX files

### DIFF
--- a/src/main/java/org/primefaces/component/export/ExcelXExporter.java
+++ b/src/main/java/org/primefaces/component/export/ExcelXExporter.java
@@ -37,5 +37,19 @@ public class ExcelXExporter extends ExcelExporter {
         return "attachment;filename="+ filename + ".xlsx";
     }
 
+    @Override
+    protected void writeExcelToResponse(ExternalContext externalContext, Workbook generatedExcel, String filename) throws IOException {
+    	externalContext.setResponseContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    	externalContext.setResponseHeader("Expires", "0");
+    	externalContext.setResponseHeader("Cache-Control","must-revalidate, post-check=0, pre-check=0");
+    	externalContext.setResponseHeader("Pragma", "public");
+    	externalContext.setResponseHeader("Content-disposition", getContentDisposition(filename));
+    	externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE, "true", Collections.<String, Object>emptyMap());
+
+        OutputStream out = externalContext.getResponseOutputStream();
+        generatedExcel.write(out);
+        externalContext.responseFlushBuffer();        
+    }
+
 }
 


### PR DESCRIPTION
Overrides ExcelXExport's writeExcelToResponse method with the only change being correcting the mime type in the setResponseContentType() call. The problem was if you set a p:dataExporter's type to "xlsx", the browser would see the file correctly as a .xlsx file but then send the file to Excel as a filename.xlsx.xls file.

This seems like it's only a problem for Firefox (I'm using version 46.0.1) and may or may not be limited to Windows 7 64-bit. The current code works fine for me in Chrome 51 and IE 11, but this patch does not seem to adversely affect them in any way.

The error/warning I would see in Excel said "The file you are trying to open, 'filename.xlsx.xls', is in a different format than specified by the file extension. Verify that the file is not corrupted and is from a trusted source before opening the file. Do you want to open the file now? Yes/No/Help"

I'm sorry this is a bit vague and possibly specific to Firefox, but there's a few technologies interacting here and I'm not entirely sure who to blame. Firefox may be doing it "correct" and the other browsers are performing some hack to make it work, if you look at the official list of mime types you can see that xlsx is different that xls:

https://blogs.msdn.microsoft.com/vsofficedeveloper/2008/05/08/office-2007-file-format-mime-types-for-http-content-streaming-2/

This patch sets the xlsx mime type to the one in this document.
