### PR TITLE
Fix #4335: TreeNode interface extend Serializable.

### DIFF
--- a/src/main/java/org/primefaces/model/CheckboxTreeNode.java
+++ b/src/main/java/org/primefaces/model/CheckboxTreeNode.java
@@ -15,10 +15,9 @@
  */
 package org.primefaces.model;
 
-import java.io.Serializable;
 import java.util.List;
 
-public class CheckboxTreeNode implements TreeNode, Serializable {
+public class CheckboxTreeNode implements TreeNode {
 
     public static final String DEFAULT_TYPE = "default";
 

--- a/src/main/java/org/primefaces/model/DefaultTreeNode.java
+++ b/src/main/java/org/primefaces/model/DefaultTreeNode.java
@@ -15,10 +15,9 @@
  */
 package org.primefaces.model;
 
-import java.io.Serializable;
 import java.util.List;
 
-public class DefaultTreeNode implements TreeNode, Serializable {
+public class DefaultTreeNode implements TreeNode {
 
     public static final String DEFAULT_TYPE = "default";
 

--- a/src/main/java/org/primefaces/model/TreeNode.java
+++ b/src/main/java/org/primefaces/model/TreeNode.java
@@ -15,9 +15,10 @@
  */
 package org.primefaces.model;
 
+import java.io.Serializable;
 import java.util.List;
 
-public interface TreeNode {
+public interface TreeNode extends Serializable {
 
     public String getType();
 


### PR DESCRIPTION
@tandraschko You can reject this if you want, but this does seem like a harmless change that I can definitely see being useful.