### PR TITLE
Fix #3466: SelectOneMenu escaping HTML in all scenarios.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -769,7 +769,12 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
             else {
                 this.label.removeClass('ui-state-disabled');
-                this.label.text(displayedLabel);
+                // prevent <select one> from being turned into <select></select>
+                if (displayedLabel.indexOf('</') !== -1 || displayedLabel.indexOf('/>') !== -1) {
+                    this.label.html(displayedLabel);
+                } else {
+                    this.label.text(displayedLabel);
+                }
             }
         }
     },


### PR DESCRIPTION
It was necessary to do the check for a closing </ tag /> to prevent the issue with Select One being turned into a closing "select" tag.