### PR TITLE
Escape option to pconfirm

### DIFF
--- a/src/main/java/org/primefaces/behavior/confirm/ConfirmBehavior.java
+++ b/src/main/java/org/primefaces/behavior/confirm/ConfirmBehavior.java
@@ -32,7 +32,8 @@ public class ConfirmBehavior extends AbstractBehavior {
         message(String.class),
         icon(String.class),
         disabled(Boolean.class),
-        beforeShow(String.class);
+        beforeShow(String.class),
+        escape(Boolean.class);
 
         public final Class<?> expectedType;
 
@@ -53,15 +54,17 @@ public class ConfirmBehavior extends AbstractBehavior {
         String headerText = JSONObject.quote(this.getHeader());
         String messageText = JSONObject.quote(this.getMessage());
         String beforeShow = JSONObject.quote(this.getBeforeShow());
-
+        String escape = JSONObject.quote(String.valueOf(this.isEscape()));
+        
         if (component instanceof Confirmable) {
             String sourceProperty = (source == null) ? "source:this" : "source:\"" + source + "\"";
             String script = "PrimeFaces.confirm({" + sourceProperty
-                    + ",header:" + headerText
-                    + ",message:" + messageText
-                    + ",icon:\"" + getIcon()
-                    + "\",beforeShow:" + beforeShow
-                    + "});return false;";
+                                                   + ",escape:" + escape
+                                                   + ",header:" + headerText
+                                                   + ",message:" + messageText
+                                                   + ",icon:\"" + getIcon()
+                                                   + "\",beforeShow:" + beforeShow
+                                                   + "});return false;";
             ((Confirmable) component).setConfirmationScript(script);
 
             return null;
@@ -112,7 +115,16 @@ public class ConfirmBehavior extends AbstractBehavior {
     public String getBeforeShow() {
         return eval(PropertyKeys.beforeShow, null);
     }
+
     public void setBeforeShow(String beforeShow) {
         setLiteral(PropertyKeys.beforeShow, beforeShow);
+    }
+
+    public boolean isEscape() {
+        return eval(PropertyKeys.escape, Boolean.FALSE);
+    }
+
+    public void setEscape(boolean escape) {
+        setLiteral(PropertyKeys.escape, escape);
     }
 }

--- a/src/main/java/org/primefaces/behavior/confirm/ConfirmBehaviorHandler.java
+++ b/src/main/java/org/primefaces/behavior/confirm/ConfirmBehaviorHandler.java
@@ -29,6 +29,7 @@ public class ConfirmBehaviorHandler extends AbstractBehaviorHandler<ConfirmBehav
     private final TagAttribute icon;
     private final TagAttribute disabled;
     private final TagAttribute beforeShow;
+    private final TagAttribute escape;
 
     public ConfirmBehaviorHandler(BehaviorConfig config) {
         super(config);
@@ -37,6 +38,7 @@ public class ConfirmBehaviorHandler extends AbstractBehaviorHandler<ConfirmBehav
         this.icon = this.getAttribute(ConfirmBehavior.PropertyKeys.icon.name());
         this.disabled = this.getAttribute(ConfirmBehavior.PropertyKeys.disabled.name());
         this.beforeShow = this.getAttribute(ConfirmBehavior.PropertyKeys.beforeShow.name());
+        this.escape = this.getAttribute(ConfirmBehavior.PropertyKeys.escape.name());
     }
 
     @Override
@@ -49,6 +51,7 @@ public class ConfirmBehaviorHandler extends AbstractBehaviorHandler<ConfirmBehav
         setBehaviorAttribute(ctx, behavior, this.icon, ConfirmBehavior.PropertyKeys.icon.expectedType);
         setBehaviorAttribute(ctx, behavior, this.disabled, ConfirmBehavior.PropertyKeys.disabled.expectedType);
         setBehaviorAttribute(ctx, behavior, this.beforeShow, ConfirmBehavior.PropertyKeys.beforeShow.expectedType);
+        setBehaviorAttribute(ctx, behavior, this.escape, ConfirmBehavior.PropertyKeys.escape.expectedType);
 
         return behavior;
     }

--- a/src/main/resources-maven-jsf/standard-facelets-taglib.xml
+++ b/src/main/resources-maven-jsf/standard-facelets-taglib.xml
@@ -372,6 +372,12 @@
         <required>false</required>
         <type>java.lang.Boolean</type>
     </attribute>
+    <attribute>
+        <description>Escape the message attribute.</description>
+        <name>escape</name>
+        <required>false</required>
+        <type>java.lang.Boolean</type>
+    </attribute>
 </tag>
 
 <tag>

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -740,8 +740,13 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
         if(msg.header)
             this.title.text(msg.header);
 
-        if(msg.message)
-            this.message.text(msg.message);
+        if(msg.message){
+            if (msg.escape == "false"){
+            	this.message.html(msg.message);
+            }else{
+            	this.message.text(msg.message);
+            }
+        }
 
         this.show();
     }


### PR DESCRIPTION
As discussed in the issue #60 and in this thread https://forum.primefaces.org/viewtopic.php?f=3&t=53195&p=161912

@melloware asked me to create a pull request with the fix I did. So here it is.

The default value of the escape option will be false.
Sorry for the confusion, previous pull request I missed the change on standard-facelets-taglib.xml which I added in this one.