### PR TITLE
Fix #3873: CommandLink always attempt to render children.

### DIFF
--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -129,9 +129,8 @@ public class CommandLinkRenderer extends CoreRenderer {
             if (label != null) {
                 writer.writeText(label, "value");
             }
-            else {
-                renderChildren(context, link);
-            }
+
+            renderChildren(context, link);
 
             writer.endElement("a");
         }
@@ -150,9 +149,8 @@ public class CommandLinkRenderer extends CoreRenderer {
             if (label != null) {
                 writer.writeText(label, "value");
             }
-            else {
-                renderChildren(context, link);
-            }
+            
+            renderChildren(context, link);
 
             writer.endElement("span");
         }


### PR DESCRIPTION
Screenshot of fix: 
![image](https://user-images.githubusercontent.com/4399574/42816763-e05c5650-8999-11e8-85d1-92749c829d1b.png)
