### PR TITLE
Fix #2987: Rename render to renderTimeline in JS 

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -555,11 +555,11 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
     },
     
     /**
-     * Force render the timeline component 
+     * Force render the timeline component.
      * 
      * @param animate flag to animate the render action (optional)
      */
-    render: function (animate) {
+    renderTimeline: function (animate) {
         this.instance.render({'animate': animate});
     },
     


### PR DESCRIPTION
Because this is a DeferredWidget the render method was actually being called when used in a dialog before the component was rendered.  I simply renamed the render method to renderTimeLine so if users still want to use it to redraw or animate they can but it won't collide with the widget render method.

