### PR TITLE
closes #3348 - replace easymock with mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,11 +160,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>3.5.1</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.15.0</version>
             <scope>test</scope>
-        </dependency>
+        </dependency>        
         <dependency>
             <groupId>de.odysseus.juel</groupId>
             <artifactId>juel-impl</artifactId>


### PR DESCRIPTION
- migrated EasyMock to Mockito for `InputNumberTest`
- benefits/differences at first glance:
    - mocks are 'nice' out of the box (e.g. empty collections are returned automatically)
    - `replace` call not needed
    - partial mocking is somewhat easier and more concise (`thenCallRealMethod`, `doCallRealMethod `or `spy`)
