### PR TITLE
#2515 Support null values in Captcha

### DIFF
--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -93,7 +93,7 @@ import org.primefaces.json.JSONObject;
 
 		StringBuilder postParams = new StringBuilder();
 		postParams.append("secret=").append(URLEncoder.encode(privateKey, "UTF-8"));
-		postParams.append("&response=").append(URLEncoder.encode((String) value, "UTF-8"));
+		postParams.append("&response=").append(value == null ? "" : URLEncoder.encode((String) value, "UTF-8"));
 
         String params = postParams.toString();
         postParams.setLength(0);


### PR DESCRIPTION
This change is to support null values in Captcha when context param
javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL is set to
true.