### PR TITLE
Fix #4020 SelectBooleanButton: Remove type attribute

### DIFF
--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -74,7 +74,6 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         //button
         writer.startElement("div", null);
         writer.writeAttribute("id", clientId, "id");
-        writer.writeAttribute("type", "button", null);
         writer.writeAttribute("class", styleClass, null);
         if (disabled) {
             writer.writeAttribute("disabled", "disabled", null);


### PR DESCRIPTION
I have tested this change. I think the type attribute on the main div tag is not necessary to be rendered.