### PR TITLE
Fix #2747: Added binary resource filtering exclusions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,9 +366,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.2</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <nonFilteredFileExtensions>
+                       <nonFilteredFileExtension>eot</nonFilteredFileExtension>
+                       <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
+                       <nonFilteredFileExtension>woff</nonFilteredFileExtension>
+                       <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
+                    </nonFilteredFileExtensions>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Fix #2747: Added binary resource filtering exclusions.

Added the extensions for binaries that should be ignored by resource filtering.