### PR TITLE
Fix #3143 - InputText: focus on RTL still on left side

### DIFF
--- a/src/main/java-templates/org/primefaces/component/inputtext/InputTextTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/inputtext/InputTextTemplate.java
@@ -3,3 +3,7 @@
     public final static String MOBILE_STYLE_CLASS = "ui-input-text ui-body-inherit ui-corner-all ui-shadow-inset ui-input-has-clear";
     public final static String MOBILE_SEARCH_STYLE_CLASS = "ui-input-search ui-body-inherit ui-corner-all ui-shadow-inset ui-input-has-clear";
     public final static String MOBILE_CLEAR_ICON_CLASS = "ui-input-clear ui-btn ui-icon-delete ui-btn-icon-notext ui-corner-all ui-input-clear-hidden";
+
+    public boolean isRTL() {
+        return this.getDir().equalsIgnoreCase("rtl");
+    }

--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -75,7 +75,7 @@ public class InputTextRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
-        ComponentUtils.encodeDirection(context, inputText);
+        renderRTLDirection(context, inputText);
         renderPassThruAttributes(context, inputText, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputText, HTML.INPUT_TEXT_EVENTS);
 

--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -16,9 +16,11 @@
 package org.primefaces.component.inputtext;
 
 import java.io.IOException;
+
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
+
 import org.primefaces.context.RequestContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
@@ -73,6 +75,7 @@ public class InputTextRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
+        ComponentUtils.encodeDirection(context, inputText);
         renderPassThruAttributes(context, inputText, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputText, HTML.INPUT_TEXT_EVENTS);
 

--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -15,6 +15,7 @@
  */
 package org.primefaces.renderkit;
 
+import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,18 +23,30 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
+
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
 import javax.el.ValueExpression;
-import javax.faces.component.*;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
+import javax.faces.component.UISelectItem;
+import javax.faces.component.UISelectItems;
+import javax.faces.component.ValueHolder;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 import javax.faces.model.SelectItem;
 
+import org.primefaces.component.api.RTLAware;
 import org.primefaces.util.ComponentUtils;
 
 public abstract class InputRenderer extends CoreRenderer {
+
+    public <T extends UIComponent & RTLAware> void renderRTLDirection(FacesContext context, T component) throws IOException {
+        if (ComponentUtils.isRTL(context, component)) {
+            context.getResponseWriter().writeAttribute("dir", "rtl", null);
+        }
+    }
 
     protected List<SelectItem> getSelectItems(FacesContext context, UIInput component) {
         List<SelectItem> selectItems = new ArrayList<SelectItem>();

--- a/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -15,7 +15,6 @@
  */
 package org.primefaces.util;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -602,11 +601,5 @@ public class ComponentUtils {
             return false;
         }
         return object1.equals(object2);
-    }
-    
-    public static <T extends UIComponent & RTLAware> void encodeDirection(FacesContext context, T component) throws IOException {
-        if (isRTL(context, component)) {
-            context.getResponseWriter().writeAttribute("dir", "rtl", null);
-        }
     }
 }

--- a/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -15,6 +15,7 @@
  */
 package org.primefaces.util;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -601,5 +602,11 @@ public class ComponentUtils {
             return false;
         }
         return object1.equals(object2);
+    }
+    
+    public static <T extends UIComponent & RTLAware> void encodeDirection(FacesContext context, T component) throws IOException {
+        if (isRTL(context, component)) {
+            context.getResponseWriter().writeAttribute("dir", "rtl", null);
+        }
     }
 }

--- a/src/main/resources-maven-jsf/ui/inputText.xml
+++ b/src/main/resources-maven-jsf/ui/inputText.xml
@@ -20,6 +20,9 @@
         <interface>
             <name>org.primefaces.component.api.Widget</name>
         </interface>
+        <interface>
+            <name>org.primefaces.component.api.RTLAware</name>
+        </interface>
     </interfaces>
     <attributes>
         &input_component_attributes;


### PR DESCRIPTION
I decided to put the method `encodeDirection` in `ComponentUtils` as it is a utility method. I could have write that in `CoreRenderer` too, but since most of the `CoreRenderer` component are not `RTLAware` I thought it gives more sense to put it in `ComponentUtils`. Let me know what do you think