### PR TITLE
#1654 - initialdescendant component state is incorrectly handled during

### DIFF
--- a/src/main/java/org/primefaces/component/api/UIData.java
+++ b/src/main/java/org/primefaces/component/api/UIData.java
@@ -1131,7 +1131,17 @@ public class UIData extends javax.faces.component.UIData {
                 }
                 Object descendantState = saveDescendantInitialComponentStates(
                         facesContext, childsIterator, true);
-                Object state = child.saveState(facesContext);
+                Object state = null;
+                if (child.initialStateMarked())
+                {
+                	child.clearInitialState();
+                	state = child.saveState(facesContext);
+                	child.markInitialState();
+                }
+                else
+                {
+                	state = child.saveState(facesContext);
+                }
                 childStates.add(new Object[] { state, descendantState });
             }
         }


### PR DESCRIPTION
Initialdescendant component state is incorrectly handled during render response phase - it is neccesary to check if the initialState is marked. Otherwise we get delta state in case we need full state.
