### PR TITLE
Fix #4449: InputText/TextArea handle mouse cut and paste for counter.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtext.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtext.js
@@ -16,7 +16,7 @@ PrimeFaces.widget.InputText = PrimeFaces.widget.BaseWidget.extend({
 
             if(this.counter) {
                 var $this = this;
-                this.jq.on('keyup.inputtext-counter', function(e) {
+                this.jq.on('input.inputtext-counter', function(e) {
                     $this.updateCounter();
                 });
             }

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
@@ -29,7 +29,7 @@ PrimeFaces.widget.InputTextarea = PrimeFaces.widget.DeferredWidget.extend({
 
             if(this.counter) {
                 var $this = this;
-                this.jq.on('keyup.inputtextarea-counter', function(e) {
+                this.jq.on('input.inputtextarea-counter', function(e) {
                     $this.updateCounter();
                 });
             }


### PR DESCRIPTION
Was using the wrong event keyup instead of "input".

input event = event occurs when the text content of an element is changed through the user interface.

I have tested in IE11, Edge, Firefox, and Chrome and now the counter is updated whether you right click and cut/paste or typing etc.

