### PR TITLE
closes #48 - CSV delimiter may be specified

### DIFF
--- a/src/main/java/org/primefaces/component/export/CSVExporter.java
+++ b/src/main/java/org/primefaces/component/export/CSVExporter.java
@@ -33,6 +33,20 @@ import org.primefaces.util.Constants;
 
 public class CSVExporter extends Exporter {
 
+    private CSVOptions csvOptions;
+    
+    public CSVExporter(ExporterOptions options) {
+        csvOptions = CSVOptions.EXCEL;
+        if (options != null) {
+            if (options instanceof CSVOptions) {
+                csvOptions = (CSVOptions) options;
+            }
+            else {
+                throw new IllegalArgumentException("Options must be an instance of CSVOptions.");
+            }
+        }
+    }
+    
     @Override
     public void export(FacesContext context, DataTable table, String filename, boolean pageOnly, boolean selectionOnly,
             String encodingType, MethodExpression preProcessor, MethodExpression postProcessor, ExporterOptions options,
@@ -96,7 +110,7 @@ public class CSVExporter extends Exporter {
 
             if (col.isRendered() && col.isExportable()) {
                 if (firstCellWritten) {
-                    builder.append(",");
+                    builder.append(csvOptions.getDelimiterChar());
                 }
 
                 UIComponent facet = col.getFacet(columnType.facet());
@@ -127,7 +141,7 @@ public class CSVExporter extends Exporter {
             }
         }
 
-        builder.append("\n");
+        builder.append(csvOptions.getEndOfLineSymbols());
     }
 
     @Override
@@ -142,7 +156,7 @@ public class CSVExporter extends Exporter {
 
             if (col.isRendered() && col.isExportable()) {
                 if (firstCellWritten) {
-                    builder.append(",");
+                    builder.append(csvOptions.getDelimiterChar());
                 }
 
                 try {
@@ -172,7 +186,7 @@ public class CSVExporter extends Exporter {
             addColumnValue(builder, col.getChildren(), col);
 
             if (iterator.hasNext()) {
-                builder.append(",");
+                builder.append(csvOptions.getDelimiterChar());
             }
         }
     }
@@ -184,20 +198,20 @@ public class CSVExporter extends Exporter {
     }
 
     protected void addColumnValue(StringBuilder builder, String value) throws IOException {
-        value = (value == null) ? "" : value.replaceAll("\"", "\"\"");
+        value = (value == null) ? "" : value.replace(csvOptions.getQuoteString(), csvOptions.getDoubleQuoteString());
 
-        builder.append("\"" + value + "\"");
+        builder.append(csvOptions.getQuoteChar()).append(value).append(csvOptions.getQuoteChar());
     }
 
     protected void addColumnValue(StringBuilder builder, List<UIComponent> components, UIColumn column) throws IOException {
         FacesContext context = FacesContext.getCurrentInstance();
 
-        builder.append("\"");
+        builder.append(csvOptions.getQuoteChar());
 
         if (column.getExportFunction() != null) {
             String value = exportColumnByFunction(context, column);
             //escape double quotes
-            value = value == null ? "" : value.replaceAll("\"", "\"\"");
+            value = value == null ? "" : value.replace(csvOptions.getQuoteString(), csvOptions.getDoubleQuoteString());
 
             builder.append(value);
         }
@@ -207,18 +221,18 @@ public class CSVExporter extends Exporter {
                     String value = exportValue(context, component);
 
                     //escape double quotes
-                    value = value == null ? "" : value.replaceAll("\"", "\"\"");
+                    value = value == null ? "" : value.replace(csvOptions.getQuoteString(), csvOptions.getDoubleQuoteString());
 
                     builder.append(value);
                 }
             }
         }
 
-        builder.append("\"");
+        builder.append(csvOptions.getQuoteChar());
     }
 
     @Override
     protected void postRowExport(DataTable table, Object document) {
-        ((StringBuilder) document).append("\n");
+        ((StringBuilder) document).append(csvOptions.getEndOfLineSymbols());
     }
 }

--- a/src/main/java/org/primefaces/component/export/CSVOptions.java
+++ b/src/main/java/org/primefaces/component/export/CSVOptions.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2009-2018 PrimeTek.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.component.export;
+
+public class CSVOptions implements ExporterOptions {
+    
+    public static final CSVOptions STANDARD = new  CSVOptions('"', ',', "\r\n");
+    
+    public static final CSVOptions EXCEL = new  CSVOptions('"', ',', "\n");
+    
+    public static final CSVOptions EXCEL_NORTHERN_EUROPE = new  CSVOptions('"', ';', "\n");
+    
+    public static final CSVOptions TABS = new  CSVOptions('"', '\t', "\n");
+    
+    private static final String STYLING_NOT_SUPPORTED = "CSV does not support styling.";
+
+    private final char quoteChar;
+
+    private final char delimiterChar;
+
+    private final String endOfLineSymbols;
+
+    private final String quoteString;
+    
+    private final String doubleQuoteString;
+    
+    public CSVOptions(char quoteChar, char delimiterChar, String endOfLineSymbols) {
+        this.quoteChar = quoteChar;
+        this.delimiterChar = delimiterChar;
+        this.endOfLineSymbols = endOfLineSymbols;
+        quoteString = Character.toString(quoteChar);
+        doubleQuoteString = quoteString + quoteString; 
+    }
+
+    public char getQuoteChar() {
+        return quoteChar;
+    }
+
+    public char getDelimiterChar() {
+        return delimiterChar;
+    }
+
+    public String getEndOfLineSymbols() {
+        return endOfLineSymbols;
+    }
+
+    public String getQuoteString() {
+        return quoteString;
+    }
+
+    public String getDoubleQuoteString() {
+        return doubleQuoteString;
+    }
+
+    @Override
+    public String getFacetFontStyle() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getFacetFontColor() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getFacetBgColor() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getFacetFontSize() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getCellFontStyle() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getCellFontColor() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+    @Override
+    public String getCellFontSize() {
+        throw new UnsupportedOperationException(STYLING_NOT_SUPPORTED);
+    }
+
+}

--- a/src/main/java/org/primefaces/component/export/DataExporter.java
+++ b/src/main/java/org/primefaces/component/export/DataExporter.java
@@ -118,7 +118,7 @@ public class DataExporter implements ActionListener, StateHolder {
         }
 
         try {
-            Exporter exporter = ExporterFactory.getExporterForType(exportAs);
+            Exporter exporter = ExporterFactory.getExporterForType(exportAs, exporterOptions);
 
             if (!repeating) {
                 List components = SearchExpressionFacade.resolveComponents(context, event.getComponent(), tables);

--- a/src/main/java/org/primefaces/component/export/ExporterFactory.java
+++ b/src/main/java/org/primefaces/component/export/ExporterFactory.java
@@ -19,7 +19,7 @@ import javax.faces.FacesException;
 
 public class ExporterFactory {
 
-    public static Exporter getExporterForType(String type) {
+    public static Exporter getExporterForType(String type, ExporterOptions options) {
         Exporter exporter = null;
 
         try {
@@ -35,7 +35,7 @@ public class ExporterFactory {
                     break;
 
                 case CSV:
-                    exporter = new CSVExporter();
+                    exporter = new CSVExporter(options);
                     break;
 
                 case XML:


### PR DESCRIPTION
**Sample XHTML:**
 ```xml
<p:dataExporter type="csv" target="tbl" fileName="cars" options="#{dataExporterView.csvOptions}" />
```

**Sample bean:**
```java
    public ExporterOptions getCsvOptions() {
        // return new CSVOptions('"', ';', "\n");
        // is equivalent to 
        return CSVOptions.EXCEL_NORTHERN_EUROPE;
    }
```

**Some notes:**
- predefined options in the style of [super-csv](https://github.com/super-csv/super-csv
): STANDARD, EXCEL, EXCEL_NORTHERN_EUROPE, TABS
- besides delimiter character also allow specification of quote character and end of line symbols (Windows -> CRLF, Unix -> LF, Mac -> CR) to be most flexible
- `Exporter `and `ExporterOptions `are not very well designed, resulting in massive use of `UnsupportedOperationException`
- tested before and after with binary comparison -> no differences
