### PR TITLE
#4560, change default labelSeparator from ',' to ', '

### DIFF
--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuBase.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuBase.java
@@ -201,7 +201,7 @@ abstract class SelectCheckboxMenuBase extends HtmlSelectManyCheckbox implements 
     }
 
     public String getLabelSeparator() {
-        return (String) getStateHelper().eval(PropertyKeys.labelSeparator, ",");
+        return (String) getStateHelper().eval(PropertyKeys.labelSeparator, ", ");
     }
 
     public void setLabelSeparator(String labelSeparator) {

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -310,7 +310,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
                 .attr("scrollHeight", menu.getScrollHeight(), Integer.MAX_VALUE)
                 .attr("showHeader", menu.isShowHeader(), true)
                 .attr("updateLabel", menu.isUpdateLabel(), false)
-                .attr("labelSeparator", menu.getLabelSeparator(), ",")
+                .attr("labelSeparator", menu.getLabelSeparator(), ", ")
                 .attr("emptyLabel", menu.getEmptyLabel())
                 .attr("multiple", menu.isMultiple(), false)
                 .attr("dynamic", menu.isDynamic(), false)

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -19,7 +19,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.showHeader = (this.cfg.showHeader === undefined) ? true : this.cfg.showHeader;
         this.cfg.dynamic = this.cfg.dynamic === true ? true : false;
         this.isDynamicLoaded = false;
-        this.cfg.labelSeparator = (this.cfg.labelSeparator === undefined) ? ',' : this.cfg.labelSeparator;
+        this.cfg.labelSeparator = (this.cfg.labelSeparator === undefined) ? ', ' : this.cfg.labelSeparator;
 
         if(!this.disabled) {
             if(this.cfg.multiple) {


### PR DESCRIPTION
#4560, include the space after the comma for the default labelSeparator.