### PR TITLE
Fix #4505: Correct both up and down propagation on backing bean

### DIFF
--- a/src/main/java/org/primefaces/component/api/UITree.java
+++ b/src/main/java/org/primefaces/component/api/UITree.java
@@ -200,7 +200,7 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
     }
 
     public boolean isPropagateSelectionDown() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionDown, false);
+        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionDown, true);
     }
 
     public void setPropagateSelectionDown(boolean _propagateSelectionDown) {
@@ -208,7 +208,7 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
     }
 
     public boolean isPropagateSelectionUp() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionUp, false);
+        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionUp, true);
     }
 
     public void setPropagateSelectionUp(boolean _propagateSelectionUp) {

--- a/src/main/java/org/primefaces/component/api/UITree.java
+++ b/src/main/java/org/primefaces/component/api/UITree.java
@@ -32,6 +32,7 @@ import javax.faces.event.*;
 
 import org.primefaces.component.columns.Columns;
 import org.primefaces.component.tree.UITreeNode;
+import org.primefaces.model.CheckboxTreeNode;
 import org.primefaces.model.TreeNode;
 import org.primefaces.util.MessageFactory;
 import org.primefaces.util.SharedStringBuilder;
@@ -64,7 +65,9 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
         requiredMessage,
         skipChildren,
         showUnselectableCheckbox,
-        nodeVar;
+        nodeVar,
+        propagateSelectionDown,
+        propagateSelectionUp;
     }
 
     public String getRowKey() {
@@ -194,6 +197,22 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
 
     public Object getLocalSelectedNodes() {
         return getStateHelper().get(PropertyKeys.selection);
+    }
+
+    public boolean isPropagateSelectionDown() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionDown, false);
+    }
+
+    public void setPropagateSelectionDown(boolean _propagateSelectionDown) {
+        getStateHelper().put(PropertyKeys.propagateSelectionDown, _propagateSelectionDown);
+    }
+
+    public boolean isPropagateSelectionUp() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionUp, false);
+    }
+
+    public void setPropagateSelectionUp(boolean _propagateSelectionUp) {
+        getStateHelper().put(PropertyKeys.propagateSelectionUp, _propagateSelectionUp);
     }
 
     protected TreeNode findTreeNode(TreeNode searchRoot, String rowKey) {
@@ -496,6 +515,9 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
 
     public void updateSelection(FacesContext context) {
         String selectionMode = getSelectionMode();
+        boolean propagateSelectionDown = isPropagateSelectionDown();
+        boolean propagateSelectionUp = isPropagateSelectionUp();
+
         ValueExpression selectionVE = getValueExpression(UITree.PropertyKeys.selection.toString());
 
         if (selectionMode != null && selectionVE != null) {
@@ -516,13 +538,23 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
 
                 if (previousSelections != null) {
                     for (TreeNode node : previousSelections) {
-                        node.setSelected(false);
+                        if (node instanceof CheckboxTreeNode) {
+                            ((CheckboxTreeNode) node).setSelected(false, propagateSelectionDown, propagateSelectionUp);
+                        }
+                        else {
+                            node.setSelected(false);
+                        }
                     }
                 }
 
                 if (selections != null) {
                     for (TreeNode node : selections) {
-                        node.setSelected(true);
+                        if (node instanceof CheckboxTreeNode) {
+                            ((CheckboxTreeNode) node).setSelected(true, propagateSelectionDown, propagateSelectionUp);
+                        }
+                        else {
+                            node.setSelected(true);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/primefaces/component/tree/TreeBase.java
+++ b/src/main/java/org/primefaces/component/tree/TreeBase.java
@@ -42,8 +42,6 @@ abstract class TreeBase extends UITree implements Widget, RTLAware, ClientBehavi
         datakey,
         animate,
         orientation,
-        propagateSelectionUp,
-        propagateSelectionDown,
         dir,
         draggable,
         droppable,
@@ -147,22 +145,6 @@ abstract class TreeBase extends UITree implements Widget, RTLAware, ClientBehavi
 
     public void setOrientation(String orientation) {
         getStateHelper().put(PropertyKeys.orientation, orientation);
-    }
-
-    public boolean isPropagateSelectionUp() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionUp, true);
-    }
-
-    public void setPropagateSelectionUp(boolean propagateSelectionUp) {
-        getStateHelper().put(PropertyKeys.propagateSelectionUp, propagateSelectionUp);
-    }
-
-    public boolean isPropagateSelectionDown() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.propagateSelectionDown, true);
-    }
-
-    public void setPropagateSelectionDown(boolean propagateSelectionDown) {
-        getStateHelper().put(PropertyKeys.propagateSelectionDown, propagateSelectionDown);
     }
 
     public String getDir() {

--- a/src/main/java/org/primefaces/model/CheckboxTreeNode.java
+++ b/src/main/java/org/primefaces/model/CheckboxTreeNode.java
@@ -136,6 +136,27 @@ public class CheckboxTreeNode implements TreeNode, Serializable {
         return this.selected;
     }
 
+    public void setSelected(boolean value, boolean propagateDown, boolean propagateUp) {
+        this.partialSelected = false;
+        this.selected = value;
+
+        if (propagateDown && propagateUp) {
+            this.setSelected(value);
+        }
+        else if (!propagateDown && propagateUp) {
+            if (this.getParent() != null) {
+                ((CheckboxTreeNode) this.getParent()).propagateSelectionUp();
+            }
+        }
+        else if (propagateDown && !propagateUp) {
+            if (!isLeaf()) {
+                for (TreeNode child : children) {
+                    ((CheckboxTreeNode) child).propagateSelectionDown(value);
+                }
+            }
+        }
+    }
+
     public void setSelected(boolean value, boolean propagate) {
         if (propagate) {
             this.setSelected(value);

--- a/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
+++ b/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
@@ -28,7 +28,7 @@ PrimeFaces.widget.BaseTree = PrimeFaces.widget.BaseWidget.extend({
             this.cursorNode = this.jq.find('.ui-treenode[data-rowkey="' + this.cursorNode.data('rowkey') + '"]');
         }
 
-        if(this.isCheckboxSelection()) {
+        if(this.isCheckboxSelection() && this.cfg.propagateUp) {
             this.preselectCheckbox();
         }
     },


### PR DESCRIPTION
class UITree: Get values of propagateSelectionDown and propagateSelectionUp. If selectionMode is 'checkbox', call setSelected method of CheckboxTreeNode with propagateSelectionDown and propagateSelectionUp.

class CheckboxTreeNode: Add setSelected method with the two parameters propagateSelectionDown and propagateSelectionUp to process independently up and down.

function initSelection: Add constraint propagateUp to not propagate minus icons to parents if propagateUp is false