### PR TITLE
Fix #4517: Remove visibility css property on overlay panel

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -177,7 +177,6 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
         //replace visibility hidden with display none for effect support, toggle marker class
         this.jq.removeClass('ui-overlay-hidden').addClass('ui-overlay-visible').css({
             'display':'none'
-            ,'visibility':'visible'
         });
 
         if(this.cfg.showEffect) {
@@ -245,7 +244,6 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
         //replace display block with visibility hidden for hidden container support, toggle marker class
         this.jq.removeClass('ui-overlay-visible').addClass('ui-overlay-hidden').css({
             'display':'block'
-            ,'visibility':'hidden'
         });
 
         if(this.cfg.onHide) {


### PR DESCRIPTION
This should fix #4517 by removing visibility css property on overlay panel as it is already in ui-overlay-visible and ui-overlay-hidden class and not correctly handled on show and hide actions