### PR TITLE
Fix #3270: Autocomplete fire clear event when forceselection=true.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -941,6 +941,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
             if(!this.cfg.multiple) {
                 this.hinput.val('');
             }
+            this.fireClearEvent();
         }
 
         return valid;


### PR DESCRIPTION
@fanste can you review this fix. Basically when forceselection=true when it checks whether there is a match an there is no match it sets the Input to ''.  I just added the fireClearEvent to happen when that occurs.