### PR TITLE
Fix #4339: Force label to String prevents IE scientific notation.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -915,7 +915,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         if(this.cfg.labelTemplate && value !== '&nbsp;') {
             return this.cfg.labelTemplate.replace('{0}', value);
         }
-        return value;
+        return String(value);
     },
 
     changeAriaValue: function (item) {


### PR DESCRIPTION
IE Javascript engine is confusing the val as a number.  Simply always convert the val to a String when displaying the label fixes the issue. https://github.com/primefaces/primefaces/issues/4339