### PR TITLE
Add generic parameter MenuElement to MenuGroup.getElements

### DIFF
--- a/src/main/java/org/primefaces/model/menu/MenuGroup.java
+++ b/src/main/java/org/primefaces/model/menu/MenuGroup.java
@@ -21,5 +21,5 @@ public interface MenuGroup extends MenuElement {
 
     public int getElementsCount();
 
-    public List getElements();
+    public List<MenuElement> getElements();
 }


### PR DESCRIPTION
The parameter is used in subclasses anyway and MenuElements are the
only kind of elements which make sense to place in the list of
elements of a menu group.