### PR TITLE
Fix #2306 Eclipse .gitignore for .classpath/.project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .idea/
 *.iml
 *~
+/.classpath
+/.project


### PR DESCRIPTION
Fix #2306 Eclipse .gitignore for .classpath/.project