### PR TITLE
fix #1828 datatable filter prevent keys LEFT,RIGHT,HOME,END

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -397,6 +397,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             }
         })
         .on(this.cfg.filterEvent + '.dataTable', function(e) {
+            var key = e.which,
+            keyCode = $.ui.keyCode;
+            if (key === keyCode.END||key === keyCode.HOME||key === keyCode.LEFT||key === keyCode.RIGHT) {
+                return;
+            }
+
             if($this.filterTimeout) {
                 clearTimeout($this.filterTimeout);
             }


### PR DESCRIPTION
Hi, I add prevent for press keys LEFT, RIGHT, HOME, END. Table should not filter if somebody want to move cursor only. It is well eliminate each filter useless request.