### PR TITLE
PrimeFaces.widget.SelectManyCheckbox clear() function

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.js
@@ -1628,6 +1628,16 @@ PrimeFaces.widget.SelectManyCheckbox = PrimeFaces.widget.BaseWidget.extend({
                 checkbox.removeClass('ui-state-active').children('.ui-chkbox-icon').addClass('ui-icon-blank').removeClass('ui-icon-check');
             }
         });
+    },
+
+    clear: function() {
+        this.inputs
+            .removeAttr('checked');
+        this.outputs
+            .removeClass('ui-state-active')
+            .children('.ui-chkbox-icon')
+            .addClass('ui-icon-blank')
+            .removeClass('ui-icon-check');
     }
 
 });


### PR DESCRIPTION
Add client side function clear() to PrimeFaces.widget.SelectManyCheckbox widget to uncheck all items.
This functions provides convenient approach to uncheck all items.  Otherwise in order to do this, one would need to do this outside the widget something like this:
```
PF('myWidget').inputs
   .removeAttr('checked');
PF('myWidget').outputs
   .removeClass('ui-state-active')
   .children('.ui-chkbox-icon')
   .addClass('ui-icon-blank')
   .removeClass('ui-icon-check');
```