### PR TITLE
Fix #726: Aristo theme allow large FontAwesome icons.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces-aristo/theme.css
+++ b/src/main/resources/META-INF/resources/primefaces-aristo/theme.css
@@ -12,12 +12,6 @@ a {
     outline: none;
 }
 
-.ui-icon {
-    -moz-border-radius: 10px;
-    -webkit-border-radius: 10px;
-    border-radius: 10px;
-}
-
 /*
  * jQuery UI CSS Framework @VERSION
  *


### PR DESCRIPTION
Removed ui-icon style that was preventing large FA icons and seems to have no impact on regular icons as well.  Rule determined to be unnecessary.