### PR TITLE
Fix #3052: OutputLabel respect @NotBlank @NotEmpty bean validations.

### DIFF
--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -17,6 +17,7 @@ package org.primefaces.component.outputlabel;
 
 import org.primefaces.util.EditableValueHolderState;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -174,12 +175,13 @@ public class OutputLabelRenderer extends CoreRenderer {
                 return false;
             }
             for (ConstraintDescriptor<?> constraintDescriptor : constraints) {
-                String annotationClassName = constraintDescriptor.getAnnotation().annotationType().getSimpleName();
-                if (constraintDescriptor.getAnnotation().annotationType().equals(NotNull.class)) {
-                    // GitHub #14 skip @NotNull check
+                Class<? extends Annotation> annotationType = constraintDescriptor.getAnnotation().annotationType();
+                // GitHub #14 skip @NotNull check
+                if (annotationType.equals(NotNull.class)) {
                     return RequestContext.getCurrentInstance(context).getApplicationContext().getConfig().isInterpretEmptyStringAsNull();
                 }
                 // GitHub #3052 @NotBlank,@NotEmpty Hibernate and BeanValidator 2.0
+                String annotationClassName = annotationType.getSimpleName();
                 if ("NotBlank".equals(annotationClassName) || "NotEmpty".equals(annotationClassName)) {
                     return true;
                 }
@@ -197,7 +199,7 @@ public class OutputLabelRenderer extends CoreRenderer {
 
     @Override
     public void encodeChildren(FacesContext context, UIComponent component) throws IOException {
-        //Do nothing
+        // Do nothing
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -106,14 +106,13 @@ public class OutputLabelRenderer extends CoreRenderer {
                             styleClass.append(" ui-state-error");
                         }
 
-                        
                         if ("auto".equals(indicateRequired)) {
                             state.setRequired(input.isRequired());
 
                             // fallback if required=false
                             if (!state.isRequired()) {
                                 PrimeConfiguration config = RequestContext.getCurrentInstance(context).getApplicationContext().getConfig();
-                                if (config.isBeanValidationAvailable() && isNotNullDefined(input, context)) {
+                                if (config.isBeanValidationAvailable() && isBeanValidationDefined(input, context)) {
                                     state.setRequired(true);
                                 }
                             }
@@ -166,31 +165,30 @@ public class OutputLabelRenderer extends CoreRenderer {
         writer.endElement("span");
     }
 
-    protected boolean isNotNullDefined(UIInput input, FacesContext context) {
-
-        // skip @NotNull check
-        // see GitHub #14
-        if (!RequestContext.getCurrentInstance(context).getApplicationContext().getConfig().isInterpretEmptyStringAsNull()) {
-            return false;
-        }
-
+    protected boolean isBeanValidationDefined(UIInput input, FacesContext context) {
         try {
             Set<ConstraintDescriptor<?>> constraints = BeanValidationMetadataExtractor.extractDefaultConstraintDescriptors(
-                    context,
-                    RequestContext.getCurrentInstance(context),
-                    ValueExpressionAnalyzer.getExpression(context.getELContext(), input.getValueExpression("value")));
-            if (constraints != null && !constraints.isEmpty()) {
-                for (ConstraintDescriptor<?> constraintDescriptor : constraints) {
-                    if (constraintDescriptor.getAnnotation().annotationType().equals(NotNull.class)) {
-                        return true;
-                    }
+                        context, RequestContext.getCurrentInstance(context),
+                        ValueExpressionAnalyzer.getExpression(context.getELContext(), input.getValueExpression("value")));
+            if (constraints == null || constraints.isEmpty()) {
+                return false;
+            }
+            for (ConstraintDescriptor<?> constraintDescriptor : constraints) {
+                String annotationClassName = constraintDescriptor.getAnnotation().annotationType().getSimpleName();
+                if (constraintDescriptor.getAnnotation().annotationType().equals(NotNull.class)) {
+                    // GitHub #14 skip @NotNull check
+                    return RequestContext.getCurrentInstance(context).getApplicationContext().getConfig().isInterpretEmptyStringAsNull();
+                }
+                // GitHub #3052 @NotBlank,@NotEmpty Hibernate and BeanValidator 2.0
+                if ("NotBlank".equals(annotationClassName) || "NotEmpty".equals(annotationClassName)) {
+                    return true;
                 }
             }
         }
         catch (PropertyNotFoundException e) {
-            String message = "Skip evaluating @NotNull for outputLabel and referenced component \"" + input.getClientId(context) + "\" because"
-                    + " the ValueExpression of the \"value\" attribute"
-                    + " isn't resolvable completely (e.g. a sub-expression returns null)";
+            String message = "Skip evaluating [@NotNull,@NotBlank,@NotEmpty] for outputLabel and referenced component \"" + input.getClientId(context)
+                        + "\" because the ValueExpression of the \"value\" attribute"
+                        + " isn't resolvable completely (e.g. a sub-expression returns null)";
             LOG.log(Level.FINE, message);
         }
 


### PR DESCRIPTION
Fix #3052: OutputLabel respect @NotBlank @NotEmpty bean validations.

- Combined all validation checks so we just loop over Constraints once and not twice.
- Use class Simplename so it catches both Hibernate and Bean Validation 2.0 NotEmpty NotBlank