### PR TITLE
Fix #2520 - clearTimeout when value is empty so that the second last …

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -480,6 +480,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
 
         if(!value.length) {
             $this.hide();
+            $this.deleteTimeout();
         }
 
         if(value.length >= $this.cfg.minLength) {

--- a/src/main/resources/META-INF/resources/primefaces/mobile/widgets/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/mobile/widgets/autocomplete.js
@@ -30,6 +30,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
 
             if(value.length === 0) {
                 $this.hide();
+                clearTimeout($this.timeout);
             }
             else {
                 $this.showClearIcon();


### PR DESCRIPTION
…timeout on latest deleted char won't be triggered

To fix #2520 

Sample:

Xhtml:

```xhtml
<html xmlns="http://www.w3.org/1999/xhtml"
	xmlns:h="http://xmlns.jcp.org/jsf/html"
	xmlns:f="http://xmlns.jcp.org/jsf/core"
	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
	xmlns:p="http://primefaces.org/ui"
	xmlns:pe="http://primefaces.org/ui/extensions">

<h:head>
</h:head>

<h:body>
	<h:form>
		<h:panelGrid columns="2" cellpadding="5">
			<p:outputLabel value="Delay(1000):" for="acDelay" />
			<p:autoComplete id="acDelay" queryDelay="1000"
				value="#{autoCompleteView.txt3}"
				completeMethod="#{autoCompleteView.completeText}" effect="blind" />
		</h:panelGrid>
	</h:form>
</h:body>

</html>

```


bean:

```java
package test;

import java.io.Serializable;
import java.util.ArrayList;
import java.util.List;

import javax.faces.bean.ManagedBean;
import javax.faces.bean.ViewScoped;

@ManagedBean(name = "autoCompleteView")
@ViewScoped
public class AutoCompleteView implements Serializable {

    /**
     * 
     */
    private static final long serialVersionUID = 4334771747958794917L;

    private String txt3;

    public List<String> completeText(String query) {
	List<String> results = new ArrayList<String>();
	for (int i = 0; i < 10; i++) {
	    results.add(query + i);
	}

	return results;
    }

    public String getTxt3() {
	return txt3;
    }

    public void setTxt3(String txt3) {
	this.txt3 = txt3;
    }

}

```

