### PR TITLE
Fix #3487: Keyboard support unicode characters.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/keyboard/keyboard.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyboard/keyboard.js
@@ -961,8 +961,8 @@ PrimeFaces.widget.KeyboardUtils = {
 	},
 
 	createLayoutFromTemplate : function(template) {
-	    // GitHub #3487: Unicode conversion
-	    template =  decodeURIComponent(JSON.parse('"' + template.replace(/\"/g, '\\"') + '"'));
+		// GitHub #3487: Unicode conversion
+		template =  decodeURIComponent(JSON.parse('"' + template.replace(/\"/g, '\\"') + '"'));
 		var lines = template.split(','),
 		template = new Array(lines.length);
 

--- a/src/main/resources/META-INF/resources/primefaces/keyboard/keyboard.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyboard/keyboard.js
@@ -961,6 +961,8 @@ PrimeFaces.widget.KeyboardUtils = {
 	},
 
 	createLayoutFromTemplate : function(template) {
+	    // GitHub #3487: Unicode conversion
+	    template =  decodeURIComponent(JSON.parse('"' + template.replace(/\"/g, '\\"') + '"'));
 		var lines = template.split(','),
 		template = new Array(lines.length);
 


### PR DESCRIPTION
Found a trick to convert the code to unicode https://stackoverflow.com/questions/7885096/how-do-i-decode-a-string-with-escaped-unicode

This may have been a Jquery change that this somehow worked in PF 6.1 but not in 6.2.  Either way the test case now passes.