### PR TITLE
Core: Prevent IE exceptions for clearSelection

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -253,7 +253,7 @@
             if(window.getSelection) {
                 if(window.getSelection().empty) {
                     window.getSelection().empty();
-                } else if(window.getSelection().removeAllRanges) {
+                } else if(window.getSelection().removeAllRanges && window.getSelection().rangeCount > 0 && window.getSelection().getRangeAt(0).getClientRects().length > 0) {
                     window.getSelection().removeAllRanges();
                 }
             }


### PR DESCRIPTION
This PR relates to #1799

---

``` js
window.getSelection().rangeCount > 0
```

is required in order to prevent `IndexSizeError`-exceptions in IE
