### PR TITLE
Fix #4473: Datepicker log warning and default to locale en_US.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -91,8 +91,13 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
     
     configureLocale: function() {
         var localeSettings = PrimeFaces.locales[this.cfg.locale];
+        
+        if (!localeSettings) {
+            console.log('DatePicker locale '+this.cfg.locale+' not detected. Default to en_US.');
+            localeSettings = PrimeFaces.locales['en_US'];
+        }
 
-        if(localeSettings) {
+        if (localeSettings) {
             var locale = {};
             for(var setting in localeSettings) {
                 locale[setting] = localeSettings[setting];


### PR DESCRIPTION
@mertsincan I detect if the locale can be loaded or not just log a console warning and default to en_US so the DatePicker always loads.