### PR TITLE
fix: schedule: URL events enable phishing attacks (#4154)

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
@@ -68,7 +68,8 @@ abstract class ScheduleBase extends UIComponentBase implements Widget, ClientBeh
         weekNumberCalculator,
         nextDayThreshold,
         slotEventOverlap,
-        urlTarget
+        urlTarget,
+        noOpener
     }
 
     public ScheduleBase() {
@@ -383,6 +384,15 @@ abstract class ScheduleBase extends UIComponentBase implements Widget, ClientBeh
     public void setUrlTarget(String urlTarget) {
         getStateHelper().put(PropertyKeys.urlTarget, urlTarget);
     }
+
+    public boolean isNoOpener() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.noOpener, true);
+    }
+
+    public void setNoOpener(boolean noOpener) {
+        getStateHelper().put(PropertyKeys.noOpener, noOpener);
+    }
+
 
     @Override
     public String resolveWidgetVar() {

--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -213,7 +213,8 @@ public class ScheduleRenderer extends CoreRenderer {
                 .attr("weekNumbers", isShowWeekNumbers, false)
                 .attr("nextDayThreshold", schedule.getNextDayThreshold(), "09:00:00")
                 .attr("slotEventOverlap", schedule.isSlotEventOverlap(), true)
-                .attr("urlTarget", schedule.getUrlTarget(), "_blank");
+                .attr("urlTarget", schedule.getUrlTarget(), "_blank")
+                .attr("noOpener", schedule.isNoOpener(), true);
 
         String columnFormat = schedule.getColumnFormat();
         if (columnFormat != null) {

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -15591,6 +15591,12 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description><![CDATA[Whether for URL events access to the opener window from the target site should be prevented (phishing protection), default value is true.]]></description>
+            <name>noOpener</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <tag-name>scrollPanel</tag-name>

--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -79,7 +79,9 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
         this.cfg.eventClick = function(calEvent, jsEvent, view) {
             if (calEvent.url) {
                 var targetWindow = window.open('', $this.cfg.urlTarget);
-                targetWindow.opener = null;
+                if ($this.cfg.noOpener) {
+                    targetWindow.opener = null;    
+                }
                 targetWindow.location = calEvent.url;
                 return false;
             }

--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -78,7 +78,9 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
 
         this.cfg.eventClick = function(calEvent, jsEvent, view) {
             if (calEvent.url) {
-                window.open(calEvent.url, $this.cfg.urlTarget);
+                var targetWindow = window.open('', $this.cfg.urlTarget);
+                targetWindow.opener = null;
+                targetWindow.location = calEvent.url;
                 return false;
             }
 


### PR DESCRIPTION
After applying this PR you can perform the reproduction steps from the issue once again. Then you'll notice the redirect on the opener is gone and the target site is showing 
![image](https://user-images.githubusercontent.com/13161711/47360770-979d2500-d6d0-11e8-93d6-a32f114ad5dd.png)
