### PR TITLE
FilterBy attribute of <p:columns> cause a crash when valueExpression …

### DIFF
--- a/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
@@ -625,8 +625,23 @@ import javax.faces.event.BehaviorEvent;
     public String resolveDynamicField(ValueExpression expression) {
         if(expression != null) {
             String expressionString = expression.getExpressionString();
+            
+            //2016.08.05:schlebe: valueExpr can be a method and it not necessary a element of an array !!!
+            //<correction>
             expressionString = expressionString.substring(expressionString.indexOf("[") + 1, expressionString.indexOf("]"));            
             expressionString = "#{" + expressionString + "}";
+            
+            int iOpen = expressionString.indexOf("[");
+            if (iOpen >= 0)
+                {   
+                int iClose = expressionString.indexOf("]");
+                expressionString = expressionString.substring(iOpen + 1, iClose);            
+                expressionString = "#{" + expressionString + "}";
+                }
+            //</correction>
+
+            //expressionString = expressionString.substring(expressionString.indexOf("[") + 1, expressionString.indexOf("]"));            
+            //expressionString = "#{" + expressionString + "}";
             
             FacesContext context = getFacesContext();
             ELContext eLContext = context.getELContext();


### PR DESCRIPTION
…is a method

The program return an error when it executes the substring on expressionString because indexOf("]") return -1.

This worked correctly on Primefaces 5.3 !

This bug is discussed on Primefaces forum at http://forum.primefaces.org/viewtopic.php?f=3&t=46468

SORRY IMPORTANT: in code source I have forgotten to remove followinf line just before int iOpen =

expressionString = expressionString.substring(expressionString.indexOf("[") + 1, expressionString.indexOf("]"));  
             expressionString = "#{" + expressionString + "}";

and I don't find how to remove it now !
