### PR TITLE
#2465: inputNumber: clearing value doesn't function with browser Edge

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/2-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/2-inputnumber.js
@@ -99,7 +99,10 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
     },
 
     setValueToHiddenInput: function(value, triggerEvent) {
-        if (value !== "") {
+    	  // TODO: is there an existing PF way to detect Edge browser?
+    		var isEdge = navigator.userAgent.match(/Edge\/\d./);
+    		// "removeAttr('value')" doesn't work with Browser Edge
+        if (value !== "" || isEdge) {
             this.hiddenInput.attr('value', value);
         } else {
             this.hiddenInput.removeAttr('value');


### PR DESCRIPTION
Instead of changing condition to "if (value !== "" || isEdge) {..." it may be ok to always use "this.hiddenInput.attr('value', value);"?