### PR TITLE
Fix #1967 Don't hide datatable content when overflow.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -1,7 +1,6 @@
 .ui-datatable table {
 	border-collapse:collapse;
     width: 100%;
-    table-layout: fixed;
 }
 
 .ui-datatable-tablewrapper {
@@ -31,7 +30,6 @@
 .ui-datatable tfoot td,
 .ui-datatable tfoot th{
     padding: 4px 10px;
-    overflow: hidden;
     border-width: 1px;
     border-style: solid;
 }


### PR DESCRIPTION
Having overflow:hidden was causing the issue.

Additionally, as table-layout:fixed, some content fields could overflow their boundaries, causing problems on some fields (p:spinner for example). Letting default table-layout:auto (so cells are resized using their cell contents) fixes this issue too, making resizing much better.