### PR TITLE
Fix #3404 - filtered node preserves the original expanded state

### DIFF
--- a/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -1194,6 +1194,7 @@ public class TreeTableRenderer extends DataRenderer {
         }
 
         newNode.setSelected(node.isSelected());
+        newNode.setExpanded(node.isExpanded());
 
         return newNode;
     }


### PR DESCRIPTION
Fix #3404 