### PR TITLE
Fix #2352 TriStateCheckbox not respecting valid=false.

### DIFF
--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -117,6 +117,7 @@ public class TriStateCheckboxRenderer extends InputRenderer {
 		ResponseWriter writer = context.getResponseWriter();
 		String styleClass = HTML.CHECKBOX_BOX_CLASS;
 		styleClass = (valCheck == 1 || valCheck == 2) ? styleClass + " ui-state-active" : styleClass;
+		styleClass = !checkbox.isValid() ? styleClass + " ui-state-error" : styleClass;
 		styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
 
 		//if stateIcon is defined use it insted of default icons.


### PR DESCRIPTION
Fix #2352 TriStateCheckbox not respecting valid=false. This makes it just like SelectBooleanCheckbox.