### PR TITLE
remove oraclejdk7 from travis.yml since it is no longer supported by …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 
 jdk:
 - oraclejdk8
-- oraclejdk7
 - openjdk7
 # `openjdk8` not available
 


### PR DESCRIPTION
…travisCI

The travisCI build always shows the red cross because of the failure of oraclejdk7

For example:

https://github.com/primefaces/primefaces/commits/master

> 
![image](https://user-images.githubusercontent.com/10467831/31082040-5f749300-a753-11e7-85e8-f8174db901bc.png)

The reason is: https://github.com/travis-ci/travis-ci/issues/7884

> My guess is that we can no longer support oraclejdk7 on our recent build images due to Oracle's withdrawal. http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html

We should remove oraclejdk7 from `travis.yml` as we already have openjdk7 in the config.



