### PR TITLE
Fix #2345 TextEditor add jquery.js as required script.

### DIFF
--- a/src/main/resources-maven-jsf/ui/textEditor.xml
+++ b/src/main/resources-maven-jsf/ui/textEditor.xml
@@ -62,6 +62,12 @@
 			<name>texteditor/texteditor.css</name>
 		</resource>
 		<resource>
+			<name>jquery/jquery.js</name>
+		</resource>
+		<resource>
+			<name>jquery/jquery-plugins.js</name>
+		</resource>
+		<resource>
 			<name>core.js</name>
 		</resource>
 		<resource>


### PR DESCRIPTION
I wasn't sure if jquery-ui was needed also but i always see it included in other components so i figured it would not hurt.