### PR TITLE
Fix #2862: SelectOneMenu editable try and match item in list.

### DIFF
--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -48,7 +48,19 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         if (menu.isEditable()) {
             Map<String, String> params = context.getExternalContext().getRequestParameterMap();
 
-            menu.setSubmittedValue(params.get(menu.getClientId(context) + "_editableInput"));
+            // default to user entered input
+            String editorInput = params.get(menu.getClientId(context) + "_editableInput");
+            menu.setSubmittedValue(editorInput);
+
+            // #2862 check if it matches a label and if so use the value
+            List<SelectItem> selectItems = getSelectItems(context, menu);
+            for (int i = 0; i < selectItems.size(); i++) {
+                SelectItem item = selectItems.get(i);
+                if (item.getLabel().equalsIgnoreCase(editorInput)) {
+                    menu.setSubmittedValue(item.getValue());
+                    break;
+                }
+            }
 
             decodeBehaviors(context, menu);
         }


### PR DESCRIPTION
Fix #2862: SelectOneMenu editable try and match item in list.

- Use the user typed in value as a default
- Search the SelectItems list and if it matches a Label "ignoring case" it uses that items value and not its label.  

Question:  Should I ignore case?  So I guess you could have two labels "mello" and "Mello" and they could have different meanings?  I just prefer to search case insensitively and not annoy a user with having to type the text in EXACTLY.