### PR TITLE
fixes #3282 slider input validation

### DIFF
--- a/src/main/java-templates/org/primefaces/component/slider/SliderTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/slider/SliderTemplate.java
@@ -76,18 +76,20 @@ import org.primefaces.util.MessageFactory;
                 String valueToStr = getSubmittedValue(inputTo).toString();
                 double valueFrom = Double.valueOf(valueFromStr);
                 double valueTo = Double.valueOf(valueToStr);
-                if (valueFrom < this.getMinValue() || valueFrom > this.getMaxValue()) {
-                    this.setValid(false);
-                    inputFrom.setValid(false);
-                }
-                if (valueTo > this.getMaxValue() || valueTo < this.getMinValue()) {
-                    this.setValid(false);
-                    inputTo.setValid(false);
-                }
                 if (valueTo < valueFrom) {
                     this.setValid(false);
                     inputFrom.setValid(false);
                     inputTo.setValid(false);
+                }
+                else {
+                    if (valueFrom < this.getMinValue() || valueFrom > this.getMaxValue()) {
+                        this.setValid(false);
+                        inputFrom.setValid(false);
+                    }
+                    if (valueTo > this.getMaxValue() || valueTo < this.getMinValue()) {
+                        this.setValid(false);
+                        inputTo.setValid(false);
+                    }
                 }
             }
             else {

--- a/src/main/java-templates/org/primefaces/component/slider/SliderTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/slider/SliderTemplate.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.HashMap;
 import javax.faces.event.PhaseId;
 import javax.faces.event.BehaviorEvent;
+import org.primefaces.expression.SearchExpressionFacade;
+import javax.faces.application.FacesMessage;
+import org.primefaces.util.MessageFactory;
 
 
     private final static String DEFAULT_EVENT = "slideEnd";
@@ -56,4 +59,61 @@ import javax.faces.event.BehaviorEvent;
         else {
             super.queueEvent(event);
         }
+    }
+
+    public final static String VALUE_OUT_OF_RANGE = "primefaces.slider.OUT_OF_RANGE";
+
+    @Override
+    public void validate(FacesContext context) {
+        super.validate(context);
+        
+        if(isValid()) {
+            String[] inputIds = this.getFor().split(",");
+            if (this.isRange()) {
+                UIInput inputFrom = (UIInput) SearchExpressionFacade.resolveComponent(context, this, inputIds[0].trim());
+                UIInput inputTo = (UIInput) SearchExpressionFacade.resolveComponent(context, this, inputIds[1].trim());
+                String valueFromStr = getSubmittedValue(inputFrom).toString();
+                String valueToStr = getSubmittedValue(inputTo).toString();
+                double valueFrom = Double.valueOf(valueFromStr);
+                double valueTo = Double.valueOf(valueToStr);
+                if (valueFrom < this.getMinValue() || valueFrom > this.getMaxValue()) {
+                    this.setValid(false);
+                    inputFrom.setValid(false);
+                }
+                if (valueTo > this.getMaxValue() || valueTo < this.getMinValue()) {
+                    this.setValid(false);
+                    inputTo.setValid(false);
+                }
+                if (valueTo < valueFrom) {
+                    this.setValid(false);
+                    inputFrom.setValid(false);
+                    inputTo.setValid(false);
+                }
+            }
+            else {
+                UIInput input = (UIInput) SearchExpressionFacade.resolveComponent(context, this, inputIds[0].trim());
+                String valueStr = getSubmittedValue(input).toString();
+                double value = Double.valueOf(valueStr);
+                if (value < this.getMinValue() || value > this.getMaxValue()) {
+                    this.setValid(false);
+                    input.setValid(false);
+                }
+            }
+
+            if (!isValid()) {
+                String validatorMessage = getValidatorMessage();
+                FacesMessage msg = null;
+                if (validatorMessage != null) {
+                    msg = new FacesMessage(FacesMessage.SEVERITY_ERROR, validatorMessage, validatorMessage);
+                }
+                else {
+                    msg = MessageFactory.getMessage(VALUE_OUT_OF_RANGE, FacesMessage.SEVERITY_ERROR, null);
+                }
+                context.addMessage(getClientId(context), msg);
+            }
+        }
+    }
+
+    private Object getSubmittedValue(UIInput input) {
+        return input.getSubmittedValue() == null && input.isLocalValueSet() ? input.getValue() : input.getSubmittedValue();
     }

--- a/src/main/resources-maven-jsf/ui/slider.xml
+++ b/src/main/resources-maven-jsf/ui/slider.xml
@@ -12,7 +12,7 @@
     <componentFamily>org.primefaces.component</componentFamily>
     <rendererType>org.primefaces.component.SliderRenderer</rendererType>
     <rendererClass>org.primefaces.component.slider.SliderRenderer</rendererClass>
-    <parent>javax.faces.component.UIComponentBase</parent>
+    <parent>javax.faces.component.UIInput</parent>
     <description>Slider is used to provide input with various customization options like orientation, display modes and skinning.</description>
     <interfaces>
         <interface>

--- a/src/main/resources/org/primefaces/Messages.properties
+++ b/src/main/resources/org/primefaces/Messages.properties
@@ -18,3 +18,4 @@ primefaces.datatable.SORT_LABEL = Sort
 primefaces.datatable.SORT_ASC = Ascending
 primefaces.datatable.SORT_DESC = Descending
 primefaces.rowgrouptoggler.aria.ROW_GROUP_TOGGLER = Toggle Row Group
+primefaces.slider.OUT_OF_RANGE = Validation Error: Value is out of range.

--- a/src/main/resources/org/primefaces/Messages_en.properties
+++ b/src/main/resources/org/primefaces/Messages_en.properties
@@ -18,3 +18,4 @@ primefaces.datatable.SORT_LABEL = Sort
 primefaces.datatable.SORT_ASC = Ascending
 primefaces.datatable.SORT_DESC = Descending
 primefaces.rowgrouptoggler.aria.ROW_GROUP_TOGGLER = Toggle Row Group
+primefaces.slider.OUT_OF_RANGE = Validation Error: Value is out of range.


### PR DESCRIPTION
- Range checks are performed in process validations phase, therefore the slider now extends `UIInput`
- if values are out of range a validation error will be thrown and the submitted values will be rejected
- tested with your showcase xhtml, as well range as simple slider seem to work correctly