### PR TITLE
Fix #4145: Picklist Firefox issue dragging elements with checkboxes.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/picklist/picklist.js
+++ b/src/main/resources/META-INF/resources/primefaces/picklist/picklist.js
@@ -54,6 +54,7 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
                 cancel: '.ui-state-disabled,.ui-chkbox-box',
                 connectWith: this.jqId + ' .ui-picklist-list',
                 revert: 1,
+                helper: 'clone',
                 update: function(event, ui) {
                     $this.unselectItem(ui.item);
 


### PR DESCRIPTION
Added http://api.jqueryui.com/sortable/#option-helper

 If set to "clone", then the element will be cloned and the clone will be dragged. This fixes the Firefox issue reported here 6 years ago.  

https://bugzilla.mozilla.org/show_bug.cgi?id=787944