### PR TITLE
Fix #4295: Calendar position properly on open at bottom of screen.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
@@ -29,3 +29,4 @@ jquery.ui.pfextensions:
 - Sortable performance fix (/https://github.com/primefaces/primefaces/issues/3675)
 - Timepicker Fix (https://github.com/primefaces/primefaces/issues/2811)
 - Timepicker Fix (https://github.com/primefaces/primefaces/issues/3765)
+- Datepicker Position Fix (https://github.com/primefaces/primefaces/issues/4295)

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.js
@@ -60,6 +60,7 @@
                 var checkedOffset = $.datepicker._checkOffset(inst, offset, isFixed);
                 inst.dpDiv.css({top: checkedOffset.top + "px"});
             };
+            this.updateDatePickerPosition(inst);
         });
     };
 


### PR DESCRIPTION
This fix only needed to be applied in the pf.extensions and works perfectly.  Test case verified in IE, Chrome, and Firefox.