### PR TITLE
Fix #4110 Use css class to hide scroll buttons.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
@@ -152,6 +152,11 @@
 
 .ui-tabs .ui-tabs-navscroller {
     overflow: hidden;
+    padding-left: 18px;
+}
+
+.ui-tabs .ui-tabs-navscroller.ui-tabs-navscroller-btn-hidden {
+    padding-left: 0;
 }
 
 .ui-tabs-scrollable .ui-tabs-nav li {
@@ -163,6 +168,9 @@
     height: 28px;
     z-index: 100;
     cursor: pointer;
+}
+
+.ui-tabs .ui-tabs-navscroller.ui-tabs-navscroller-btn-hidden .ui-tabs-navscroller-btn {
     display: none;
 }
 

--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -226,15 +226,15 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         if(this.headerContainer.length) {
             var overflown = ((this.lastTab.position().left + this.lastTab.width()) - this.firstTab.position().left) > this.navscroller.innerWidth();
             if (overflown) {
-                this.navscroller.css('padding-left', '18px');
-                this.navcrollerLeft.attr('tabindex', this.tabindex).show();
-                this.navcrollerRight.attr('tabindex', this.tabindex).show();
+                this.navscroller.removeClass('ui-tabs-navscroller-btn-hidden');
+                this.navcrollerLeft.attr('tabindex', this.tabindex);
+                this.navcrollerRight.attr('tabindex', this.tabindex);
                 this.restoreScrollState();
             }
             else {
-                this.navscroller.css('padding-left', '0px');
-                this.navcrollerLeft.attr('tabindex', this.tabindex).hide();
-                this.navcrollerRight.attr('tabindex', this.tabindex).hide();
+                this.navscroller.addClass('ui-tabs-navscroller-btn-hidden');
+                this.navcrollerLeft.attr('tabindex', this.tabindex);
+                this.navcrollerRight.attr('tabindex', this.tabindex);
             }
         }
     },


### PR DESCRIPTION
I propose this change to resolve #4110, I'm trying to avoid to break custom themes or templates. You could test it or give any suggestion.