### PR TITLE
fixes #3320 - min value of spinner broken

### DIFF
--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -53,7 +53,7 @@ public class SpinnerRenderer extends InputRenderer {
                 submittedValue = submittedValue.substring(0, (submittedValue.length() - suffix.length()));
             }
 
-            parsedSubmittedValue = Double.valueOf(submittedValue);
+            parsedSubmittedValue = Double.parseDouble(submittedValue);
             if (parsedSubmittedValue < spinner.getMin()) {
                 parsedSubmittedValue = spinner.getMin();
             }

--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -82,7 +82,7 @@ public class SpinnerRenderer extends InputRenderer {
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("Spinner", spinner.resolveWidgetVar(), clientId)
                 .attr("step", spinner.getStepFactor(), 1.0)
-                .attr("min", spinner.getMin(), Double.MIN_VALUE)
+                .attr("min", spinner.getMin(), -Double.MIN_VALUE)
                 .attr("max", spinner.getMax(), Double.MAX_VALUE)
                 .attr("prefix", spinner.getPrefix(), null)
                 .attr("suffix", spinner.getSuffix(), null)

--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -39,9 +39,12 @@ public class SpinnerRenderer extends InputRenderer {
         decodeBehaviors(context, spinner);
 
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(spinner.getClientId(context) + "_input");
+        if (submittedValue == null || submittedValue.isEmpty()) {
+            return;
+        }
         String prefix = spinner.getPrefix();
         String suffix = spinner.getSuffix();
-
+        double parsedSubmittedValue = spinner.getMin();
         try {
             if (prefix != null && submittedValue.startsWith(prefix)) {
                 submittedValue = submittedValue.substring(prefix.length());
@@ -50,19 +53,19 @@ public class SpinnerRenderer extends InputRenderer {
                 submittedValue = submittedValue.substring(0, (submittedValue.length() - suffix.length()));
             }
 
-            double parsedSubmittedValue = Double.parseDouble(submittedValue);
+            parsedSubmittedValue = Double.valueOf(submittedValue);
             if (parsedSubmittedValue < spinner.getMin()) {
-                submittedValue = String.valueOf(spinner.getMin());
+                parsedSubmittedValue = spinner.getMin();
             }
             else if (parsedSubmittedValue > spinner.getMax()) {
-                submittedValue = String.valueOf(spinner.getMax());
+                parsedSubmittedValue = spinner.getMax();
             }
         }
         catch (Exception e) {
-            submittedValue = String.valueOf(spinner.getMin());
+            parsedSubmittedValue = spinner.getMin();
         }
         finally {
-            spinner.setSubmittedValue(submittedValue);
+            spinner.setSubmittedValue(ComponentUtils.getConverter(context, spinner).getAsString(context, spinner, parsedSubmittedValue));
         }
     }
 

--- a/src/main/resources-maven-jsf/ui/spinner.xml
+++ b/src/main/resources-maven-jsf/ui/spinner.xml
@@ -39,8 +39,8 @@
             <name>min</name>
             <required>false</required>
             <type>java.lang.Double</type>
-            <defaultValue>0.0</defaultValue>
-            <description>Minimum boundary value. Default is 0.</description>
+            <defaultValue>-java.lang.Double.MIN_VALUE</defaultValue>
+            <description>Minimum boundary value. Default is min double value.</description>
         </attribute>
         <attribute>
             <name>max</name>

--- a/src/main/resources-maven-jsf/ui/spinner.xml
+++ b/src/main/resources-maven-jsf/ui/spinner.xml
@@ -39,8 +39,8 @@
             <name>min</name>
             <required>false</required>
             <type>java.lang.Double</type>
-            <defaultValue>java.lang.Double.MIN_VALUE</defaultValue>
-            <description>Minimum boundary value. Default is min double value.</description>
+            <defaultValue>0.0</defaultValue>
+            <description>Minimum boundary value. Default is 0.</description>
         </attribute>
         <attribute>
             <name>max</name>


### PR DESCRIPTION
- changed default `min ` value of spinner to `0.0`, since similar components use this as well, this is more consistent and solves some nasty bugs when dealing with `java.lang.Double.MIN_VALUE ` which is (contrary to my expectations) positive and would have been wrong before, if there were any range checks; negative numbers have to be allowed explicitly by specifying `min` attribute value
- another bug producing the message `must be a number consisting of one or more digits` happened when value was mapped to `Integer ` because the internal `double ` value was not converted back correctly