### PR TITLE
Timeline events displayed on wrong group after zoom (timeAxis not on top)

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/timeline/0-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/0-timeline.js
@@ -5336,7 +5336,7 @@ links.Timeline.prototype.stackCalculateFinal = function(items) {
             if (axisOnTop) {
                 groupBase += Math.max(options.groupMinHeight, group.labelHeight) + eventMargin;
             } else {
-                groupBase -= (options.groupMinHeight + eventMargin);
+                 groupBase -= (Math.max(options.groupMinHeight, group.labelHeight) + eventMargin);
             }
             continue;
         }


### PR DESCRIPTION
Unfortunately only fixed the case with timeAxis on top (#1995 ).
Now fixing the other case xD
