### PR TITLE
Fix #2318 - Treetable: hook page event

### DIFF
--- a/src/main/java-templates/org/primefaces/component/treetable/TreeTableTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/treetable/TreeTableTemplate.java
@@ -15,6 +15,7 @@ import org.primefaces.event.NodeUnselectEvent;
 import org.primefaces.event.NodeExpandEvent;
 import org.primefaces.event.NodeCollapseEvent;
 import org.primefaces.event.ColumnResizeEvent;
+import org.primefaces.event.data.PageEvent;
 import org.primefaces.component.column.Column;
 import java.lang.StringBuilder;
 import java.util.ArrayList;
@@ -125,6 +126,7 @@ import org.primefaces.model.filter.StartsWithFilterConstraint;
         put("rowEditInit", RowEditEvent.class);
         put("rowEditCancel", RowEditEvent.class);
         put("cellEdit", CellEditEvent.class);
+        put("page", PageEvent.class);
     }});
 
     private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
@@ -248,6 +250,14 @@ import org.primefaces.model.filter.StartsWithFilterConstraint;
                 }
 
                 wrapperEvent = new CellEditEvent(this, behaviorEvent.getBehavior(), column, rowKey);
+                wrapperEvent.setPhaseId(behaviorEvent.getPhaseId());
+            }
+            else if(eventName.equals("page")) {
+                int rows = this.getRowsToRender();
+                int first = Integer.parseInt(params.get(clientId + "_first"));
+                int page = rows > 0 ? (int) (first / rows) : 0;
+        
+                wrapperEvent = new PageEvent(this, behaviorEvent.getBehavior(), page);
                 wrapperEvent.setPhaseId(behaviorEvent.getPhaseId());
             }
             


### PR DESCRIPTION
Fix #2318 

Example (I only put partial code here since the page event is quite common)

```java
public void page(PageEvent e) {
	System.out.println(e.getPage());
    }
```

```xhtml
<p:ajax event="page" listener="#{treeTableDocumentService.page}"></p:ajax>
```

looks like we already have all the AJAX setup in js already. Why not complete it 😃 ?

![image](https://user-images.githubusercontent.com/10467831/31847901-d30a0534-b5ea-11e7-9a7a-89e6d41b385e.png)


server console

![image](https://user-images.githubusercontent.com/10467831/31847909-fb945c7a-b5ea-11e7-9aeb-87270e7226df.png)
