### PR TITLE
#2643 at my (position) attribute to dialog

### DIFF
--- a/src/main/java/org/primefaces/component/dialog/DialogBase.java
+++ b/src/main/java/org/primefaces/component/dialog/DialogBase.java
@@ -47,6 +47,7 @@ abstract class DialogBase extends UIPanel implements Widget, RTLAware, ClientBeh
         styleClass,
         showEffect,
         hideEffect,
+        my,
         position,
         closable,
         onShow,
@@ -192,6 +193,14 @@ abstract class DialogBase extends UIPanel implements Widget, RTLAware, ClientBeh
 
     public void setHideEffect(String hideEffect) {
         getStateHelper().put(PropertyKeys.hideEffect, hideEffect);
+    }
+
+    public String getMy() {
+        return (String) getStateHelper().eval(PropertyKeys.my, null);
+    }
+
+    public void setMy(String my) {
+        getStateHelper().put(PropertyKeys.my, my);
     }
 
     public String getPosition() {

--- a/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
+++ b/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
@@ -66,6 +66,7 @@ public class DialogRenderer extends CoreRenderer {
                 .attr("dynamic", dialog.isDynamic(), false)
                 .attr("showEffect", dialog.getShowEffect(), null)
                 .attr("hideEffect", dialog.getHideEffect(), null)
+                .attr("my", dialog.getMy(), null)
                 .attr("position", dialog.getPosition(), null)
                 .attr("closeOnEscape", dialog.isCloseOnEscape(), false)
                 .attr("fitViewport", dialog.isFitViewport(), false)

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -8205,7 +8205,15 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Defines where the dialog should be displayed.]]>
+                <![CDATA[Position of the dialog relative to the target. Default is "center".]]>
+            </description>
+            <name>my</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines where the dialog should be displayed. Default is "center".]]>
             </description>
             <name>position</name>
             <required>false</required>

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -25,6 +25,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.cfg.resizable = this.cfg.resizable === false ? false : true;
         this.cfg.minWidth = this.cfg.minWidth||150;
         this.cfg.minHeight = this.cfg.minHeight||this.titlebar.outerHeight();
+        this.cfg.my = this.cfg.my||'center';
         this.cfg.position = this.cfg.position||'center';
         this.parent = this.jq.parent();
 
@@ -347,7 +348,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
             this.cfg.position = this.cfg.position.replace(',', ' ');
 
             this.jq.position({
-                        my: 'center'
+                        my: this.cfg.my
                         ,at: this.cfg.position
                         ,collision: 'fit'
                         ,of: window


### PR DESCRIPTION
PR for #2643. Added 'my' attribute to the dialog to improve the positioning of it.

I am still not sure if the 'position' attribute should be renamed to 'at'.
Which is the name in the jquery component. Also the 'my' and 'at' attributes are always occur together in the following components: AutoComplete, Menu, OverlayPanel, SlideMenu and TieredMenu
But it would break  backward compatibility.