### PR TITLE
Fix #2806: Tooltip CSS default background.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
+++ b/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
@@ -17,6 +17,7 @@
 .ui-tooltip .ui-tooltip-text {
    padding: 3px 10px;
    background-color: rgb(76, 76, 76);
+   background-image: none;
    color: #ffffff;
 }
 


### PR DESCRIPTION
Fix #2806: Tooltip CSS default background for IE11 Aristo issue.