### PR TITLE
ToolbarVisible feature for textEditor (issue #2499)

### DIFF
--- a/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
+++ b/src/main/java/org/primefaces/component/texteditor/TextEditorRenderer.java
@@ -68,7 +68,7 @@ public class TextEditorRenderer extends CoreRenderer {
         if (style != null) writer.writeAttribute("style", style, null);
         if (styleClass != null) writer.writeAttribute("class", editor.getStyleClass(), null);
 
-        if (toolbar != null) {
+        if (toolbar != null && editor.isToolbarVisible()) {
             writer.startElement("div", editor);
             writer.writeAttribute("id", clientId + "_toolbar", null);
             writer.writeAttribute("class", "ui-editor-toolbar", null);
@@ -95,6 +95,7 @@ public class TextEditorRenderer extends CoreRenderer {
         String clientId = editor.getClientId(context);
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.initWithDomReady("TextEditor", editor.resolveWidgetVar(), clientId)
+                .attr("toolbarVisible", editor.isToolbarVisible())
                 .attr("readOnly", editor.isReadonly(), false)
                 .attr("placeholder", editor.getPlaceholder(), null)
                 .attr("height", editor.getHeight(), Integer.MIN_VALUE);

--- a/src/main/resources-maven-jsf/ui/textEditor.xml
+++ b/src/main/resources-maven-jsf/ui/textEditor.xml
@@ -59,6 +59,13 @@
 			<type>java.lang.String</type>
             <description>Placeholder text to show when editor is empty..</description>
 		</attribute>
+		<attribute>
+			<name>toolbarVisible</name>
+			<required>false</required>
+			<type>java.lang.Boolean</type>
+			<defaultValue>true</defaultValue>
+			<description>show / hide the editor toolbar visibility.</description>
+		</attribute>
 	</attributes>
 	<resources>
 		<resource>

--- a/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
+++ b/src/main/resources/META-INF/resources/primefaces/texteditor/texteditor.js
@@ -69,7 +69,7 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
 
         //toolbar
         this.toolbar = $(this.jqId + '_toolbar');
-        if(!this.toolbar.length) {
+        if(!this.toolbar.length && this.cfg.toolbarVisible) {
             this.jq.prepend(this.toolbarTemplate);
             this.toolbar = this.jq.children('.ui-editor-toolbar')
             this.toolbar.attr('id', this.id + '_toolbar');
@@ -82,7 +82,7 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
 
         this.cfg.theme = 'snow';
         this.cfg.modules = {
-            toolbar: PrimeFaces.escapeClientId(this.id + '_toolbar')
+            toolbar: this.cfg.toolbarVisible ? PrimeFaces.escapeClientId(this.id + '_toolbar') : false
         };
 
         //initialize


### PR DESCRIPTION
- doesn't set the toolbarTemplate is toolbar length == 0 and
toolbarVisible == false
- set toolbarVisible inside module to false to hide the toolbar.
- attribute defaultValue to true for JSF component
- TextEditorRenderer doesn't send the toolbar if toolbarVisible is false
and send the value of the attribute to JS.