### PR TITLE
Fix #753: SelectOneMenu alignment issues for Editable.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -224,6 +224,7 @@
     zoom: 1;
     cursor: pointer;
     padding-right: 2em;
+    vertical-align: top;
 }
 
 .ui-selectonemenu .ui-selectonemenu-trigger {


### PR DESCRIPTION
Verified the veritical-align:top fixes it with no side effects.

![image](https://user-images.githubusercontent.com/4399574/32115814-416abb42-bb16-11e7-8336-92e072bf14c9.png)
