### PR TITLE
Fix #4161 Append overlay panel in the body by default.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
@@ -7,6 +7,7 @@ PrimeFaces.widget.LightBox = PrimeFaces.widget.BaseWidget.extend({
         this._super(cfg);
 
         this.links = this.jq.children(':not(.ui-lightbox-inline)');
+        this.cfg.appendTo = this.cfg.appendTo || '@(body)';
 
         this.createPanel();
 


### PR DESCRIPTION
This is a fix to #4161. The panel should be appended to the body.