### PR TITLE
Fix #1470

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/terminal/terminal.js
+++ b/src/main/resources/META-INF/resources/primefaces/terminal/terminal.js
@@ -87,7 +87,14 @@ PrimeFaces.widget.Terminal = PrimeFaces.widget.BaseWidget.extend({
                             
                             // show promt again and focus input
                             $this.promptContainerParent.show();
-                            $this.focus();
+                            
+                            if(PrimeFaces.isIE()) {
+                            	window.setTimeout(function(){
+                            		$this.focus();
+                             	}, 50);
+                            } else {
+                            	$this.focus();
+                            }
 
                             // add response
                             $this.processResponse(content);


### PR DESCRIPTION
Fixes #1470 with a js workaround; If the browser is IE, there is a small timeout before calling `focus()`.
