### PR TITLE
Fix #3453: bind defaultCommand to keypress and rely on e.which

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
@@ -17,9 +17,9 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
         }
 
         //attach keypress listener to parent form
-        this.jqTarget.closest('form').off('keydown.' + this.id).on('keydown.' + this.id, function(e) {
+        this.jqTarget.closest('form').off('keypress.' + this.id).on('keypress.' + this.id, function(e) {
            var keyCode = $.ui.keyCode;
-           if(e.which == keyCode.ENTER || e.which == keyCode.NUMPAD_ENTER) {
+           if(e.which == keyCode.ENTER) {
                 //do not proceed if event target is not in this scope or target is a textarea,button or link
                 if (($this.scope && $this.scope[0] != e.target && $this.scope.find(e.target).length == 0)
                    || $(e.target).is('textarea,button,input[type="submit"],a')) {


### PR DESCRIPTION
This fixes #3453 by binding defaultCommand to keypress.
Numpad enter is never reported as `e.which == keyCode.NUMPAD_ENTER` ([details](https://gist.github.com/david0/36a6b3cf0d07dd1fe1296fcfbe8527ba)). Instead on **keypress** `l` is repored as `108` (but not on keydown). Because of this, its needed drop numpad too.