### PR TITLE
Revert "Fix #2130 - dialog max height and max width should fit viewport"

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
@@ -1,4 +1,4 @@
-.ui-dialog { position: fixed; padding: 0; overflow: hidden; display:none; max-height: 100vh; max-width: 100vw; }
+.ui-dialog { position: fixed; padding: 0; overflow: hidden; display:none; }
 .ui-dialog.ui-dialog-absolute { position: absolute; }
 .ui-dialog.ui-overlay-hidden {display:block;}
 .ui-dialog .ui-dialog-titlebar { padding: .4em .4em .4em 1em; position: relative; border:0px; }


### PR DESCRIPTION
This reverts commit 1ce0426d83232b304a77bac6907950cfb400091f.

Relevant to: https://github.com/primefaces/primefaces/issues/4524