### PR TITLE
add toolbarVisible functionality to the textEditor

### DIFF
--- a/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
+++ b/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
@@ -95,6 +95,7 @@ public class TextEditorRenderer extends CoreRenderer{
 		String clientId = editor.getClientId(context);
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("TextEditor", editor.resolveWidgetVar(), clientId)
+                .attr("toolbarVisible", editor.isToolbarVisible(), true)
                 .attr("readOnly", editor.isReadonly(), false)
                 .attr("placeholder", editor.getPlaceholder(), null)
                 .attr("height", editor.getHeight(), Integer.MIN_VALUE);

--- a/src/main/resources-maven-jsf/ui/textEditor.xml
+++ b/src/main/resources-maven-jsf/ui/textEditor.xml
@@ -59,6 +59,12 @@
 			<type>java.lang.String</type>
             <description>Placeholder text to show when editor is empty..</description>
 		</attribute>
+		<attribute>
+			<name>toolbarVisible</name>
+			<required>false</required>
+			<type>java.lang.Boolean</type>
+			<description>toolbarVisible is set to show / hide the toolbar of the editor container</description>
+		</attribute>
 	</attributes>
 	<resources>
 		<resource>

--- a/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
+++ b/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
@@ -82,7 +82,7 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
 
         this.cfg.theme = 'snow';
         this.cfg.modules = {
-            toolbar: PrimeFaces.escapeClientId(this.id + '_toolbar')
+            toolbar: this.cfg.toolbarVisible ? PrimeFaces.escapeClientId(this.id + '_toolbar') : false
         };
 
         //initialize


### PR DESCRIPTION
# Functionality
This change allow to render textEditor with / without toolbar.

This functionality use the Quill behavior for the toolbar module : 
```
the toolbar is not visible if you pass false to the toolbar module
```
The parameter is active by default to keep the current behavior.

# Usecase
This can be useful when you display a list of comment and provide a button to edit them.

- The list render all editor as readonly and hide the toolbar.
- The textEditor to edit an element provide a textEditor with a toolbar