### PR TITLE
Fix #3916: FileUpload allow % and + in file name.

### DIFF
--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -177,6 +177,9 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
 
     private String decode(String encoded) {
         try {
+            // GitHub #3916 escape + and % before decode
+            encoded = encoded.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
+            encoded = encoded.replaceAll("\\+", "%2B");
             return URLDecoder.decode(encoded, "UTF-8");
         }
         catch (UnsupportedEncodingException ex) {

--- a/src/test/java/org/primefaces/model/NativeUploadedFileTest.java
+++ b/src/test/java/org/primefaces/model/NativeUploadedFileTest.java
@@ -61,6 +61,30 @@ public class NativeUploadedFileTest {
         // Assert
         Assert.assertEquals("Test;123.txt", output);
     }
+    
+    @Test
+    public void testPercent() {
+        // Arrange
+        final String input = "form-data; name=\"XXX:XXX\"; filename=\"test%.jpg\"; charset=\"UTF-8\"";
+
+        // Act
+        final String output = file.getContentDispositionFileName(input);
+
+        // Assert
+        Assert.assertEquals("test%.jpg", output);
+    }
+    
+    @Test
+    public void testPlus() {
+        // Arrange
+        final String input = "form-data; name=\"XXX:XXX\"; filename=\"test+.jpg\"; charset=\"UTF-8\"";
+
+        // Act
+        final String output = file.getContentDispositionFileName(input);
+
+        // Assert
+        Assert.assertEquals("test+.jpg", output);
+    }
 
     @Test
     public void testSlashes() {


### PR DESCRIPTION
Based on this Stack overflow solution: https://stackoverflow.com/questions/6067673/urldecoder-illegal-hex-characters-in-escape-pattern-for-input-string

Wrote test cases that failed and then passed after I implemented the fix.