### PR TITLE
jQuery.fn.size() is deprecated; use the .length property as of Jquery 1.8+

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/charts/charts.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/charts.js
@@ -21112,10 +21112,10 @@ PrimeFaces.widget.Chart = PrimeFaces.widget.DeferredWidget.extend({
         var tableLegend = this.jq.find('table.jqplot-table-legend'),
             tr = tableLegend.find('tr.jqplot-table-legend');
         
-        if(tr.size() > 1) {
+        if(tr.length > 1) {
             var trFirst = tableLegend.find('tr.jqplot-table-legend:first'),
                 trLast = tableLegend.find('tr.jqplot-table-legend:last'),
-                length = trFirst.children('td').size() - trLast.children('td').size();
+                length = trFirst.children('td').length - trLast.children('td').length;
 
             for(var i = 0; i < length; i++) {
                 trLast.append('<td></td>');

--- a/src/main/resources/META-INF/resources/primefaces/dock/dock.js
+++ b/src/main/resources/META-INF/resources/primefaces/dock/dock.js
@@ -329,9 +329,9 @@ jQuery.iFisheye = {
 						var pointer = jQuery.iUtil.getPointer(e);
 						var toAdd = 0;
 						if (el.fisheyeCfg.halign && el.fisheyeCfg.halign == 'center')
-							var posx = pointer.x - el.fisheyeCfg.pos.x - (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.size())/2 - el.fisheyeCfg.itemWidth/2;
+							var posx = pointer.x - el.fisheyeCfg.pos.x - (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.length)/2 - el.fisheyeCfg.itemWidth/2;
 						else if (el.fisheyeCfg.halign && el.fisheyeCfg.halign == 'right')
-							var posx = pointer.x - el.fisheyeCfg.pos.x - el.offsetWidth + el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.size();
+							var posx = pointer.x - el.fisheyeCfg.pos.x - el.offsetWidth + el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.length;
 						else
 							var posx = pointer.x - el.fisheyeCfg.pos.x;
 						var posy = Math.pow(pointer.y - el.fisheyeCfg.pos.y - el.offsetHeight/2,2);
@@ -366,12 +366,12 @@ jQuery.iFisheye = {
 	{
 		if (el.fisheyeCfg.halign)
 			if (el.fisheyeCfg.halign == 'center')
-				el.fisheyeCfg.container.get(0).style.left = (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.size())/2 - toAdd/2 + 'px';
+				el.fisheyeCfg.container.get(0).style.left = (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.length)/2 - toAdd/2 + 'px';
 			else if (el.fisheyeCfg.halign == 'left')
-				el.fisheyeCfg.container.get(0).style.left =  - toAdd/el.fisheyeCfg.items.size() + 'px';
+				el.fisheyeCfg.container.get(0).style.left =  - toAdd/el.fisheyeCfg.items.length + 'px';
 			else if (el.fisheyeCfg.halign == 'right')
-				el.fisheyeCfg.container.get(0).style.left =  (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.size()) - toAdd/2 + 'px';
-		el.fisheyeCfg.container.get(0).style.width = el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.size() + toAdd + 'px';
+				el.fisheyeCfg.container.get(0).style.left =  (el.offsetWidth - el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.length) - toAdd/2 + 'px';
+		el.fisheyeCfg.container.get(0).style.width = el.fisheyeCfg.itemWidth * el.fisheyeCfg.items.length + toAdd + 'px';
 	},
 
 	positionItems : function(el)

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.js
@@ -486,7 +486,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         }
         
         //for Screen Readers
-        for(var i = 0; i < this.items.size(); i++) {
+        for(var i = 0; i < this.items.length; i++) {
             this.items.eq(i).attr('id', this.id + '_' + i);
         }
         


### PR DESCRIPTION
As reported by the JQuery 1.x migrate tool size() should be .length as of 1.8+.  This will help ease the eventual transition to JQ 3.0.

```
JQMIGRATE: Migrate is installed with logging active, version 1.4.1
jquery-migrate-1.4.1.js:45 JQMIGRATE: jQuery.fn.size() is deprecated; use the .length property
migrateWarn @ jquery-migrate-1.4.1.js:45
```
