### PR TITLE
Fix #2334 Terminal added escape property.

### DIFF
--- a/src/main/java/org/primefaces/component/terminal/TerminalRenderer.java
+++ b/src/main/java/org/primefaces/component/terminal/TerminalRenderer.java
@@ -46,6 +46,7 @@ public class TerminalRenderer extends CoreRenderer {
         String styleClass = terminal.getStyleClass();
         styleClass = (styleClass == null) ? Terminal.CONTAINER_CLASS : Terminal.CONTAINER_CLASS + " " + styleClass;
         String welcomeMessage = terminal.getWelcomeMessage();
+        String prompt = terminal.getPrompt();
         String inputId = clientId + "_input";
         
         writer.startElement("div", terminal);
@@ -57,7 +58,10 @@ public class TerminalRenderer extends CoreRenderer {
         
         if(welcomeMessage != null) {
             writer.startElement("div", null);
-            writer.writeText(welcomeMessage, null);
+            if(terminal.isEscape())
+               writer.writeText(welcomeMessage, null);
+            else
+               writer.write(welcomeMessage);
             writer.endElement("div");
         }
         
@@ -68,7 +72,10 @@ public class TerminalRenderer extends CoreRenderer {
         writer.startElement("div", null);
         writer.startElement("span", null);
         writer.writeAttribute("class", Terminal.PROMPT_CLASS, null);
-        writer.writeText(terminal.getPrompt(), null);
+        if(terminal.isEscape())
+           writer.writeText(prompt, null);
+        else
+           writer.write(prompt);
         writer.endElement("span");
         
         writer.startElement("input", null);

--- a/src/main/resources-maven-jsf/ui/terminal.xml
+++ b/src/main/resources-maven-jsf/ui/terminal.xml
@@ -53,6 +53,13 @@
 			<type>javax.el.MethodExpression</type>
             <description>Method to execute by passing command and the arguments.</description>
 		</attribute>
+        <attribute>
+            <name>escape</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <defaultValue>true</defaultValue>
+            <description>Defines if the terminal is escaped or not.</description>
+        </attribute>
 	</attributes>
 	<resources>
         <resource>


### PR DESCRIPTION
I didn't feel the need to have separate escapes for welcomeMessage and Prompt so they use the same escape property.