### PR TITLE
Fix #4120: Dialog client side API resetPosition().

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -308,6 +308,14 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
         this.resizers = this.jq.children('.ui-resizable-handle');
     },
+    
+    /**
+     * Client side API convenience call to reset the dialog position based on
+     * the "position" requested.
+     */
+    resetPosition: function() {
+       this.initPosition();
+    },
 
     initPosition: function() {
         var $this = this;


### PR DESCRIPTION
Rather than rename initPosition() I thought it was better to leave that in place and just create an overloaded method called "resetPosition()" that we can then add to the PrimeFaces documentation.