### PR TITLE
Fix #3955 FileDownload "Response already committed" warning

### DIFF
--- a/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -92,7 +92,9 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
                 outputStream.write(buffer, 0, length);
             }
 
-            externalContext.setResponseStatus(200);
+            if (!externalContext.isResponseCommitted()) {
+                externalContext.setResponseStatus(200);
+            }
             externalContext.responseFlushBuffer();
             context.responseComplete();
         }


### PR DESCRIPTION
Resolves #3955 by checking in FileDownloadActionListener to see if a response has already been committed before calling setStatus()