### PR TITLE
Fix incomplete PR #2898

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
@@ -31,7 +31,7 @@ PrimeFaces.widget.SelectManyMenu = PrimeFaces.widget.SelectListbox.extend({
                         $this.unselectAll();
                     }
 
-                    if(metaKey && item.hasClass('ui-state-highlight')) {
+                    if((metaKey || $this.cfg.showCheckbox) && item.hasClass('ui-state-highlight')) {
                         $this.unselectItem(item);
                     }
                     else {


### PR DESCRIPTION
 #2898 implemented the ability to click the label in a `selectManyMenu` to select an additional option, but missed the deselection part. This PR fixxes that.