### PR TITLE
Fix #3066 #3067 - Jquery 3.x on load in replacement of load function

### DIFF
--- a/src/main/java/org/primefaces/util/WidgetBuilder.java
+++ b/src/main/java/org/primefaces/util/WidgetBuilder.java
@@ -83,7 +83,7 @@ public class WidgetBuilder {
     public WidgetBuilder initWithComponentLoad(String widgetClass, String widgetVar, String id, String targetId) throws IOException {
 
         this.renderScriptBlock(id);
-        context.getResponseWriter().write("$(PrimeFaces.escapeClientId(\"" + targetId + "\")).load(function(){");
+        context.getResponseWriter().write("$(PrimeFaces.escapeClientId(\"" + targetId + "\")).on(\"load\",function(){");
         this.init(widgetClass, widgetVar, id, true);
 
         return this;

--- a/src/main/java/org/primefaces/util/WidgetBuilder.java
+++ b/src/main/java/org/primefaces/util/WidgetBuilder.java
@@ -74,7 +74,7 @@ public class WidgetBuilder {
     public WidgetBuilder initWithWindowLoad(String widgetClass, String widgetVar, String id) throws IOException {
 
         this.renderScriptBlock(id);
-        context.getResponseWriter().write("$(window).load(function(){");
+        context.getResponseWriter().write("$(window).on(\"load\",function(){");
         this.init(widgetClass, widgetVar, id, true);
 
         return this;

--- a/src/test/java/org/primefaces/util/WidgetBuilderTest.java
+++ b/src/test/java/org/primefaces/util/WidgetBuilderTest.java
@@ -61,7 +61,7 @@ public class WidgetBuilderTest {
         builder.finish();
 
         assertEquals(
-        		"<script id=\"accoId_s\" type=\"text/javascript\">$(PrimeFaces.escapeClientId(\"test\")).load(function(){PrimeFaces.cw(\"AccordionPanel\",\"acco\",{id:\"accoId\"});});</script>",
+        		"<script id=\"accoId_s\" type=\"text/javascript\">$(PrimeFaces.escapeClientId(\"test\")).on(\"load\",function(){PrimeFaces.cw(\"AccordionPanel\",\"acco\",{id:\"accoId\"});});</script>",
         		writer.toString());
     }
 

--- a/src/test/java/org/primefaces/util/WidgetBuilderTest.java
+++ b/src/test/java/org/primefaces/util/WidgetBuilderTest.java
@@ -48,7 +48,7 @@ public class WidgetBuilderTest {
         builder.finish();
 
         assertEquals(
-        		"<script id=\"accoId_s\" type=\"text/javascript\">$(window).load(function(){PrimeFaces.cw(\"AccordionPanel\",\"acco\",{id:\"accoId\"});});</script>",
+        		"<script id=\"accoId_s\" type=\"text/javascript\">$(window).on(\"load\",function(){PrimeFaces.cw(\"AccordionPanel\",\"acco\",{id:\"accoId\"});});</script>",
         		writer.toString());
     }
 


### PR DESCRIPTION
#3066 #3067 

https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed


can be verified by

1. http://localhost:8080/showcase/ui/multimedia/galleria.xhtml

2. http://localhost:8080/showcase/ui/multimedia/cropper.xhtml