### PR TITLE
Fix #2650 - Datatable: duplicate cliend ids in custom facet paginator

### DIFF
--- a/src/main/java/org/primefaces/component/api/Pageable.java
+++ b/src/main/java/org/primefaces/component/api/Pageable.java
@@ -20,6 +20,8 @@ import javax.faces.context.FacesContext;
 
 public interface Pageable {
 
+    public String getId();
+
     public String getClientId(FacesContext context);
 
     public String getPaginatorPosition();

--- a/src/main/java/org/primefaces/renderkit/DataRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/DataRenderer.java
@@ -96,7 +96,8 @@ public class DataRenderer extends CoreRenderer {
             else {
                 UIComponent elementFacet = pageable.getFacet(element);
                 if (elementFacet != null) {
-                    elementFacet.setId(pageable.getId() + "_" + position);
+                    String facetName = element.replaceAll("[\\W+]", "_").toLowerCase();
+                    elementFacet.setId(pageable.getId() + facetName + position);
                     elementFacet.encodeAll(context);
                 }
                 else {

--- a/src/main/java/org/primefaces/renderkit/DataRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/DataRenderer.java
@@ -18,9 +18,11 @@ package org.primefaces.renderkit;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
+
 import org.primefaces.component.api.Pageable;
 import org.primefaces.component.api.UIData;
 import org.primefaces.component.paginator.CurrentPageReportRenderer;
@@ -94,6 +96,7 @@ public class DataRenderer extends CoreRenderer {
             else {
                 UIComponent elementFacet = pageable.getFacet(element);
                 if (elementFacet != null) {
+                    elementFacet.setId(pageable.getId() + "_" + position);
                     elementFacet.encodeAll(context);
                 }
                 else {


### PR DESCRIPTION
I realized it is necessary to add the facet name in the id otherwise, it might still have id conlicts