### PR TITLE
Adding InputGroup support to Password, InputMask and Calendar

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
@@ -34,6 +34,7 @@
 .ui-inputgroup > .ui-password:not(:first-child),
 .ui-inputgroup > .ui-inputnumber:not(:first-child) > .ui-inputtext,
 .ui-inputgroup > .ui-inputmask:not(:first-child),
+.ui-inputgroup > .ui-calendar:not(:first-child) > .ui-inputfield,
 .ui-inputgroup > .ui-selectonemenu:not(:first-child),
 .ui-inputgroup > .ui-selectonebutton:not(:first-child) > .ui-button {
     border-top-left-radius: 0;
@@ -46,6 +47,7 @@
 .ui-inputgroup > .ui-inputnumber:not(:last-child) > .ui-inputtext,
 .ui-inputgroup > .ui-inputmask:not(:last-child),
 .ui-inputgroup > .ui-selectonemenu:not(:last-child),
+.ui-inputgroup > .ui-calendar:not(:last-child) > .ui-inputfield,
 .ui-inputgroup > .ui-selectonebutton:not(:last-child) > .ui-button {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;

--- a/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
@@ -33,6 +33,7 @@
 .ui-inputgroup > .ui-inputtext:not(:first-child),
 .ui-inputgroup > .ui-password:not(:first-child),
 .ui-inputgroup > .ui-inputnumber:not(:first-child) > .ui-inputtext,
+.ui-inputgroup > .ui-inputmask:not(:first-child),
 .ui-inputgroup > .ui-selectonemenu:not(:first-child),
 .ui-inputgroup > .ui-selectonebutton:not(:first-child) > .ui-button {
     border-top-left-radius: 0;
@@ -43,6 +44,7 @@
 .ui-inputgroup > .ui-inputtext:not(:last-child),
 .ui-inputgroup > .ui-password:not(:last-child),
 .ui-inputgroup > .ui-inputnumber:not(:last-child) > .ui-inputtext,
+.ui-inputgroup > .ui-inputmask:not(:last-child),
 .ui-inputgroup > .ui-selectonemenu:not(:last-child),
 .ui-inputgroup > .ui-selectonebutton:not(:last-child) > .ui-button {
     border-top-right-radius: 0;

--- a/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/inputgroup.css
@@ -25,11 +25,13 @@
     border-left: 0 none;
 }
 
-.ui-inputgroup .ui-inputtext {
+.ui-inputgroup .ui-inputtext,
+.ui-inputgroup .ui-password {
     padding-left: .5em;
 }
 
 .ui-inputgroup > .ui-inputtext:not(:first-child),
+.ui-inputgroup > .ui-password:not(:first-child),
 .ui-inputgroup > .ui-inputnumber:not(:first-child) > .ui-inputtext,
 .ui-inputgroup > .ui-selectonemenu:not(:first-child),
 .ui-inputgroup > .ui-selectonebutton:not(:first-child) > .ui-button {
@@ -39,6 +41,7 @@
 }
 
 .ui-inputgroup > .ui-inputtext:not(:last-child),
+.ui-inputgroup > .ui-password:not(:last-child),
 .ui-inputgroup > .ui-inputnumber:not(:last-child) > .ui-inputtext,
 .ui-inputgroup > .ui-selectonemenu:not(:last-child),
 .ui-inputgroup > .ui-selectonebutton:not(:last-child) > .ui-button {


### PR DESCRIPTION
This pull request improves the issue #2632 adding support for other components like Calendar, Password and InputMask.

To make a test, you can create an `xhtml` like this:

```
<div class="ui-g ui-fluid">
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<p:password />
			<p:commandButton value="Go" />
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<span class="ui-inputgroup-addon"><i class="fa fa-calendar"></i></span>
			<p:calendar mask="99/99/9999" />
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<span class="ui-inputgroup-addon"><i class="fa fa-id-card-o"></i></span>
			<p:inputMask mask="99.99.99.99" value="123456" />
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<span class="ui-inputgroup-addon"><i class="fa fa-user"></i></span>
			<p:inputText placeholder="Username" />
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<span class="ui-inputgroup-addon">$</span>
			<p:inputText placeholder="Price" />
			<span class="ui-inputgroup-addon">.00</span>
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<span class="ui-inputgroup-addon">%</span>
			<p:inputNumber decimalPlaces="2" decimalSeparator="," value="100"/>
		</div>
	</div>
	<div class="ui-g-12 ui-md-6">
		<div class="ui-inputgroup">
			<p:inputNumber decimalPlaces="2" decimalSeparator="," value="100"/>
			<span class="ui-inputgroup-addon">%</span>
		</div>
	</div>
</div>
```

Thank you

