### PR TITLE
Fix problem always empty submittedValue in p:inputNumber

### DIFF
--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -64,7 +64,7 @@ public class InputNumberRenderer extends InputRenderer {
 
         decodeBehaviors(context, inputNumber);
 
-        String inputId = inputNumber.getClientId(context) + "_hinput";
+        String inputId = inputNumber.getClientId(context) + "_input";
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(inputId);
 
         if (submittedValue != null) {


### PR DESCRIPTION
Currently the encodeOutput method is creating an input with suffix id "_input", but the decode method it is expecting / capturing the value of an input with suffix id "_hinput". That is causing empty string in submittedValue, no matter value the inputNumber is filled on.

```java

protected void encodeOutput(FacesContext context, InputNumber inputNumber, String clientId) throws IOException {
        ResponseWriter writer = context.getResponseWriter();
        String inputId = clientId + "_input";
     // [...]
}

```

```java
   @Override
    public void decode(FacesContext context, UIComponent component) {
       // [...]
        String inputId = inputNumber.getClientId(context) + "_hinput";
    }
```