### PR TITLE
Use offsetHeight and offsetWidth instead of jQuery .height() and .width() functions to determine panel dimensions

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -334,9 +334,9 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             //hide the panel and remove focus from label
             var offset = $this.panel.offset();
             if(e.pageX < offset.left ||
-                e.pageX > offset.left + $this.panel.width() ||
+                e.pageX > offset.left + $this.panel[0].offsetWidth ||
                 e.pageY < offset.top ||
-                e.pageY > offset.top + $this.panel.height()) {
+                e.pageY > offset.top + $this.panel[0].offsetHeight) {
 
                 $this.hide(true);
             }

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -255,9 +255,9 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
 
             if (e.pageX < offset.left ||
-                e.pageX > offset.left + $this.panel.width() ||
+                e.pageX > offset.left + $this.panel[0].offsetWidth ||
                 e.pageY < offset.top ||
-                e.pageY > offset.top + $this.panel.height()) {
+                e.pageY > offset.top + $this.panel[0].offsetHeight) {
 
                 $this.hide();
 

--- a/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
@@ -280,9 +280,9 @@ PrimeFaces.widget.LightBox = PrimeFaces.widget.BaseWidget.extend({
             }
             
             if(pageX < offset.left ||
-                pageX > offset.left + $this.panel.width() ||
+                pageX > offset.left + $this.panel[0].offsetWidth ||
                 pageY < offset.top ||
-                pageY > offset.top + $this.panel.height()) {
+                pageY > offset.top + $this.panel[0].offsetHeight) {
 
                 e.preventDefault();
                 $this.hide();


### PR DESCRIPTION
As requested by @tandraschko in the comments of PR #3287 - investigate other places where offsetWidth and offsetHeight should be used instead of jQuery .height() and .width() functions.

According to jQuery 3.0 migration notes ( https://jquery.com/upgrade-guide/3.0/#breaking-change-width-height-css-quot-width-quot-and-css-quot-height-quot-can-return-non-integer-values ) the change to width() and height() functions may have introduced issues in calculations expecting the old pre 3.0 functionality. However it appears the alternate method to calculate dimensions changes more than just float vs integer return type.

I did not attempt to change all calls to height() and width() in the PF application, as that would have been well beyond my means to test. I did focus on the areas where the code was identical to the code fixed in PR #3287. In most cases, the variance was not as great, but there was still a meaningful variance in dimensions.
