### PR TITLE
Fixed NPE and other improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
                     <source>1.6</source>
                     <target>1.6</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/primefaces/model/filter/ContainsFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/ContainsFilterConstraint.java
@@ -20,6 +20,7 @@ import org.primefaces.util.Constants;
 
 public class ContainsFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase(locale);
 

--- a/src/main/java/org/primefaces/model/filter/EndsWithFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/EndsWithFilterConstraint.java
@@ -20,6 +20,7 @@ import org.primefaces.util.Constants;
 
 public class EndsWithFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase(locale);
 

--- a/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 public class EqualsFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;

--- a/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
@@ -20,6 +20,7 @@ import org.primefaces.util.Constants;
 
 public class ExactFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase(locale);
 

--- a/src/main/java/org/primefaces/model/filter/GlobalFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/GlobalFilterConstraint.java
@@ -20,6 +20,7 @@ import org.primefaces.util.Constants;
 
 public class GlobalFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase(locale);
 

--- a/src/main/java/org/primefaces/model/filter/GreaterThanEqualsFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/GreaterThanEqualsFilterConstraint.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 public class GreaterThanEqualsFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;

--- a/src/main/java/org/primefaces/model/filter/GreaterThanFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/GreaterThanFilterConstraint.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 public class GreaterThanFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;

--- a/src/main/java/org/primefaces/model/filter/InFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/InFilterConstraint.java
@@ -17,12 +17,12 @@ package org.primefaces.model.filter;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Locale;
 import javax.faces.FacesException;
 
 public class InFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;
@@ -44,9 +44,8 @@ public class InFilterConstraint implements FilterConstraint {
         }
 
         if (collection != null && !collection.isEmpty()) {
-            for (Iterator<? extends Object> it = collection.iterator(); it.hasNext();) {
-                Object object = it.next();
-                if (object.equals(value)) {
+            for (Object object : collection) {
+                if (object != null && object.equals(value)) {
                     return true;
                 }
             }

--- a/src/main/java/org/primefaces/model/filter/LessThanEqualsFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/LessThanEqualsFilterConstraint.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 public class LessThanEqualsFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;

--- a/src/main/java/org/primefaces/model/filter/LessThanFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/LessThanFilterConstraint.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 public class LessThanFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         if (filter == null) {
             return true;

--- a/src/main/java/org/primefaces/model/filter/StartsWithFilterConstraint.java
+++ b/src/main/java/org/primefaces/model/filter/StartsWithFilterConstraint.java
@@ -20,6 +20,7 @@ import org.primefaces.util.Constants;
 
 public class StartsWithFilterConstraint implements FilterConstraint {
 
+    @Override
     public boolean applies(Object value, Object filter, Locale locale) {
         String filterText = (filter == null) ? null : filter.toString().trim().toLowerCase(locale);
 


### PR DESCRIPTION
What I have fixed so far:
- fixed NPE in InFilterConstraint when value is NULL
- added missing `@Override` annotation in all filter constraint classes
- Code such as `for (Iterator<? extends Object> it = collection.iterator(); it.hasNext();) {` can be replaced with a simple `for()` iteration

The NPE fixes an issue when a filtered value is NULL, which may happen when you have this JSF code:

````
<f:facet name="filter">
	<p:selectCheckboxMenu
		filter="true"
		filterMatchMode="contains"
		label="#{msg.LABEL_BRANCH_OFFICES}"
		onchange="PF('employeeList').filter()"
		updateLabel="true"
		title="#{msg.FILTER_BY_MULTIPLE_EMPLOYEES_TITLE}"
		>
		<f:converter converterId="BranchOfficeConverter" />
		<f:selectItem itemValue="#{null}" itemLabel="#{msg.NONE_SELECTED}" />
		<f:selectItems value="#{branchOfficeController.allBranchOffices()}" var="branchOffice" itemValue="#{branchOffice}" itemLabel="#{beanHelper.renderBranchOffice(branchOffice)}" />
	</p:selectCheckboxMenu>
</f:facet>
````

This has been stripped out from a real-world application (no example/demo stuff). So pardon me for custom stuff.

I also propose to move on from 1.6 to 1.7 as it (as you may know) has many improvements that shortens your code.

**Prior 1.6**:
````
if (someVar != null && someVar.equals(otherVar))
````

**With 1.7+**:
````
import java.util.Objects;

if (Objects.equals(someVar, otherVar))
````

As you can see, this is much smaller code. Sure there is lot's of more new stuff but I'm to lazy to dig that all up. 

Also I would recommend using "this." everywhere you access a class' field to avoid confusion and help the compiler.

Next is 'final' keyword which you should use in parameters and local variables where possible to avoid assigning parameters with new values accidentally and to help the compiler with optimizing the code.

I could do that both with 1.6 but surely not the `Objects` thing (only with 1.7+).

`@Override` also aids the compiler in finding accidentally changed method signatures.
