### PR TITLE
Fixed #2690 - not to encode menu button if no children

### DIFF
--- a/src/main/java/org/primefaces/component/splitbutton/SplitButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/splitbutton/SplitButtonRenderer.java
@@ -87,8 +87,10 @@ public class SplitButtonRenderer extends OutcomeTargetRenderer {
         }
 
         encodeDefaultButton(context, button, buttonId);
-        encodeMenuIcon(context, button, menuButtonId);
-        encodeMenu(context, button, menuId);
+        if (button.getChildCount() > 0) {
+            encodeMenuIcon(context, button, menuButtonId);
+            encodeMenu(context, button, menuId);
+        }
 
         writer.endElement("div");
     }
@@ -157,16 +159,19 @@ public class SplitButtonRenderer extends OutcomeTargetRenderer {
             writer.writeAttribute("disabled", "disabled", "disabled");
         }
 
-        //icon    
-        writer.startElement("span", null);
-        writer.writeAttribute("class", "ui-button-icon-left ui-icon ui-icon-triangle-1-s", null);
-        writer.endElement("span");
+        
+        if (button.getChildCount() > 0) { 
+            //icon    
+            writer.startElement("span", null);
+            writer.writeAttribute("class", "ui-button-icon-left ui-icon ui-icon-triangle-1-s", null);
+            writer.endElement("span");
 
-        //text
-        writer.startElement("span", null);
-        writer.writeAttribute("class", HTML.BUTTON_TEXT_CLASS, null);
-        writer.write("ui-button");
-        writer.endElement("span");
+            //text
+            writer.startElement("span", null);
+            writer.writeAttribute("class", HTML.BUTTON_TEXT_CLASS, null);
+            writer.write("ui-button");
+            writer.endElement("span");
+        }
 
         writer.endElement("button");
     }


### PR DESCRIPTION
Fix #2690 

Test code:

```xhtml
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml"
	xmlns:ui="http://java.sun.com/jsf/facelets"
	xmlns:f="http://java.sun.com/jsf/core"
	xmlns:p="http://primefaces.org/ui"
	xmlns:h="http://java.sun.com/jsf/html">

<h:head>
	<title>PrimeFaces Test</title>
</h:head>
<h:body>

	<h1>#{testView.testString}</h1>

	<p:splitButton value="Save" icon="ui-icon-disk" iconPos="right">
		<p:menuitem value="Homepage" url="http://www.primefaces.org" icon="ui-icon-extlink" />
	</p:splitButton>

</h:body>
</html>
```

![snapshot1](https://user-images.githubusercontent.com/10467831/31579417-464b66c2-b0fb-11e7-9561-11a0e3f4bc7a.png)


---

and 

```xhtml
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml"
	xmlns:ui="http://java.sun.com/jsf/facelets"
	xmlns:f="http://java.sun.com/jsf/core"
	xmlns:p="http://primefaces.org/ui"
	xmlns:h="http://java.sun.com/jsf/html">

<h:head>
	<title>PrimeFaces Test</title>
</h:head>
<h:body>

	<h1>#{testView.testString}</h1>

	<p:splitButton value="Save" icon="ui-icon-disk" iconPos="right">
	</p:splitButton>

</h:body>
</html>
```

![snapshot1](https://user-images.githubusercontent.com/10467831/31579423-755750c0-b0fb-11e7-983d-58e1fc8cb7f0.png)
