### PR TITLE
Fix #2536 - don't skip defaultCommand on enter key press if target is…

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
@@ -21,7 +21,7 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
            var keyCode = $.ui.keyCode;
            if(e.which == keyCode.ENTER || e.which == keyCode.NUMPAD_ENTER) {
                 //do not proceed if event target is not in this scope or target is a textarea,button or link
-                if(($this.scope && $this.scope.find(e.target).length == 0)||$(e.target).is('textarea,button,input[type="submit"],a')) {
+                if(($this.scope && $this.scope[0] != e.target && $this.scope.find(e.target).length == 0)||$(e.target).is('textarea,button,input[type="submit"],a')) {
                     return true;
                 }
 


### PR DESCRIPTION
… the same as scope

based on the idea from #2536 in the bug description.

>The root cause:
Line 24 of forms.defaultcommand.js as it uses $.find to test if the event.target is a child of the scope. It never tests if event.target is the scope itself.

> ($this.scope && $this.scope.find(e.target).length == 0) should be changed to something like ($this.scope && $this.scope.find(e.target).length == 0 && this.scope.get(0) != e.target)

replicated and tested locally:

![image](https://user-images.githubusercontent.com/10467831/28244227-03e25ce8-69aa-11e7-9962-13c019877715.png)
