### PR TITLE
Fix #3457: Layout script output in incorrect place.

### DIFF
--- a/src/main/java/org/primefaces/component/layout/LayoutRenderer.java
+++ b/src/main/java/org/primefaces/component/layout/LayoutRenderer.java
@@ -38,8 +38,6 @@ public class LayoutRenderer extends CoreRenderer {
         Layout layout = (Layout) component;
         String clientId = layout.getClientId(context);
 
-        encodeScript(context, layout);
-
         if (layout.isElementLayout()) {
             writer.startElement("div", layout);
             writer.writeAttribute("id", clientId, "id");
@@ -57,6 +55,8 @@ public class LayoutRenderer extends CoreRenderer {
         if (layout.isElementLayout()) {
             writer.endElement("div");
         }
+        
+        encodeScript(context, layout);
     }
 
     protected void encodeScript(FacesContext context, Layout layout) throws IOException {


### PR DESCRIPTION
Wow this was tricky.  On ajax="false" update the script was being output before the DOM was built and this the Center Pane was missing.  I have no idea how this wasn't broken before!

I simply moved encodeScript() method to the encodeEnd() instead of encodeBegin() and it fixes it.  Much thanks to @GedMarc!