### PR TITLE
Fix #709 and #1760 Charts single quote escaping.

### DIFF
--- a/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
@@ -40,7 +40,7 @@ public class LineRenderer extends CartesianPlotRenderer {
             for(Iterator<Object> x = series.getData().keySet().iterator(); x.hasNext();) {
                 Object xValue = x.next();
                 Number yValue = series.getData().get(xValue);
-                String yValueAsString = (yValue != null) ? yValue.toString() : "null";
+                String yValueAsString = ComponentUtils.escapeText((yValue != null) ? yValue.toString() : "null");
 
                 writer.write("[");
                 

--- a/src/main/java/org/primefaces/component/chart/renderer/MeterGaugeRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/MeterGaugeRenderer.java
@@ -22,6 +22,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import org.primefaces.component.chart.Chart;
 import org.primefaces.model.chart.MeterGaugeChartModel;
+import org.primefaces.util.ComponentUtils;
 
 public class MeterGaugeRenderer extends BasePlotRenderer {
 
@@ -49,7 +50,7 @@ public class MeterGaugeRenderer extends BasePlotRenderer {
         encodeNumberList(context, "ticks", model.getTicks());
 
         if(gaugeLabel != null) {
-            writer.write(",gaugeLabel:\"" + gaugeLabel + "\"");
+            writer.write(",gaugeLabel:\"" + ComponentUtils.escapeText(gaugeLabel) + "\"");
             writer.write(",gaugeLabelPosition:\"" + model.getGaugeLabelPosition() + "\"");
         }
               

--- a/src/main/java/org/primefaces/model/chart/BarChartSeries.java
+++ b/src/main/java/org/primefaces/model/chart/BarChartSeries.java
@@ -17,6 +17,7 @@ package org.primefaces.model.chart;
 
 import java.io.IOException;
 import java.io.Writer;
+import org.primefaces.util.ComponentUtils;
 
 public class BarChartSeries extends ChartSeries {
 
@@ -40,7 +41,7 @@ public class BarChartSeries extends ChartSeries {
     @Override
     public void encode(Writer writer) throws IOException {
         writer.write("{");
-        writer.write("label:'" + this.getLabel() + "'");
+        writer.write("label:\"" + ComponentUtils.escapeText(this.getLabel()) + "\"");
 
         writer.write(",renderer: $.jqplot." + this.getRenderer());
         

--- a/src/main/java/org/primefaces/model/chart/ChartSeries.java
+++ b/src/main/java/org/primefaces/model/chart/ChartSeries.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.primefaces.util.ComponentUtils;
 
 public class ChartSeries implements Serializable {
 
@@ -82,7 +83,7 @@ public class ChartSeries implements Serializable {
     public void encode(Writer writer) throws IOException {
         String renderer = this.getRenderer();
         writer.write("{");
-        writer.write("label:'" + label + "'");
+        writer.write("label:\"" + ComponentUtils.escapeText(label) + "\"");
 
         if(renderer != null) writer.write(",renderer: $.jqplot." + renderer);
         if(xaxis != null) writer.write(",xaxis:\"" + xaxis + "\"");

--- a/src/main/java/org/primefaces/model/diagram/overlay/LabelOverlay.java
+++ b/src/main/java/org/primefaces/model/diagram/overlay/LabelOverlay.java
@@ -16,6 +16,7 @@
 package org.primefaces.model.diagram.overlay;
 
 import java.io.Serializable;
+import org.primefaces.util.ComponentUtils;
 
 public class LabelOverlay implements Overlay, Serializable {
 
@@ -67,7 +68,7 @@ public class LabelOverlay implements Overlay, Serializable {
     }
 
     public String toJS(StringBuilder sb) {
-        sb.append("['Label',{label:'").append(label).append("'");
+        sb.append("['Label',{label:\"").append(ComponentUtils.escapeText(label)).append("\"");
         
         if(styleClass != null) sb.append(",cssClass:'").append(styleClass).append("'");
         if(location != 0.5) sb.append(",location:").append(location);


### PR DESCRIPTION
Fixes #709
Fixes #1760 

Tested using the showcase by changing the label Boys and Girls to Boy's and Girl's and proved it was broken and that my fix has fixed it.

Looked for label: anywhere in code and fixed ' to \" and used the ComponentUtils.escapeText(); to escape it as well.