### PR TITLE
fixes #3290

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -6,4 +6,5 @@
 
 <suppressions>
     <suppress files="[\\/]generated-sources[\\/]" checks="[a-zA-Z0-9]*"/>
+    <suppress files="BoundedInputStream\.java"  checks="[a-zA-Z0-9]*"/>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,9 @@
                     <includes>
                         <include>src/main/java/**</include>
                     </includes>
+                    <excludes>
+                        <exclude>**/BoundedInputStream.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/org/primefaces/component/fileupload/CommonsFileUploadDecoder.java
+++ b/src/main/java/org/primefaces/component/fileupload/CommonsFileUploadDecoder.java
@@ -15,13 +15,14 @@
  */
 package org.primefaces.component.fileupload;
 
-import javax.faces.context.FacesContext;
-import javax.servlet.ServletRequestWrapper;
 import org.apache.commons.fileupload.FileItem;
 import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.DefaultUploadedFile;
 import org.primefaces.model.UploadedFileWrapper;
 import org.primefaces.webapp.MultipartRequest;
+
+import javax.faces.context.FacesContext;
+import javax.servlet.ServletRequestWrapper;
 
 public class CommonsFileUploadDecoder {
 
@@ -53,11 +54,11 @@ public class CommonsFileUploadDecoder {
         FileItem file = request.getFileItem(inputToDecodeId);
 
         if (file != null) {
-            if (file.getName().isEmpty()) {
-                fileUpload.setSubmittedValue("");
+            if (!file.getName().isEmpty() && isValidFile(fileUpload, file)) {
+                fileUpload.setSubmittedValue(new UploadedFileWrapper(new DefaultUploadedFile(file, fileUpload)));
             }
             else {
-                fileUpload.setSubmittedValue(new UploadedFileWrapper(new DefaultUploadedFile(file)));
+                fileUpload.setSubmittedValue("");
             }
         }
     }
@@ -66,8 +67,14 @@ public class CommonsFileUploadDecoder {
         String clientId = fileUpload.getClientId(context);
         FileItem file = request.getFileItem(clientId);
 
-        if (file != null) {
-            fileUpload.queueEvent(new FileUploadEvent(fileUpload, new DefaultUploadedFile(file)));
+        if (file != null && isValidFile(fileUpload, file)) {
+            fileUpload.queueEvent(new FileUploadEvent(fileUpload, new DefaultUploadedFile(file, fileUpload)));
         }
     }
+
+    private static boolean isValidFile(FileUpload fileUpload, FileItem fileItem) {
+        // TODO some more checks could be performed here, e.g. allowed types
+        return fileUpload.getSizeLimit() == null || fileItem.getSize() <= fileUpload.getSizeLimit();
+    }
+
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -90,10 +90,10 @@ public class FileUploadRenderer extends CoreRenderer {
                     .attr("process", SearchExpressionFacade.resolveClientIds(context, fileUpload, process), null)
                     .attr("maxFileSize", fileUpload.getSizeLimit(), Long.MAX_VALUE)
                     .attr("fileLimit", fileUpload.getFileLimit(), Integer.MAX_VALUE)
-                    .attr("invalidFileMessage", fileUpload.getInvalidFileMessage(), null)
-                    .attr("invalidSizeMessage", fileUpload.getInvalidSizeMessage(), null)
-                    .attr("fileLimitMessage", fileUpload.getFileLimitMessage(), null)
-                    .attr("messageTemplate", fileUpload.getMessageTemplate(), null)
+                    .attr("invalidFileMessage", escapeText(fileUpload.getInvalidFileMessage()), null)
+                    .attr("invalidSizeMessage", escapeText(fileUpload.getInvalidSizeMessage()), null)
+                    .attr("fileLimitMessage", escapeText(fileUpload.getFileLimitMessage()), null)
+                    .attr("messageTemplate", escapeText(fileUpload.getMessageTemplate()), null)
                     .attr("previewWidth", fileUpload.getPreviewWidth(), 80)
                     .attr("disabled", fileUpload.isDisabled(), false)
                     .attr("sequentialUploads", fileUpload.isSequential(), false)
@@ -109,7 +109,9 @@ public class FileUploadRenderer extends CoreRenderer {
         }
         else {
             wb.init("SimpleFileUpload", fileUpload.resolveWidgetVar(), clientId)
-                    .attr("skinSimple", fileUpload.isSkinSimple(), false);
+                    .attr("skinSimple", fileUpload.isSkinSimple(), false)
+                    .attr("maxFileSize", fileUpload.getSizeLimit(), Long.MAX_VALUE)
+                    .attr("invalidSizeMessage", escapeText(fileUpload.getInvalidSizeMessage()), null);
         }
 
         wb.finish();

--- a/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
+++ b/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
@@ -51,8 +51,8 @@ public class NativeFileUploadDecoder {
 
         Part part = request.getPart(inputToDecodeId);
 
-        if (part != null) {
-            fileUpload.setSubmittedValue(new UploadedFileWrapper(new NativeUploadedFile(part)));
+        if (part != null && isValidFile(fileUpload, part)) {
+            fileUpload.setSubmittedValue(new UploadedFileWrapper(new NativeUploadedFile(part, fileUpload)));
         }
         else {
             fileUpload.setSubmittedValue("");
@@ -63,9 +63,14 @@ public class NativeFileUploadDecoder {
         String clientId = fileUpload.getClientId(context);
         Part part = request.getPart(clientId);
 
-        if (part != null) {
-            fileUpload.queueEvent(new FileUploadEvent(fileUpload, new NativeUploadedFile(part)));
+        if (part != null && isValidFile(fileUpload, part)) {
+            fileUpload.queueEvent(new FileUploadEvent(fileUpload, new NativeUploadedFile(part, fileUpload)));
         }
+    }
+
+    private static boolean isValidFile(FileUpload fileUpload, Part part) {
+        // TODO some more checks could be performed here, e.g. allowed types
+        return fileUpload.getSizeLimit() == null || part.getSize() <= fileUpload.getSizeLimit();
     }
 
 }

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -36,10 +36,10 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.convert.ConverterException;
 import javax.imageio.ImageIO;
 
-import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.model.CroppedImage;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
+import org.primefaces.util.BoundedInputStream;
 
 public class ImageCropperRenderer extends CoreRenderer {
 

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -36,6 +36,7 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.convert.ConverterException;
 import javax.imageio.ImageIO;
 
+import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.model.CroppedImage;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.WidgetBuilder;
@@ -183,6 +184,11 @@ public class ImageCropperRenderer extends CoreRenderer {
                 }
             }
 
+            // wrap input stream by BoundedInputStream to prevent uncontrolled resource consumption (#3286)
+            if (cropper.getSizeLimit() != null) {
+                inputStream = new BoundedInputStream(inputStream, cropper.getSizeLimit());
+            }
+            
             BufferedImage outputImage = ImageIO.read(inputStream);
             inputStream.close();
 

--- a/src/main/java/org/primefaces/model/DefaultUploadedFile.java
+++ b/src/main/java/org/primefaces/model/DefaultUploadedFile.java
@@ -21,8 +21,8 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.component.fileupload.FileUpload;
+import org.primefaces.util.BoundedInputStream;
 
 /**
  *

--- a/src/main/java/org/primefaces/model/DefaultUploadedFile.java
+++ b/src/main/java/org/primefaces/model/DefaultUploadedFile.java
@@ -21,6 +21,8 @@ import java.io.InputStream;
 import java.io.Serializable;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.primefaces.component.fileupload.FileUpload;
 
 /**
  *
@@ -29,12 +31,14 @@ import org.apache.commons.fileupload.FileItem;
 public class DefaultUploadedFile implements UploadedFile, Serializable {
 
     private FileItem fileItem;
-
+    private Long sizeLimit;
+    
     public DefaultUploadedFile() {
     }
 
-    public DefaultUploadedFile(FileItem fileItem) {
+    public DefaultUploadedFile(FileItem fileItem, FileUpload fileUpload) {
         this.fileItem = fileItem;
+        this.sizeLimit = fileUpload.getSizeLimit();
     }
 
     public String getFileName() {
@@ -42,7 +46,7 @@ public class DefaultUploadedFile implements UploadedFile, Serializable {
     }
 
     public InputStream getInputstream() throws IOException {
-        return fileItem.getInputStream();
+        return sizeLimit == null ? fileItem.getInputStream() : new BoundedInputStream(fileItem.getInputStream(), sizeLimit);
     }
 
     public long getSize() {

--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -15,6 +15,9 @@
  */
 package org.primefaces.model;
 
+import org.apache.commons.io.input.BoundedInputStream;
+import org.primefaces.component.fileupload.FileUpload;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,13 +35,15 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
     private Part part;
     private String filename;
     private byte[] cachedContent;
+    private Long sizeLimit;
 
     public NativeUploadedFile() {
     }
 
-    public NativeUploadedFile(Part part) {
+    public NativeUploadedFile(Part part, FileUpload fileUpload) {
         this.part = part;
         this.filename = resolveFilename(part);
+        this.sizeLimit = fileUpload.getSizeLimit();
     }
 
     public String getFileName() {
@@ -46,7 +51,7 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
     }
 
     public InputStream getInputstream() throws IOException {
-        return part.getInputStream();
+        return sizeLimit == null ? part.getInputStream() : new BoundedInputStream(part.getInputStream(), sizeLimit);
     }
 
     public long getSize() {

--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -15,8 +15,8 @@
  */
 package org.primefaces.model;
 
-import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.component.fileupload.FileUpload;
+import org.primefaces.util.BoundedInputStream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/org/primefaces/util/BoundedInputStream.java
+++ b/src/main/java/org/primefaces/util/BoundedInputStream.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This is a stream that will only supply bytes up to a certain length - if its
+ * position goes above that, it will stop.
+ * <p>
+ * This is useful to wrap ServletInputStreams. The ServletInputStream will block
+ * if you try to read content from it that isn't there, because it doesn't know
+ * whether the content hasn't arrived yet or whether the content has finished.
+ * So, one of these, initialized with the Content-length sent in the
+ * ServletInputStream's header, will stop it blocking, providing it's been sent
+ * with a correct content length.
+ *
+ * @since 2.0
+ */
+public class BoundedInputStream extends InputStream {
+
+    // changed by PrimeFaces: copied from org.apache.commons.io.IOUtils.EOF
+    private static final int EOF = -1;
+    
+    /** the wrapped input stream */
+    private final InputStream in;
+
+    /** the max length to provide */
+    private final long max;
+
+    /** the number of bytes already returned */
+    private long pos = 0;
+
+    /** the marked position */
+    private long mark = EOF; 
+
+    /** flag if close should be propagated */
+    private boolean propagateClose = true;
+
+    /**
+     * Creates a new <code>BoundedInputStream</code> that wraps the given input
+     * stream and limits it to a certain size.
+     *
+     * @param in The wrapped input stream
+     * @param size The maximum number of bytes to return
+     */
+    public BoundedInputStream(final InputStream in, final long size) {
+        // Some badly designed methods - eg the servlet API - overload length
+        // such that "-1" means stream finished
+        this.max = size;
+        this.in = in;
+    }
+
+    /**
+     * Creates a new <code>BoundedInputStream</code> that wraps the given input
+     * stream and is unlimited.
+     *
+     * @param in The wrapped input stream
+     */
+    public BoundedInputStream(final InputStream in) {
+        this(in, EOF);
+    }
+
+    /**
+     * Invokes the delegate's <code>read()</code> method if
+     * the current position is less than the limit.
+     * @return the byte read or -1 if the end of stream or
+     * the limit has been reached.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read() throws IOException {
+        if (max >= 0 && pos >= max) {
+            return EOF;
+        }
+        final int result = in.read();
+        pos++;
+        return result;
+    }
+
+    /**
+     * Invokes the delegate's <code>read(byte[])</code> method.
+     * @param b the buffer to read the bytes into
+     * @return the number of bytes read or -1 if the end of stream or
+     * the limit has been reached.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return this.read(b, 0, b.length);
+    }
+
+    /**
+     * Invokes the delegate's <code>read(byte[], int, int)</code> method.
+     * @param b the buffer to read the bytes into
+     * @param off The start offset
+     * @param len The number of bytes to read
+     * @return the number of bytes read or -1 if the end of stream or
+     * the limit has been reached.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (max>=0 && pos>=max) {
+            return EOF;
+        }
+        final long maxRead = max>=0 ? Math.min(len, max-pos) : len;
+        final int bytesRead = in.read(b, off, (int)maxRead);
+
+        if (bytesRead==EOF) {
+            return EOF;
+        }
+
+        pos+=bytesRead;
+        return bytesRead;
+    }
+
+    /**
+     * Invokes the delegate's <code>skip(long)</code> method.
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public long skip(final long n) throws IOException {
+        final long toSkip = max>=0 ? Math.min(n, max-pos) : n;
+        final long skippedBytes = in.skip(toSkip);
+        pos+=skippedBytes;
+        return skippedBytes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int available() throws IOException {
+        if (max>=0 && pos>=max) {
+            return 0;
+        }
+        return in.available();
+    }
+
+    /**
+     * Invokes the delegate's <code>toString()</code> method.
+     * @return the delegate's <code>toString()</code>
+     */
+    @Override
+    public String toString() {
+        return in.toString();
+    }
+
+    /**
+     * Invokes the delegate's <code>close()</code> method
+     * if {@link #isPropagateClose()} is {@code true}.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public void close() throws IOException {
+        if (propagateClose) {
+            in.close();
+        }
+    }
+
+    /**
+     * Invokes the delegate's <code>reset()</code> method.
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    public synchronized void reset() throws IOException {
+        in.reset();
+        pos = mark;
+    }
+
+    /**
+     * Invokes the delegate's <code>mark(int)</code> method.
+     * @param readlimit read ahead limit
+     */
+    @Override
+    public synchronized void mark(final int readlimit) {
+        in.mark(readlimit);
+        mark = pos;
+    }
+
+    /**
+     * Invokes the delegate's <code>markSupported()</code> method.
+     * @return true if mark is supported, otherwise false
+     */
+    @Override
+    public boolean markSupported() {
+        return in.markSupported();
+    }
+
+    /**
+     * Indicates whether the {@link #close()} method
+     * should propagate to the underling {@link InputStream}.
+     *
+     * @return {@code true} if calling {@link #close()}
+     * propagates to the <code>close()</code> method of the
+     * underlying stream or {@code false} if it does not.
+     */
+    public boolean isPropagateClose() {
+        return propagateClose;
+    }
+
+    /**
+     * Set whether the {@link #close()} method
+     * should propagate to the underling {@link InputStream}.
+     *
+     * @param propagateClose {@code true} if calling
+     * {@link #close()} propagates to the <code>close()</code>
+     * method of the underlying stream or
+     * {@code false} if it does not.
+     */
+    public void setPropagateClose(final boolean propagateClose) {
+        this.propagateClose = propagateClose;
+    }
+}

--- a/src/main/resources-maven-jsf/ui/imageCropper.xml
+++ b/src/main/resources-maven-jsf/ui/imageCropper.xml
@@ -87,6 +87,13 @@
             <defaultValue>0</defaultValue>
             <description>Maximum box height of the cropping area.</description>
         </attribute>
+        <attribute>
+            <name>sizeLimit</name>
+            <required>false</required>
+            <type>java.lang.Long</type>
+            <defaultValue>10485760</defaultValue>
+            <description>Maximum number of bytes the image may consist of. Default is 10MB.</description>
+        </attribute>
     </attributes>
     <resources>
         <resource>

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
@@ -464,6 +464,9 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
     init: function(cfg) {
         this._super(cfg);
 
+        this.cfg.invalidSizeMessage = this.cfg.invalidSizeMessage || 'Invalid file size';
+        this.maxFileSize = this.cfg.maxFileSize;
+        
         if(this.cfg.skinSimple) {
             this.button = this.jq.children('.ui-button');
             this.input = $(this.jqId + '_input');
@@ -498,8 +501,14 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
         });
 
         this.input.on('change.fileupload', function() {
-            var filename = PrimeFaces.escapeHTML($this.input.val().replace(/\\/g, '/').replace(/.*\//, ''));
-            $this.display.text(filename);
+            var files = $this.input[0].files;
+            var file = files.length > 0 ? files[files.length - 1] : null;
+            var validMsg = $this.validate($this.input[0], file); 
+            if(validMsg) {
+                $this.display.text(PrimeFaces.escapeHTML(validMsg));
+            } else {
+                $this.display.text(PrimeFaces.escapeHTML($this.input.val().replace(/\\/g, '/').replace(/.*\//, '')));
+            }
         })
         .on('focus.fileupload', function() {
             $this.button.addClass('ui-state-focus');
@@ -508,6 +517,16 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
             $this.button.removeClass('ui-state-focus');
         });
 
+    },
+    
+    validate: function(input, file) {
+        var $this = this;
+        
+        if(file && $this.cfg.maxFileSize && file.size > $this.cfg.maxFileSize) {
+            $(input).replaceWith($(input).val('').clone(true));
+            return $this.cfg.invalidSizeMessage;
+        }
+        return null;
     }
 
 });


### PR DESCRIPTION
- server side validation of `p:fileUpload sizeLimit` for both commons-fileupload and servlet 3.0 implementation
- `UploadedFile.getInputStream` now gets wrapped by `BoundedInputStream ` (commons-io) and therefore limits reading to sizeLimit
- client side validation in simple mode: `p:fileUpload mode="simple" skinSimple="true" `