### PR TITLE
Schedule: do not bind a view change listener on prev/next year buttons

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -191,7 +191,8 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
     },
 
     bindViewChangeListener: function() {
-        var viewButtons = this.jqc.find('> .fc-toolbar button:not(.fc-prev-button,.fc-next-button,.fc-today-button)'),
+        var excludedClasses = '.fc-prev-button,.fc-next-button,.fc-prevYear-button,.fc-nextYear-button,.fc-today-button';
+        var viewButtons = this.jqc.find('> .fc-toolbar button:not(' + excludedClasses + ')'),
             $this = this;
 
         viewButtons.each(function(i) {


### PR DESCRIPTION
When the prev/next year buttons are enabled on the schedule, they are serialized as the 'view' state of ajax requests: `scheduleId_view: prevYear`.
Under some circumstance I couldn't reproduce on the showcase, this caused the schedule to instantiate a view from a spec which didn't exit, causing a javacript error and preventing the schedule to be rendered : 
```
var spec = this.getViewSpec(viewType); // viewType === 'prevYear', spec === false
return new spec['class'](this, viewType, spec.options, spec.duration);
// Uncaught TypeError: spec.class is not a constructor 

```

This pull request prevents the viewChange listener to be bound on those buttons, like for the prev/next month buttons.
