### PR TITLE
Fix #2370 Tooltip add CSS style to prevent flicker.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
+++ b/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
@@ -1,6 +1,7 @@
 .ui-tooltip {
     position:absolute;
     display:none;
+    pointer-events: none;
 }
 
 .ui-tooltip.ui-tooltip-right,


### PR DESCRIPTION
Fix #2370 Tooltip add CSS style to prevent flicker.
    - This was fix was simple and I agree with it.  It prevents the flicker behavior described in the ticket