### PR TITLE
Fix #4289

### DIFF
--- a/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -46,10 +46,10 @@ public class InputMaskRenderer extends InputRenderer {
         String clientId = inputMask.getClientId(context);
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(clientId);
 
-        if (submittedValue != null) {
+        if (submittedValue != null && !submittedValue.isEmpty()) {
             Pattern pattern = translateMaskIntoRegex(context, inputMask);
             if (!pattern.matcher(submittedValue).matches()) {
-                submittedValue = null;
+                submittedValue = "";
             }
 
             inputMask.setSubmittedValue(submittedValue);


### PR DESCRIPTION
The submittedValue should not be set to null when the  submittedValue does not match the mask attribute. Instead set it to empty string. This ensures that the validation of the component is correctly executed.