### PR TITLE
Fixed error counting the number of options in a select when there are…

### DIFF
--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -143,7 +143,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         
         writer.startElement("div", menu);
         writer.writeAttribute("class", SelectManyMenu.LIST_CONTAINER_CLASS, null);
-        writer.writeAttribute("style", "height:" + calculateWrapperHeight(menu, selectItems.size()), null);
+        writer.writeAttribute("style", "height:" + calculateWrapperHeight(menu, countSelectItems(selectItems)), null);
 
         if(customContent) {
             writer.startElement("table", null);

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -138,7 +138,7 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         
         writer.startElement("div", listbox);
         writer.writeAttribute("class", SelectOneListbox.LIST_CONTAINER_CLASS, null);
-        writer.writeAttribute("style", "height:" + calculateWrapperHeight(listbox, selectItems.size()), null);
+        writer.writeAttribute("style", "height:" + calculateWrapperHeight(listbox, countSelectItems(selectItems)), null);
 
         if(customContent) {
             writer.startElement("table", null);

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -233,7 +233,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         
         writer.startElement("div", null);
         writer.writeAttribute("class", SelectOneMenu.ITEMS_WRAPPER_CLASS, null);
-        writer.writeAttribute("style", "height:" + calculateWrapperHeight(menu, selectItems.size()), null);
+        writer.writeAttribute("style", "height:" + calculateWrapperHeight(menu, countSelectItems(selectItems)), null);
 
         if(customContent) {
             writer.startElement("table", menu);

--- a/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -16,9 +16,13 @@
 package org.primefaces.renderkit;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
+import javax.faces.model.SelectItem;
+import javax.faces.model.SelectItemGroup;
 
 public class SelectRenderer extends InputRenderer {
     
@@ -63,5 +67,15 @@ public class SelectRenderer extends InputRenderer {
             }
         }
         return false;
+    }
+    
+    protected int countSelectItems(List<SelectItem> selectItems) {
+        int count = selectItems.size();
+        for (SelectItem selectItem : selectItems) {
+            if(selectItem instanceof SelectItemGroup){
+                count += countSelectItems(Arrays.asList(((SelectItemGroup)selectItem).getSelectItems()));
+            }
+        }
+        return count;
     }
 }


### PR DESCRIPTION
#… items inside groups (SelectItemGroup). 
This issue can cause problems rendering selects with groups with a large number of options inside (not setting a fixed height by default).

Grouping example in the showcase http://www.primefaces.org/showcase/ui/input/oneMenu.xhtml

For example: a `<p:selectOneMenu>` with 4 groups of 5 items each, ends up rendering a huge panel with an `<ul>` with 24 `<li>` without scroll (`height: auto`) because for the renderer there are only 4 items