### PR TITLE
Fix #953: Schedule convert to double first in case browser sends decimal.

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/Schedule.java
+++ b/src/main/java/org/primefaces/component/schedule/Schedule.java
@@ -154,8 +154,8 @@ public class Schedule extends ScheduleBase {
             else if (eventName.equals("eventResize")) {
                 String resizedEventId = params.get(clientId + "_resizedEventId");
                 ScheduleEvent resizedEvent = getValue().getEvent(resizedEventId);
-                int dayDelta = Integer.parseInt(params.get(clientId + "_dayDelta"));
-                int minuteDelta = Integer.parseInt(params.get(clientId + "_minuteDelta"));
+                int dayDelta = Double.valueOf(params.get(clientId + "_dayDelta")).intValue();
+                int minuteDelta = Double.valueOf(params.get(clientId + "_minuteDelta")).intValue();
 
                 Calendar calendar = Calendar.getInstance();
                 calendar.setTime(resizedEvent.getEndDate());

--- a/src/main/java/org/primefaces/component/schedule/Schedule.java
+++ b/src/main/java/org/primefaces/component/schedule/Schedule.java
@@ -132,8 +132,8 @@ public class Schedule extends ScheduleBase {
             else if (eventName.equals("eventMove")) {
                 String movedEventId = params.get(clientId + "_movedEventId");
                 ScheduleEvent movedEvent = getValue().getEvent(movedEventId);
-                int dayDelta = (int) Double.parseDouble(params.get(clientId + "_dayDelta"));
-                int minuteDelta = (int) Double.parseDouble(params.get(clientId + "_minuteDelta"));
+                int dayDelta = Double.valueOf(params.get(clientId + "_dayDelta")).intValue();
+                int minuteDelta = Double.valueOf(params.get(clientId + "_minuteDelta")).intValue();
 
                 Calendar calendar = Calendar.getInstance();
                 calendar.setTime(movedEvent.getStartDate());


### PR DESCRIPTION
We have seen this with other components where some browsers like Firefox decide to send 37.4 instead of 37.  So its safer to convert to Double first and then convert to int.