### PR TITLE
fixed right-to-left direction in tabView (issue #1513)

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
@@ -137,10 +137,6 @@
     direction: rtl;
 }
 
-.ui-tabs-rtl .ui-tabs-nav li, .ui-tabs-rtl .ui-tabs-nav li a {
-    float: right;
-}
-
 /** Scroll **/
 .ui-tabs-scrollable .ui-tabs-nav {
     width:5000px;


### PR DESCRIPTION
Removed the right-floating from the tabs if rtl is used which caused #1513. Tested with all orientations in Chrome 48.0.2564.82.
