### PR TITLE
Ignore special keys on dataTable filters

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -402,8 +402,13 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         })
         .on(this.cfg.filterEvent + '.dataTable', function(e) {
             var key = e.which,
-            keyCode = $.ui.keyCode;
-            if (key === keyCode.END||key === keyCode.HOME||key === keyCode.LEFT||key === keyCode.RIGHT) {
+            keyCode = $.ui.keyCode,
+            ignoredKeys = [keyCode.END, keyCode.HOME, keyCode.LEFT, keyCode.RIGHT, keyCode.UP, keyCode.DOWN,
+                keyCode.TAB, 16/*Shift*/, 17/*Ctrl*/, 18/*Alt*/, 91, 92, 93/*left/right Win/Cmd*/,
+                keyCode.ESCAPE, keyCode.PAGE_UP, keyCode.PAGE_DOWN,
+                19/*pause/break*/, 20/*caps lock*/, 44/*print screen*/, 144/*num lock*/, 145/*scroll lock*/];
+
+            if (ignoredKeys.indexOf(key) > -1) {
                 return;
             }
 


### PR DESCRIPTION
Using key combinations to switch tasks (Alt+Tab) or to go back to filter's input from another input element (Shift+Tab) triggers dataTable filtering - that's an extra ajax request. And there are lots of other special keys which can trigger filtering when not needed (Enter and F* keys intentionally left unignored as some could use it to force filtering).