### PR TITLE
Fix #1745 tab navigation between editable cells in dataTable with non editable columns

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2395,7 +2395,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     },
 
     tabCell: function(cell, forward) {
-        var targetCell = forward ? cell.next() : cell.prev();
+        var targetCell = forward ? cell.nextAll('td.ui-editable-column:first') : cell.prevAll('td.ui-editable-column:first');
         if(targetCell.length == 0) {
             var tabRow = forward ? cell.parent().next() : cell.parent().prev();
             targetCell = forward ? tabRow.children('td.ui-editable-column:first') : tabRow.children('td.ui-editable-column:last');

--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -1454,7 +1454,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
     },
     
     tabCell: function(cell, forward) {
-        var targetCell = forward ? cell.next() : cell.prev();
+        var targetCell = forward ? cell.nextAll('td.ui-editable-column:first') : cell.prevAll('td.ui-editable-column:first');
         if(targetCell.length == 0) {
             var tabRow = forward ? cell.parent().next() : cell.parent().prev();
             targetCell = forward ? tabRow.children('td.ui-editable-column:first') : tabRow.children('td.ui-editable-column:last');


### PR DESCRIPTION
Just a little JS tweak to skip non editable columns