### PR TITLE
Fix #3326: SelectOne displaying &nbsp; incorrectly.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -802,9 +802,11 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
 
             if (value === '&nbsp;') {
-                this.label.text(labelText);
                 if (labelText != '&nbsp;') {
+                   this.label.text(labelText);
                    this.label.addClass('ui-state-disabled');
+                } else {
+                    this.label.html(labelText);
                 }
             }
             else {


### PR DESCRIPTION
Looks like this was a Jquery 3.0 change as label.text('&nbsp;') used to work now it needs to be label.html('&nbsp;');