### PR TITLE
Fix #495: DialogFramework add position option.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
@@ -62,7 +62,7 @@ if (!PrimeFaces.dialog) {
                 if(!$frame.data('initialized')) {
                     PrimeFaces.cw.call(rootWindow.PrimeFaces, 'DynamicDialog', dialogWidgetVar, {
                         id: dialogId,
-                        position: 'center',
+                        position: cfg.options.position||'center',
                         sourceComponentId: cfg.sourceComponentId,
                         sourceWidgetVar: cfg.sourceWidgetVar,
                         onHide: function() {


### PR DESCRIPTION
Fix #495: DialogFramework add position option

`options.put("position", "center");`