### PR TITLE
Fix #1312 and #1603 RFC6266 encoding of Content-Disposition headers.

### DIFF
--- a/src/main/java/org/primefaces/component/export/CSVExporter.java
+++ b/src/main/java/org/primefaces/component/export/CSVExporter.java
@@ -29,6 +29,7 @@ import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 
 import org.primefaces.component.datatable.DataTable;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 
 public class CSVExporter extends Exporter {
@@ -144,7 +145,7 @@ public class CSVExporter extends Exporter {
 		externalContext.setResponseHeader("Expires", "0");
 		externalContext.setResponseHeader("Cache-Control","must-revalidate, post-check=0, pre-check=0");
 		externalContext.setResponseHeader("Pragma", "public");
-		externalContext.setResponseHeader("Content-disposition", "attachment;filename=\""+ filename + ".csv\"");
+		externalContext.setResponseHeader("Content-disposition", ComponentUtils.createContentDisposition("attachment", filename+".csv"));
 		externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE, "true", Collections.<String, Object>emptyMap());
     }
     

--- a/src/main/java/org/primefaces/component/export/ExcelExporter.java
+++ b/src/main/java/org/primefaces/component/export/ExcelExporter.java
@@ -46,6 +46,7 @@ import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 
 import org.primefaces.component.datatable.DataTable;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 
 public class ExcelExporter extends Exporter {
@@ -262,7 +263,7 @@ public class ExcelExporter extends Exporter {
     }
     
     protected String getContentDisposition(String filename) {
-        return "attachment;filename=\""+ filename + ".xls\"";
+        return ComponentUtils.createContentDisposition("attachment", filename+".xls");
     }
     
     public void exportTable(FacesContext context, DataTable table, Sheet sheet, boolean pageOnly, boolean selectionOnly) {

--- a/src/main/java/org/primefaces/component/export/ExcelXExporter.java
+++ b/src/main/java/org/primefaces/component/export/ExcelXExporter.java
@@ -25,6 +25,7 @@ import org.apache.poi.xssf.usermodel.XSSFColor;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.primefaces.util.ComponentUtils;
 
 public class ExcelXExporter extends ExcelExporter {
 
@@ -45,7 +46,7 @@ public class ExcelXExporter extends ExcelExporter {
     
     @Override
     protected String getContentDisposition(String filename) {
-        return "attachment;filename="+ filename + ".xlsx";
+        return ComponentUtils.createContentDisposition("attachment", filename+".xlsx");
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/export/PDFExporter.java
+++ b/src/main/java/org/primefaces/component/export/PDFExporter.java
@@ -331,7 +331,7 @@ public class PDFExporter extends Exporter {
     	externalContext.setResponseHeader("Expires", "0");
     	externalContext.setResponseHeader("Cache-Control","must-revalidate, post-check=0, pre-check=0");
     	externalContext.setResponseHeader("Pragma", "public");
-    	externalContext.setResponseHeader("Content-disposition", "attachment;filename=\"" + fileName + ".pdf\"");
+    	externalContext.setResponseHeader("Content-disposition", ComponentUtils.createContentDisposition("attachment", fileName+".pdf"));
     	externalContext.setResponseContentLength(baos.size());
     	externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE, "true", Collections.<String, Object>emptyMap());
     	OutputStream out = externalContext.getResponseOutputStream();

--- a/src/main/java/org/primefaces/component/export/XMLExporter.java
+++ b/src/main/java/org/primefaces/component/export/XMLExporter.java
@@ -26,6 +26,7 @@ import javax.faces.context.FacesContext;
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.datatable.DataTable;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.XMLUtils;
 
@@ -145,7 +146,7 @@ public class XMLExporter extends Exporter {
 		externalContext.setResponseHeader("Expires", "0");
 		externalContext.setResponseHeader("Cache-Control","must-revalidate, post-check=0, pre-check=0");
 		externalContext.setResponseHeader("Pragma", "public");
-		externalContext.setResponseHeader("Content-disposition", "attachment;filename=\""+ filename + ".xml\"");
+		externalContext.setResponseHeader("Content-disposition", ComponentUtils.createContentDisposition("attachment", filename+".xml"));
 		externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE, "true", Collections.<String, Object>emptyMap());
     }
 	

--- a/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -32,6 +32,7 @@ import javax.faces.event.ActionListener;
 
 import org.primefaces.context.RequestContext;
 import org.primefaces.model.StreamedContent;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 
 public class FileDownloadActionListener implements ActionListener, StateHolder {
@@ -69,7 +70,7 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
 
         try {
             externalContext.setResponseContentType(content.getContentType());
-            externalContext.setResponseHeader("Content-Disposition", contentDispositionValue + ";filename=\"" + content.getName() + "\"");
+            externalContext.setResponseHeader("Content-Disposition", ComponentUtils.createContentDisposition(contentDispositionValue, content.getName()));
             externalContext.addResponseCookie(Constants.DOWNLOAD_COOKIE + monitorKeyValue, "true", Collections.<String, Object>emptyMap());
             
             if(content.getContentLength() != null){

--- a/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -15,6 +15,8 @@
  */
 package org.primefaces.util;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -554,6 +556,47 @@ public class ComponentUtils {
         }
 
         return viewId;
+    }
+    
+    /**
+     * Duplicate code from OmniFacew project under apache license:
+     * https://github.com/omnifaces/omnifaces/blob/develop/license.txt
+     * <p>
+     * URI-encode the given string using UTF-8. URIs (paths and filenames) have different encoding rules as compared to
+     * URL query string parameters. {@link URLEncoder} is actually only for www (HTML) form based query string parameter
+     * values (as used when a webbrowser submits a HTML form). URI encoding has a lot in common with URL encoding, but
+     * the space has to be %20 and some chars doesn't necessarily need to be encoded.
+     * @param string The string to be URI-encoded using UTF-8.
+     * @return The given string, URI-encoded using UTF-8, or <code>null</code> if <code>null</code> was given.
+     * @throws UnsupportedEncodingException if UTF-8 is not supported
+     */
+    public static String encodeURI(String string) throws UnsupportedEncodingException {
+       if (string == null) {
+          return null;
+       }
+
+       return URLEncoder.encode(string, "UTF-8")
+          .replace("+", "%20")
+          .replace("%21", "!")
+          .replace("%27", "'")
+          .replace("%28", "(")
+          .replace("%29", ")")
+          .replace("%7E", "~");
+    }
+    
+    /**
+     * Creates an RFC 6266 Content-Dispostion header following all UTF-8 conventions.
+     * <p>
+     * @param value e.g. "attachment"
+     * @param filename the name of the file
+     * @return a valid Content-Disposition header in UTF-8 format
+     */
+    public static String createContentDisposition(String value, String filename)  {
+       try {
+          return String.format("%s;filename=\"%2$s\"; filename*=UTF-8''%2$s", value, encodeURI(filename));
+       } catch (UnsupportedEncodingException e) {
+          throw new FacesException(e);
+       }
     }
 
 }

--- a/src/test/java/org/primefaces/util/ComponentUtilsTest.java
+++ b/src/test/java/org/primefaces/util/ComponentUtilsTest.java
@@ -30,4 +30,9 @@ public class ComponentUtilsTest {
 		id="form:test";
 		assertEquals("#form\\\\:test", ComponentUtils.escapeJQueryId(id));
 	}
+	
+	@Test
+   public void createContentDisposition() {
+	   assertEquals("attachment;filename=\"Test%20Spaces.txt\"; filename*=UTF-8''Test%20Spaces.txt", ComponentUtils.createContentDisposition("attachment", "Test Spaces.txt"));
+   }
 }


### PR DESCRIPTION
Fix #1312 and #1603 RFC6266 encoding of Content-Disposition headers.
 - I found all places in the code using Content-Disposition attachment
 - Refactored code to use this new util for properly encoding for RFC6266 compliance.
 - added Unit Test of the Disposition Header.