### PR TITLE
Fix #3976: BarChartSeries not respecting axes if present.

### DIFF
--- a/src/main/java/org/primefaces/model/chart/BarChartSeries.java
+++ b/src/main/java/org/primefaces/model/chart/BarChartSeries.java
@@ -45,6 +45,16 @@ public class BarChartSeries extends ChartSeries {
         writer.write("label:\"" + ComponentUtils.escapeText(this.getLabel()) + "\"");
 
         writer.write(",renderer: $.jqplot." + this.getRenderer());
+        
+        AxisType xaxis = this.getXaxis();
+        if (xaxis != null) {
+            writer.write(",xaxis:\"" + xaxis + "\"");
+        }
+
+        AxisType yaxis = this.getYaxis();
+        if (yaxis != null) {
+            writer.write(",yaxis:\"" + yaxis + "\"");
+        }
 
         if (disableStack) writer.write(",disableStack:true");
 


### PR DESCRIPTION
Fix #3976: BarChartSeries not respecting axes if present.