### PR TITLE
Don't show autocomplete itemtip if there was no content defined

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -500,7 +500,17 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
             this.itemtip.hide();
         }
         else {
-            var content = item.is('li') ? item.next('.ui-autocomplete-itemtip-content') : item.children('td:last');
+            var content;
+            if(item.is('li')) {
+                content = item.next('.ui-autocomplete-itemtip-content');
+            } else {
+                if(item.children('td:last').hasClass('ui-autocomplete-itemtip-content')) {
+                    content = item.children('td:last');
+                } else {
+                    this.itemtip.hide();
+                    return;
+                }
+            }
 
             this.itemtip.html(content.html())
                         .css({


### PR DESCRIPTION
With the old ternary operator assignment of content, it would always return "item.children('td:last')" if item wasn't a li element. The problem with that is if no itemtip content was defined (td.ui-autocomplete-itemtip-content) then it would just dump the same autocomplete result content into the itemtip. I didn't think this looked very good so now it checks if td:last has the itemtip content class and if it doesn't, hides the itemtip and then returns early.
