### PR TITLE
Fix #3625

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
+++ b/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
@@ -35,7 +35,13 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
             callback.apply(document, args);
         }
 
-        this.jq.children().hide().filter(this.jqId + '_' + event).show();
+        if (event !== 'complete' || this.jq.children().filter(this.toFacetId('complete')).length) {
+            this.jq.children().hide().filter(this.toFacetId(event)).show();
+        }
+    },
+
+    toFacetId: function(event) {
+        return this.jqId + '_' + event;
     },
 
     bindToStandard: function() {


### PR DESCRIPTION
Fix #3625 for the problem details.

f5a88de8768a9e6f1c5da6b276ac0ef3e68847b7 introduces the following change: When an ajax request completes the success and error facets are only hidden when a complete facet is present. Otherwise the success or error facet respectively will remain visible until a new ajax request is started.

Additionally to this change the documentation should be updated to reflect this imho .