### PR TITLE
fix JSF 2.0 incompatible use of enum

### DIFF
--- a/src/main/java/org/primefaces/component/repeat/UIRepeat.java
+++ b/src/main/java/org/primefaces/component/repeat/UIRepeat.java
@@ -781,8 +781,16 @@ public class UIRepeat extends UINamingContainer {
     }
 
     private boolean requiresRowIteration(VisitContext ctx) {
-
-        return !ctx.getHints().contains(VisitHint.SKIP_ITERATION);
+    	 try {
+             //JSF 2.1
+             VisitHint skipHint = VisitHint.valueOf("SKIP_ITERATION");
+             return !ctx.getHints().contains(skipHint);
+         }
+         catch(IllegalArgumentException e) {
+             //JSF 2.0
+             Object skipHint = ctx.getFacesContext().getAttributes().get("javax.faces.visit.SKIP_ITERATION");
+             return !Boolean.TRUE.equals(skipHint);
+         }
 
     }
 


### PR DESCRIPTION
The SKIP_ITERATION Enum is introduced in JSF 2.1
the fix was also applied on the UIData Component some years before. See
org.primefaces.component.api.UIData.shouldVisitRows(FacesContext,
VisitContext)