### PR TITLE
Messages: Removed duplicate detail and summary from messages

### DIFF
--- a/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
+++ b/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
@@ -174,7 +174,11 @@ public class MessagesRenderer extends UINotificationRenderer {
             writer.writeAttribute("aria-atomic", "true", null);
 
             String summary = message.getSummary() != null ? message.getSummary() : "";
-            String detail = message.getDetail() != null ? message.getDetail() : summary;
+            String detail = message.getDetail() != null ? message.getDetail() : "";
+            
+            if (summary != null && summary.equals(detail)) {
+                detail = "";    
+            }
 
             if (uiMessages.isShowSummary()) {
                 writer.startElement("span", null);


### PR DESCRIPTION
When rendering messages, only show detail if it differs from the summary to avoid duplication of message content in detail view.

![image](https://user-images.githubusercontent.com/12007706/40450964-7555f7bc-5edd-11e8-8bc6-9d150812d0ea.png)
