### PR TITLE
Fix #4140 / #1836: Spotlight and any modal dialog/overlays prevent scrolling.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,6 +666,7 @@
                                 <include>${project.build.directory}/classes/META-INF/resources/primefaces/jquery/jquery.rangy.js</include>
                                 <include>${project.build.directory}/classes/META-INF/resources/primefaces/jquery/jquery.browser.js</include>
                                 <include>${project.build.directory}/classes/META-INF/resources/primefaces/jquery/jquery.ui.touch-punch.js</include>
+                                <include>${project.build.directory}/classes/META-INF/resources/primefaces/jquery/jquery.disablescroll.js</include>
                                 <include>${project.build.directory}/classes/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.js</include>
                             </includes>
                         </aggregation>

--- a/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -50,6 +50,7 @@ if (!PrimeFaces.utils) {
 
         addModal: function(id, zIndex, tabbablesCallback) {
             PrimeFaces.utils.preventTabbing(id, zIndex, tabbablesCallback);
+            PrimeFaces.utils.preventScrolling();
 
             var modalId = id + '_modal';
 
@@ -120,6 +121,7 @@ if (!PrimeFaces.utils) {
             // if the id does NOT contain a ':'
             $(document.body).children("[id='" + modalId + "']").remove();
 
+            PrimeFaces.utils.enableScrolling();
             PrimeFaces.utils.enableTabbing(id);
         },
 
@@ -258,6 +260,40 @@ if (!PrimeFaces.utils) {
             }
 
             scrollParent.off(scrollNamespace);
+        },
+
+        /**
+         * Disables scrolling from scrollbars, mousewheels, touchmoves and keypresses 
+         * on a given scrollable element, typically $(window).
+         * 
+         * @param {type} element the DOM element to prevent scrolling (default to $(window))
+         */
+        preventScrolling: function(element) {
+            var scrollElement = $(window);
+            if (element) {
+                scrollElement = $(element);
+            }
+
+            scrollElement.disablescroll({
+                handleScrollbar: true,
+                handleWheel: true,
+                handleKeys: true,
+                scrollEventKeys: [33,34] //page up, page down
+            });
+        },
+
+        /**
+         * Enables scrolling again if previously disabled.
+         * 
+         * @param {type} element the DOM element to allow scrolling (default to $(window))
+         */
+        enableScrolling: function(element) {
+            var scrollElement = $(window);
+            if (element) {
+                scrollElement = $(element);
+            }
+
+            scrollElement.disablescroll('undo');
         }
     };
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
@@ -10,6 +10,7 @@ List of Plugins
 - Cursor Position (https://github.com/beviz/jquery-caret-position-getter)
 - Browser (https://github.com/gabceb/jquery-browser-plugin/releases)
 - Autosize (https://github.com/jackmoore/autosize)
+- Disable Scroll (https://github.com/realjoshharrison/jquery-disablescroll)
 
 
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.disablescroll.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.disablescroll.js
@@ -1,0 +1,116 @@
+/**
+ * $.disablescroll
+ * Author: Josh Harrison - aloof.co
+ * URL: https://github.com/realjoshharrison/jquery-disablescroll
+ *
+ * Disables scroll events from mousewheels, touchmoves and keypresses.
+ * Use while jQuery is animating the scroll position for a guaranteed super-smooth ride!
+ */
+
+;(function($) {
+
+    "use strict";
+
+    var instance, proto;
+
+    function UserScrollDisabler($container, options) {
+        // spacebar: 32, pageup: 33, pagedown: 34, end: 35, home: 36
+        // left: 37, up: 38, right: 39, down: 40
+        this.opts = $.extend({
+            handleWheel : true,
+            handleScrollbar: true,
+            handleKeys : true,
+            scrollEventKeys : [32, 33, 34, 35, 36, 37, 38, 39, 40]
+        }, options);
+        
+        this.$container = $container;
+        this.$document = $(document);
+        this.lockToScrollPos = [0, 0];
+
+        this.disable();
+    }
+
+    proto = UserScrollDisabler.prototype;
+
+    proto.disable = function() {
+        var t = this;
+
+        if(t.opts.handleWheel) {
+            t.$container.on(
+                "mousewheel.disablescroll DOMMouseScroll.disablescroll touchmove.disablescroll",
+                t._handleWheel
+            );
+        }
+        
+        if(t.opts.handleScrollbar) {
+            t.lockToScrollPos = [
+                t.$container.scrollLeft(),
+                t.$container.scrollTop()
+            ];
+            t.$container.on("scroll.disablescroll", function() {
+                t._handleScrollbar.call(t);
+            });
+        }
+
+        if(t.opts.handleKeys) {
+            t.$document.on("keydown.disablescroll", function(event) {
+                t._handleKeydown.call(t, event);
+            });
+        }
+    };
+        
+    proto.undo = function() {
+        var t = this;
+        t.$container.off(".disablescroll");
+        if(t.opts.handleKeys) {
+            t.$document.off(".disablescroll");
+        }
+    };
+    
+    proto._handleWheel = function(event) {
+        event.preventDefault();
+    };
+    
+    proto._handleScrollbar = function() {
+        this.$container.scrollLeft(this.lockToScrollPos[0]);
+        this.$container.scrollTop(this.lockToScrollPos[1]);
+    };
+    
+    proto._handleKeydown = function(event) {
+        for (var i = 0; i < this.opts.scrollEventKeys.length; i++) {
+            if (event.keyCode === this.opts.scrollEventKeys[i]) {
+                event.preventDefault();
+                return;
+            }
+        }
+    };
+        
+
+    // Plugin wrapper for object
+    $.fn.disablescroll = function(method) {
+
+        // If calling for the first time, instantiate the object and save
+        // reference. The plugin can therefore only be instantiated once per
+        // page. You can pass options object in through the method parameter.
+        if( ! instance && (typeof method === "object" || ! method)) {
+            instance = new UserScrollDisabler(this, method);
+        }
+
+        // Instance created, no method specified. Call disable again
+        if(instance && typeof method === "undefined") {
+            instance.disable();
+        }
+
+        // Instance already created, and a method is being explicitly called,
+        // e.g. .disablescroll('undo');
+        else if(instance && instance[method]) {
+            instance[method].call(instance);
+        }
+
+        return this;
+    };
+
+    // Global access
+    window.UserScrollDisabler = UserScrollDisabler;
+
+})(jQuery);

--- a/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
+++ b/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
@@ -71,6 +71,7 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
 
         this.target.data('zindex',this.target.zIndex()).css('z-index', ++PrimeFaces.zindex);
 
+        PrimeFaces.utils.preventScrolling();
         PrimeFaces.utils.preventTabbing(this.id, $this.target.zIndex(), function() {
             return $this.target.find(':tabbable');
         });
@@ -82,6 +83,7 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
 
     unbindEvents: function() {
         PrimeFaces.utils.enableTabbing(this.id);
+        PrimeFaces.utils.enableScrolling();
         $(window).off('resize.spotlight');
     },
 


### PR DESCRIPTION
Fixes #4140 / #1836 / #200.

- Uses a Jquery plugin Disable Scroll (https://github.com/realjoshharrison/jquery-disablescroll)
- Adds two new Primefaces.util method for preventScrolling and enableScrolling.
- Disables scrolling from scrollbars, mousewheels, touchmoves and PAGE_UP/PAGE_DOWN keypresses
- Tested in:

Mac: Chrome 38
Mac: Firefox 33.1
Mac: Safari 7.1
Windows: IE 7-11
Windows: Chrome 38
Windows: Firefox 33.1
Android: Chrome 38
iOS 7.1 and 8.1: Safari
