### PR TITLE
Fix for PF issue #3285. Use panel's offsetWidth and offsetHeight to m…

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
+++ b/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
@@ -159,9 +159,9 @@ PrimeFaces.widget.ColumnToggler = PrimeFaces.widget.DeferredWidget.extend({
             //hide the panel and remove focus from label
             var offset = $this.panel.offset();
             if(e.pageX < offset.left ||
-                e.pageX > offset.left + $this.panel.width() ||
+                e.pageX > offset.left + $this.panel[0].offsetWidth ||
                 e.pageY < offset.top ||
-                e.pageY > offset.top + $this.panel.height()) {
+                e.pageY > offset.top + $this.panel[0].offsetHeight) {
 
                 $this.hide();
             }


### PR DESCRIPTION
Use panel's offsetWidth and offsetHeight to measure the Datatable column toggler panel.