### PR TITLE
fixes #1629 (tabview outline in chrome)

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
@@ -23,6 +23,7 @@
     float: left;
     padding: .5em 1em;
     text-decoration: none;
+    outline: none;
 }
 
 .ui-tabs .ui-tabs-nav li.ui-tabs-selected a,


### PR DESCRIPTION
Fixes the issue #1629.

Tabview a elements strangely had outline created by chrome. Simply fixed it by setting outline to none.
