### PR TITLE
Use converter on attribute itemLabel when creating SelectItem

### DIFF
--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -25,6 +25,7 @@ import java.util.RandomAccess;
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
 import javax.el.ValueExpression;
+import javax.faces.application.Application;
 import javax.faces.component.*;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
@@ -141,7 +142,24 @@ public abstract class InputRenderer extends CoreRenderer {
             itemLabelValue = label;
         }
 
-        String itemLabel = itemLabelValue == null ? String.valueOf(value) : String.valueOf(itemLabelValue);
+        String itemLabel;
+	final Application application = context.getApplication();
+	if (itemLabelValue == null) {
+	    final Converter converter = application.createConverter(value.getClass());
+	    if (converter != null) {
+		itemLabel = converter.getAsString(context, uiSelectItems, value);
+	    } else {
+		itemLabel = String.valueOf(value);
+	    }
+
+	} else {
+	    final Converter converter = application.createConverter(itemLabelValue.getClass());
+	    if (converter != null) {
+		itemLabel = converter.getAsString(context, uiSelectItems, itemLabelValue);
+	    } else {
+		itemLabel = String.valueOf(itemLabelValue);
+	    }
+	}
         boolean disabled = itemDisabled == null ? false : Boolean.valueOf(itemDisabled.toString());
         boolean escaped = itemEscaped == null ? true : Boolean.valueOf(itemEscaped.toString());
         boolean noSelectionOption = noSelection == null ? false : Boolean.valueOf(noSelection.toString());


### PR DESCRIPTION
When using dropList the EL used in the itemLabel attribute of selectItems might be an Object where the String.valueOf(object) is not relevant.
This fix makes use of any javax.faces.convert.Converter declared for the object referenced so it can call the appropriate getAsString method to display it correctly.

I've been using it in one project and it's working well but i'm open to discuss of this implementation.