### PR TITLE
Don't hide autocomplete panel if itemtip clicked

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -166,12 +166,14 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                 return;
             }
             
-            var itemtipOffset = $this.itemtip.offset();
-            if (e.pageX >= itemtipOffset.left &&
-                e.pageX <= itemtipOffset.left + $this.itemtip.width() &&
-                e.pageY >= itemtipOffset.top &&
-                e.pageY <= itemtipOffset.top + $this.itemtip.width()) {
-                return;
+            if($this.itemtip) {
+                var itemtipOffset = $this.itemtip.offset();
+                if (e.pageX >= itemtipOffset.left &&
+                    e.pageX <= itemtipOffset.left + $this.itemtip.width() &&
+                    e.pageY >= itemtipOffset.top &&
+                    e.pageY <= itemtipOffset.top + $this.itemtip.width()) {
+                    return;
+                }
             }
             
             var panelOffset = $this.panel.offset();

--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -162,11 +162,19 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                 return;
             }
             
-            var offset = $this.panel.offset();
             if(e.target === $this.input.get(0)) {
                 return;
             }
             
+            var itemtipOffset = $this.itemtip.offset();
+            if (e.pageX >= itemtipOffset.left &&
+                e.pageX <= itemtipOffset.left + $this.itemtip.width() &&
+                e.pageY >= itemtipOffset.top &&
+                e.pageY <= itemtipOffset.top + $this.itemtip.width()) {
+                return;
+            }
+            
+            var panelOffset = $this.panel.offset();
             if (e.pageX < offset.left ||
                 e.pageX > offset.left + $this.panel.width() ||
                 e.pageY < offset.top ||


### PR DESCRIPTION
If the itemtip is the target of the mousedown event, then don't hide the entire autocomplete result panel. This allows the user to click an anchor link in the itemtip or copy text from it if necessary.
