### PR TITLE
Fix #3486: TriStateCheckBox failsafe toggle() method.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
@@ -70,6 +70,10 @@ PrimeFaces.widget.TriStateCheckbox = PrimeFaces.widget.BaseWidget.extend({
 
     toggle:function (direction) {
         if (!this.disabled) {
+            // default to switch to next state
+            if (isNaN(direction)) {
+                direction = 1;
+            }
             var oldValue = parseInt(this.input.val());
             var newValue = this.fixedMod((oldValue + direction),3);
             this.input.val(newValue);


### PR DESCRIPTION
Fix #3486: TriStateCheckBox failsafe toggle() method.

Just added failsafe check so you can use toggle() or toggle(direction).  toggle() by default advances to the next state just like the documentation says.