### PR TITLE
Fix Issue # 1944(Image Cropper throws java.awt.image.RasterFormatException: negative or zero width, when cropper is deselected)

### DIFF
--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -148,9 +148,9 @@ public class ImageCropperRenderer extends CoreRenderer {
         int w = (int) Double.parseDouble(cropCoords[2]);
         int h = (int) Double.parseDouble(cropCoords[3]);
 
-	if((w==0)&&(h==0)){
+	if (w <= 0 || h <= 0) {
             return null;
-        }
+        }    
 	    
         ImageCropper cropper = (ImageCropper) component;
         Resource resource = getImageResource(context, cropper);

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -148,6 +148,10 @@ public class ImageCropperRenderer extends CoreRenderer {
         int w = (int) Double.parseDouble(cropCoords[2]);
         int h = (int) Double.parseDouble(cropCoords[3]);
 
+	if((w==0)&&(h==0)){
+            return null;
+        }
+	    
         ImageCropper cropper = (ImageCropper) component;
         Resource resource = getImageResource(context, cropper);
         InputStream inputStream;


### PR DESCRIPTION
p:imageCropper throws exception when the image is deselected.
For this i have added a check in function in 
**@Class ImageCropperRenderer** 
@Method  **getConvertedValue**

add these two lines ,where i check the width and height are not equals to zero.

  if((w==0)&&(h==0)){
            return null;
        }
