### PR TITLE
Growl: Update growl not to show detail if it matches the content of summary

### DIFF
--- a/src/main/java/org/primefaces/component/growl/GrowlRenderer.java
+++ b/src/main/java/org/primefaces/component/growl/GrowlRenderer.java
@@ -96,6 +96,10 @@ public class GrowlRenderer extends UINotificationRenderer {
                 String summary = escapeText(message.getSummary());
                 String detail = escapeText(message.getDetail());
 
+                if (summary != null && summary.equals(detail)) {
+                    detail = "";    
+                }
+
                 writer.write("{");
 
                 if (growl.isShowSummary() && growl.isShowDetail()) {


### PR DESCRIPTION
When rendering messages, only show detail if it differs from the summary to avoid duplication of message content in detail view.

![image](https://user-images.githubusercontent.com/12007706/40450964-7555f7bc-5edd-11e8-8bc6-9d150812d0ea.png)
