### PR TITLE
Fix#1889 (p:calendar timeControlType="select" does not work with national time pattern)

### DIFF
--- a/src/main/java-templates/org/primefaces/component/calendar/CalendarTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/calendar/CalendarTemplate.java
@@ -77,7 +77,7 @@ import javax.faces.event.PhaseId;
     public boolean hasTime() {
         String pattern = getPattern();
 
-        return (pattern != null && pattern.indexOf(":") != -1);
+        return (pattern != null && (pattern.contains("HH") || pattern.contains("mm") || pattern.contains("ss")));
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -200,7 +200,7 @@ public class CalendarRenderer extends InputRenderer {
             wb.attr("showOtherMonths", true).attr("selectOtherMonths", calendar.isSelectOtherMonths());
         }
 
-        if (calendar.hasTime()) {
+       
             String timeControlType = calendar.getTimeControlType();
             
             wb.attr("timeOnly", calendar.isTimeOnly())
@@ -224,7 +224,7 @@ public class CalendarRenderer extends InputRenderer {
             if (timeControlObject != null && timeControlType.equalsIgnoreCase("custom")) {
                 wb.nativeAttr("timeControlObject", timeControlObject);
             }
-        }
+       
 
         if (mask != null && !mask.equals("false")) {
             String patternTemplate = calendar.getPattern() == null ? pattern : calendar.getPattern();

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -200,7 +200,7 @@ public class CalendarRenderer extends InputRenderer {
             wb.attr("showOtherMonths", true).attr("selectOtherMonths", calendar.isSelectOtherMonths());
         }
 
-       
+        if (calendar.hasTime()) {
             String timeControlType = calendar.getTimeControlType();
             
             wb.attr("timeOnly", calendar.isTimeOnly())
@@ -224,7 +224,7 @@ public class CalendarRenderer extends InputRenderer {
             if (timeControlObject != null && timeControlType.equalsIgnoreCase("custom")) {
                 wb.nativeAttr("timeControlObject", timeControlObject);
             }
-       
+        }
 
         if (mask != null && !mask.equals("false")) {
             String patternTemplate = calendar.getPattern() == null ? pattern : calendar.getPattern();


### PR DESCRIPTION
The **if (hasTime()) Condition** in CalenderRenderer.java is buggy,it returns true only when the pattern is not null or contains (":") ,so that's why no pattern runs except that contains separator **(:)**.

Here is the code for checking time.
**public boolean hasTime() { 
     String pattern = getPattern(); 
     return (pattern != null && pattern.indexOf(":") != -1); 
}**
The work around is to comment the check and it will works for all the patterns alongwith any separator.
It has no consequence,even the user doesn't mention time with the pattern.