### PR TITLE
Restore displayed row count after export of lazy datatable

### DIFF
--- a/src/main/java/org/primefaces/component/export/Exporter.java
+++ b/src/main/java/org/primefaces/component/export/Exporter.java
@@ -247,6 +247,7 @@ public abstract class Exporter {
 
             //restore
             table.setFirst(first);
+            table.setRows(rows);
             table.setRowIndex(-1);
             table.clearLazyCache();
             table.loadLazyData();


### PR DESCRIPTION
There is currently a bug with the excel export of a lazy datatable: after the export, the datable content is cleared and reloaded, but with an incorrect page size. The page size was changed in order to fetch the entire content of the table before exporting it (into Excel/CSV/...). However, it's not set back to its original value. This commit fixes that.

Cf https://code.google.com/archive/p/primefaces/issues/6728 and more specificly comments 2 and 3.