### PR TITLE
Message: Only show detail if it actually differs from summary

### DIFF
--- a/src/main/java/org/primefaces/component/message/MessageRenderer.java
+++ b/src/main/java/org/primefaces/component/message/MessageRenderer.java
@@ -114,7 +114,7 @@ public class MessageRenderer extends UINotificationRenderer {
                     if (uiMessage.isShowSummary()) {
                         encodeText(writer, msg.getSummary(), severityKey + "-summary", escape);
                     }
-                    if (uiMessage.isShowDetail()) {
+                    if (uiMessage.isShowDetail() && msg.getSummary() != null && !msg.getSummary().equals(msg.getDetail())) {
                         encodeText(writer, msg.getDetail(), severityKey + "-detail", escape);
                     }
                 }


### PR DESCRIPTION
When rendering messages, only show detail if it differs from the summary to avoid duplication of message content in detail view.

![image](https://user-images.githubusercontent.com/12007706/40450964-7555f7bc-5edd-11e8-8bc6-9d150812d0ea.png)
