### PR TITLE
selectOneRadio label and inputNumber label&component highlight fix

### DIFF
--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -169,6 +169,10 @@ public class InputNumberRenderer extends InputRenderer {
         
         writer.writeAttribute("class", styleClass, null);
 
+        if(RequestContext.getCurrentInstance().getApplicationContext().getConfig().isClientSideValidationEnabled()) {
+            renderValidationMetadata(context, inputNumber);
+        }
+
         writer.endElement("input");
     }
 

--- a/src/main/resources/META-INF/resources/primefaces/validation/validation.js
+++ b/src/main/resources/META-INF/resources/primefaces/validation/validation.js
@@ -1114,6 +1114,7 @@ if (window.PrimeFaces) {
                     for(var i = 0; i < radios.length; i++) {
                         radios.eq(i).addClass('ui-state-error');
                     }
+                    PrimeFaces.validator.Highlighter.highlightLabel(container);
                 },
 
                 unhighlight: function(element) {
@@ -1123,6 +1124,7 @@ if (window.PrimeFaces) {
                     for(var i = 0; i < radios.length; i++) {
                         radios.eq(i).removeClass('ui-state-error');
                     }
+                    PrimeFaces.validator.Highlighter.unhighlightLabel(container);
                 }
 
             },

--- a/src/main/resources/META-INF/resources/primefaces/validation/validation.js
+++ b/src/main/resources/META-INF/resources/primefaces/validation/validation.js
@@ -1144,11 +1144,14 @@ if (window.PrimeFaces) {
             'inputnumber': {
 
                 highlight: function(element) {
-                    element.prev().addClass('ui-state-error');
+                    element.addClass('ui-state-error');
+                    PrimeFaces.validator.Highlighter.highlightLabel(element);
                 },
 
                 unhighlight: function(element) {
-                    element.prev().removeClass('ui-state-error');
+                    element.removeClass('ui-state-error');
+                    PrimeFaces.validator.Highlighter.unhighlightLabel(element);
+
                 }
 
             }


### PR DESCRIPTION
When client side validation enabled select one radio does not highlight its associated label, made a small change to support that as i asked in https://github.com/primefaces/primefaces/issues/2022 so issue can be closed with with this PR. In addition to that inputNumber csv is also broken and added fix for that aswell.