### PR TITLE
Fix #1993 for XML downloads.

### DIFF
--- a/src/main/java/org/primefaces/component/export/XMLExporter.java
+++ b/src/main/java/org/primefaces/component/export/XMLExporter.java
@@ -58,8 +58,6 @@ public class XMLExporter extends Exporter {
             	
         writer.flush();
         writer.close();
-        
-        externalContext.responseFlushBuffer();
 	}
     
     @Override


### PR DESCRIPTION
Same fix that was applied for Excel applied to XMLExporter.  Tested and verified it is fixed.