### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+# specifying other dists doesn't make sense because `trusty` doesn't have `oraclejdk8` (fails due to `Sorry, but JDK '[oraclejdk8]' is not known.`) which is the only supported JDK currently. Testing on Mac OSX doesn't make too much sense since it will run the same `maven` based build routine.
+
+jdk:
+- oraclejdk8
+- oraclejdk7
+- openjdk7
+# `openjdk8` not available
+
+install:
+- git clone https://github.com/primefaces/maven-jsf-plugin && cd maven-jsf-plugin && mvn install && cd ..
+
+script:
+- mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version
+# add --update-snapshots if snapshots are used
+- mvn test verify --batch-mode


### PR DESCRIPTION
Allows usage of the [Travis CI service](https://travis-ci.org) which provides free - as in gratis - testing for FLOSS projects and integrates well with github.com. It can be used as additional CI service in order to spot issues.