### PR TITLE
Fix #2720: Hidden elements should have the `hidden` HTML attribute

### DIFF
--- a/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
@@ -81,7 +81,7 @@ public class CheckboxRenderer extends InputRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("class", "ui-chkbox-clone", null);
         writer.writeAttribute("data-itemindex", checkbox.getItemIndex(), null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
@@ -23,6 +23,7 @@ import org.primefaces.component.radiobutton.RadioButtonRenderer;
 import org.primefaces.component.selectmanycheckbox.SelectManyCheckbox;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.SharedStringBuilder;
 
@@ -81,6 +82,7 @@ public class CheckboxRenderer extends InputRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("class", "ui-chkbox-clone", null);
         writer.writeAttribute("data-itemindex", checkbox.getItemIndex(), null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
@@ -23,7 +23,6 @@ import org.primefaces.component.radiobutton.RadioButtonRenderer;
 import org.primefaces.component.selectmanycheckbox.SelectManyCheckbox;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.SharedStringBuilder;
 
@@ -82,7 +81,7 @@ public class CheckboxRenderer extends InputRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("class", "ui-chkbox-clone", null);
         writer.writeAttribute("data-itemindex", checkbox.getItemIndex(), null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -121,7 +121,7 @@ public class InputSwitchRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (checked) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -22,7 +22,6 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -122,7 +121,7 @@ public class InputSwitchRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (checked) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -22,6 +22,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -121,6 +122,7 @@ public class InputSwitchRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (checked) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
@@ -22,6 +22,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.component.selectoneradio.SelectOneRadio;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.SharedStringBuilder;
 
@@ -81,6 +82,7 @@ public class RadioButtonRenderer extends InputRenderer {
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("class", "ui-radio-clone", null);
         writer.writeAttribute("data-itemindex", button.getItemIndex(), null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
@@ -22,7 +22,6 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.component.selectoneradio.SelectOneRadio;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.SharedStringBuilder;
 
@@ -82,7 +81,7 @@ public class RadioButtonRenderer extends InputRenderer {
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("class", "ui-radio-clone", null);
         writer.writeAttribute("data-itemindex", button.getItemIndex(), null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
@@ -81,7 +81,7 @@ public class RadioButtonRenderer extends InputRenderer {
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("class", "ui-radio-clone", null);
         writer.writeAttribute("data-itemindex", button.getItemIndex(), null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (tabindex != null) writer.writeAttribute("tabindex", tabindex, null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -25,7 +25,6 @@ import javax.faces.convert.ConverterException;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -95,7 +94,7 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);

--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -94,7 +94,7 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);

--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -25,6 +25,7 @@ import javax.faces.convert.ConverterException;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -94,6 +95,7 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);

--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.convert.ConverterException;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -103,7 +102,7 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("autocomplete", "off", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (labelledBy != null) {
             writer.writeAttribute("aria-labelledby", labelledBy, null);

--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -102,7 +102,7 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("autocomplete", "off", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (labelledBy != null) {
             writer.writeAttribute("aria-labelledby", labelledBy, null);

--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -23,6 +23,7 @@ import javax.faces.convert.ConverterException;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -102,6 +103,7 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("autocomplete", "off", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (labelledBy != null) {
             writer.writeAttribute("aria-labelledby", labelledBy, null);

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -319,7 +319,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("readonly", "readonly", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
         if (tabindex != null) {
             writer.writeAttribute("tabindex", tabindex, null);
         }

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -31,6 +31,7 @@ import javax.faces.render.Renderer;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
@@ -319,6 +320,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("readonly", "readonly", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
         if (tabindex != null) {
             writer.writeAttribute("tabindex", tabindex, null);
         }

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -31,7 +31,6 @@ import javax.faces.render.Renderer;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
@@ -320,7 +319,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("readonly", "readonly", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
         if (tabindex != null) {
             writer.writeAttribute("tabindex", tabindex, null);
         }

--- a/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -29,7 +29,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -140,7 +139,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         renderOnchange(context, button);
 

--- a/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -139,7 +139,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         renderOnchange(context, button);
 

--- a/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -29,6 +29,7 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -139,6 +140,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         renderOnchange(context, button);
 

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -30,6 +30,7 @@ import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectManyMenuRenderer extends SelectManyRenderer {
@@ -112,6 +113,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("multiple", "multiple", null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         renderDomEvents(context, menu, SelectManyMenu.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -30,7 +30,6 @@ import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectManyMenuRenderer extends SelectManyRenderer {
@@ -113,7 +112,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("multiple", "multiple", null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         renderDomEvents(context, menu, SelectManyMenu.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -112,7 +112,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("multiple", "multiple", null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         renderDomEvents(context, menu, SelectManyMenu.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
@@ -28,6 +28,7 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -137,6 +138,7 @@ public class SelectOneButtonRenderer extends SelectOneRenderer {
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
         writer.writeAttribute("tabindex", "-1", null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         if (selected) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
@@ -137,7 +137,7 @@ public class SelectOneButtonRenderer extends SelectOneRenderer {
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
         writer.writeAttribute("tabindex", "-1", null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         if (selected) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
@@ -28,7 +28,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -138,7 +137,7 @@ public class SelectOneButtonRenderer extends SelectOneRenderer {
         writer.writeAttribute("value", itemValueAsString, null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
         writer.writeAttribute("tabindex", "-1", null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         if (selected) writer.writeAttribute("checked", "checked", null);
         if (disabled) writer.writeAttribute("disabled", "disabled", null);

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -29,7 +29,6 @@ import org.primefaces.component.column.Column;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectOneListboxRenderer extends SelectOneRenderer {
@@ -110,7 +109,7 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         writer.writeAttribute("id", inputid, "id");
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         renderDomEvents(context, listbox, SelectOneListbox.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -109,7 +109,7 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         writer.writeAttribute("id", inputid, "id");
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         renderDomEvents(context, listbox, SelectOneListbox.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -29,6 +29,7 @@ import org.primefaces.component.column.Column;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectOneListboxRenderer extends SelectOneRenderer {
@@ -109,6 +110,7 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         writer.writeAttribute("id", inputid, "id");
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         renderDomEvents(context, listbox, SelectOneListbox.DOM_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -33,7 +33,6 @@ import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -135,7 +134,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("autocomplete", "off", null);
         //for keyboard accessibility and ScreenReader
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
         writer.writeAttribute("role", "combobox", null);
         writer.writeAttribute("aria-haspopup", "true", null);
         writer.writeAttribute("aria-expanded", "false", null);

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -134,7 +134,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("autocomplete", "off", null);
         //for keyboard accessibility and ScreenReader
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
         writer.writeAttribute("role", "combobox", null);
         writer.writeAttribute("aria-haspopup", "true", null);
         writer.writeAttribute("aria-expanded", "false", null);

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -33,6 +33,7 @@ import org.primefaces.context.RequestContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
@@ -134,6 +135,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("autocomplete", "off", null);
         //for keyboard accessibility and ScreenReader
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
         writer.writeAttribute("role", "combobox", null);
         writer.writeAttribute("aria-haspopup", "true", null);
         writer.writeAttribute("aria-expanded", "false", null);

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -33,7 +33,6 @@ import org.primefaces.component.radiobutton.RadioButton;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
 import org.primefaces.util.GridLayoutUtils;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
@@ -317,7 +316,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
         writer.writeAttribute("name", name, null);
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("value", value, null);
-        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
+        writer.writeAttribute("hidden", "true", null);
 
         renderDomEvents(context, radio, SelectOneRadio.SUPPORTED_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -316,7 +316,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
         writer.writeAttribute("name", name, null);
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("value", value, null);
-        writer.writeAttribute("hidden", "true", null);
+        writer.writeAttribute("hidden", "hidden", null);
 
         renderDomEvents(context, radio, SelectOneRadio.SUPPORTED_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -33,6 +33,7 @@ import org.primefaces.component.radiobutton.RadioButton;
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.GridLayoutUtils;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
@@ -316,6 +317,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
         writer.writeAttribute("name", name, null);
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("value", value, null);
+        writer.writeAttribute("hidden", Constants.EMPTY_STRING, null);
 
         renderDomEvents(context, radio, SelectOneRadio.SUPPORTED_EVENTS);
 


### PR DESCRIPTION
Fix #2720: Hidden elements should have the `hidden` HTML attribute

I found everywhere "ui-helper-hidden-accessible" was hiding an input and added the hidden HTML attribute.