### PR TITLE
Add explicit specification of checkstyle version

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -10,12 +10,9 @@
 
     <module name="FileTabCharacter"/>
 
-    <!-- allow usage of CHECKSTYLE:OFF and CHECKSTYLE:ON -->
-    <module name="SuppressionCommentFilter"/>
-
     <module name="TreeWalker">
-
-        <module name="FileContentsHolder"/>
+        <!-- allow usage of CHECKSTYLE:OFF and CHECKSTYLE:ON -->
+        <module name="SuppressionCommentFilter"/>
 
         <property name="cacheFile" value="${checkstyle.cache.file}"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,13 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                      <groupId>com.puppycrawl.tools</groupId>
+                      <artifactId>checkstyle</artifactId>
+                      <version>8.11</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>


### PR DESCRIPTION
Specifying the explicit checkstyle version to be used by
maven-checkstyle-plugin allows to use more up-to-date version than
6.18 which is used by default and be more flexible to upgrade in the
future.