### PR TITLE
Fix #2331: SelectOneMenu added keyup/keydown for Editable.

### DIFF
--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -225,6 +225,15 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                 writer.writeAttribute("placeholder", menu.getPlaceholder(), null);
             }
 
+            if (menu.getOnkeydown() != null) {
+                writer.writeAttribute("onkeydown", menu.getOnkeydown(), null);
+                this.renderDomEvent(context, menu, "onkeydown", "keydown", "keydown", null);
+            }
+            if (menu.getOnkeyup() != null) {
+                writer.writeAttribute("onkeyup", menu.getOnkeyup(), null);
+                this.renderDomEvent(context, menu, "onkeyup", "keyup", "keyup", null);
+            }
+
             writer.endElement("input");
         }
         else {


### PR DESCRIPTION
Fix #2331: SelectOneMenu added keyup/keydown for Editable.

Tested and verified using showcase code and verify the console printed out the keyup and keydown events.

```xml
<p:selectOneMenu id="city" value="#{selectOneMenuView.city}" effect="fold" editable="true" onkeyup="console.log('keyup');" onkeydown="console.log('keydown');">
```