### PR TITLE
OutputLabelRenderer: Evaluate composite constraints

### DIFF
--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -167,8 +167,9 @@ public class OutputLabelRenderer extends CoreRenderer {
 
     protected boolean isBeanValidationDefined(UIInput input, FacesContext context) {
         try {
+            PrimeApplicationContext applicationContext = PrimeApplicationContext.getCurrentInstance(context);
             Set<ConstraintDescriptor<?>> constraints = BeanValidationMetadataExtractor.extractDefaultConstraintDescriptors(context,
-                    RequestContext.getCurrentInstance(context),
+                    applicationContext,
                     ValueExpressionAnalyzer.getExpression(context.getELContext(), input.getValueExpression("value")));
             if (constraints == null || constraints.isEmpty()) {
                 return false;

--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -179,7 +179,8 @@ public class OutputLabelRenderer extends CoreRenderer {
                     return true;
                 }
             }
-        } catch (PropertyNotFoundException e) {
+        } 
+        catch (PropertyNotFoundException e) {
             String message = "Skip evaluating [@NotNull,@NotBlank,@NotEmpty] for outputLabel and referenced component \"" + input.getClientId(context)
                         + "\" because the ValueExpression of the \"value\" attribute"
                         + " isn't resolvable completely (e.g. a sub-expression returns null)";

--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -181,8 +181,8 @@ public class OutputLabelRenderer extends CoreRenderer {
             }
         } catch (PropertyNotFoundException e) {
             String message = "Skip evaluating [@NotNull,@NotBlank,@NotEmpty] for outputLabel and referenced component \"" + input.getClientId(context)
-                    + "\" because the ValueExpression of the \"value\" attribute"
-                    + " isn't resolvable completely (e.g. a sub-expression returns null)";
+                        + "\" because the ValueExpression of the \"value\" attribute"
+                        + " isn't resolvable completely (e.g. a sub-expression returns null)";
             LOG.log(Level.FINE, message);
         }
 

--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -207,7 +207,7 @@ public class OutputLabelRenderer extends CoreRenderer {
         // Check composite constraints as well
         if (!isBeanValidation && constraintDescriptor.getComposingConstraints() != null) {
             for (ConstraintDescriptor<?> innerConstraintDescriptor : constraintDescriptor.getComposingConstraints()) {
-                isBeanValidation = isValidationAnnotation(context, innerConstraintDescriptor);
+                isBeanValidation = isValidationAnnotation(applicationContext, innerConstraintDescriptor);
                 if (isBeanValidation) {
                     break;
                 }

--- a/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -175,7 +175,7 @@ public class OutputLabelRenderer extends CoreRenderer {
                 return false;
             }
             for (ConstraintDescriptor<?> constraintDescriptor : constraints) {
-                if (isValidationAnnotation(context, constraintDescriptor)) {
+                if (isValidationAnnotation(applicationContext, constraintDescriptor)) {
                     return true;
                 }
             }
@@ -190,13 +190,13 @@ public class OutputLabelRenderer extends CoreRenderer {
         return false;
     }
 
-    protected boolean isValidationAnnotation(FacesContext context, ConstraintDescriptor<?> constraintDescriptor) {
+    protected boolean isValidationAnnotation(PrimeApplicationContext applicationContext, ConstraintDescriptor<?> constraintDescriptor) {
         boolean isBeanValidation = false;
 
         Class<? extends Annotation> annotationType = constraintDescriptor.getAnnotation().annotationType();
         // GitHub #14 skip @NotNull check
         if (annotationType.equals(NotNull.class)) {
-            isBeanValidation = RequestContext.getCurrentInstance(context).getApplicationContext().getConfig().isInterpretEmptyStringAsNull();
+            isBeanValidation = applicationContext.getConfig().isInterpretEmptyStringAsNull();
         }
         // GitHub #3052 @NotBlank,@NotEmpty Hibernate and BeanValidator 2.0
         String annotationClassName = annotationType.getSimpleName();


### PR DESCRIPTION
The current OutputLabelRenderer will look at the constraints directly added to the value property and will miss any constraint added as part of a composite constraint.

This PR will change the behaviour and also look at the composite constraints to check whether bean validation (or the required marker) should be set.

(The issue for this PR will follow later.)