### PR TITLE
Fix #3984 AutoComplete width for multiple=true

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -823,7 +823,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         var panelWidth = null;
 
         if(this.cfg.multiple) {
-            panelWidth = this.multiItemContainer.innerWidth() - (this.input.position().left - this.multiItemContainer.position().left);
+            panelWidth = this.multiItemContainer.outerWidth();
         }
         else {
             if(this.panel.is(':visible')) {


### PR DESCRIPTION
This change is to fix a problem with the autocomplete panel width when the attribute **multiple** is **true**. You could check this problem in the showcase:
- https://www.primefaces.org/showcase/ui/input/autoComplete.xhtml

The panel width when we select the first item from the list looks fine, but when we select the second item the panel width is shorter, if we select the third item the panel width is even shorter.