### PR TITLE
Fix #1689: Add "aria-invalid" to invalid components.

### DIFF
--- a/src/main/java/org/primefaces/component/message/MessageRenderer.java
+++ b/src/main/java/org/primefaces/component/message/MessageRenderer.java
@@ -155,7 +155,7 @@ public class MessageRenderer extends UINotificationRenderer {
     }
 
     protected void encodeScript(FacesContext context, Message uiMessage, UIComponent target) throws IOException {
-        boolean tooltip = uiMessage.getDisplay().equals("tooltip") ;
+        boolean tooltip = "tooltip".equals(uiMessage.getDisplay());
         if (tooltip || uiMessage.isShowDetail()) {
             String clientId = uiMessage.getClientId(context);
             String targetClientId = (target instanceof InputHolder) ? ((InputHolder) target).getInputClientId() : target.getClientId(context);

--- a/src/main/java/org/primefaces/component/message/MessageRenderer.java
+++ b/src/main/java/org/primefaces/component/message/MessageRenderer.java
@@ -48,7 +48,6 @@ public class MessageRenderer extends UINotificationRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String display = uiMessage.getDisplay();
         boolean iconOnly = display.equals("icon");
-        boolean escape = uiMessage.isEscape();
         String style = uiMessage.getStyle();
         String containerClass = display.equals("tooltip") ? "ui-message ui-helper-hidden" : "ui-message";
         String styleClass = uiMessage.getStyleClass();
@@ -113,10 +112,10 @@ public class MessageRenderer extends UINotificationRenderer {
 
                 if (!iconOnly) {
                     if (uiMessage.isShowSummary()) {
-                        encodeText(writer, msg.getSummary(), severityKey + "-summary", escape);
+                        encodeText(context, uiMessage, msg.getSummary(), severityKey + "-summary");
                     }
                     if (uiMessage.isShowDetail()) {
-                        encodeText(writer, msg.getDetail(), severityKey + "-detail", escape);
+                        encodeText(context, uiMessage, msg.getDetail(), severityKey + "-detail");
                     }
                 }
 
@@ -130,11 +129,13 @@ public class MessageRenderer extends UINotificationRenderer {
         writer.endElement("div");
     }
 
-    protected void encodeText(ResponseWriter writer, String text, String severity, boolean escape) throws IOException {
+    protected void encodeText(FacesContext context, Message uiMessage, String text, String severity) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
         writer.startElement("span", null);
         writer.writeAttribute("class", "ui-message-" + severity, null);
+        writer.writeAttribute("id", uiMessage.getClientId(context) + '_' + severity, null);
 
-        if (escape) {
+        if (uiMessage.isEscape()) {
             writer.writeText(text, null);
         }
         else {
@@ -154,13 +155,15 @@ public class MessageRenderer extends UINotificationRenderer {
     }
 
     protected void encodeScript(FacesContext context, Message uiMessage, UIComponent target) throws IOException {
-        if (uiMessage.getDisplay().equals("tooltip")) {
+        boolean tooltip = uiMessage.getDisplay().equals("tooltip") ;
+        if (tooltip || uiMessage.isShowDetail()) {
             String clientId = uiMessage.getClientId(context);
             String targetClientId = (target instanceof InputHolder) ? ((InputHolder) target).getInputClientId() : target.getClientId(context);
             WidgetBuilder wb = getWidgetBuilder(context);
 
             wb.init("Message", uiMessage.resolveWidgetVar(), clientId)
                     .attr("target", targetClientId)
+                    .attr("tooltip", tooltip, false)
                     .finish();
         }
     }

--- a/src/main/java/org/primefaces/renderkit/InputRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/InputRenderer.java
@@ -75,9 +75,24 @@ public abstract class InputRenderer extends CoreRenderer {
     }
 
     /**
+     * Adds "aria-invalid" if the component is invalid.
+     *
+     * @param context the {@link FacesContext}
+     * @param component the {@link UIInput} component to add attributes for
+     * @throws IOException if any error occurs writing the response
+     */
+    protected void renderARIAInvalid(FacesContext context, UIInput component) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+        if (!component.isValid()) {
+            writer.writeAttribute(HTML.ARIA_INVALID, "true", null);
+        }
+    }
+
+    /**
      * Adds the following accessibility attributes to an HTML DOM element.
      * <pre>
      * "aria-required" if the component is required
+     * "aria-invalid" if the component is invalid
      * "aria-labelledby" if the component has a labelledby attribute
      * "disabled" and "aria-disabled" if the component is disabled
      * "readonly" and "aria-readonly" if the component is readonly
@@ -95,6 +110,7 @@ public abstract class InputRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
 
         renderARIARequired(context, component);
+        renderARIAInvalid(context, component);
 
         String labelledBy = (String) component.getAttributes().get("labelledby");
         if (labelledBy != null) {

--- a/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.validation.metadata.ConstraintDescriptor;
 
+import org.primefaces.util.HTML;
+
 public class NotNullClientValidationConstraint implements ClientValidationConstraint {
 
     private static final String MESSAGE_METADATA = "data-p-notnull-msg";
@@ -34,6 +36,8 @@ public class NotNullClientValidationConstraint implements ClientValidationConstr
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
         }
+
+        metadata.put(HTML.VALIDATION_METADATA.REQUIRED, Boolean.TRUE);
 
         return metadata;
     }

--- a/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import javax.validation.constraints.NotNull;
 import javax.validation.metadata.ConstraintDescriptor;
 
-import org.primefaces.util.HTML;
-
 public class NotNullClientValidationConstraint implements ClientValidationConstraint {
 
     private static final String MESSAGE_METADATA = "data-p-notnull-msg";
@@ -36,8 +34,6 @@ public class NotNullClientValidationConstraint implements ClientValidationConstr
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
         }
-
-        metadata.put(HTML.VALIDATION_METADATA.REQUIRED, "true");
 
         return metadata;
     }

--- a/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
@@ -37,7 +37,7 @@ public class NotNullClientValidationConstraint implements ClientValidationConstr
             metadata.put(MESSAGE_METADATA, message);
         }
 
-        metadata.put(HTML.VALIDATION_METADATA.REQUIRED, Boolean.TRUE);
+        metadata.put(HTML.VALIDATION_METADATA.REQUIRED, "true");
 
         return metadata;
     }

--- a/src/main/resources/META-INF/resources/primefaces/messages/messages.js
+++ b/src/main/resources/META-INF/resources/primefaces/messages/messages.js
@@ -9,7 +9,13 @@ PrimeFaces.widget.Message = PrimeFaces.widget.BaseWidget.extend({
         var text = this.jq.children('.ui-message-error-detail').text();
         
         if(text) {
-           $(PrimeFaces.escapeClientId(this.cfg.target)).data('tooltip', text);
+           var target = $(PrimeFaces.escapeClientId(this.cfg.target));
+           
+           if (this.cfg.tooltip) {
+              target.data('tooltip', text);
+           }
+           
+           target.attr('aria-describedby', this.id + '_error-detail');
         } 
    }
 });

--- a/src/main/resources/META-INF/resources/primefaces/validation/validation.js
+++ b/src/main/resources/META-INF/resources/primefaces/validation/validation.js
@@ -674,7 +674,12 @@ if (window.PrimeFaces) {
             newValue = submittedValue;
         }
 
-        if(valid && element.data('p-required') && (newValue === null || newValue === '')) {
+        var required = element.data('p-required');
+        if (required) {
+           element.attr('aria-required', true);
+        }
+
+        if(valid && required && (newValue === null || newValue === '')) {
             var requiredMessageStr = element.data('p-rmsg'),
             requiredMsg = (requiredMessageStr) ? {summary:requiredMessageStr,detail:requiredMessageStr} : vc.getMessage('javax.faces.component.UIInput.REQUIRED', vc.getLabel(element));
             vc.addMessage(element, requiredMsg);
@@ -709,10 +714,14 @@ if (window.PrimeFaces) {
         var highlighterType = element.data('p-hl')||'default',
         highlighter = PrimeFaces.validator.Highlighter.types[highlighterType];
 
-        if(valid)
+        if(valid) {
             highlighter.unhighlight(element);
-        else
+            element.attr('aria-invalid', false);
+        }
+        else {
             highlighter.highlight(element);
+            element.attr('aria-invalid', true);
+        }
     };
 
     PrimeFaces.validateInstant = function(el) {


### PR DESCRIPTION
This PR follows the ARIA spec exactly. it does the following.

1. Marks Input components with aria-invalid=true if they are invalid.

2. If a `<p:message>` is attached to the Input field for validation message then aria-describedby is added to the Input component pointing to the `<span>` containing the validation error message.

I had to slightly modify the Message component to accomplish this.