### PR TITLE
Fix #472: Calendar "inline" ability to use time.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -177,7 +177,10 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
                 }
             }
             else {
-                var newDate = $.datepicker.formatDate(_self.cfg.dateFormat, _self.getDate());
+                var newDate = _self.cfg.timeOnly ? '' : $.datepicker.formatDate(_self.cfg.dateFormat, _self.getDate());
+                if(_self.cfg.timeFormat) {
+                   newDate += ' ' + _self.jqEl.find('.ui_tpicker_time_input')[0].value;
+                }
 
                 _self.input.val(newDate);
                 _self.fireDateSelectEvent();


### PR DESCRIPTION
Found this fix on the forum: https://forum.primefaces.org/viewtopic.php?p=95453

I modified it slightly and it works quite well.  I researched better ways of formatting the time but the TimePicker does not give an elegant way of formatting time as you can see here: http://trentrichardson.com/examples/timepicker/#utility_examples

So the best solution is this one and to just read the timepicker input value.