### PR TITLE
set value of spinner with suffix even if no suffix was entered (fixes #1561)

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -172,8 +172,11 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
         else {
             if(this.cfg.prefix && value.indexOf(this.cfg.prefix) === 0) {
                 value = value.substring(this.cfg.prefix.length, value.length);
-            }  else if(this.cfg.suffix && value.indexOf(this.cfg.suffix) === (value.length - this.cfg.suffix.length)) {
-                value = value.substring(0, value.length - this.cfg.suffix.length);
+            }  else {
+                var ix = value.indexOf(this.cfg.suffix);
+                if(this.cfg.suffix && ix > -1 && ix === (value.length - this.cfg.suffix.length)) {
+                    value = value.substring(0, value.length - this.cfg.suffix.length);
+                }
             }
             
             if(this.cfg.precision)


### PR DESCRIPTION
Suffix handling is now only applied, if the input value really contains a suffix.
