### PR TITLE
#2120 - avoid unnecesary Integer Object creation and use primitive in…

### DIFF
--- a/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java
@@ -541,7 +541,7 @@ import org.primefaces.component.datatable.TableState;
             
             if(this.isClientCacheRequest(context)) {
                 Map<String,String> params = context.getExternalContext().getRequestParameterMap();
-                first = Integer.valueOf(params.get(getClientId(context) + "_first")) + getRows();
+                first = Integer.parseInt(params.get(getClientId(context) + "_first")) + getRows();
             }           
             
             if(this.isMultiViewState()) {


### PR DESCRIPTION
…t instead

Slight improvement for https://github.com/primefaces/primefaces/commit/435c835a289447f970c7b6814a0ce28e8ef523e8

of this line

https://github.com/primefaces/primefaces/blob/88ab4bfbdaa6e0c1e38d288d434b1fb37f5090ec/src/main/java-templates/org/primefaces/component/datatable/DataTableTemplate.java#L544

Comments: 

https://github.com/primefaces/primefaces/commit/435c835a289447f970c7b6814a0ce28e8ef523e8#commitcomment-21374617

> parseInt should be better, avoid unnecessary object creation


https://github.com/primefaces/primefaces/commit/435c835a289447f970c7b6814a0ce28e8ef523e8#commitcomment-25516712

> Yes, the valueOf returns an Integer object while parseInt returns a primitive int. Since first and and row are both primitive. So it makes sense to use parseInt instead of using valueOf.

> Currently the expression is int = Integer + int.

> There is no harm to change it to int = int + int to improve the efficiency in this case.