### PR TITLE
display rating stars as non-floating inline-blocks.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/rating/rating.css
+++ b/src/main/resources/META-INF/resources/primefaces/rating/rating.css
@@ -1,7 +1,6 @@
 .ui-rating-star,
 .ui-rating-cancel {
-    float: left;
-    display: block;
+    display: inline-block;
     overflow: hidden;
     text-indent: -999em;
     cursor: pointer;


### PR DESCRIPTION
This is a fix for #1392.

p:rating uses floating blocks for the stars without clearing the float, which causes the enclosing div to be of height 0. The height seems to be correct, if non-floating inline-blocks are used. 
