### PR TITLE
p:inputNumber takes view's locale into account (Fixes #1575)

### DIFF
--- a/src/main/java-templates/org/primefaces/component/inputnumber/InputNumberTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/inputnumber/InputNumberTemplate.java
@@ -1,3 +1,5 @@
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
     public final static String STYLE_CLASS = "ui-inputnumber ui-widget";
 
@@ -20,3 +22,40 @@
     public String getLabelledBy() {
         return (String) getStateHelper().get("labelledby");
     } 
+
+    public String getDecimalSeparator() {
+        return (String) getStateHelper().eval("decimalSeparator", getCalculatedDecimalSepartor());
+    }
+
+    public void setDecimalSeparator(final String decimalSeparator) {
+        getStateHelper().put("decimalSeparator", decimalSeparator);
+    }
+
+    public String getThousandSeparator() {
+        return (String) getStateHelper().eval("thousandSeparator", getCalculatedThousandSeparator());
+    }
+
+    public void setThousandSeparator(final String thousandSeparator) {
+        getStateHelper().put("thousandSeparator", thousandSeparator);
+    }
+
+    private String getCalculatedDecimalSepartor(){
+        String decimalSeparator = (String) getStateHelper().eval("decimalSeparator", null);
+        if (decimalSeparator==null){
+            Locale locale = FacesContext.getCurrentInstance().getViewRoot().getLocale();
+            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols(locale);
+            decimalSeparator = Character.toString(decimalFormatSymbols.getDecimalSeparator());
+        }
+        return decimalSeparator;
+    }
+
+    private String getCalculatedThousandSeparator(){
+        String thousandSeparator = (String) getStateHelper().eval("thousandSeparator", null);
+        if (thousandSeparator==null){
+            Locale locale = FacesContext.getCurrentInstance().getViewRoot().getLocale();
+            DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols(locale);
+            thousandSeparator =  Character.toString(decimalFormatSymbols.getGroupingSeparator());
+        }
+        return thousandSeparator;
+    }
+

--- a/src/main/resources-maven-jsf/ui/inputNumber.xml
+++ b/src/main/resources-maven-jsf/ui/inputNumber.xml
@@ -39,15 +39,15 @@
             <name>decimalSeparator</name>
             <required>false</required>
             <type>java.lang.String</type>
-            <defaultValue>.</defaultValue>
-            <description>Decimal separator char. Default is '.'.</description>
+            <ignoreInComponent>true</ignoreInComponent>
+            <description>Decimal separator char. Default is taken from the view's locale.</description>
         </attribute>
         <attribute>
             <name>thousandSeparator</name>
             <required>false</required>
             <type>java.lang.String</type>
-            <defaultValue>,</defaultValue>
-            <description>Thousand separator char. Default is ','.</description>
+            <ignoreInComponent>true</ignoreInComponent>
+            <description>Thousand separator char. Default is taken from the view's locale.</description>
         </attribute>
         <attribute>
             <name>symbol</name>


### PR DESCRIPTION
Problem was, that decimal/thousand separators were given statically in the taglib xml-file. Changed it to ignore the attributes in the component - unsure, if this is the way to go.
