### PR TITLE
Fix #2811: Regression issue firing too many events after TimePicker 1…

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -1579,7 +1579,6 @@
 		}
 
 		/* PrimeFaces Customization
-	    var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
 		var now = new Date();
 		now.setMinutes(now.getMinutes() + now.getTimezoneOffset() + parseInt(tzoffset, 10));
 		this._setTime(inst, now);
@@ -1588,7 +1587,7 @@
 		*/
 	      
         // PrimeFaces custom code to handle Today button
-        selectLocalTimezone(tp_inst); 
+		var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
         var now = new Date();
         this._setTime(inst, now);
         $('.ui-datepicker-today', inst.dpDiv).click();

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -1578,18 +1578,16 @@
 		  return;
 		}
 
-		/* PrimeFaces Customization
+		var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
 		var now = new Date();
 		now.setMinutes(now.getMinutes() + now.getTimezoneOffset() + parseInt(tzoffset, 10));
 		this._setTime(inst, now);
 		this._setDate(inst, now);
+		
+		/* PrimeFaces Customization
 		tp_inst._onSelectHandler();
 		*/
-	      
         // PrimeFaces custom code to handle Today button
-		var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
-        var now = new Date();
-        this._setTime(inst, now);
         $('.ui-datepicker-today', inst.dpDiv).click();
 	};
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -988,7 +988,9 @@
 				this.$input.val(formattedDateTime);
 			}
 
+			/* PrimeFaces Customization
 			// this.$input.trigger("change"); https://github.com/primefaces/primefaces/issues/2811
+			*/
 		},
 
 		_onFocus: function () {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -2259,12 +2259,10 @@
 	 * @return {void}
 	 */
 	$.timepicker.log = function () {
-	    /* PrimeFaces Customization
 		// Older IE (9, maybe 10) throw error on accessing `window.console.log.apply`, so check first.
 		if (window.console && window.console.log && window.console.log.apply) {
 			window.console.log.apply(window.console, Array.prototype.slice.call(arguments));
 		}
-		*/
 	};
 
 	/*

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -984,7 +984,7 @@
 				this.$input.val(formattedDateTime);
 			}
 
-			this.$input.trigger("change");
+			// this.$input.trigger("change"); https://github.com/primefaces/primefaces/issues/2811
 		},
 
 		_onFocus: function () {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -191,6 +191,7 @@
 						return tp_inst._defaults.evnts.beforeShow.call($input[0], input, dp_inst, tp_inst);
 					}
 				},
+				/* PrimeFaces Customization
 				onChangeMonthYear: function (year, month, dp_inst) {
 					// Update the time as well : this prevents the time from disappearing from the $input field.
 					// tp_inst._updateDateTime(dp_inst);
@@ -198,6 +199,7 @@
 						tp_inst._defaults.evnts.onChangeMonthYear.call($input[0], year, month, dp_inst, tp_inst);
 					}
 				},
+				*/
 				onClose: function (dateText, dp_inst) {
 					if (tp_inst.timeDefined === true && $input.val() !== '') {
 						tp_inst._updateDateTime(dp_inst);
@@ -885,7 +887,9 @@
 				if (this.$timeObj[0].setSelectionRange) {
 					var sPos = this.$timeObj[0].selectionStart;
 					var ePos = this.$timeObj[0].selectionEnd;
+					/* PrimeFaces Customization
 					//this.$timeObj[0].setSelectionRange(sPos, ePos); // Primefaces github issue; #1421
+					*/
 				}
 			}
 
@@ -1572,12 +1576,20 @@
 		  return;
 		}
 
-		var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
+		/* PrimeFaces Customization
+	    var tzoffset = $.timepicker.timezoneOffsetNumber(tp_inst.timezone);
 		var now = new Date();
 		now.setMinutes(now.getMinutes() + now.getTimezoneOffset() + parseInt(tzoffset, 10));
 		this._setTime(inst, now);
 		this._setDate(inst, now);
 		tp_inst._onSelectHandler();
+		*/
+	      
+        // PrimeFaces custom code to handle Today button
+        selectLocalTimezone(tp_inst); 
+        var now = new Date();
+        this._setTime(inst, now);
+        $('.ui-datepicker-today', inst.dpDiv).click();
 	};
 
 	/*
@@ -2250,10 +2262,12 @@
 	 * @return {void}
 	 */
 	$.timepicker.log = function () {
+	    /* PrimeFaces Customization
 		// Older IE (9, maybe 10) throw error on accessing `window.console.log.apply`, so check first.
 		if (window.console && window.console.log && window.console.log.apply) {
 			window.console.log.apply(window.console, Array.prototype.slice.call(arguments));
 		}
+		*/
 	};
 
 	/*

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -191,7 +191,6 @@
 						return tp_inst._defaults.evnts.beforeShow.call($input[0], input, dp_inst, tp_inst);
 					}
 				},
-				/* PrimeFaces Customization
 				onChangeMonthYear: function (year, month, dp_inst) {
 					// Update the time as well : this prevents the time from disappearing from the $input field.
 					// tp_inst._updateDateTime(dp_inst);
@@ -199,7 +198,6 @@
 						tp_inst._defaults.evnts.onChangeMonthYear.call($input[0], year, month, dp_inst, tp_inst);
 					}
 				},
-				*/
 				onClose: function (dateText, dp_inst) {
 					if (tp_inst.timeDefined === true && $input.val() !== '') {
 						tp_inst._updateDateTime(dp_inst);


### PR DESCRIPTION
Fix #2811: Regression issue firing too many events after TimePicker 1.6.3 upgrade.

Original ticket was https://code.google.com/archive/p/primefaces/issues/5702