### PR TITLE
fix #899: enhance dialog fitViewport funcionality

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -108,17 +108,10 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.BaseWidget.extend({
 
     fitViewport: function() {
         var winHeight = $(window).height(),
-        contentPadding = this.content.innerHeight() - this.content.height();
-
-        if(this.jq.innerHeight() > winHeight) {
-            this.content.height(winHeight - this.titlebar.innerHeight() - contentPadding);
-        }
-        
-        var winHeight = $(window).height(),
         dialogMargin = this.jq.outerHeight(true) - this.jq.outerHeight(),
-        titlebarHeight, contentPadding, footerHeight;
+        titlebarHeight, contentPadding, footerHeight; 
 
-        if (!this.isVisible()) {
+        if (!this.isVisible()) { 
             var dialogClone = this.jq.clone()
                 .attr("id", false)
                 .css({visibility:"hidden", display:"block", position:"absolute"});
@@ -131,7 +124,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.BaseWidget.extend({
             footerHeight = $footer ? $footer.innerHeight() : 0;
 
             dialogClone.remove();
-        } else {
+        } else { 
             titlebarHeight = this.titlebar.innerHeight();
             contentPadding = this.content.innerHeight() - this.content.height();
             footerHeight = (this.footer ? this.footer.innerHeight() : 0);

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -113,6 +113,31 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.BaseWidget.extend({
         if(this.jq.innerHeight() > winHeight) {
             this.content.height(winHeight - this.titlebar.innerHeight() - contentPadding);
         }
+        
+        var winHeight = $(window).height(),
+        dialogMargin = this.jq.outerHeight(true) - this.jq.outerHeight(),
+        titlebarHeight, contentPadding, footerHeight;
+
+        if (!this.isVisible()) {
+            var dialogClone = this.jq.clone()
+                .attr("id", false)
+                .css({visibility:"hidden", display:"block", position:"absolute"});
+            $("body").append(dialogClone);
+            var $content = dialogClone.children('.ui-dialog-content'),
+                $footer = dialogClone.children('.ui-dialog-footer');
+
+            titlebarHeight = dialogClone.children('.ui-dialog-titlebar').innerHeight();
+            contentPadding = $content.innerHeight() - $content.height();
+            footerHeight = $footer ? $footer.innerHeight() : 0;
+
+            dialogClone.remove();
+        } else {
+            titlebarHeight = this.titlebar.innerHeight();
+            contentPadding = this.content.innerHeight() - this.content.height();
+            footerHeight = (this.footer ? this.footer.innerHeight() : 0);
+        }
+
+        this.content.height(winHeight - dialogMargin - titlebarHeight - contentPadding - footerHeight);
     },
 
     enableModality: function() {
@@ -622,6 +647,10 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.BaseWidget.extend({
     bindResizeListener: function() {
         var $this = this;
         $(window).on(this.resizeNS, function() {
+            if ($this.cfg.fitViewport) {
+                $this.fitViewport();
+            }
+
             $this.initPosition();
         });
     },


### PR DESCRIPTION
Hi I fixed issue #899. If fitViewPort is true, dialog computes height by dialog margin, titlebar, content and footer (if exists). For correct compute dialog height I had to create his clone with different css styles. I added support for responsivity. If window resize is fired, fitVieport function is called.