### PR TITLE
Add null check for clearer exception message

### DIFF
--- a/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -273,6 +273,9 @@ public class TreeTableRenderer extends DataRenderer {
         TreeNode root = tt.getValue();
         boolean hasPaginator = tt.isPaginator();
 
+        if (root == null) {
+            throw new FacesException("treeTable's value must be null");
+        }
         if (!(root instanceof TreeNode)) {
             throw new FacesException("treeTable's value must be an instance of " + TreeNode.class.getName());
         }


### PR DESCRIPTION
'null instanceof SomeClass' is false which leads to an error message
complaining about the value being of the the wrong type which is not the
case.