### PR TITLE
Fix# 3477

### DIFF
--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -199,8 +199,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
 
     protected void encodeLabel(FacesContext context, SelectOneMenu menu, List<SelectItem> selectItems) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
-        String valueToRender = ComponentUtils.getValueToRender(context, menu);
-
+        
         if (menu.isEditable()) {
             writer.startElement("input", null);
             writer.writeAttribute("type", "text", null);
@@ -215,7 +214,13 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                 writer.writeAttribute("disabled", "disabled", null);
             }
 
+            String valueToRender = ComponentUtils.getValueToRender(context, menu);
             if (valueToRender != null) {
+                for (SelectItem anItem : selectItems) {
+                    if (isSelected(context, menu, valueToRender, anItem.getValue().toString(), null)) {
+                        valueToRender = anItem.getLabel();
+                    }
+                }
                 writer.writeAttribute("value", valueToRender, null);
             }
 


### PR DESCRIPTION
#3477 

Modify encodeLabel so that the label of the matching select item is presented as the input's value when the selectOneMenu is editable. If no match in select items, then the valueToRender will be displayed.