### PR TITLE
Fix #3097

### DIFF
--- a/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -19,6 +19,7 @@ import java.beans.BeanInfo;
 import java.util.List;
 import javax.faces.FacesException;
 import javax.faces.component.ContextCallback;
+import javax.faces.component.EditableValueHolder;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.view.AttachedObjectTarget;
@@ -39,6 +40,11 @@ public class CompositeUtils {
      */
     public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite,
             final ContextCallback callback) {
+        if (composite instanceof EditableValueHolder) {
+            callback.invokeContextCallback(context, composite);
+            return;
+        }
+
         BeanInfo info = (BeanInfo) composite.getAttributes().get(UIComponent.BEANINFO_KEY);
         List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
                 .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
@@ -64,15 +70,10 @@ public class CompositeUtils {
                     final UIComponent child = childs.get(0);
 
                     composite.invokeOnComponent(context, composite.getClientId(context), new ContextCallback() {
-                        
+
                         @Override
                         public void invokeContextCallback(FacesContext context, UIComponent target) {
-                            if (isComposite(child)) {
-                                invokeOnDeepestEditableValueHolder(context, child, callback);
-                            }
-                            else {
-                                callback.invokeContextCallback(context, child);
-                            }
+                            invokeOnDeepestEditableValueHolder(context, child, callback);
                         }
                     });
                 }


### PR DESCRIPTION
Fixes asterisk and identifying UIInput for composite components without `<cc:editableValueHolder />`

Reproducer: https://github.com/kapitanrum/primefaces-test/tree/demo-label-input-messages

### Before fix
![primefaces-3097 - before](https://user-images.githubusercontent.com/450737/41591473-1c0bf73c-73ba-11e8-9391-0abba33c1b18.png)
![primefaces-3097 - before - validation](https://user-images.githubusercontent.com/450737/41591506-38292ea8-73ba-11e8-9f01-1364307626eb.png)


### After fix
![primefaces-3097 - after](https://user-images.githubusercontent.com/450737/41591496-2b0441e0-73ba-11e8-9b40-52c85ce252ef.png)
![primefaces-3097 - after - validation](https://user-images.githubusercontent.com/450737/41591500-3055eafe-73ba-11e8-876e-b13aee4ba6ff.png)
