### PR TITLE
Change COMMON_EVENTS to OUTPUT_EVENTS

### DIFF
--- a/src/main/java/org/primefaces/component/link/LinkRenderer.java
+++ b/src/main/java/org/primefaces/component/link/LinkRenderer.java
@@ -61,7 +61,7 @@ public class LinkRenderer extends OutcomeTargetRenderer {
             writer.writeAttribute("href", targetURL, null);
             writer.writeAttribute("class", styleClass, "styleClass");
             renderPassThruAttributes(context, link, HTML.LINK_ATTRS_WITHOUT_EVENTS);
-            renderDomEvents(context, link, HTML.COMMON_EVENTS);
+            renderDomEvents(context, link, HTML.OUTPUT_EVENTS);
             renderContent(context, link);
             writer.endElement("a");
         }


### PR DESCRIPTION
Bring the actual capabilities of p:link up to par with the documentation (at least as far as onfocus and onblur is concerned).

PR for #3637