### PR TITLE
scrollable table now  also scrolls to selected row when focused.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -441,7 +441,11 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         this.getFocusableTbody().on('focus', function(e) {
             //ignore mouse click on row
             if(!$this.mousedownOnRow) {
-                $this.focusedRow = $this.tbody.children('tr.ui-widget-content.ui-datatable-selectable').eq(0);
+                $this.focusedRow = $this.tbody.children('tr.ui-widget-content.ui-datatable-selectable.ui-state-highlight').eq(0);
+                if ($this.focusedRow.length == 0) {
+                    $this.focusedRow = $this.tbody.children('tr.ui-widget-content.ui-datatable-selectable').eq(0);
+                }
+
                 $this.highlightFocusedRow();
                 
                 if($this.cfg.scrollable) {


### PR DESCRIPTION
Fix for #1230 and #1381.

Now, when the table body gets the focus, it will scroll to the selected row. If no row is selected, it will scroll to the first selectable row (which is the current behavior).

Test, please.
