### PR TITLE
Fix #2619 - PickListRenderer: valid attribute value for multiple

### DIFF
--- a/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
+++ b/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
@@ -242,7 +242,7 @@ public class PickListRenderer extends CoreRenderer {
         writer.startElement("select", null);
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("name", clientId, null);
-        writer.writeAttribute("multiple", "true", null);
+        writer.writeAttribute("multiple", "multiple", null);
         writer.writeAttribute("class", "ui-helper-hidden", null);
 
         //items generated on client side


### PR DESCRIPTION
multiple attribute value did not conform to w3c html standards. Instead of 'true' the value of multiple is now 'multiple'.