### PR TITLE
Fix #2811: Calendar change events fired when date did not change.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
@@ -19,7 +19,9 @@ jquery.autosize.js:
 - Added fix to autosize from https://github.com/jackmoore/autosize/issues/225
 
 jquery.ui.timepicker.js:
-- Added fix to timepicker from https://github.com/trentrichardson/jQuery-Timepicker-Addon/issues/848
+- Timepicker Fix https://github.com/trentrichardson/jQuery-Timepicker-Addon/issues/848
+- Timepicker Fix https://github.com/primefaces/primefaces/issues/2811
+- 
 
 jquery.maskedinput.js:
 - line 116: Added arrow keys fix to mask (https://github.com/primefaces/primefaces/issues/1481)

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -223,6 +223,10 @@
 			tp_inst.pmNames = $.map(tp_inst._defaults.pmNames, function (val) {
 				return val.toUpperCase();
 			});
+			
+	         /* PrimeFaces Hooks */
+            tp_inst._updateDateTime = $.timepicker._updateDateTime;
+            tp_inst._onTimeChange = $.timepicker._onTimeChange;
 
 			// detect which units are supported
 			tp_inst.support = detectSupport(
@@ -885,7 +889,7 @@
 				if (this.$timeObj[0].setSelectionRange) {
 					var sPos = this.$timeObj[0].selectionStart;
 					var ePos = this.$timeObj[0].selectionEnd;
-					//this.$timeObj[0].setSelectionRange(sPos, ePos); // Primefaces github issue; #1421
+					this.$timeObj[0].setSelectionRange(sPos, ePos);
 				}
 			}
 
@@ -926,12 +930,11 @@
 			var formattedDateTime = this.formattedDate;
 
 			// if a slider was changed but datepicker doesn't have a value yet, set it
-			var originalValue = dp_inst.lastVal;
-			if (originalValue === "") {
-				dp_inst.currentYear = dp_inst.selectedYear;
-				dp_inst.currentMonth = dp_inst.selectedMonth;
-				dp_inst.currentDay = dp_inst.selectedDay;
-			}
+			if (dp_inst.lastVal === "") {
+                dp_inst.currentYear = dp_inst.selectedYear;
+                dp_inst.currentMonth = dp_inst.selectedMonth;
+                dp_inst.currentDay = dp_inst.selectedDay;
+            }
 
 			/*
 			* remove following lines to force every changes in date picker to change the input value
@@ -985,9 +988,7 @@
 				this.$input.val(formattedDateTime);
 			}
 
-			if (originalValue != formattedDateTime) {
-				this.$input.trigger("change"); // PrimeFaces https://github.com/primefaces/primefaces/issues/2811
-			}
+			this.$input.trigger("change");
 		},
 
 		_onFocus: function () {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -926,7 +926,8 @@
 			var formattedDateTime = this.formattedDate;
 
 			// if a slider was changed but datepicker doesn't have a value yet, set it
-			if (dp_inst.lastVal === "") {
+			var originalValue = dp_inst.lastVal;
+	        if (originalValue === "") {
                 dp_inst.currentYear = dp_inst.selectedYear;
                 dp_inst.currentMonth = dp_inst.selectedMonth;
                 dp_inst.currentDay = dp_inst.selectedDay;
@@ -984,7 +985,9 @@
 				this.$input.val(formattedDateTime);
 			}
 
-			this.$input.trigger("change");
+	        if (originalValue != formattedDateTime) {
+	            this.$input.trigger("change"); // PrimeFaces https://github.com/primefaces/primefaces/issues/2811
+	        }
 		},
 
 		_onFocus: function () {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -927,11 +927,11 @@
 
 			// if a slider was changed but datepicker doesn't have a value yet, set it
 			var originalValue = dp_inst.lastVal;
-	        if (originalValue === "") {
-                dp_inst.currentYear = dp_inst.selectedYear;
-                dp_inst.currentMonth = dp_inst.selectedMonth;
-                dp_inst.currentDay = dp_inst.selectedDay;
-            }
+			if (originalValue === "") {
+				dp_inst.currentYear = dp_inst.selectedYear;
+				dp_inst.currentMonth = dp_inst.selectedMonth;
+				dp_inst.currentDay = dp_inst.selectedDay;
+			}
 
 			/*
 			* remove following lines to force every changes in date picker to change the input value
@@ -985,9 +985,9 @@
 				this.$input.val(formattedDateTime);
 			}
 
-	        if (originalValue != formattedDateTime) {
-	            this.$input.trigger("change"); // PrimeFaces https://github.com/primefaces/primefaces/issues/2811
-	        }
+			if (originalValue != formattedDateTime) {
+				this.$input.trigger("change"); // PrimeFaces https://github.com/primefaces/primefaces/issues/2811
+			}
 		},
 
 		_onFocus: function () {


### PR DESCRIPTION
OK I was able to review all the old changes and none of them need to be applied anymore as they were fixed in TimePicker 1.6.3.

However, I was able to narrow down this bug and only fire the Ajax event if the date actually did change.

@tandraschko @jxmai I tried everything to move this code into jquery.pfextensions.js but it just would not pick up the methods.  Maybe I was doing it wrong but I was doing this...

`$.timepicker._updateDateTime = function (dp_inst) {`

Just like the$datepicker overrides but I must be missing something.