### PR TITLE
Fix #108: SelectOneRadio add unselectable attribute.

### DIFF
--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
@@ -31,7 +31,8 @@ abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements Widget {
 
         widgetVar,
         columns,
-        plain
+        plain,
+        unselectable
     }
 
     public SelectOneRadioBase() {
@@ -65,6 +66,14 @@ abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements Widget {
 
     public void setPlain(boolean plain) {
         getStateHelper().put(PropertyKeys.plain, plain);
+    }
+
+    public boolean isUnselectable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.unselectable, false);
+    }
+
+    public void setUnselectable(boolean unselectable) {
+        getStateHelper().put(PropertyKeys.unselectable, unselectable);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -95,7 +95,8 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
 
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("SelectOneRadio", radio.resolveWidgetVar(), clientId)
-                .attr("custom", custom, false).finish();
+                .attr("custom", custom, false)
+                .attr("unselectable", radio.isUnselectable()).finish();
     }
 
     protected void encodeResponsiveLayout(FacesContext context, SelectOneRadio radio) throws IOException {

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -17418,6 +17418,12 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description><![CDATA[Unselectable mode when true clicking a radio again will clear the selection. Default false.]]></description>
+            <name>unselectable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <tag-name>separator</tag-name>

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectoneradio.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectoneradio.js
@@ -71,6 +71,9 @@ PrimeFaces.widget.SelectOneRadio = PrimeFaces.widget.BaseWidget.extend({
                 input.trigger('change');
             }
             else {
+                if ($this.cfg.unselectable) {
+                    $this.unselect($this.checkedRadio);
+                }
                 $this.fireClickEvent(input, e);
             }
         });


### PR DESCRIPTION
I know this is an old ticket but I just ran into this at a client and need this behavior so they can unselect a default because the database field allows null selection and once it was set it was impossible to unset it.

Default is of course "false" which is current default behavior.