### PR TITLE
Fix #484 Barcode: new "qrerrorcorrection" attribute

### DIFF
--- a/src/main/java/org/primefaces/component/barcode/BarcodeRenderer.java
+++ b/src/main/java/org/primefaces/component/barcode/BarcodeRenderer.java
@@ -68,6 +68,7 @@ public class BarcodeRenderer extends CoreRenderer {
                     .append("&").append(Constants.DYNAMIC_CONTENT_TYPE_PARAM).append("=").append(dynamicContentType.toString())
                     .append("&gen=").append(type)
                     .append("&fmt=").append(barcode.getFormat())
+                    .append("&qrec=").append(barcode.getQrerrorcorrection())
                     .append("&").append(Constants.DYNAMIC_CONTENT_CACHE_PARAM).append("=").append(barcode.isCache())
                     .append("&ori=").append(barcode.getOrientation())
                     .toString();

--- a/src/main/resources-maven-jsf/ui/barcode.xml
+++ b/src/main/resources-maven-jsf/ui/barcode.xml
@@ -44,6 +44,13 @@
             <defaultValue>0</defaultValue>
             <description>The barcode orientation in terms of angle (0, 90, 180, 270).</description>
 		</attribute>
+        <attribute>
+            <name>qrerrorcorrection</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+            <defaultValue>L</defaultValue>
+            <description>The QR Code error correction level. L (default) – up to 7% damage. M – up to 15% damage. Q – up to 25% damage. H – up to 30% damage</description>
+        </attribute>
 		<attribute>
 			<name>value</name>
 			<required>false</required>


### PR DESCRIPTION
- added new attribute "qrerrorcorrection" defaulting to "L"
- values are from ISO RFC for QR Error correction
Level L – up to 7% damage
Level M – up to 15% damage
Level Q – up to 25% damage
Level H – up to 30% damage