### PR TITLE
Fix #2747: Replace ${project.version} in core.js.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
+                <filtering>true</filtering>
             </resource>
         </resources>
 


### PR DESCRIPTION
Fix #2747: Replace ${project.version} in core.js.