### PR TITLE
Fix #3279 - Inplace: wrong style buttons

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inplace/inplace.css
+++ b/src/main/resources/META-INF/resources/primefaces/inplace/inplace.css
@@ -2,4 +2,3 @@
 .ui-inplace .ui-inplace-disabled {cursor: default;}
 .ui-inplace .ui-inplace-content {}
 .ui-inplace .ui-inplace-editor {margin-left:0.1em;}
-.ui-inplace .ui-inplace-editor .ui-button-icon-only .ui-button-text {padding:0}


### PR DESCRIPTION
@tandraschko @jxmai @melloware @mertsincan  Let me know what you think about this new "style"
![image](https://user-images.githubusercontent.com/7521311/35780858-573fa9ee-09e2-11e8-9f5b-f17a79c174e1.png)

It looks like before that, it was done on purpose but this style always interrogate me... I'd like to keep it as the picture above shows as it is compliant with `p:button` showing only icon