### PR TITLE
Messages, Message, Growl: Do not show duplicate values for summary and detail

### DIFF
--- a/src/main/java/org/primefaces/component/growl/GrowlRenderer.java
+++ b/src/main/java/org/primefaces/component/growl/GrowlRenderer.java
@@ -99,6 +99,11 @@ public class GrowlRenderer extends UINotificationRenderer {
                 writer.write("{");
 
                 if (growl.isShowSummary() && growl.isShowDetail()) {
+                    
+                    if (summary != null && summary.equals(detail)) {
+                        detail = "";   
+                    }
+                    
                     writer.writeText("summary:\"" + summary + "\",detail:\"" + detail + "\"", null);
                 }
                 else if (growl.isShowSummary() && !growl.isShowDetail()) {

--- a/src/main/java/org/primefaces/component/message/MessageRenderer.java
+++ b/src/main/java/org/primefaces/component/message/MessageRenderer.java
@@ -111,11 +111,24 @@ public class MessageRenderer extends UINotificationRenderer {
                 }
 
                 if (!iconOnly) {
+                    
                     if (uiMessage.isShowSummary()) {
                         encodeText(writer, msg.getSummary(), severityKey + "-summary", escape);
                     }
+
                     if (uiMessage.isShowDetail()) {
-                        encodeText(writer, msg.getDetail(), severityKey + "-detail", escape);
+                        boolean detailDifferentThanVisibleSummary = true;
+                        
+                        if (uiMessage.isShowSummary()) {
+                        
+                            if (msg.getSummary() != null && msg.getSummary().equals(msg.getDetail())) {
+                                detailDifferentThanVisibleSummary = false;
+                            }
+                        }
+
+                        if (detailDifferentThanVisibleSummary) {
+                            encodeText(writer, msg.getDetail(), severityKey + "-detail", escape);
+                        }
                     }
                 }
 

--- a/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
+++ b/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
@@ -175,6 +175,13 @@ public class MessagesRenderer extends UINotificationRenderer {
 
             String summary = message.getSummary() != null ? message.getSummary() : "";
             String detail = message.getDetail() != null ? message.getDetail() : summary;
+            
+            if (uiMessages.isShowSummary() && uiMessages.isShowDetail()) {
+                
+                if (summary.equals(detail)) {
+                    detail = "";   
+                }
+            }
 
             if (uiMessages.isShowSummary()) {
                 writer.startElement("span", null);


### PR DESCRIPTION
If summary and detail is visible, only display the summary content if the detail would have been exactly the same.

If only summary or only detail is visible, it should not be affected by this PR.

If the detail message differs from the summary, both should be displayed.