### PR TITLE
Fix #2795: Schedule use description for tooltip.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/schedule.js
@@ -13357,6 +13357,13 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
                     $this.tip.text('');
                 }
             };
+        } else {
+            // PF #2795 default to regular tooltip
+            this.cfg.eventRender = function(event, element) {
+                if(event.description) {
+                   element.attr('title', event.description);
+                }
+            };
         }
     },
 


### PR DESCRIPTION
If not using PF Tooltips set the title attribute of the Event by default to use a regular browser tooltip.