### PR TITLE
Fix #95 and #171: Charts escape non numeric data consistently.

### DIFF
--- a/src/main/java/org/primefaces/component/chart/renderer/BarRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/BarRenderer.java
@@ -42,7 +42,7 @@ public class BarRenderer extends CartesianPlotRenderer {
             writer.write("[");
             for (Iterator<Object> its = series.getData().keySet().iterator(); its.hasNext();) {
                 Number value = series.getData().get(its.next());
-                String valueToRender = value != null ? value.toString() : "null";
+                String valueToRender = escapeChartData(value);
 
                 if (horizontal) {
                     writer.write("[");

--- a/src/main/java/org/primefaces/component/chart/renderer/BasePlotRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/BasePlotRenderer.java
@@ -92,12 +92,12 @@ public abstract class BasePlotRenderer {
     }
     
     protected String escapeChartData(Object value) {
-        // default to "null" if null and JSON escape it
-        String result = ComponentUtils.escapeText(String.valueOf(value));
+        // default to "null" if null
+        String result = String.valueOf(value);
 
         // do NOT quote numbers but quote all other objects
         if (value instanceof Number == false) {
-            result = "\"" + result + "\"";
+            result = "\"" + ComponentUtils.escapeText(result) + "\"";
         }
 
         return result;

--- a/src/main/java/org/primefaces/component/chart/renderer/BasePlotRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/BasePlotRenderer.java
@@ -90,4 +90,16 @@ public abstract class BasePlotRenderer {
             writer.write(",resetAxesOnResize:" + false);
         }
     }
+    
+    protected String escapeChartData(Object value) {
+        // default to "null" if null and JSON escape it
+        String result = ComponentUtils.escapeText(String.valueOf(value));
+
+        // do NOT quote numbers but quote all other objects
+        if (value instanceof Number == false) {
+            result = "\"" + result + "\"";
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/org/primefaces/component/chart/renderer/BubbleRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/BubbleRenderer.java
@@ -37,14 +37,14 @@ public class BubbleRenderer extends CartesianPlotRenderer {
         for (Iterator<BubbleChartSeries> it = data.iterator(); it.hasNext();) {
             BubbleChartSeries s = it.next();
             writer.write("[");
-            writer.write(String.valueOf(s.getX()));
+            writer.write(escapeChartData(s.getX()));
             writer.write(",");
-            writer.write(String.valueOf(s.getY()));
+            writer.write(escapeChartData(s.getY()));
             writer.write(",");
-            writer.write(String.valueOf(s.getRadius()));
-            writer.write(",\"");
-            writer.write(ComponentUtils.escapeText(String.valueOf(s.getLabel())));
-            writer.write("\"]");
+            writer.write(escapeChartData(s.getRadius()));
+            writer.write(",");
+            writer.write(escapeChartData(s.getLabel()));
+            writer.write("]");
 
             if (it.hasNext()) {
                 writer.write(",");

--- a/src/main/java/org/primefaces/component/chart/renderer/BubbleRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/BubbleRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.component.chart.Chart;
 import org.primefaces.model.chart.BubbleChartModel;
 import org.primefaces.model.chart.BubbleChartSeries;
-import org.primefaces.util.ComponentUtils;
 
 public class BubbleRenderer extends CartesianPlotRenderer {
 

--- a/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
@@ -45,7 +45,7 @@ public class DonutRenderer extends BasePlotRenderer {
                 String key = it.next();
                 Number value = map.get(key);
 
-                writer.write("[\"" + ComponentUtils.escapeText(key) + "\"," + value + "]");
+                writer.write("[" + escapeChartData(key) + "," + value + "]");
 
                 if (it.hasNext()) {
                     writer.write(",");

--- a/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import org.primefaces.component.chart.Chart;
 import org.primefaces.model.chart.DonutChartModel;
-import org.primefaces.util.ComponentUtils;
 
 public class DonutRenderer extends BasePlotRenderer {
 

--- a/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
@@ -23,7 +23,6 @@ import org.primefaces.component.chart.Chart;
 import org.primefaces.model.chart.CartesianChartModel;
 import org.primefaces.model.chart.ChartSeries;
 import org.primefaces.model.chart.LineChartModel;
-import org.primefaces.util.ComponentUtils;
 
 public class LineRenderer extends CartesianPlotRenderer {
 

--- a/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/LineRenderer.java
@@ -40,17 +40,11 @@ public class LineRenderer extends CartesianPlotRenderer {
             for (Iterator<Object> x = series.getData().keySet().iterator(); x.hasNext();) {
                 Object xValue = x.next();
                 Number yValue = series.getData().get(xValue);
-                String yValueAsString = ComponentUtils.escapeText((yValue != null) ? yValue.toString() : "null");
+                String yValueAsString = escapeChartData(yValue);
+                String xValueAsString = escapeChartData(xValue);
 
                 writer.write("[");
-
-                if (xValue instanceof String) {
-                    writer.write("\"" + ComponentUtils.escapeText(xValue.toString()) + "\"," + yValueAsString);
-                }
-                else {
-                    writer.write(xValue + "," + yValueAsString);
-                }
-
+                writer.write(xValueAsString + "," + yValueAsString);
                 writer.write("]");
 
                 if (x.hasNext()) {

--- a/src/main/java/org/primefaces/component/chart/renderer/MeterGaugeRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/MeterGaugeRenderer.java
@@ -31,7 +31,7 @@ public class MeterGaugeRenderer extends BasePlotRenderer {
         ResponseWriter writer = context.getResponseWriter();
         MeterGaugeChartModel model = (MeterGaugeChartModel) chart.getModel();
 
-        writer.write(",data:[[" + model.getValue() + "]]");
+        writer.write(",data:[[" + escapeChartData(model.getValue()) + "]]");
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/chart/renderer/OhlcRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/OhlcRenderer.java
@@ -36,15 +36,15 @@ public class OhlcRenderer extends CartesianPlotRenderer {
         for (Iterator<OhlcChartSeries> it = data.iterator(); it.hasNext();) {
             OhlcChartSeries s = it.next();
             writer.write("[");
-            writer.write(String.valueOf(s.getValue()));
+            writer.write(escapeChartData(s.getValue()));
             writer.write(",");
-            writer.write(String.valueOf(s.getOpen()));
+            writer.write(escapeChartData(s.getOpen()));
             writer.write(",");
-            writer.write(String.valueOf(s.getHigh()));
+            writer.write(escapeChartData(s.getHigh()));
             writer.write(",");
-            writer.write(String.valueOf(s.getLow()));
+            writer.write(escapeChartData(s.getLow()));
             writer.write(",");
-            writer.write(String.valueOf(s.getClose()));
+            writer.write(escapeChartData(s.getClose()));
             writer.write("]");
 
             if (it.hasNext()) {

--- a/src/main/java/org/primefaces/component/chart/renderer/PieRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/PieRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import org.primefaces.component.chart.Chart;
 import org.primefaces.model.chart.PieChartModel;
-import org.primefaces.util.ComponentUtils;
 
 public class PieRenderer extends BasePlotRenderer {
 

--- a/src/main/java/org/primefaces/component/chart/renderer/PieRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/PieRenderer.java
@@ -35,7 +35,7 @@ public class PieRenderer extends BasePlotRenderer {
             String key = it.next();
             Number value = model.getData().get(key);
 
-            writer.write("[\"" + ComponentUtils.escapeText(key) + "\"," + value + "]");
+            writer.write("[" + escapeChartData(key) + "," + value + "]");
 
             if (it.hasNext()) {
                 writer.write(",");


### PR DESCRIPTION
Fix #95 Dates issue not wrapped in quotes in charts
Fix #171 OHLC chart not escaped consistently.

Went through all charts making their data  elements consistent by:

- If Data is NULL then the word "null" is used
- If Data is a Number then its not wrapped in Quotes all others are quoted such as Date, String, etc
- Escape the JSON data in case the String value has a character that needs to be escaped.