### PR TITLE
Fix #1036 SelectOneMenu: new customContent attribute for overriding d…

### DIFF
--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -268,7 +268,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
     
     protected void encodePanelContent(FacesContext context, SelectOneMenu menu, List<SelectItem> selectItems) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
-        boolean customContent = menu.getVar() != null;
+        boolean customContent = menu.isCustomContent();
         
         if(customContent) {
             writer.startElement("table", menu);
@@ -336,7 +336,6 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         for(SelectItem selectItem : selectItems) {
             String itemLabel = selectItem.getLabel();
             itemLabel = isValueBlank(itemLabel) ? "&nbsp;" : itemLabel;
-            Object itemValue = selectItem.getValue();
             String itemStyleClass = SelectOneMenu.ROW_CLASS;
             if(selectItem.isNoSelectionOption()) {
                 itemStyleClass = itemStyleClass + " ui-noselection-option"; 
@@ -351,24 +350,25 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                 writer.writeAttribute("title", selectItem.getDescription(), null);
             }
 
-            if(itemValue == null || itemValue instanceof String) {
-                writer.startElement("td", null);
-                writer.writeAttribute("colspan", columns.size(), null);
-                writer.writeText(selectItem.getLabel(), null);
-                writer.endElement("td");
-            } 
-            else {
+            if(menu.isCustomContent()) {
                 for(Column column : columns) {
                     String style = column.getStyle();
                     String styleClass = column.getStyleClass();
-                    
+                  
                     writer.startElement("td", null);
                     if(style != null) writer.writeAttribute("style", style, null);
                     if(styleClass != null) writer.writeAttribute("class", styleClass, null);
-                    
+                  
                     renderChildren(context, column);
                     writer.endElement("td");
                 }
+            } 
+            else {
+               writer.startElement("td", null);
+               writer.writeAttribute("colspan", columns.size(), null);
+               writer.writeText(selectItem.getLabel(), null);
+               writer.endElement("td");
+
             }
 
             writer.endElement("tr");

--- a/src/main/resources-maven-jsf/ui/selectOneMenu.xml
+++ b/src/main/resources-maven-jsf/ui/selectOneMenu.xml
@@ -202,6 +202,13 @@
             <defaultValue>false</defaultValue>
             <description>Defines if lazy loading is enabled for the element. If the value is "true", the overlay is not rendered on window load to improve performance.</description>
 		</attribute>
+        <attribute>
+            <name>customContent</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <defaultValue>false</defaultValue>
+            <description>Defines if custom content is displayed in the overlay for the element. If the value is "true", custom content is displayed in the overlay using p:column objects.</description>
+        </attribute>
 	</attributes>
     <resources>
         <resource>


### PR DESCRIPTION
- Added new property called customContent which defaults to FALSE.
- Switch if statement to if customContent=true attempt the custom content rendering no matter what, else do the default rendering behavior.