### PR TITLE
PF-2383 Add p:ajax support to p:textEditor

### DIFF
--- a/src/main/java-templates/org/primefaces/component/texteditor/TextEditorTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/texteditor/TextEditorTemplate.java
@@ -1,0 +1,17 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.faces.event.AjaxBehaviorEvent;
+
+    private static final Collection<String> EVENT_NAMES=Collections.unmodifiableCollection(Arrays.asList("blur","change","click","dblclick","focus","keydown","keypress","keyup","mousedown","mousemove","mouseout","mouseover","mouseup","select"));
+
+    @Override
+    public Collection<String> getEventNames(){
+        return EVENT_NAMES;
+    }
+
+    public String getDefaultEventName() {
+        return "change";
+    }

--- a/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
+++ b/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
@@ -98,7 +98,7 @@ public class TextEditorRenderer extends CoreRenderer{
                 .attr("readOnly", editor.isReadonly(), false)
                 .attr("placeholder", editor.getPlaceholder(), null)
                 .attr("height", editor.getHeight(), Integer.MIN_VALUE);
-        
+        encodeClientBehaviors(context, editor);
         wb.finish();
 	}
     

--- a/src/main/resources-maven-jsf/ui/textEditor.xml
+++ b/src/main/resources-maven-jsf/ui/textEditor.xml
@@ -20,6 +20,9 @@
 		<interface>
 			<name>org.primefaces.component.api.Widget</name>
 		</interface>
+     <interface>
+      <name>javax.faces.component.behavior.ClientBehaviorHolder</name>
+     </interface>
 	</interfaces>
 	<attributes>
 		&input_component_attributes;

--- a/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
+++ b/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
@@ -87,14 +87,54 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
         
         //initialize
         this.editor = new Quill(PrimeFaces.escapeClientId(this.id) + '_editor', this.cfg);
-        
+
+        var events = ["keyup", "keydown", "click", "dblclick", "keypress", "mousedown", "mousemove", "mouseout",
+                      "mouseover", "mouseup"];
+
+        $.each(events, function(index, value) {
+            $this._registerEvent(value);
+        });
+
         //set initial value
         this.input.val(this.getEditorValue());
         
         //update input on change
         this.editor.on('text-change', function(delta, oldDelta, source) {
             $this.input.val($this.getEditorValue());
+            if($this.cfg.behaviors) {
+                var changeBehavior = $this.cfg.behaviors['change'];
+                if(changeBehavior) {
+                    changeBehavior.call($this);
+                }
+            }
         });
+        this.editor.on('selection-change', function(range, oldRange, source) {
+           if(range && !oldRange) {
+               if($this.cfg.behaviors && $this.cfg.behaviors["focus"]) {
+                   var changeBehavior = $this.cfg.behaviors["focus"];
+                   if(changeBehavior) {
+                       changeBehavior.call($this);
+                   }
+               }
+           }
+           if(!range && oldRange) {
+               if($this.cfg.behaviors && $this.cfg.behaviors["blur"]) {
+                   var changeBehavior = $this.cfg.behaviors["blur"];
+                   if(changeBehavior) {
+                       changeBehavior.call($this);
+                   }
+               }
+           }
+           if(range && oldRange) {
+               if($this.cfg.behaviors && $this.cfg.behaviors["select"]) {
+                  var changeBehavior = $this.cfg.behaviors["select"];
+                  if(changeBehavior) {
+                      changeBehavior.call($this);
+                  }
+               }
+           }
+        });
+
     },
     
     getEditorValue: function() {
@@ -106,6 +146,18 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
     
     clear: function() {
         this.editor.setText('');
+    },
+
+    _registerEvent: function(event) {
+        var $this = this;
+        if(this.cfg.behaviors && this.cfg.behaviors[event]) {
+            this.editorContainer.on(event, function () {
+                var changeBehavior = $this.cfg.behaviors[event];
+                if(changeBehavior) {
+                    changeBehavior.call($this);
+                }
+            });
+        }
     }
     
 });


### PR DESCRIPTION
This hooks up all basic events for p:ajax inside a p:textEditor. See #2383.