### PR TITLE
fix #2089

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectlistbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectlistbox.js
@@ -62,10 +62,46 @@ PrimeFaces.widget.SelectListbox = PrimeFaces.widget.BaseWidget.extend({
             this.setupFilterMatcher();
         }
     },
+    
+    selectAll: function() {
+        var jqClone = this.selectAll0();
+        this.jq.replaceWith(jqClone);
+        this.jq = jqClone;
+        this.init(this.cfg);
+    },
 
+    selectAll0: function() {
+        var jqClone = this.jq.clone();
+        var input = jqClone.find(this.jqId + '_input');
+        var listContainer = jqClone.children('.ui-selectlistbox-listcontainer');
+        var listElement = listContainer.children('.ui-selectlistbox-list');
+        var options = $(input).children('option');
+        var allItems = listElement.find('.ui-selectlistbox-item');
+        var items = allItems.filter(':not(.ui-state-disabled)');
+        items.addClass("ui-state-highlight");
+        options.prop('selected', true);
+        
+        return jqClone;
+    },
+    
     unselectAll: function() {
-        this.items.removeClass('ui-state-highlight ui-state-hover');
-        this.options.filter(':selected').prop('selected', false);
+        var jqClone = this.unselectAll0();
+        this.jq.replaceWith(jqClone);
+        this.jq = jqClone;
+        this.init(this.cfg);
+    },
+    
+    unselectAll0: function() {
+        var jqClone = this.jq.clone();
+        var input = jqClone.find(this.jqId + '_input');
+        var listContainer = jqClone.children('.ui-selectlistbox-listcontainer');
+        var listElement = listContainer.children('.ui-selectlistbox-list');
+        var options = $(input).children('option');
+        var allItems = listElement.find('.ui-selectlistbox-item');
+        var items = allItems.filter(':not(.ui-state-disabled)');
+        items.removeClass("ui-state-highlight");
+        options.prop('selected', false);
+        return jqClone;
     },
 
     selectItem: function(item) {

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
@@ -100,15 +100,35 @@ PrimeFaces.widget.SelectManyMenu = PrimeFaces.widget.SelectListbox.extend({
     },
 
     selectAll: function() {
-        for(var i = 0; i < this.items.length; i++) {
-            this.selectItem(this.items.eq(i));
+        var jqClone = this.selectAll0();
+        this.jq.replaceWith(jqClone);
+        this.jq = jqClone;
+        this.init(this.cfg);
+    },
+
+    selectAll0: function() {
+        var jqClone = this._super();
+        if(this.cfg.showCheckbox) {
+            var checkboxes = jqClone.find('.ui-selectlistbox-item:not(.ui-state-disabled) div.ui-chkbox > div.ui-chkbox-box');
+            checkboxes.addClass('ui-state-active').children('span.ui-chkbox-icon').removeClass('ui-icon-blank').addClass('ui-icon-check');
         }
+        return jqClone;
     },
 
     unselectAll: function() {
-        for(var i = 0; i < this.items.length; i++) {
-            this.unselectItem(this.items.eq(i));
+        var jqClone = this.unselectAll0();
+        this.jq.replaceWith(jqClone);
+        this.jq = jqClone;
+        this.init(this.cfg);
+    },
+
+    unselectAll0: function() {
+        var jqClone = this._super();
+        if(this.cfg.showCheckbox) {
+            var checkboxes = jqClone.find('.ui-selectlistbox-item:not(.ui-state-disabled) div.ui-chkbox > div.ui-chkbox-box');
+            checkboxes.removeClass('ui-state-active').children('span.ui-chkbox-icon').addClass('ui-icon-blank').removeClass('ui-icon-check');
         }
+        return jqClone;
     },
 
     selectItem: function(item) {


### PR DESCRIPTION
This improves performance of selectAll/unselectAll on selectManyMenu by partially cloning and replacing the DOM.
It is a follow-up PR on https://github.com/primefaces/primefaces/pull/2090.

@tandraschko Regarding your comment on the other PR:
> NOTE: it would be great if you could first provide a issue for adding selectAll/unselectAll methos for those widgets and then, in a second step, provide a PR to improve the performance.

These methods seem to have been added to selectlistbox widget already.