### PR TITLE
add openjdk8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: java
 
 jdk:
 - oraclejdk8
+- openjdk8
 # - openjdk7  (not possible since JSF 2.3 dependency - we need to compile it)
-# - openjdk8  (not available currently)
 
 install:
 - git clone https://github.com/primefaces/maven-jsf-plugin && cd maven-jsf-plugin && mvn install && cd ..


### PR DESCRIPTION
Open JDK has been available in Travis for quite a while

See: https://github.com/travis-ci/travis-ci/issues/6483