### PR TITLE
Fix #4214 TriStateCheckbox: Move tabIndex attribute to the input element

### DIFF
--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -99,7 +99,11 @@ public class TriStateCheckboxRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("value", valCheck, null);
+        writer.writeAttribute("autocomplete", "off", null);
+        writer.writeAttribute("readonly", "readonly", null);
+
         renderAccessibilityAttributes(context, checkbox);
+        renderPassThruAttributes(context, checkbox, HTML.TAB_INDEX);
 
         if (checkbox.getOnchange() != null) {
             writer.writeAttribute("onchange", checkbox.getOnchange(), null);
@@ -158,7 +162,6 @@ public class TriStateCheckboxRenderer extends InputRenderer {
         }
 
         writer.startElement("div", null);
-        writer.writeAttribute("tabIndex", checkbox.getTabindex() == null ? 0 : checkbox.getTabindex(), "tabindex");
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("data-iconstates", statesIconsClasses, null);
         if (!LangUtils.isValueBlank(stateOneTitle) || !LangUtils.isValueBlank(stateTwoTitle) || !LangUtils.isValueBlank(stateThreeTitle)) {

--- a/src/main/java/org/primefaces/util/HTML.java
+++ b/src/main/java/org/primefaces/util/HTML.java
@@ -208,7 +208,7 @@ public class HTML {
     public static final String CHECKBOX_ALL_CLASS = "ui-chkbox ui-chkbox-all ui-widget";
     public static final String CHECKBOX_CLASS = "ui-chkbox ui-widget";
     public static final String CHECKBOX_BOX_CLASS = "ui-chkbox-box ui-widget ui-corner-all ui-state-default";
-    public static final String CHECKBOX_INPUT_WRAPPER_CLASS = "ui-helper-hidden";
+    public static final String CHECKBOX_INPUT_WRAPPER_CLASS = "ui-helper-hidden-accessible";
     public static final String CHECKBOX_UNCHECKED_ICON_CLASS = "ui-chkbox-icon ui-icon ui-icon-blank ui-c";
     public static final String CHECKBOX_CHECKED_ICON_CLASS = "ui-chkbox-icon ui-icon ui-icon-check ui-c";
     public static final String CHECKBOX_PARTIAL_CHECKED_ICON_CLASS = "ui-chkbox-icon ui-icon ui-icon-minus ui-c";

--- a/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/tristatecheckbox/tristatecheckbox.js
@@ -17,53 +17,56 @@ PrimeFaces.widget.TriStateCheckbox = PrimeFaces.widget.BaseWidget.extend({
 
         //bind events if not disabled
         if (!this.disabled) {
-            this.box.on('mouseover', function(e) {
+            this.box.on('mouseover.triStateCheckbox', function () {
                 $this.box.addClass('ui-state-hover');
             })
-            .on('mouseout', function(e) {
+            .on('mouseout.triStateCheckbox', function () {
                 $this.box.removeClass('ui-state-hover');
             })
-            .on('click', function(e) {
+            .on('click.triStateCheckbox', function () {
                 $this.toggle(1);
-                if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-            })
-            .on('focus', function(e) {
+                $this.input.trigger('focus');
+            });
+            
+            this.input.on('focus.triStateCheckbox', function () {
                 $this.box.addClass('ui-state-focus');
             })
-            .on('blur', function(e) {
+            .on('blur.triStateCheckbox', function () {
                 $this.box.removeClass('ui-state-focus');
+            })
+            .on('keydown.triStateCheckbox', function (e) {
+                var keyCode = $.ui.keyCode;
+
+                switch (e.which) {
+                    case keyCode.SPACE:
+                    case keyCode.UP:
+                    case keyCode.RIGHT:
+                    case keyCode.LEFT:
+                    case keyCode.DOWN:
+                        e.preventDefault();
+                        break;
+                }
+            })            
+            .on('keyup.triStateCheckbox', function (e) {
+                var keyCode = $.ui.keyCode;
+
+                switch(e.which) {
+                    case keyCode.SPACE:
+                    case keyCode.UP:
+                    case keyCode.RIGHT:
+                        $this.toggle(1);
+                        break;
+                    case keyCode.LEFT:
+                    case keyCode.DOWN:
+                        $this.toggle(-1);
+                        break;
+                }
             });
 
             //toggle state on label click
-            this.itemLabel.click(function(event) {
+            this.itemLabel.on('click.triStateCheckbox', function() {
                 $this.toggle(1);
-                if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-            });
-
-            //adding accesibility
-            this.box.on('keydown', function(event) {
-                switch (event.keyCode) {
-                    case 38:
-                        $this.toggle(1);
-                        if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-                        break;
-                    case 40:
-                        $this.toggle(-1);
-                        if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-                        break;
-                    case 39:
-                        $this.toggle(1);
-                        if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-                        break;
-                    case 37:
-                        $this.toggle(-1);
-                        if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-                        break;
-                    case 32:
-                        $this.toggle(1);
-                        if (event.preventDefault) { event.preventDefault(); } else { event.returnValue = false; }
-                        break;
-                }
+                $this.input.trigger('focus');
             });
 
             // client behaviors


### PR DESCRIPTION
This PR resolves #4214. The event keydown was necessary to disable the auto scrolling when the spacebar is pressed in Chrome.