### PR TITLE
Label attribute should not be required for the selectCheckboxMenu

### DIFF
--- a/src/main/resources-maven-jsf/ui/selectCheckboxMenu.xml
+++ b/src/main/resources-maven-jsf/ui/selectCheckboxMenu.xml
@@ -33,7 +33,7 @@
         </attribute>
         <attribute>
             <name>label</name>
-            <required>true</required>
+            <required>false</required>
             <type>java.lang.String</type>
             <ignoreInComponent>true</ignoreInComponent>
         </attribute>


### PR DESCRIPTION
Fixes #2996.