### PR TITLE
Fix #4047: Add "aria-required" attribute and refactored ARIA attributes.

### DIFF
--- a/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -212,9 +212,9 @@ public class AccordionPanelRenderer extends CoreRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("class", headerClass, null);
         writer.writeAttribute("role", "tab", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(active), null);
-        writer.writeAttribute("aria-selected", String.valueOf(active), null);
-        writer.writeAttribute("aria-label", tab.getAriaLabel(), null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("tabindex", tabindex, null);
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
@@ -245,7 +245,7 @@ public class AccordionPanelRenderer extends CoreRenderer {
         writer.writeAttribute("id", tab.getClientId(context), null);
         writer.writeAttribute("class", contentClass, null);
         writer.writeAttribute("role", "tabpanel", null);
-        writer.writeAttribute("aria-hidden", String.valueOf(!active), null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
 
         if (dynamic) {
             if (active) {

--- a/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -180,7 +180,6 @@ public class AutoCompleteRenderer extends InputRenderer {
         String inputStyle = ac.getInputStyle();
         String inputStyleClass = ac.getInputStyleClass();
         inputStyleClass = (inputStyleClass == null) ? styleClass : styleClass + " " + inputStyleClass;
-        String labelledBy = ac.getLabelledBy();
         String autocompleteProp = (ac.getAutocomplete() != null) ? ac.getAutocomplete() : "off";
 
         writer.startElement("input", null);
@@ -190,14 +189,11 @@ public class AutoCompleteRenderer extends InputRenderer {
         writer.writeAttribute("class", inputStyleClass, null);
         writer.writeAttribute("autocomplete", autocompleteProp, null);
 
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
-
         if (inputStyle != null) {
             writer.writeAttribute("style", inputStyle, null);
         }
 
+        renderAccessibilityAttributes(context, ac);
         renderPassThruAttributes(context, ac, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, ac, HTML.INPUT_TEXT_EVENTS);
 
@@ -247,16 +243,6 @@ public class AutoCompleteRenderer extends InputRenderer {
             }
 
             requestMap.remove(var);
-        }
-
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (ac.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
-        if (ac.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
         }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
@@ -463,16 +449,8 @@ public class AutoCompleteRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("autocomplete", autocompleteProp, null);
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", "disabled");
-        }
-        if (ac.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
-        if (ac.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
-        }
 
+        renderAccessibilityAttributes(context, ac);
         renderPassThruAttributes(context, ac, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, ac, HTML.INPUT_TEXT_EVENTS);
 

--- a/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -26,7 +26,6 @@ import javax.faces.convert.ConverterException;
 import javax.faces.event.PhaseId;
 
 import org.primefaces.component.column.Column;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.event.AutoCompleteEvent;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
@@ -245,9 +244,7 @@ public class AutoCompleteRenderer extends InputRenderer {
             requestMap.remove(var);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, ac);
-        }
+        renderValidationMetadata(context, ac);
 
         writer.endElement("input");
     }
@@ -282,9 +279,7 @@ public class AutoCompleteRenderer extends InputRenderer {
             writer.writeAttribute("disabled", "disabled", "disabled");
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, ac);
-        }
+        renderValidationMetadata(context, ac);
 
         for (int i = 0; i < values.size(); i++) {
             String value = values.get(i);

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -98,7 +98,6 @@ public class CalendarRenderer extends InputRenderer {
     protected void encodeInput(FacesContext context, Calendar calendar, String id, String value, boolean popup) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String type = popup ? calendar.getType() : "hidden";
-        String labelledBy = calendar.getLabelledBy();
         String inputStyle = calendar.getInputStyle();
         String inputStyleClass = calendar.getInputStyleClass();
 
@@ -107,19 +106,21 @@ public class CalendarRenderer extends InputRenderer {
         writer.writeAttribute("name", id, null);
         writer.writeAttribute("type", type, null);
 
-        if (calendar.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
-        }
-
         if (!isValueBlank(value)) {
             writer.writeAttribute("value", value, null);
         }
 
+        boolean readonly = false;
+        boolean disabled = false;
+
         if (popup) {
             inputStyleClass = (inputStyleClass == null) ? Calendar.INPUT_STYLE_CLASS
                                                         : Calendar.INPUT_STYLE_CLASS + " " + inputStyleClass;
+            readonly = calendar.isReadonly() || calendar.isReadonlyInput();
+
             if (calendar.isDisabled()) {
                 inputStyleClass = inputStyleClass + " ui-state-disabled";
+                disabled = true;
             }
             if (!calendar.isValid()) {
                 inputStyleClass = inputStyleClass + " ui-state-error";
@@ -130,20 +131,12 @@ public class CalendarRenderer extends InputRenderer {
             if (inputStyle != null) {
                 writer.writeAttribute("style", inputStyle, null);
             }
-            if (calendar.isReadonly() || calendar.isReadonlyInput()) {
-                writer.writeAttribute("readonly", "readonly", null);
-            }
-            if (calendar.isDisabled()) {
-                writer.writeAttribute("disabled", "disabled", null);
-            }
 
             renderPassThruAttributes(context, calendar, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
             renderDomEvents(context, calendar, HTML.INPUT_TEXT_EVENTS);
         }
 
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
+        renderAccessibilityAttributes(context, calendar, disabled, readonly);
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, calendar);

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -29,7 +29,6 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
@@ -138,9 +137,7 @@ public class CalendarRenderer extends InputRenderer {
 
         renderAccessibilityAttributes(context, calendar, disabled, readonly);
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, calendar);
-        }
+        renderValidationMetadata(context, calendar);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
@@ -83,11 +83,10 @@ public class CheckboxRenderer extends InputRenderer {
         writer.writeAttribute("class", "ui-chkbox-clone", null);
         writer.writeAttribute("data-itemindex", checkbox.getItemIndex(), null);
 
+        renderAccessibilityAttributes(context, selectManyCheckbox, disabled, selectManyCheckbox.isReadonly());
+
         if (tabindex != null) {
             writer.writeAttribute("tabindex", tabindex, null);
-        }
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
         }
 
         String onchange = buildEvent(context, selectManyCheckbox, checkbox, "onchange", "change", "valueChange");

--- a/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/checkbox/CheckboxRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.radiobutton.RadioButtonRenderer;
 import org.primefaces.component.selectmanycheckbox.SelectManyCheckbox;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.HTML;
@@ -98,9 +97,7 @@ public class CheckboxRenderer extends InputRenderer {
             writer.writeAttribute("onclick", onclick, null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, selectManyCheckbox);
-        }
+        renderValidationMetadata(context, selectManyCheckbox);
 
         writer.endElement("input");
         writer.endElement("div");

--- a/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
+++ b/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
@@ -143,13 +143,8 @@ public class ChipsRenderer extends InputRenderer {
         writer.writeAttribute("class", "ui-widget", null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("autocomplete", "off", null);
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", "disabled");
-        }
-        if (chips.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", "readonly");
-        }
 
+        renderAccessibilityAttributes(context, chips);
         renderPassThruAttributes(context, chips, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, chips, HTML.INPUT_TEXT_EVENTS);
 

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
@@ -74,7 +74,7 @@ public class CommandButtonRenderer extends CoreRenderer {
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("name", clientId, "name");
         writer.writeAttribute("class", button.resolveStyleClass(), "styleClass");
-        writer.writeAttribute("aria-label", button.getAriaLabel(), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, button.getAriaLabel(), null);
 
         if (onclick != null) {
             if (button.requiresConfirmation()) {

--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -81,7 +81,7 @@ public class CommandLinkRenderer extends CoreRenderer {
             writer.writeAttribute("href", "#", null);
             writer.writeAttribute("class", styleClass, null);
             if (link.getTitle() != null) {
-                writer.writeAttribute("aria-label", link.getTitle(), null);
+                writer.writeAttribute(HTML.ARIA_LABEL, link.getTitle(), null);
             }
 
             if (ajax) {

--- a/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
+++ b/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
@@ -134,6 +134,7 @@ public class ConfirmDialogRenderer extends CoreRenderer {
 
         writer.startElement("div", null);
         writer.writeAttribute("class", Dialog.CONTENT_CLASS, null);
+        writer.writeAttribute("id", dialog.getClientId(context) + "_content", null);
 
         //severity
         writer.startElement("span", null);

--- a/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
+++ b/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
@@ -25,6 +25,7 @@ import org.primefaces.component.dialog.Dialog;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 import org.primefaces.util.WidgetBuilder;
 
@@ -111,7 +112,7 @@ public class ConfirmDialogRenderer extends CoreRenderer {
             writer.writeAttribute("href", "#", null);
             writer.writeAttribute("class", Dialog.TITLE_BAR_CLOSE_CLASS, null);
             if (ariaLabel != null) {
-                writer.writeAttribute("aria-label", ariaLabel, null);
+                writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
             }
 
             writer.startElement("span", null);

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -428,7 +428,7 @@ public class DataTableRenderer extends DataRenderer {
 
         if (summary != null) {
             writer.writeAttribute("summary", summary, null);
-            writer.writeAttribute("aria-describedby", clientId + "_summary", null);
+            writer.writeAttribute(HTML.ARIA_DESCRIBEDBY, clientId + "_summary", null);
         }
 
         encodeThead(context, table);
@@ -711,7 +711,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("class", columnClass, null);
         writer.writeAttribute("role", "columnheader", null);
-        writer.writeAttribute("aria-label", ariaHeaderLabel, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaHeaderLabel, null);
         writer.writeAttribute("scope", "col", null);
         if (style != null) {
             writer.writeAttribute("style", style, null);
@@ -882,7 +882,7 @@ public class DataTableRenderer extends DataRenderer {
                 writer.writeAttribute("class", filterStyleClass, null);
                 writer.writeAttribute("value", filterValue, null);
                 writer.writeAttribute("autocomplete", "off", null);
-                writer.writeAttribute("aria-labelledby", ariaLabelId, null);
+                writer.writeAttribute(HTML.ARIA_LABELLEDBY, ariaLabelId, null);
 
                 if (disableTabbing) {
                     writer.writeAttribute("tabindex", "-1", null);
@@ -905,7 +905,7 @@ public class DataTableRenderer extends DataRenderer {
                 writer.writeAttribute("id", filterId, null);
                 writer.writeAttribute("name", filterId, null);
                 writer.writeAttribute("class", filterStyleClass, null);
-                writer.writeAttribute("aria-labelledby", ariaLabelId, null);
+                writer.writeAttribute(HTML.ARIA_LABELLEDBY, ariaLabelId, null);
 
                 if (disableTabbing) {
                     writer.writeAttribute("tabindex", "-1", null);
@@ -1325,7 +1325,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.writeAttribute("class", rowStyleClass, null);
         writer.writeAttribute("role", "row", null);
         if (selectionEnabled) {
-            writer.writeAttribute("aria-selected", String.valueOf(selected), null);
+            writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(selected), null);
         }
 
         for (int i = columnStart; i < columnEnd; i++) {
@@ -1647,8 +1647,8 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("input", null);
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("name", table.getClientId(context) + "_checkbox", null);
-        writer.writeAttribute("aria-label", ariaRowLabel, null);
-        writer.writeAttribute("aria-checked", String.valueOf(checked), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaRowLabel, null);
+        writer.writeAttribute(HTML.ARIA_CHECKED, String.valueOf(checked), null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);
@@ -1669,7 +1669,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("input", null);
         writer.writeAttribute("type", "radio", null);
         writer.writeAttribute("name", table.getClientId(context) + "_radio", null);
-        writer.writeAttribute("aria-label", ariaRowLabel, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaRowLabel, null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);

--- a/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
+++ b/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
@@ -25,6 +25,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 import org.primefaces.util.WidgetBuilder;
 
@@ -202,7 +203,7 @@ public class DialogRenderer extends CoreRenderer {
         writer.writeAttribute("href", "#", null);
         writer.writeAttribute("class", anchorClass, null);
         if (ariaLabel != null) {
-            writer.writeAttribute("aria-label", ariaLabel, null);
+            writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
         }
 
         writer.startElement("span", null);

--- a/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
+++ b/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
@@ -188,6 +188,7 @@ public class DialogRenderer extends CoreRenderer {
 
         writer.startElement("div", null);
         writer.writeAttribute("class", Dialog.CONTENT_CLASS, null);
+        writer.writeAttribute("id", dialog.getClientId(context) + "_content", null);
 
         if (!dialog.isDynamic()) {
             renderChildren(context, dialog);

--- a/src/main/java/org/primefaces/component/export/ExcelExporter.java
+++ b/src/main/java/org/primefaces/component/export/ExcelExporter.java
@@ -60,7 +60,7 @@ public class ExcelExporter extends Exporter {
             sheetName = "Sheet";
         }
 
-        Sheet sheet = wb.createSheet(sheetName);
+        Sheet sheet = createSheet(wb, sheetName);
 
         if (preProcessor != null) {
             preProcessor.invoke(context.getELContext(), new Object[]{wb});
@@ -103,7 +103,7 @@ public class ExcelExporter extends Exporter {
                 sheetName = "Sheet" + String.valueOf(i + 1);
             }
 
-            Sheet sheet = wb.createSheet(sheetName);
+            Sheet sheet = createSheet(wb, sheetName);
             applyOptions(wb, table, sheet, options);
             exportTable(context, table, sheet, pageOnly, selectionOnly);
 
@@ -247,6 +247,10 @@ public class ExcelExporter extends Exporter {
 
     protected Workbook createWorkBook() {
         return new HSSFWorkbook();
+    }
+
+    protected Sheet createSheet(Workbook wb, String sheetName) {
+        return wb.createSheet(sheetName);
     }
 
     protected void writeExcelToResponse(ExternalContext externalContext, Workbook generatedExcel, String filename) throws IOException {

--- a/src/main/java/org/primefaces/component/export/ExcelXStreamExporter.java
+++ b/src/main/java/org/primefaces/component/export/ExcelXStreamExporter.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 
 import javax.faces.context.ExternalContext;
 
+import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 /**
@@ -42,5 +44,13 @@ public class ExcelXStreamExporter extends ExcelXExporter {
     protected void writeExcelToResponse(ExternalContext externalContext, Workbook generatedExcel, String filename) throws IOException {
         super.writeExcelToResponse(externalContext, generatedExcel, filename);
         ((SXSSFWorkbook) generatedExcel).dispose();
+    }
+
+    @Override
+    protected Sheet createSheet(Workbook wb, String sheetName) {
+        SXSSFWorkbook workbook = (SXSSFWorkbook) wb;
+        SXSSFSheet sheet =  workbook.createSheet(sheetName);
+        sheet.trackAllColumnsForAutoSizing();
+        return sheet;
     }
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -248,7 +248,7 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.writeAttribute("class", cssClass, null);
         writer.writeAttribute("tabindex", tabindex, null);
         writer.writeAttribute("role", "button", null);
-        writer.writeAttribute("aria-labelledby", clientId + "_label", null);
+        writer.writeAttribute(HTML.ARIA_LABELLEDBY, clientId + "_label", null);
 
         //button icon
         writer.startElement("span", null);
@@ -284,7 +284,7 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.writeAttribute("id", inputId, null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("tabindex", "-1", null);
-        writer.writeAttribute("aria-hidden", "true", null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, "true", null);
 
         if (fileUpload.isMultiple()) {
             writer.writeAttribute("multiple", "multiple", null);
@@ -308,7 +308,7 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.writeAttribute("type", "file", null);
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("name", clientId, null);
-        writer.writeAttribute("aria-hidden", "true", null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, "true", null);
 
         if (fileUpload.isMultiple()) {
             writer.writeAttribute("multiple", "multiple", null);

--- a/src/main/java/org/primefaces/component/headerrow/HeaderRowRenderer.java
+++ b/src/main/java/org/primefaces/component/headerrow/HeaderRowRenderer.java
@@ -24,6 +24,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.component.column.Column;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 
 public class HeaderRowRenderer extends CoreRenderer {
@@ -65,8 +66,8 @@ public class HeaderRowRenderer extends CoreRenderer {
 
                     writer.startElement("a", null);
                     writer.writeAttribute("class", DataTable.ROW_GROUP_TOGGLER_CLASS, null);
-                    writer.writeAttribute("aria-expanded", String.valueOf(true), null);
-                    writer.writeAttribute("aria-label", ariaLabel, null);
+                    writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(true), null);
+                    writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
                     writer.writeAttribute("href", "#", null);
                     writer.startElement("span", null);
                     writer.writeAttribute("class", DataTable.ROW_GROUP_TOGGLER_ICON_CLASS, null);

--- a/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -23,7 +23,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -166,9 +165,7 @@ public class InputMaskRenderer extends InputRenderer {
 
         writer.writeAttribute("class", styleClass, "styleClass");
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputMask);
-        }
+        renderValidationMetadata(context, inputMask);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -156,20 +156,12 @@ public class InputMaskRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
+        renderAccessibilityAttributes(context, inputMask);
         renderPassThruAttributes(context, inputMask, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputMask, HTML.INPUT_TEXT_EVENTS);
 
-        if (inputMask.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", "disabled");
-        }
-        if (inputMask.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", "readonly");
-        }
         if (inputMask.getStyle() != null) {
             writer.writeAttribute("style", inputMask.getStyle(), "style");
-        }
-        if (inputMask.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
         }
 
         writer.writeAttribute("class", styleClass, "styleClass");

--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -203,15 +203,9 @@ public class InputNumberRenderer extends InputRenderer {
         writer.writeAttribute("type", inputNumber.getType(), null);
         writer.writeAttribute("value", valueToRender, null);
 
+        renderAccessibilityAttributes(context, inputNumber);
         renderPassThruAttributes(context, inputNumber, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputNumber, HTML.INPUT_TEXT_EVENTS);
-
-        if (inputNumber.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", "readonly");
-        }
-        if (inputNumber.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", "disabled");
-        }
 
         if (!isValueBlank(style)) {
             writer.writeAttribute("style", style, null);

--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -30,7 +30,6 @@ import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 
 import org.primefaces.component.inputtext.InputText;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.EscapeUtils;
@@ -171,9 +170,7 @@ public class InputNumberRenderer extends InputRenderer {
             writer.writeAttribute("onkeyup", inputNumber.getOnkeyup(), null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputNumber);
-        }
+        renderValidationMetadata(context, inputNumber);
 
         writer.endElement("input");
 
@@ -213,9 +210,7 @@ public class InputNumberRenderer extends InputRenderer {
 
         writer.writeAttribute("class", styleClass, null);
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputNumber);
-        }
+        renderValidationMetadata(context, inputNumber);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -128,9 +127,7 @@ public class InputSwitchRenderer extends InputRenderer {
             writer.writeAttribute("checked", "checked", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputSwitch);
-        }
+        renderValidationMetadata(context, inputSwitch);
 
         renderAccessibilityAttributes(context, inputSwitch);
         renderPassThruAttributes(context, inputSwitch, HTML.TAB_INDEX);

--- a/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -61,7 +61,6 @@ public class InputSwitchRenderer extends InputRenderer {
     protected void encodeMarkup(FacesContext context, InputSwitch inputSwitch) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         boolean checked = Boolean.valueOf(ComponentUtils.getValueToRender(context, inputSwitch));
-        boolean disabled = inputSwitch.isDisabled();
         boolean showLabels = inputSwitch.isShowLabels();
         String clientId = inputSwitch.getClientId(context);
         String style = inputSwitch.getStyle();
@@ -82,7 +81,7 @@ public class InputSwitchRenderer extends InputRenderer {
         encodeOption(context, inputSwitch.getOffLabel(), InputSwitch.OFF_LABEL_CLASS, showLabels);
         encodeOption(context, inputSwitch.getOnLabel(), InputSwitch.ON_LABEL_CLASS, showLabels);
         encodeHandle(context);
-        encodeInput(context, inputSwitch, clientId, checked, disabled);
+        encodeInput(context, inputSwitch, clientId, checked);
 
         writer.endElement("div");
     }
@@ -113,7 +112,7 @@ public class InputSwitchRenderer extends InputRenderer {
         writer.endElement("div");
     }
 
-    protected void encodeInput(FacesContext context, InputSwitch inputSwitch, String clientId, boolean checked, boolean disabled) throws IOException {
+    protected void encodeInput(FacesContext context, InputSwitch inputSwitch, String clientId, boolean checked) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = clientId + "_input";
 
@@ -128,17 +127,13 @@ public class InputSwitchRenderer extends InputRenderer {
         if (checked) {
             writer.writeAttribute("checked", "checked", null);
         }
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (inputSwitch.getTabindex() != null) {
-            writer.writeAttribute("tabindex", inputSwitch.getTabindex(), null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, inputSwitch);
         }
 
+        renderAccessibilityAttributes(context, inputSwitch);
+        renderPassThruAttributes(context, inputSwitch, HTML.TAB_INDEX);
         renderOnchange(context, inputSwitch);
         renderDomEvents(context, inputSwitch, HTML.BLUR_FOCUS_EVENTS);
 

--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -75,21 +75,13 @@ public class InputTextRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
+        renderAccessibilityAttributes(context, inputText);
         renderRTLDirection(context, inputText);
         renderPassThruAttributes(context, inputText, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputText, HTML.INPUT_TEXT_EVENTS);
 
-        if (inputText.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (inputText.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
         if (inputText.getStyle() != null) {
             writer.writeAttribute("style", inputText.getStyle(), null);
-        }
-        if (inputText.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
         }
 
         writer.writeAttribute("class", createStyleClass(inputText), "styleClass");

--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -86,9 +85,7 @@ public class InputTextRenderer extends InputRenderer {
 
         writer.writeAttribute("class", createStyleClass(inputText), "styleClass");
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputText);
-        }
+        renderValidationMetadata(context, inputText);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
@@ -130,20 +130,12 @@ public class InputTextareaRenderer extends InputRenderer {
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("name", clientId, null);
 
+        renderAccessibilityAttributes(context, inputTextarea);
         renderPassThruAttributes(context, inputTextarea, HTML.TEXTAREA_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, inputTextarea, HTML.INPUT_TEXT_EVENTS);
 
-        if (inputTextarea.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (inputTextarea.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
         if (inputTextarea.getStyle() != null) {
             writer.writeAttribute("style", inputTextarea.getStyle(), null);
-        }
-        if (inputTextarea.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
         }
 
         writer.writeAttribute("class", createStyleClass(inputTextarea), "styleClass");

--- a/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
@@ -25,7 +25,6 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.event.PhaseId;
 
 import org.primefaces.component.autocomplete.AutoComplete;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.event.AutoCompleteEvent;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
@@ -140,9 +139,7 @@ public class InputTextareaRenderer extends InputRenderer {
 
         writer.writeAttribute("class", createStyleClass(inputTextarea), "styleClass");
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, inputTextarea);
-        }
+        renderValidationMetadata(context, inputTextarea);
 
         String valueToRender = ComponentUtils.getValueToRender(context, inputTextarea);
         if (valueToRender != null) {

--- a/src/main/java/org/primefaces/component/keyboard/KeyboardRenderer.java
+++ b/src/main/java/org/primefaces/component/keyboard/KeyboardRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -115,9 +114,7 @@ public class KeyboardRenderer extends InputRenderer {
             writer.writeAttribute("style", keyboard.getStyle(), "style");
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, keyboard);
-        }
+        renderValidationMetadata(context, keyboard);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/keyboard/KeyboardRenderer.java
+++ b/src/main/java/org/primefaces/component/keyboard/KeyboardRenderer.java
@@ -105,22 +105,14 @@ public class KeyboardRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, "value");
         }
 
+        renderAccessibilityAttributes(context, keyboard);
         renderPassThruAttributes(context, keyboard, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, keyboard, HTML.INPUT_TEXT_EVENTS);
 
         writer.writeAttribute("class", styleClass, "styleClass");
 
-        if (keyboard.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", "disabled");
-        }
-        if (keyboard.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", "readonly");
-        }
         if (keyboard.getStyle() != null) {
             writer.writeAttribute("style", keyboard.getStyle(), "style");
-        }
-        if (keyboard.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
         }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {

--- a/src/main/java/org/primefaces/component/megamenu/MegaMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/megamenu/MegaMenuRenderer.java
@@ -27,6 +27,7 @@ import org.primefaces.component.menu.BaseMenuRenderer;
 import org.primefaces.component.menu.Menu;
 import org.primefaces.component.separator.UISeparator;
 import org.primefaces.model.menu.*;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class MegaMenuRenderer extends BaseMenuRenderer {
@@ -127,7 +128,7 @@ public class MegaMenuRenderer extends BaseMenuRenderer {
             writer.writeAttribute("style", style, null);
         }
         writer.writeAttribute("role", "menuitem", null);
-        writer.writeAttribute("aria-haspopup", "true", null);
+        writer.writeAttribute(HTML.ARIA_HASPOPUP, "true", null);
 
         //title
         writer.startElement("a", null);

--- a/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
@@ -78,7 +78,7 @@ public class MenuButtonRenderer extends BaseMenuRenderer {
         writer.writeAttribute("name", buttonId, null);
         writer.writeAttribute("type", "button", null);
         writer.writeAttribute("class", buttonClass, null);
-        writer.writeAttribute("aria-label", button.getAriaLabel(), "ariaLabel");
+        writer.writeAttribute(HTML.ARIA_LABEL, button.getAriaLabel(), "ariaLabel");
         if (button.isDisabled()) {
             writer.writeAttribute("disabled", "disabled", null);
         }

--- a/src/main/java/org/primefaces/component/message/MessageRenderer.java
+++ b/src/main/java/org/primefaces/component/message/MessageRenderer.java
@@ -28,6 +28,7 @@ import org.primefaces.component.api.InputHolder;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.UINotificationRenderer;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class MessageRenderer extends UINotificationRenderer {
@@ -57,7 +58,7 @@ public class MessageRenderer extends UINotificationRenderer {
 
         writer.startElement("div", uiMessage);
         writer.writeAttribute("id", uiMessage.getClientId(context), null);
-        writer.writeAttribute("aria-live", "polite", null);
+        writer.writeAttribute(HTML.ARIA_LIVE, "polite", null);
 
         if (style != null) {
             writer.writeAttribute("style", style, null);
@@ -104,7 +105,7 @@ public class MessageRenderer extends UINotificationRenderer {
 
                 writer.writeAttribute("class", styleClass, null);
                 writer.writeAttribute("role", "alert", null);
-                writer.writeAttribute("aria-atomic", "true", null);
+                writer.writeAttribute(HTML.ARIA_ATOMIC, "true", null);
 
                 if (!display.equals("text")) {
                     encodeIcon(writer, severityKey, msg.getDetail(), iconOnly);

--- a/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
+++ b/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
@@ -28,6 +28,7 @@ import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.expression.SearchExpressionHint;
 import org.primefaces.renderkit.UINotificationRenderer;
+import org.primefaces.util.HTML;
 
 public class MessagesRenderer extends UINotificationRenderer {
 
@@ -109,7 +110,7 @@ public class MessagesRenderer extends UINotificationRenderer {
             writer.writeAttribute("style", style, null);
         }
 
-        writer.writeAttribute("aria-live", "polite", null);
+        writer.writeAttribute(HTML.ARIA_LIVE, "polite", null);
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             writer.writeAttribute("data-global", String.valueOf(globalOnly), null);
@@ -168,7 +169,7 @@ public class MessagesRenderer extends UINotificationRenderer {
             writer.startElement("li", null);
 
             writer.writeAttribute("role", "alert", null);
-            writer.writeAttribute("aria-atomic", "true", null);
+            writer.writeAttribute(HTML.ARIA_ATOMIC, "true", null);
 
             String summary = message.getSummary() != null ? message.getSummary() : "";
             String detail = message.getDetail() != null ? message.getDetail() : summary;

--- a/src/main/java/org/primefaces/component/multiselectlistbox/MultiSelectListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/multiselectlistbox/MultiSelectListboxRenderer.java
@@ -69,7 +69,7 @@ public class MultiSelectListboxRenderer extends SelectOneRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
-        renderRequired(context, listbox);
+        renderAccessibilityAttributes(context, listbox);
         encodeInput(context, listbox);
         encodeLists(context, listbox, selectItems);
 

--- a/src/main/java/org/primefaces/component/multiselectlistbox/MultiSelectListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/multiselectlistbox/MultiSelectListboxRenderer.java
@@ -69,6 +69,7 @@ public class MultiSelectListboxRenderer extends SelectOneRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
+        renderRequired(context, listbox);
         encodeInput(context, listbox);
         encodeLists(context, listbox, selectItems);
 

--- a/src/main/java/org/primefaces/component/paginator/PageLinkRenderer.java
+++ b/src/main/java/org/primefaces/component/paginator/PageLinkRenderer.java
@@ -21,6 +21,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.api.Pageable;
+import org.primefaces.util.HTML;
 
 public class PageLinkRenderer {
 
@@ -34,7 +35,7 @@ public class PageLinkRenderer {
         writer.startElement("a", null);
         writer.writeAttribute("href", "#", null);
         writer.writeAttribute("class", styleClass, null);
-        writer.writeAttribute("aria-label", ariaLabel, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
         writer.writeAttribute("tabindex", tabindex, null);
 
         writer.startElement("span", null);

--- a/src/main/java/org/primefaces/component/paginator/RowsPerPageDropdownRenderer.java
+++ b/src/main/java/org/primefaces/component/paginator/RowsPerPageDropdownRenderer.java
@@ -25,6 +25,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.api.Pageable;
 import org.primefaces.component.api.UIData;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 
 public class RowsPerPageDropdownRenderer implements PaginatorElementRenderer {
@@ -69,7 +70,7 @@ public class RowsPerPageDropdownRenderer implements PaginatorElementRenderer {
             writer.writeAttribute("id", ddId, null);
             writer.writeAttribute("name", ddName, null);
             if (label != null) {
-                writer.writeAttribute("aria-labelledby", labelId, null);
+                writer.writeAttribute(HTML.ARIA_LABELLEDBY, labelId, null);
             }
             writer.writeAttribute("class", UIData.PAGINATOR_RPP_OPTIONS_CLASS, null);
             writer.writeAttribute("value", pageable.getRows(), null);

--- a/src/main/java/org/primefaces/component/password/PasswordRenderer.java
+++ b/src/main/java/org/primefaces/component/password/PasswordRenderer.java
@@ -97,18 +97,9 @@ public class PasswordRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
+        renderAccessibilityAttributes(context, password);
         renderPassThruAttributes(context, password, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, password, HTML.INPUT_TEXT_EVENTS);
-
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (password.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
-        if (password.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, password);

--- a/src/main/java/org/primefaces/component/password/PasswordRenderer.java
+++ b/src/main/java/org/primefaces/component/password/PasswordRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -100,10 +99,7 @@ public class PasswordRenderer extends InputRenderer {
         renderAccessibilityAttributes(context, password);
         renderPassThruAttributes(context, password, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, password, HTML.INPUT_TEXT_EVENTS);
-
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, password);
-        }
+        renderValidationMetadata(context, password);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
+++ b/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
@@ -208,6 +208,11 @@ public class PickListRenderer extends CoreRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("class", PickList.LIST_WRAPPER_CLASS, null);
 
+        // only render required on target list
+        if (!isSource) {
+            renderRequired(context, pickList);
+        }
+
         if (filter) {
             encodeFilter(context, pickList, listId + "_filter", isSource);
         }
@@ -364,8 +369,8 @@ public class PickListRenderer extends CoreRenderer {
         writer.writeAttribute("id", clientId + "_ariaRegion", null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
         writer.writeAttribute("role", "region", null);
-        writer.writeAttribute("aria-live", "polite", null);
-        writer.writeAttribute("aria-atomic", "true", null);
+        writer.writeAttribute(HTML.ARIA_LIVE, "polite", null);
+        writer.writeAttribute(HTML.ARIA_ATOMIC, "true", null);
         writer.endElement("div");
     }
 

--- a/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/radiobutton/RadioButtonRenderer.java
@@ -84,11 +84,10 @@ public class RadioButtonRenderer extends InputRenderer {
         writer.writeAttribute("class", "ui-radio-clone", null);
         writer.writeAttribute("data-itemindex", button.getItemIndex(), null);
 
+        renderAccessibilityAttributes(context, radio, disabled, radio.isReadonly());
+
         if (tabindex != null) {
             writer.writeAttribute("tabindex", tabindex, null);
-        }
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
         }
 
         String onchange = buildEvent(context, radio, button, "onchange", "change", "valueChange");

--- a/src/main/java/org/primefaces/component/rating/RatingRenderer.java
+++ b/src/main/java/org/primefaces/component/rating/RatingRenderer.java
@@ -86,6 +86,8 @@ public class RatingRenderer extends InputRenderer {
             writer.writeAttribute("style", style, null);
         }
 
+        renderAccessibilityAttributes(context, rating);
+
         if (rating.isCancel() && !disabled && !readonly) {
             encodeIcon(context, Rating.CANCEL_CLASS);
         }

--- a/src/main/java/org/primefaces/component/ribbon/RibbonRenderer.java
+++ b/src/main/java/org/primefaces/component/ribbon/RibbonRenderer.java
@@ -24,6 +24,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.tabview.Tab;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class RibbonRenderer extends CoreRenderer {
@@ -97,7 +98,7 @@ public class RibbonRenderer extends CoreRenderer {
                     writer.startElement("li", null);
                     writer.writeAttribute("class", headerClass, null);
                     writer.writeAttribute("role", "tab", null);
-                    writer.writeAttribute("aria-expanded", String.valueOf(active), null);
+                    writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
 
                     writer.startElement("a", null);
                     writer.writeAttribute("href", tab.getClientId(context), null);

--- a/src/main/java/org/primefaces/component/rowtoggler/RowTogglerRenderer.java
+++ b/src/main/java/org/primefaces/component/rowtoggler/RowTogglerRenderer.java
@@ -23,6 +23,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 
 public class RowTogglerRenderer extends CoreRenderer {
@@ -44,8 +45,8 @@ public class RowTogglerRenderer extends CoreRenderer {
         writer.writeAttribute("class", togglerClass, null);
         writer.writeAttribute("tabindex", toggler.getTabindex(), null);
         writer.writeAttribute("role", "button", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(expanded), null);
-        writer.writeAttribute("aria-label", ariaLabel, null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(expanded), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
 
         if (!iconOnly) {
             writeLabel(writer, expandLabel, !expanded);

--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -97,21 +97,15 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         if (checked) {
             writer.writeAttribute("checked", "checked", null);
         }
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, button);
         }
 
+        renderAccessibilityAttributes(context, button);
+        renderPassThruAttributes(context, button, HTML.TAB_INDEX);
         renderOnchange(context, button);
         renderDomEvents(context, button, HTML.BLUR_FOCUS_EVENTS);
-
-        // tabindex
-        if (button.getTabindex() != null) {
-            writer.writeAttribute("tabindex", button.getTabindex(), null);
-        }
 
         writer.endElement("input");
 

--- a/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -22,7 +22,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.convert.ConverterException;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -98,9 +97,7 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
             writer.writeAttribute("checked", "checked", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, button);
-        }
+        renderValidationMetadata(context, button);
 
         renderAccessibilityAttributes(context, button);
         renderPassThruAttributes(context, button, HTML.TAB_INDEX);

--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -85,17 +85,16 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
             writer.writeAttribute("title", title, "title");
         }
 
-        encodeInput(context, checkbox, clientId, checked, disabled);
+        encodeInput(context, checkbox, clientId, checked);
         encodeOutput(context, checkbox, checked, disabled);
         encodeItemLabel(context, checkbox, clientId);
 
         writer.endElement("div");
     }
 
-    protected void encodeInput(FacesContext context, SelectBooleanCheckbox checkbox, String clientId, boolean checked, boolean disabled) throws IOException {
+    protected void encodeInput(FacesContext context, SelectBooleanCheckbox checkbox, String clientId, boolean checked) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = clientId + "_input";
-        String labelledBy = checkbox.getLabelledBy();
 
         writer.startElement("div", checkbox);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
@@ -105,31 +104,22 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
         writer.writeAttribute("autocomplete", "off", null);
-        writer.writeAttribute("aria-hidden", "true", null);
-
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
+        writer.writeAttribute(HTML.ARIA_HIDDEN, "true", null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);
-            writer.writeAttribute("aria-checked", "true", null);
+            writer.writeAttribute(HTML.ARIA_CHECKED, "true", null);
         }
         else {
-            writer.writeAttribute("aria-checked", "false", null);
-        }
-
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (checkbox.getTabindex() != null) {
-            writer.writeAttribute("tabindex", checkbox.getTabindex(), null);
+            writer.writeAttribute(HTML.ARIA_CHECKED, "false", null);
         }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, checkbox);
         }
 
+        renderAccessibilityAttributes(context, checkbox);
+        renderPassThruAttributes(context, checkbox, HTML.TAB_INDEX);
         renderOnchange(context, checkbox);
         renderDomEvents(context, checkbox, HTML.BLUR_FOCUS_EVENTS);
 

--- a/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectbooleancheckbox/SelectBooleanCheckboxRenderer.java
@@ -22,7 +22,6 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.convert.ConverterException;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -114,9 +113,7 @@ public class SelectBooleanCheckboxRenderer extends InputRenderer {
             writer.writeAttribute(HTML.ARIA_CHECKED, "false", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, checkbox);
-        }
+        renderValidationMetadata(context, checkbox);
 
         renderAccessibilityAttributes(context, checkbox);
         renderPassThruAttributes(context, checkbox, HTML.TAB_INDEX);

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -79,7 +79,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
             writer.writeAttribute("title", title, "title");
         }
 
-        renderRequired(context, menu);
+        renderAccessibilityAttributes(context, menu);
         encodeKeyboardTarget(context, menu);
         encodeInputs(context, menu, selectItems);
         if (menu.isMultiple()) {

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -79,6 +79,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
             writer.writeAttribute("title", title, "title");
         }
 
+        renderRequired(context, menu);
         encodeKeyboardTarget(context, menu);
         encodeInputs(context, menu, selectItems);
         if (menu.isMultiple()) {

--- a/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -72,6 +72,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
+        renderRequired(context, button);
         encodeSelectItems(context, button, selectItems);
 
         writer.endElement("div");

--- a/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -72,7 +72,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
-        renderRequired(context, button);
+        renderAccessibilityAttributes(context, button);
         encodeSelectItems(context, button, selectItems);
 
         writer.endElement("div");

--- a/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
@@ -70,6 +70,7 @@ public class SelectManyCheckboxRenderer extends SelectManyRenderer {
             writer.startElement("span", checkbox);
             writer.writeAttribute("id", checkbox.getClientId(context), "id");
             writer.writeAttribute("class", "ui-helper-hidden", null);
+            renderRequired(context, checkbox);
             encodeCustomLayout(context, checkbox);
             writer.endElement("span");
         }
@@ -110,6 +111,7 @@ public class SelectManyCheckboxRenderer extends SelectManyRenderer {
         if (style != null) {
             writer.writeAttribute("style", style, "style");
         }
+        renderRequired(context, checkbox);
 
         List<SelectItem> selectItems = getSelectItems(context, checkbox);
         Converter converter = checkbox.getConverter();
@@ -195,6 +197,7 @@ public class SelectManyCheckboxRenderer extends SelectManyRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
+        renderRequired(context, checkbox);
         encodeSelectItems(context, checkbox, layout);
 
         writer.endElement("table");

--- a/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
@@ -31,7 +31,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.model.SelectItemGroup;
 import javax.faces.render.Renderer;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.GridLayoutUtils;
@@ -230,9 +229,7 @@ public class SelectManyCheckboxRenderer extends SelectManyRenderer {
             writer.writeAttribute("disabled", "disabled", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, checkbox);
-        }
+        renderValidationMetadata(context, checkbox);
 
         writer.endElement("input");
 

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -32,6 +32,7 @@ import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectManyMenuRenderer extends SelectManyRenderer {
@@ -104,7 +105,6 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
 
         ResponseWriter writer = context.getResponseWriter();
         String inputid = clientId + "_input";
-        String labelledBy = menu.getLabelledBy();
 
         writer.startElement("div", null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
@@ -115,19 +115,9 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         writer.writeAttribute("multiple", "multiple", null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
 
+        renderAccessibilityAttributes(context, menu);
+        renderPassThruAttributes(context, menu, HTML.TAB_INDEX);
         renderDomEvents(context, menu, SelectManyMenu.DOM_EVENTS);
-
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
-
-        if (menu.getTabindex() != null) {
-            writer.writeAttribute("tabindex", menu.getTabindex(), null);
-        }
-
-        if (menu.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, menu);

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -28,7 +28,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 
 import org.primefaces.component.column.Column;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.renderkit.SelectManyRenderer;
 import org.primefaces.util.ComponentUtils;
@@ -118,10 +117,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
         renderAccessibilityAttributes(context, menu);
         renderPassThruAttributes(context, menu, HTML.TAB_INDEX);
         renderDomEvents(context, menu, SelectManyMenu.DOM_EVENTS);
-
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, menu);
-        }
+        renderValidationMetadata(context, menu);
 
         encodeSelectItems(context, menu, selectItems);
 

--- a/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
@@ -71,6 +71,7 @@ public class SelectOneButtonRenderer extends SelectOneRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
+        renderRequired(context, button);
         encodeSelectItems(context, button, selectItems);
 
         writer.endElement("div");

--- a/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonebutton/SelectOneButtonRenderer.java
@@ -71,7 +71,7 @@ public class SelectOneButtonRenderer extends SelectOneRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
-        renderRequired(context, button);
+        renderAccessibilityAttributes(context, button);
         encodeSelectItems(context, button, selectItems);
 
         writer.endElement("div");

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -28,7 +28,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 
 import org.primefaces.component.column.Column;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -115,10 +114,7 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         renderAccessibilityAttributes(context, listbox);
         renderPassThruAttributes(context, listbox, HTML.TAB_INDEX);
         renderDomEvents(context, listbox, SelectOneListbox.DOM_EVENTS);
-
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, listbox);
-        }
+        renderValidationMetadata(context, listbox);
 
         encodeSelectItems(context, listbox, selectItems);
 

--- a/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonelistbox/SelectOneListboxRenderer.java
@@ -31,6 +31,7 @@ import org.primefaces.component.column.Column;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectOneListboxRenderer extends SelectOneRenderer {
@@ -102,7 +103,6 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
 
         ResponseWriter writer = context.getResponseWriter();
         String inputid = clientId + "_input";
-        String labelledBy = listbox.getLabelledBy();
 
         writer.startElement("div", listbox);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
@@ -112,15 +112,9 @@ public class SelectOneListboxRenderer extends SelectOneRenderer {
         writer.writeAttribute("name", inputid, null);
         writer.writeAttribute("size", "2", null);   //prevent browser to send value when no item is selected
 
+        renderAccessibilityAttributes(context, listbox);
+        renderPassThruAttributes(context, listbox, HTML.TAB_INDEX);
         renderDomEvents(context, listbox, SelectOneListbox.DOM_EVENTS);
-
-        if (listbox.getTabindex() != null) {
-            writer.writeAttribute("tabindex", listbox.getTabindex(), null);
-        }
-
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, listbox);

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -32,7 +32,6 @@ import javax.faces.model.SelectItemGroup;
 import javax.faces.render.Renderer;
 
 import org.primefaces.component.column.Column;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
@@ -199,9 +198,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
 
         renderOnchange(context, menu);
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, menu);
-        }
+        renderValidationMetadata(context, menu);
 
         encodeSelectItems(context, menu, selectItems, values, submittedValues, converter);
 

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -42,11 +42,11 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
-        if (!shouldDecode(component)) {
+        SelectOneMenu menu = (SelectOneMenu) component;
+        if (!shouldDecode(menu)) {
             return;
         }
 
-        SelectOneMenu menu = (SelectOneMenu) component;
         if (menu.isEditable()) {
             Map<String, String> params = context.getExternalContext().getRequestParameterMap();
 

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -122,14 +122,15 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("class", styleClass, "styleclass");
         writer.writeAttribute("role", "combobox", null);
-        writer.writeAttribute("aria-haspopup", "true", null);
-        writer.writeAttribute("aria-expanded", "false", null);
+        writer.writeAttribute(HTML.ARIA_HASPOPUP, "true", null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, "false", null);
         if (style != null) {
             writer.writeAttribute("style", style, "style");
         }
         if (title != null) {
             writer.writeAttribute("title", title, "title");
         }
+        renderAccessibilityAttributes(context, menu);
 
         encodeInput(context, menu, clientId, selectItems, values, submittedValues, converter);
         encodeLabel(context, menu, selectItems);
@@ -144,7 +145,6 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
 
         ResponseWriter writer = context.getResponseWriter();
         String focusId = clientId + "_focus";
-        String labelledBy = menu.getLabelledBy();
 
         //input for accessibility
         writer.startElement("div", null);
@@ -155,18 +155,11 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("name", focusId, null);
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("autocomplete", "off", null);
-        //for keyboard accessibility and ScreenReader
-        writer.writeAttribute("aria-expanded", "false", null);
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
-        if (menu.getTabindex() != null) {
-            writer.writeAttribute("tabindex", menu.getTabindex(), null);
-        }
-        if (menu.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
 
+        //for keyboard accessibility and ScreenReader
+        writer.writeAttribute(HTML.ARIA_EXPANDED, "false", null);
+        renderAccessibilityAttributes(context, menu);
+        renderPassThruAttributes(context, menu, HTML.TAB_INDEX);
         renderDomEvents(context, menu, HTML.BLUR_FOCUS_EVENTS);
 
         writer.endElement("input");
@@ -193,7 +186,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("tabindex", "-1", null);
-        writer.writeAttribute("aria-hidden", "true", null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, "true", null);
         if (menu.isDisabled()) {
             writer.writeAttribute("disabled", "disabled", null);
         }

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -60,7 +60,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             for (int i = 0; i < selectItems.size(); i++) {
                 SelectItem item = selectItems.get(i);
                 if (item.getLabel().equalsIgnoreCase(editorInput)) {
-                    menu.setSubmittedValue(item.getValue());
+                    menu.setSubmittedValue(getOptionAsString(context, menu, menu.getConverter(), item.getValue()));
                     break;
                 }
             }

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -32,7 +32,6 @@ import javax.faces.model.SelectItem;
 import javax.faces.render.Renderer;
 
 import org.primefaces.component.radiobutton.RadioButton;
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.SelectOneRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.GridLayoutUtils;
@@ -340,9 +339,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
             writer.writeAttribute("disabled", "disabled", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, radio);
-        }
+        renderValidationMetadata(context, radio);
 
         writer.endElement("input");
 

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -115,6 +115,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
         if (style != null) {
             writer.writeAttribute("style", style, "style");
         }
+        renderRequired(context, radio);
 
         Converter converter = radio.getConverter();
         String name = radio.getClientId(context);
@@ -176,6 +177,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
+        renderRequired(context, radio);
         encodeSelectItems(context, radio, selectItems, layout);
 
         writer.endElement("table");

--- a/src/main/java/org/primefaces/component/signature/SignatureRenderer.java
+++ b/src/main/java/org/primefaces/component/signature/SignatureRenderer.java
@@ -65,6 +65,8 @@ public class SignatureRenderer extends CoreRenderer {
             writer.writeAttribute("class", styleClass, null);
         }
 
+        renderAccessibilityAttributes(context, signature);
+
         encodeInputField(context, signature, clientId + "_value", signature.getValue());
 
         if (signature.getValueExpression(Signature.PropertyKeys.base64Value.toString()) != null) {

--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -130,10 +129,7 @@ public class SpinnerRenderer extends InputRenderer {
         renderAccessibilityAttributes(context, spinner);
         renderPassThruAttributes(context, spinner, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, spinner, HTML.INPUT_TEXT_EVENTS);
-
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, spinner);
-        }
+        renderValidationMetadata(context, spinner);
 
         writer.endElement("input");
     }

--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -112,7 +112,6 @@ public class SpinnerRenderer extends InputRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = spinner.getClientId(context) + "_input";
         String inputClass = spinner.isValid() ? Spinner.INPUT_CLASS : Spinner.INPUT_CLASS + " ui-state-error";
-        String labelledBy = spinner.getLabelledBy();
 
         writer.startElement("input", null);
         writer.writeAttribute("id", inputId, null);
@@ -128,21 +127,9 @@ public class SpinnerRenderer extends InputRenderer {
             writer.writeAttribute("value", valueToRender, null);
         }
 
+        renderAccessibilityAttributes(context, spinner);
         renderPassThruAttributes(context, spinner, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, spinner, HTML.INPUT_TEXT_EVENTS);
-
-        if (spinner.isDisabled()) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (spinner.isReadonly()) {
-            writer.writeAttribute("readonly", "readonly", null);
-        }
-        if (spinner.isRequired()) {
-            writer.writeAttribute("aria-required", "true", null);
-        }
-        if (labelledBy != null) {
-            writer.writeAttribute("aria-labelledby", labelledBy, null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, spinner);

--- a/src/main/java/org/primefaces/component/tabmenu/TabMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/tabmenu/TabMenuRenderer.java
@@ -26,6 +26,7 @@ import org.primefaces.component.menu.AbstractMenu;
 import org.primefaces.component.menu.BaseMenuRenderer;
 import org.primefaces.model.menu.MenuElement;
 import org.primefaces.model.menu.MenuItem;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class TabMenuRenderer extends BaseMenuRenderer {
@@ -94,8 +95,8 @@ public class TabMenuRenderer extends BaseMenuRenderer {
         writer.startElement("li", null);
         writer.writeAttribute("class", containerClass, null);
         writer.writeAttribute("role", "tab", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(active), null);
-        writer.writeAttribute("aria-selected", String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
 
         if (containerStyle != null) {
             writer.writeAttribute("style", containerStyle, null);

--- a/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -228,9 +228,9 @@ public class TabViewRenderer extends CoreRenderer {
         writer.startElement("li", tab);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "tab", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(active), null);
-        writer.writeAttribute("aria-selected", String.valueOf(active), null);
-        writer.writeAttribute("aria-label", tab.getAriaLabel(), null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("data-index", index, null);
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
@@ -268,7 +268,7 @@ public class TabViewRenderer extends CoreRenderer {
         if (actions != null && actions.isRendered()) {
             writer.startElement("li", null);
             writer.writeAttribute("class", "ui-tabs-actions", null);
-            writer.writeAttribute("aria-hidden", String.valueOf(!active), null);
+            writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
             actions.encodeAll(context);
             writer.endElement("li");
         }
@@ -324,7 +324,7 @@ public class TabViewRenderer extends CoreRenderer {
         writer.writeAttribute("id", tab.getClientId(context), null);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "tabpanel", null);
-        writer.writeAttribute("aria-hidden", String.valueOf(!active), null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute("data-index", index, null);
 
         if (dynamic) {

--- a/src/main/java/org/primefaces/component/tieredmenu/TieredMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/tieredmenu/TieredMenuRenderer.java
@@ -29,6 +29,7 @@ import org.primefaces.model.menu.MenuElement;
 import org.primefaces.model.menu.MenuItem;
 import org.primefaces.model.menu.Separator;
 import org.primefaces.model.menu.Submenu;
+import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
 public class TieredMenuRenderer extends BaseMenuRenderer {
@@ -130,7 +131,7 @@ public class TieredMenuRenderer extends BaseMenuRenderer {
                         writer.writeAttribute("style", style, null);
                     }
                     writer.writeAttribute("role", "menuitem", null);
-                    writer.writeAttribute("aria-haspopup", "true", null);
+                    writer.writeAttribute(HTML.ARIA_HASPOPUP, "true", null);
                     encodeSubmenu(context, menu, submenu);
                     writer.endElement("li");
                 }

--- a/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
@@ -21,7 +21,6 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
@@ -110,9 +109,7 @@ public class ToggleSwitchRenderer extends InputRenderer {
             writer.writeAttribute("checked", "checked", null);
         }
 
-        if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
-            renderValidationMetadata(context, toggleSwitch);
-        }
+        renderValidationMetadata(context, toggleSwitch);
 
         renderAccessibilityAttributes(context, toggleSwitch);
         renderPassThruAttributes(context, toggleSwitch, HTML.TAB_INDEX);

--- a/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
@@ -75,12 +75,12 @@ public class ToggleSwitchRenderer extends InputRenderer {
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("class", styleClass, "styleClass");
         writer.writeAttribute("role", "checkbox", null);
-        writer.writeAttribute("aria-checked", checked, null);
+        writer.writeAttribute(HTML.ARIA_CHECKED, checked, null);
         if (style != null) {
             writer.writeAttribute("style", style, "style");
         }
 
-        encodeInput(context, toggleSwitch, clientId, checked, disabled);
+        encodeInput(context, toggleSwitch, clientId, checked);
         encodeSlider(context);
 
         writer.endElement("div");
@@ -94,7 +94,7 @@ public class ToggleSwitchRenderer extends InputRenderer {
         writer.endElement("div");
     }
 
-    protected void encodeInput(FacesContext context, ToggleSwitch toggleSwitch, String clientId, boolean checked, boolean disabled) throws IOException {
+    protected void encodeInput(FacesContext context, ToggleSwitch toggleSwitch, String clientId, boolean checked) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = clientId + "_input";
 
@@ -109,17 +109,13 @@ public class ToggleSwitchRenderer extends InputRenderer {
         if (checked) {
             writer.writeAttribute("checked", "checked", null);
         }
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
-        if (toggleSwitch.getTabindex() != null) {
-            writer.writeAttribute("tabindex", toggleSwitch.getTabindex(), null);
-        }
 
         if (PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
             renderValidationMetadata(context, toggleSwitch);
         }
 
+        renderAccessibilityAttributes(context, toggleSwitch);
+        renderPassThruAttributes(context, toggleSwitch, HTML.TAB_INDEX);
         renderOnchange(context, toggleSwitch);
         renderDomEvents(context, toggleSwitch, HTML.BLUR_FOCUS_EVENTS);
 

--- a/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -369,7 +369,7 @@ public class TreeRenderer extends CoreRenderer {
             writer.writeAttribute("tabindex", tree.getTabindex(), null);
         }
 
-        writer.writeAttribute("aria-multiselectable", String.valueOf(multiselectable), null);
+        writer.writeAttribute(HTML.ARIA_MULITSELECTABLE, String.valueOf(multiselectable), null);
         if (tree.getStyle() != null) {
             writer.writeAttribute("style", tree.getStyle(), null);
         }
@@ -694,10 +694,10 @@ public class TreeRenderer extends CoreRenderer {
         writer.startElement("span", null);
         writer.writeAttribute("class", contentClass, null);
         writer.writeAttribute("role", "treeitem", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(expanded), null);
-        writer.writeAttribute("aria-selected", String.valueOf(selected), null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(expanded), null);
+        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(selected), null);
         if (checkbox) {
-            writer.writeAttribute("aria-checked", String.valueOf(selected), null);
+            writer.writeAttribute(HTML.ARIA_CHECKED, String.valueOf(selected), null);
         }
 
         //state icon
@@ -723,7 +723,7 @@ public class TreeRenderer extends CoreRenderer {
         }
 
         writer.writeAttribute("role", "treeitem", null);
-        writer.writeAttribute("aria-label", uiTreeNode.getAriaLabel(), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, uiTreeNode.getAriaLabel(), null);
         uiTreeNode.encodeAll(context);
         writer.endElement("span");
 

--- a/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -578,7 +578,7 @@ public class TreeTableRenderer extends DataRenderer {
         writer.writeAttribute("id", tt.getClientId(context) + "_node_" + rowKey, null);
         writer.writeAttribute("class", rowStyleClass, null);
         writer.writeAttribute("role", "row", null);
-        writer.writeAttribute("aria-expanded", String.valueOf(treeNode.isExpanded()), null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(treeNode.isExpanded()), null);
         writer.writeAttribute("data-rk", rowKey, null);
 
         if (parentRowKey != null) {
@@ -586,7 +586,7 @@ public class TreeTableRenderer extends DataRenderer {
         }
 
         if (selectionEnabled) {
-            writer.writeAttribute("aria-selected", String.valueOf(selected), null);
+            writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(selected), null);
         }
 
         for (int i = 0; i < columns.size(); i++) {
@@ -724,7 +724,7 @@ public class TreeTableRenderer extends DataRenderer {
         writer.writeAttribute("id", column.getContainerClientId(context), null);
         writer.writeAttribute("class", columnClass, null);
         writer.writeAttribute("role", "columnheader", null);
-        writer.writeAttribute("aria-label", ariaHeaderLabel, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaHeaderLabel, null);
         if (style != null) {
             writer.writeAttribute("style", style, null);
         }

--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -80,7 +80,7 @@ public class TriStateCheckboxRenderer extends InputRenderer {
             writer.writeAttribute("style", style, "style");
         }
 
-        encodeInput(context, checkbox, clientId, valCheck, disabled);
+        encodeInput(context, checkbox, clientId, valCheck);
         encodeOutput(context, checkbox, valCheck, disabled);
         encodeItemLabel(context, checkbox);
 
@@ -88,7 +88,7 @@ public class TriStateCheckboxRenderer extends InputRenderer {
     }
 
     protected void encodeInput(final FacesContext context, final TriStateCheckbox checkbox, final String clientId,
-                               final int valCheck, final boolean disabled) throws IOException {
+                               final int valCheck) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = clientId + "_input";
 
@@ -98,12 +98,8 @@ public class TriStateCheckboxRenderer extends InputRenderer {
         writer.startElement("input", null);
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
-
         writer.writeAttribute("value", valCheck, null);
-
-        if (disabled) {
-            writer.writeAttribute("disabled", "disabled", null);
-        }
+        renderAccessibilityAttributes(context, checkbox);
 
         if (checkbox.getOnchange() != null) {
             writer.writeAttribute("onchange", checkbox.getOnchange(), null);

--- a/src/main/java/org/primefaces/model/DefaultUploadedFile.java
+++ b/src/main/java/org/primefaces/model/DefaultUploadedFile.java
@@ -15,6 +15,7 @@
  */
 package org.primefaces.model;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.component.fileupload.FileUpload;
-import org.owasp.esapi.SafeFile;
+import org.primefaces.util.FileUploadUtils;
 
 /**
  *
@@ -44,7 +45,7 @@ public class DefaultUploadedFile implements UploadedFile, Serializable {
 
     @Override
     public String getFileName() {
-        return fileItem.getName();
+        return FileUploadUtils.getValidFilename(fileItem.getName());
     }
 
     @Override
@@ -74,7 +75,8 @@ public class DefaultUploadedFile implements UploadedFile, Serializable {
 
     @Override
     public void write(String filePath) throws Exception {
-        fileItem.write(new SafeFile(filePath));
+        String validFilePath = FileUploadUtils.getValidFilePath(filePath);
+        fileItem.write(new File(validFilePath));
     }
 
 }

--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -28,7 +28,7 @@ import java.util.List;
 import javax.faces.FacesException;
 import javax.servlet.http.Part;
 import org.apache.commons.io.input.BoundedInputStream;
-import org.owasp.esapi.SafeFile;
+import org.primefaces.util.FileUploadUtils;
 
 public class NativeUploadedFile implements UploadedFile, Serializable {
 
@@ -119,17 +119,16 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
 
     @Override
     public void write(String filePath) throws Exception {
-        SafeFile file = new SafeFile(filePath);
-        String path = file.getPath();
+        String validFilePath = FileUploadUtils.getValidFilePath(filePath);
 
         if (parts != null) {
             for (int i = 0; i < parts.size(); i++) {
                 Part p = parts.get(i);
-                p.write(path);
+                p.write(validFilePath);
             }
         }
         else {
-            part.write(path);
+            part.write(validFilePath);
         }
     }
 
@@ -138,7 +137,7 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
     }
 
     private String resolveFilename(Part part) {
-        return getContentDispositionFileName(part.getHeader("content-disposition"));
+        return FileUploadUtils.getValidFilename(getContentDispositionFileName(part.getHeader("content-disposition")));
     }
 
     private List<String> resolveFilenames(List<Part> parts) {

--- a/src/main/java/org/primefaces/model/UploadedFileWrapper.java
+++ b/src/main/java/org/primefaces/model/UploadedFileWrapper.java
@@ -21,7 +21,6 @@ import java.util.List;
 import javax.faces.FacesWrapper;
 import javax.faces.component.StateHolder;
 import javax.faces.context.FacesContext;
-import org.owasp.esapi.SafeFile;
 
 /**
  * Wrapper to avoid a UploadedFile to beeing saved in the ViewState.
@@ -70,8 +69,7 @@ public class UploadedFileWrapper implements UploadedFile, FacesWrapper<UploadedF
 
     @Override
     public void write(String filePath) throws Exception {
-        SafeFile file = new SafeFile(filePath);
-        getWrapped().write(file.getPath());
+        getWrapped().write(filePath);
     }
 
     @Override

--- a/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -707,6 +707,10 @@ public abstract class CoreRenderer extends Renderer {
     }
 
     protected void renderValidationMetadata(FacesContext context, EditableValueHolder component) throws IOException {
+        if (!PrimeApplicationContext.getCurrentInstance(context).getConfig().isClientSideValidationEnabled()) {
+            return; //GitHub #4049: short circuit method
+        }
+
         ResponseWriter writer = context.getResponseWriter();
         UIComponent comp = (UIComponent) component;
 

--- a/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -851,11 +851,11 @@ public abstract class CoreRenderer extends Renderer {
         return false;
     }
 
-    protected <T extends UIComponent> boolean isDisabled(T component) {
+    protected <T extends UIInput> boolean isDisabled(T component) {
         return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")));
     }
 
-    protected <T extends UIComponent> boolean isReadOnly(T component) {
+    protected <T extends UIInput> boolean isReadOnly(T component) {
         return Boolean.parseBoolean(String.valueOf(component.getAttributes().get("readonly")));
     }
 

--- a/src/main/java/org/primefaces/renderkit/DataRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/DataRenderer.java
@@ -37,6 +37,7 @@ import org.primefaces.component.paginator.PaginatorElementRenderer;
 import org.primefaces.component.paginator.PrevPageLinkRenderer;
 import org.primefaces.component.paginator.RowsPerPageDropdownRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.HTML;
 import org.primefaces.util.MessageFactory;
 import org.primefaces.util.WidgetBuilder;
 
@@ -92,7 +93,7 @@ public class DataRenderer extends CoreRenderer {
         writer.writeAttribute("id", id, null);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "navigation", null);
-        writer.writeAttribute("aria-label", ariaMessage, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaMessage, null);
 
         if (leftTopContent != null && isTop) {
             writer.startElement("div", null);

--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -17,6 +17,7 @@ package org.primefaces.renderkit;
 
 import java.io.IOException;
 import javax.faces.component.UIComponent;
+import javax.faces.component.UIInput;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
@@ -39,7 +40,7 @@ public abstract class InputRenderer extends CoreRenderer {
         }
     }
 
-    protected boolean shouldDecode(UIComponent component) {
+    protected boolean shouldDecode(UIInput component) {
         return !isDisabled(component) && !isReadOnly(component);
     }
 

--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -40,10 +40,7 @@ public abstract class InputRenderer extends CoreRenderer {
     }
 
     protected boolean shouldDecode(UIComponent component) {
-        boolean disabled = Boolean.parseBoolean(String.valueOf(component.getAttributes().get("disabled")));
-        boolean readonly = Boolean.parseBoolean(String.valueOf(component.getAttributes().get("readonly")));
-
-        return !disabled && !readonly;
+        return !isDisabled(component) && !isReadOnly(component);
     }
 
     public <T extends UIComponent & RTLAware> void renderRTLDirection(FacesContext context, T component) throws IOException {
@@ -51,4 +48,5 @@ public abstract class InputRenderer extends CoreRenderer {
             context.getResponseWriter().writeAttribute("dir", "rtl", null);
         }
     }
+
 }

--- a/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
@@ -27,11 +27,10 @@ public abstract class SelectManyRenderer extends SelectRenderer {
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
-        if (!shouldDecode(component)) {
+        UISelectMany selectMany = (UISelectMany) component;
+        if (!shouldDecode(selectMany)) {
             return;
         }
-
-        UISelectMany selectMany = (UISelectMany) component;
 
         String submitParam = getSubmitParam(context, selectMany);
         Map<String, String[]> params = context.getExternalContext().getRequestParameterValuesMap();

--- a/src/main/java/org/primefaces/renderkit/SelectOneRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/SelectOneRenderer.java
@@ -24,11 +24,10 @@ public abstract class SelectOneRenderer extends SelectRenderer {
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
-        if (!shouldDecode(component)) {
+        UISelectOne selectOne = (UISelectOne) component;
+        if (!shouldDecode(selectOne)) {
             return;
         }
-
-        UISelectOne selectOne = (UISelectOne) component;
 
         String clientId = getSubmitParam(context, selectOne);
         Map<String, String> params = context.getExternalContext().getRequestParameterMap();

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2009-2018 PrimeTek.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import javax.faces.FacesException;
+import org.apache.commons.io.FilenameUtils;
+import org.owasp.esapi.SafeFile;
+import org.owasp.esapi.errors.ValidationException;
+
+ /**
+ * Utilities for FileUpload components.
+ */
+public class FileUploadUtils {
+
+    private static final Pattern INVALID_FILENAME_PATTERN = Pattern.compile("([\\/:*?\"<>|])");
+
+    public static String getValidFilename(String filename) {
+        if (filename != null) {
+            if (isSystemWindows()) {
+                if (!filename.contains("\\\\")) {
+                    String[] parts = filename.substring(FilenameUtils.getPrefixLength(filename)).split(Pattern.quote(File.separator));
+                    for (String part : parts) {
+                        if (INVALID_FILENAME_PATTERN.matcher(part).find()) {
+                            throw new FacesException("Invalid filename: " + filename);
+                        }
+                    }
+                }
+                else {
+                    throw new FacesException("Invalid filename: " + filename);
+                }
+            }
+
+            String name = FilenameUtils.getName(filename);
+            String extension = FilenameUtils.EXTENSION_SEPARATOR_STR + FilenameUtils.getExtension(filename);
+
+            if (extension.isEmpty()) {
+                throw new FacesException("File must have an extension");
+            }
+            else if (name.isEmpty() || extension.equals(name)) {
+                throw new FacesException("Filename can not be the empty string");
+            }
+            else {
+                return name;
+            }
+        }
+
+        return filename;
+    }
+
+    public static String getValidFilePath(String filePath) throws ValidationException {
+        if (filePath == null || filePath.trim().equals("")) {
+            throw new FacesException("Path can not be the empty string or null");
+        }
+
+        try {
+            SafeFile file = new SafeFile(filePath);
+            File parentFile = file.getParentFile();
+
+            if (!file.exists()) {
+                throw new ValidationException("Invalid directory", "Invalid directory, \"" + file + "\" does not exist.");
+            }
+            if (!parentFile.exists()) {
+                throw new ValidationException("Invalid directory", "Invalid directory, specified parent does not exist.");
+            }
+            if (!parentFile.isDirectory()) {
+                throw new ValidationException("Invalid directory", "Invalid directory, specified parent is not a directory.");
+            }
+            if (!file.getCanonicalPath().startsWith(parentFile.getCanonicalPath())) {
+                throw new ValidationException("Invalid directory", "Invalid directory, \"" + file + "\" does not inside specified parent.");
+            }
+
+            if (!file.getCanonicalPath().equals(filePath)) {
+                throw new ValidationException("Invalid directory", "Invalid directory name does not match the canonical path");
+            }
+        }
+        catch (IOException ex) {
+            throw new ValidationException("Invalid directory", "Failure to validate directory path");
+        }
+
+        return filePath;
+    }
+
+    public static boolean isSystemWindows() {
+        return File.separatorChar == '\\';
+    }
+}

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -31,36 +31,35 @@ public class FileUploadUtils {
     private static final Pattern INVALID_FILENAME_PATTERN = Pattern.compile("([\\/:*?\"<>|])");
 
     public static String getValidFilename(String filename) {
-        if (filename != null) {
-            if (isSystemWindows()) {
-                if (!filename.contains("\\\\")) {
-                    String[] parts = filename.substring(FilenameUtils.getPrefixLength(filename)).split(Pattern.quote(File.separator));
-                    for (String part : parts) {
-                        if (INVALID_FILENAME_PATTERN.matcher(part).find()) {
-                            throw new FacesException("Invalid filename: " + filename);
-                        }
+        if (LangUtils.isValueBlank(filename)) {
+            throw new FacesException("Filename is required.");
+        }
+
+        if (isSystemWindows()) {
+            if (!filename.contains("\\\\")) {
+                String[] parts = filename.substring(FilenameUtils.getPrefixLength(filename)).split(Pattern.quote(File.separator));
+                for (String part : parts) {
+                    if (INVALID_FILENAME_PATTERN.matcher(part).find()) {
+                        throw new FacesException("Invalid filename: " + filename);
                     }
                 }
-                else {
-                    throw new FacesException("Invalid filename: " + filename);
-                }
-            }
-
-            String name = FilenameUtils.getName(filename);
-            String extension = FilenameUtils.EXTENSION_SEPARATOR_STR + FilenameUtils.getExtension(filename);
-
-            if (extension.isEmpty()) {
-                throw new FacesException("File must have an extension");
-            }
-            else if (name.isEmpty() || extension.equals(name)) {
-                throw new FacesException("Filename can not be the empty string");
             }
             else {
-                return name;
+                throw new FacesException("Invalid filename: " + filename);
             }
         }
 
-        return filename;
+        String name = FilenameUtils.getName(filename);
+        String extension = FilenameUtils.EXTENSION_SEPARATOR_STR + FilenameUtils.getExtension(filename);
+
+        if (extension.isEmpty()) {
+            throw new FacesException("File must have an extension");
+        }
+        else if (name.isEmpty() || extension.equals(name)) {
+            throw new FacesException("Filename can not be the empty string");
+        }
+
+        return name;
     }
 
     public static String getValidFilePath(String filePath) throws ValidationException {

--- a/src/main/java/org/primefaces/util/HTML.java
+++ b/src/main/java/org/primefaces/util/HTML.java
@@ -19,6 +19,8 @@ public class HTML {
 
     public static final String[] CLICK_EVENT = {"onclick"};
 
+    public static final String[] TAB_INDEX = {"tabindex"};
+
     public static final String[] BLUR_FOCUS_EVENTS = {
         "onblur",
         "onfocus"
@@ -177,6 +179,21 @@ public class HTML {
 
     public static final String[] SELECT_ATTRS = LangUtils.concat(
             SELECT_ATTRS_WITHOUT_EVENTS, COMMON_EVENTS, CHANGE_SELECT_EVENTS, BLUR_FOCUS_EVENTS);
+
+    public final static String ARIA_ATOMIC = "aria-atomic";
+    public final static String ARIA_CHECKED = "aria-checked";
+    public final static String ARIA_DESCRIBEDBY = "aria-describedby";
+    public final static String ARIA_DISABLED = "aria-disabled";
+    public final static String ARIA_EXPANDED = "aria-expanded";
+    public final static String ARIA_HASPOPUP = "aria-haspopup";
+    public final static String ARIA_HIDDEN = "aria-hidden";
+    public final static String ARIA_LABEL = "aria-label";
+    public final static String ARIA_LABELLEDBY = "aria-labelledby";
+    public final static String ARIA_LIVE = "aria-live";
+    public final static String ARIA_MULITSELECTABLE = "aria-multiselectable";
+    public final static String ARIA_READONLY = "aria-readonly";
+    public final static String ARIA_REQUIRED = "aria-required";
+    public final static String ARIA_SELECTED = "aria-selected";
 
     public static final String BUTTON_TEXT_ONLY_BUTTON_CLASS = "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only";
     public static final String BUTTON_ICON_ONLY_BUTTON_CLASS = "ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only";

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -527,7 +527,9 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.jq.attr({
             'role': 'dialog'
             ,'aria-labelledby': this.id + '_title'
+            ,'aria-describedby': this.id + '_content'
             ,'aria-hidden': !this.cfg.visible
+            ,'aria-modal': this.cfg.modal
         });
 
         this.titlebar.children('a.ui-dialog-titlebar-icon').attr('role', 'button');

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -518,6 +518,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
         }
 
         this.updateToggler();
+        this.alignPanel();
     },
 
     setupFilterMatcher: function() {


### PR DESCRIPTION
OK this was a bigger change than I thought but every time I stepped back and looked at it I could make the code cleaner and cleaner.  What this PR does...

1. Adds "aria-required" to any UIInput component that is marked required=true.
2. Cleans up ARIA handling and "disabled" and "readonly" attribute handling to prevent cut and paste code.
3. Add ARIA handling to components that were missing it like Signature, Rating, SelectOneMenu etc etc etc.

Note: I know there is client side JS for "PrimeFaces.skinInput()" which adds aria-disabled and aria-readonly but that is A) only for input components and B) rquires developers to know to call it in every  place.  This PR ensures those attributes are set on any Input component that doesn't even need to call skinInput like Signature and Rating for example but renders the proper ARIA attributes.

@Rapster @mertsincan @tandraschko Please review.  This change seems more invasive than I think it is but cleans up the ARIA code immensely IMHO.