### PR TITLE
Fixes 3772 xss tristatecheckbox

### DIFF
--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -125,18 +125,18 @@ public class TriStateCheckboxRenderer extends InputRenderer {
         String stateTwoIconClass
                 = checkbox.getStateTwoIcon() != null ? TriStateCheckbox.UI_ICON + checkbox.getStateTwoIcon()
                 : TriStateCheckbox.UI_ICON + "ui-icon-check";
-        String stataThreeIconClass
+        String stateThreeIconClass
                 = checkbox.getStateThreeIcon() != null ? TriStateCheckbox.UI_ICON + checkbox.getStateThreeIcon()
                 : TriStateCheckbox.UI_ICON + "ui-icon-closethick";
 
-        String statesIconsClasses = "[\"" + stateOneIconClass + "\",\"" + stateTwoIconClass + "\",\"" + stataThreeIconClass + "\"]";
+        String statesIconsClasses = "[\"" + stateOneIconClass + "\",\"" + stateTwoIconClass + "\",\"" + stateThreeIconClass + "\"]";
 
         String stateOneTitle = checkbox.getStateOneTitle() == null ? "" : checkbox.getStateOneTitle();
         String stateTwoTitle = checkbox.getStateTwoTitle() == null ? "" : checkbox.getStateTwoTitle();
         String stateThreeTitle = checkbox.getStateThreeTitle() == null ? "" : checkbox.getStateThreeTitle();
 
-        String statesTitles = "[\"" + stateOneTitle + "\",\""
-                + stateTwoTitle + "\",\"" + stateThreeTitle + "\"]";
+        String statesTitles = "{\"titles\": [\"" + escapeText(stateOneTitle) + "\",\"" + escapeText(stateTwoTitle) + "\",\"" + 
+                escapeText(stateThreeTitle) + "\"]}";
 
         String iconClass = "ui-chkbox-icon ui-c"; //HTML.CHECKBOX_ICON_CLASS;
         String activeTitle = "";
@@ -149,28 +149,22 @@ public class TriStateCheckboxRenderer extends InputRenderer {
             activeTitle = stateTwoTitle;
         }
         else if (valCheck == 2) {
-            iconClass = iconClass + " " + stataThreeIconClass;
+            iconClass = iconClass + " " + stateThreeIconClass;
             activeTitle = stateThreeTitle;
         }
 
-        String dataTitles = "";
-        String titleAtt = "";
-
+        writer.startElement("div", null);
+        writer.writeAttribute("tabIndex", checkbox.getTabindex() == null ? 0 : checkbox.getTabindex(), "tabindex");
+        writer.writeAttribute("class", styleClass, null);
+        writer.writeAttribute("data-iconstates", statesIconsClasses, null);
         if (!LangUtils.isValueBlank(stateOneTitle) || !LangUtils.isValueBlank(stateTwoTitle) || !LangUtils.isValueBlank(stateThreeTitle)) {
-            dataTitles = "data-titlestates='" + statesTitles + "' ";
-            titleAtt = " title=\"" + activeTitle + "\" ";
+            writer.writeAttribute("title", activeTitle, null);
+            writer.writeAttribute("data-titlestates", statesTitles, null);
         }
-
-        String tabIndexTag = " tabIndex=0 ";
-        if (checkbox.getTabindex() != null) {
-            tabIndexTag = "tabIndex=" + checkbox.getTabindex() + " ";
-        }
-
-        // preparation with singe quotes for .data('iconstates')
-        writer.write("<div " + tabIndexTag + titleAtt + "class=\"" + styleClass + "\" data-iconstates='" + statesIconsClasses + "' "
-                + dataTitles + ">"
-                + "<span class=\"" + iconClass + "\"></span></div>");
-
+        writer.startElement("span", null);
+        writer.writeAttribute("class", iconClass, null);
+        writer.endElement("span");
+        writer.endElement("div");
     }
 
     protected void encodeItemLabel(final FacesContext context, final TriStateCheckbox checkbox) throws IOException {

--- a/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
@@ -92,8 +92,9 @@ PrimeFaces.widget.TriStateCheckbox = PrimeFaces.widget.BaseWidget.extend({
             // change title to the new one
             var iconTitles = this.box.data('titlestates');
             if(iconTitles!=null) {
-                if(iconTitles.titles!=null && iconTitles.titles.length>0) {}
+                if(iconTitles.titles!=null && iconTitles.titles.length>0) {
                     this.box.attr('title', iconTitles.titles[newValue]);
+                }
             }
 
             // fire change event

--- a/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
@@ -91,8 +91,9 @@ PrimeFaces.widget.TriStateCheckbox = PrimeFaces.widget.BaseWidget.extend({
 
             // change title to the new one
             var iconTitles = this.box.data('titlestates');
-            if(iconTitles!=null && iconTitles.length>0){
-                this.box.attr('title', iconTitles[newValue]);
+            if(iconTitles!=null) {
+                if(iconTitles.titles!=null && iconTitles.titles.length>0) {}
+                    this.box.attr('title', iconTitles.titles[newValue]);
             }
 
             // fire change event


### PR DESCRIPTION
Now `ResponseWriter.startTag/writeAttribute` methods are used in conjunction with proper JSON escaping of `data-titlestates` attribute values. The latter made some problems when attribute values are wrapped in single quotes, therefore JSON array was changed to JSON object internally (more on this problem: https://stackoverflow.com/questions/6071618/how-to-pass-an-array-into-jquery-data-attribute).