### PR TITLE
Fix #2130 - dialog max height and max width should fit viewport

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
@@ -1,4 +1,4 @@
-.ui-dialog { position: fixed; padding: 0; overflow: hidden; display:none; }
+.ui-dialog { position: fixed; padding: 0; overflow: hidden; display:none; max-height: 100vh; max-width: 100vw; }
 .ui-dialog.ui-dialog-absolute { position: absolute; }
 .ui-dialog.ui-overlay-hidden {display:block;}
 .ui-dialog .ui-dialog-titlebar { padding: .4em .4em .4em 1em; position: relative; border:0px; }


### PR DESCRIPTION
Fix #2130 

The dialog can never go out of bound :hand: 

![image](https://user-images.githubusercontent.com/10467831/32386620-d58f6d44-c08f-11e7-9102-ec853353d7f5.png)
