### PR TITLE
Catch errors when resetting Google reCaptcha

### DIFF
--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -56,7 +56,7 @@ import org.primefaces.json.JSONObject;
             } finally {
             	// the captcha token is valid for only one request, in case of an ajax request we have to get a new one
 	        if(context.getPartialViewContext().isAjaxRequest()) {
-	            PrimeFaces.current().executeScript("try { grecaptcha.reset() } catch (error) { PrimeFaces.info('Could not reset grecaptcha, that is OK if there is no reCaptcha on the page.'); PrimeFaces.debug(error); }");
+	            PrimeFaces.current().executeScript("if (document.getElementById("g-recaptcha-response")) { try { grecaptcha.reset() } catch (error) { PrimeFaces.error(error); } }");
 	        }
 	    }
 

--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -56,7 +56,7 @@ import org.primefaces.json.JSONObject;
             } finally {
             	// the captcha token is valid for only one request, in case of an ajax request we have to get a new one
 	        if(context.getPartialViewContext().isAjaxRequest()) {
-	            PrimeFaces.current().executeScript("grecaptcha.reset()");
+	            PrimeFaces.current().executeScript("try { grecaptcha.reset() } catch (error) { PrimeFaces.info('Could not reset grecaptcha, that is OK if there is no reCaptcha on the page.'); PrimeFaces.debug(error); }");
 	        }
 	    }
 

--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -56,7 +56,7 @@ import org.primefaces.json.JSONObject;
             } finally {
             	// the captcha token is valid for only one request, in case of an ajax request we have to get a new one
 	        if(context.getPartialViewContext().isAjaxRequest()) {
-	            PrimeFaces.current().executeScript("if (document.getElementById("g-recaptcha-response")) { try { grecaptcha.reset() } catch (error) { PrimeFaces.error(error); } }");
+	            PrimeFaces.current().executeScript("if (document.getElementById("g-recaptcha-response")) { try { grecaptcha.reset(); } catch (error) { PrimeFaces.error(error); } }");
 	        }
 	    }
 

--- a/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
+++ b/src/main/java-templates/org/primefaces/component/captcha/CaptchaTemplate.java
@@ -56,7 +56,7 @@ import org.primefaces.json.JSONObject;
             } finally {
             	// the captcha token is valid for only one request, in case of an ajax request we have to get a new one
 	        if(context.getPartialViewContext().isAjaxRequest()) {
-	            PrimeFaces.current().executeScript("if (document.getElementById("g-recaptcha-response")) { try { grecaptcha.reset(); } catch (error) { PrimeFaces.error(error); } }");
+	            PrimeFaces.current().executeScript("if (document.getElementById('g-recaptcha-response')) { try { grecaptcha.reset(); } catch (error) { PrimeFaces.error(error); } }");
 	        }
 	    }
 


### PR DESCRIPTION
With the shutdown of reCaptcha API v1 the behaviour of the reset-function changed. If there is no p:captcha component on the page it will now throw an error and kill any subsequent javascript calls. This can be a problem if an ajax-request causes a forward or navigation to a new page where no captcha exists.

This change will catch the error and log it using PrimeFaces.info for a short information and PrimeFaces.debug if anyone is actually interested in the stack trace / error itself.

Issue for this PR will be created in a few minutes.