### PR TITLE
Improve p:accordionPanel's activeIndex attribute documentation

### DIFF
--- a/src/main/resources-maven-jsf/ui/accordionPanel.xml
+++ b/src/main/resources-maven-jsf/ui/accordionPanel.xml
@@ -38,7 +38,7 @@
             <required>false</required>
             <type>java.lang.String</type>
             <defaultValue>0</defaultValue>
-            <description>Index of the active tab or a comma separated string of indexes when multiple mode is on. Default is zero.</description>
+            <description>Index of the active tab or a comma separated string of indexes when multiple mode is on. Default is "0". As activeIndex is a bidrectional attribute, it doesn't support MethodExpressions.</description>
         </attribute>
         <attribute>
             <name>style</name>


### PR DESCRIPTION
Add a hint that it needs to be a value expression.

closes #3959