### PR TITLE
Reset captcha even if validation fails with an exception

### DIFF
--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -53,7 +53,13 @@ import org.primefaces.json.JSONObject;
                 rd.close();
             }catch(Exception exception) {
                 throw new FacesException(exception);
-            }
+            } finally {
+            	// the captcha token is valid for only one request, in case of an ajax request we have to get a new one
+	        RequestContext requestContext = RequestContext.getCurrentInstance();
+	        if(requestContext.isAjaxRequest()) {
+	            requestContext.execute("grecaptcha.reset()");
+	        }
+	    }
 
             if(!result) {
                 setValid(false);
@@ -74,11 +80,6 @@ import org.primefaces.json.JSONObject;
 
                 context.addMessage(getClientId(context), msg);
             }
-        }
-        
-        RequestContext requestContext = RequestContext.getCurrentInstance();
-        if(requestContext.isAjaxRequest()) {
-            requestContext.execute("grecaptcha.reset()");
         }
 	}
 


### PR DESCRIPTION
Moved the captcha reset call to a finally block of the try-catch Google verify call.
This should make sure that the captcha is reset, even if an exception during the validation happens, e.g. if the response from Google does not contain the expected response (in case of a token timeout). 

Please see issue #1639 
