### PR TITLE
Fix #4461: Add ariaLabel to CommandLink and update taglib docs for ariaLabel

### DIFF
--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
@@ -46,7 +46,8 @@ abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Co
         ignoreAutoUpdate,
         validateClient,
         partialSubmitFilter,
-        form
+        form,
+        ariaLabel
     }
 
     public CommandLinkBase() {
@@ -207,6 +208,14 @@ abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Co
 
     public void setForm(String form) {
         getStateHelper().put(PropertyKeys.form, form);
+    }
+
+    public String getAriaLabel() {
+        return (String) getStateHelper().eval(PropertyKeys.ariaLabel, null);
+    }
+
+    public void setAriaLabel(String ariaLabel) {
+        getStateHelper().put(PropertyKeys.ariaLabel, ariaLabel);
     }
 
 }

--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -81,7 +81,10 @@ public class CommandLinkRenderer extends CoreRenderer {
             writer.writeAttribute("id", clientId, "id");
             writer.writeAttribute("href", "#", null);
             writer.writeAttribute("class", styleClass, null);
-            if (link.getTitle() != null) {
+            if (link.getAriaLabel() != null) {
+                writer.writeAttribute(HTML.ARIA_LABEL, link.getAriaLabel(), null);
+            }
+            else if (link.getTitle() != null) {
                 writer.writeAttribute(HTML.ARIA_LABEL, link.getTitle(), null);
             }
 

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -4288,7 +4288,7 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
-            <description><![CDATA[]]></description>
+            <description><![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]></description>
             <name>ariaLabel</name>
             <required>false</required>
             <type>java.lang.String</type>
@@ -4613,6 +4613,12 @@
         <attribute>
             <description><![CDATA[Form to serialize for an ajax request. Default is the enclosing form.]]></description>
             <name>form</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description><![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]></description>
+            <name>ariaLabel</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
@@ -11881,7 +11887,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description><![CDATA[]]></description>
+            <description><![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]></description>
             <name>ariaLabel</name>
             <required>false</required>
             <type>java.lang.String</type>
@@ -19152,7 +19158,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description><![CDATA[]]></description>
+            <description><![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]></description>
             <name>ariaLabel</name>
             <required>false</required>
             <type>java.lang.String</type>
@@ -20897,7 +20903,7 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description><![CDATA[]]></description>
+            <description><![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]></description>
             <name>ariaLabel</name>
             <required>false</required>
             <type>java.lang.String</type>


### PR DESCRIPTION
Fixed the taglib docs in all the places where ariaLabel was used to add description.
Added ariaLabel to CommandLink.