### PR TITLE
Fix #3848: ContentFlow fix when only 2 images or less.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/contentflow/contentflow.js
+++ b/src/main/resources/META-INF/resources/primefaces/contentflow/contentflow.js
@@ -2023,7 +2023,7 @@ ContentFlow.prototype = {
         var itemN = currentItem.next;
 
         this._positionItem(currentItem, 0);
-        for (var i=1; i <= this.conf.visibleItems && 2*i < this.items.length ; i++) {
+        for (var i=1; i <= this.conf.visibleItems; i++) {
             if (itemP) {
                 this._positionItem(itemP, -i);
                 this._lastStart = itemP;

--- a/src/main/resources/META-INF/resources/primefaces/contentflow/extensions.txt
+++ b/src/main/resources/META-INF/resources/primefaces/contentflow/extensions.txt
@@ -1,0 +1,1 @@
+Fix #3848: Edited line 2026 based on this fix https://github.com/orhan27799/contentflow/issues/20


### PR DESCRIPTION
Found original issue and fix here: https://github.com/orhan27799/contentflow/issues/20