### PR TITLE
Fix #1393 and #1290 - dialog framework : dialogs without height not centered by default

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
@@ -111,10 +111,6 @@ if (!PrimeFaces.dialog) {
                     dialogFrame.attr('title', title.text());
                 }
 
-                dialogFrame.data('initialized', true);
-
-                rootWindow.PF(dialogWidgetVar).show();
-
                 //adjust height
                 var frameHeight = null;
                 if(cfg.options.contentHeight)
@@ -123,6 +119,10 @@ if (!PrimeFaces.dialog) {
                     frameHeight = $frame.get(0).contentWindow.document.body.scrollHeight + (PrimeFaces.env.browser.webkit ? 5 : 25);
 
                 $frame.css('height', frameHeight);
+                
+                // fix #1290 - dialogs are not centered vertically
+                dialogFrame.data('initialized', true);
+                rootWindow.PF(dialogWidgetVar).show();
             })
             .attr('src', frameURL);
         },


### PR DESCRIPTION
In PF 5.x , Dialog Framework was able to open centered dialog windows both horizontally and vertically, without the need to specify width or height attributes. In PF 6.x this stopped working. The solution seems to be as simple as moving a pair of javascript lines in [**core.dialog.js**], from their new location in PF 6.x, to their original location in PF 5.x. Tested with IE 11, Chrome and Firefox, and apparently working...