### PR TITLE
Autocomplete itemtip also respects autoHighlight

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -575,7 +575,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
             }
 
             //show itemtip if defined
-            if(this.cfg.itemtip && firstItem.length === 1) {
+            if(this.cfg.autoHighlight && this.cfg.itemtip && firstItem.length === 1) {
                 this.showItemtip(firstItem);
             }
             


### PR DESCRIPTION
Right now if autoHighlight is set to false and the first result has an itemtip, the the first result will not be highlighted but its itemtip will appear as if it were highlighted.
