### PR TITLE
Fix #3289: SelectOne correctly handle itemEscaped options.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -802,14 +802,14 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
 
             if (value === '&nbsp;') {
-                this.label.html(labelText);
+                this.label.text(labelText);
                 if (labelText != '&nbsp;') {
                    this.label.addClass('ui-state-disabled');
                 }
             }
             else {
                 this.label.removeClass('ui-state-disabled');
-                this.label.html(displayedLabel);
+                this.label.text(displayedLabel);
             }
         }
     },


### PR DESCRIPTION
This is caused by Jquery 3.0 handling .html() differently that previous version in PrimeFaces.  it sees html tags like `<Select one Value>` and automatically makes closing tags so it was making it `<select one value></select>`.

I switched to use .text() and everything is rendering correctly again.