### PR TITLE
Fix #2364 - overlay panel should fit viewport using purely css

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.css
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.css
@@ -2,6 +2,8 @@
     padding: 0;
     margin: 0;
     position: absolute;
+    max-width: calc(100vw - (100vw - 100%));
+    max-height: 100vh;
 }
 
 .ui-overlaypanel-content {


### PR DESCRIPTION
Fix #2364 

This pull is an alternative option aside from #2859. Personally I prefer this approach since:

1. less js better performance

2. the overlay dialog is responsive now which is a big plus.

3. less code, less bug


There is no need to use overflow unlike #2859, and #2859  is not responsive

Notice that the reason we cannot use `max-width: 100vw` but to use `calc(100vw - (100vw - 100%));` is because we need to remove the width of the scrollbar if it exists.
