### PR TITLE
Fix #4348: Spotlight displayed incorrectly if page scrolled.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -272,15 +272,31 @@ if (!PrimeFaces.utils) {
         /**
          * Disables scrolling of the document body.
          */
-        preventScrolling: function(element) {
+        preventScrolling: function() {
             $(document.body).addClass('ui-overflow-hidden');
         },
 
         /**
          * Enables scrolling again if previously disabled.
          */
-        enableScrolling: function(element) {
+        enableScrolling: function() {
             $(document.body).removeClass('ui-overflow-hidden');
+        },
+        
+        /**
+         * Calculates an element offset relative to where the Window is currently scrolled.
+         */
+        calculateRelativeOffset: function (element) {
+            var result = {
+                left : 0,
+                top : 0
+            };
+            var offset = element.offset();
+            var scrollTop = $(window).scrollTop();
+            var scrollLeft = $(window).scrollLeft();
+            result.top = offset.top - scrollTop;
+            result.left = offset.left - scrollLeft;
+            return result;
         }
     };
 

--- a/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
+++ b/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
@@ -33,7 +33,7 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
     calculatePositions: function() {
         var doc = $(document),
         documentBody = $(document.body),
-        offset = this.target.offset();
+        offset = PrimeFaces.utils.calculateRelativeOffset(this.target);
 
         documentBody.children('div.ui-spotlight-top').css({
             'left': 0,


### PR DESCRIPTION
Also removed unused variables from previous PR for Spotlight in preventScrolling() and enableScrolling().