### PR TITLE
Fix #4557

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1590,20 +1590,22 @@ public class DataTable extends DataTableBase {
 
     public String getSortMetaOrder(FacesContext context) {
         List<SortMeta> multiSortMeta = getMultiSortMeta();
-        int size = multiSortMeta.size();
-        if (size > 0) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("['");
-            for (int i = 0; i < size; i++) {
-                SortMeta sortMeta = multiSortMeta.get(i);
-                if (i > 0) {
-                    sb.append("','");
+        if (multiSortMeta != null) {
+            int size = multiSortMeta.size();
+            if (size > 0) {
+                StringBuilder sb = new StringBuilder();
+                sb.append("['");
+                for (int i = 0; i < size; i++) {
+                    SortMeta sortMeta = multiSortMeta.get(i);
+                    if (i > 0) {
+                        sb.append("','");
+                    }
+                    sb.append(sortMeta.getColumn().getClientId(context));
                 }
-                sb.append(sortMeta.getColumn().getClientId(context));
-            }
-            sb.append("']");
+                sb.append("']");
 
-            return sb.toString();
+                return sb.toString();
+            }
         }
         return null;
     }

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1588,5 +1588,25 @@ public class DataTable extends DataTableBase {
         return null;
     }
 
+    public String getSortMetaOrder(FacesContext context) {
+        List<SortMeta> multiSortMeta = getMultiSortMeta();
+        int size = multiSortMeta.size();
+        if (size > 0) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("['");
+            for (int i = 0; i < size; i++) {
+                SortMeta sortMeta = multiSortMeta.get(i);
+                if (i > 0) {
+                    sb.append("','");
+                }
+                sb.append(sortMeta.getColumn().getClientId(context));
+            }
+            sb.append("']");
+
+            return sb.toString();
+        }
+        return null;
+    }
+
 
 }

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -288,7 +288,8 @@ public class DataTableRenderer extends DataRenderer {
 
         //MultiColumn Sorting
         if (table.isMultiSort()) {
-            wb.attr("multiSort", true);
+            wb.attr("multiSort", true)
+                    .nativeAttr("sortMetaOrder", table.getSortMetaOrder(context), null);
         }
 
         if (table.isStickyHeader()) {

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -190,6 +190,8 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             var columnHeader = this.sortableColumns.eq(i),
             sortIcon = columnHeader.children('span.ui-sortable-column-icon'),
             sortOrder = null,
+            columnId = null,
+            resolvedSortMetaIndex = null.
             ariaLabel = columnHeader.attr('aria-label');
 
             if(columnHeader.hasClass('ui-state-active')) {
@@ -211,10 +213,13 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 }
 
                 if($this.cfg.multiSort) {
-                    $this.addSortMeta({
-                        col: columnHeader.attr('id'),
+                    columnId = columnHeader.attr('id');
+                    resolvedSortMetaIndex = $.inArray(columnId, this.cfg.sortMetaOrder);
+
+                    this.sortMeta[resolvedSortMetaIndex] = {
+                        col: columnId,
                         order: sortOrder
-                    });
+                    };
                 }
 
                 $this.updateReflowDD(columnHeader, sortOrder);

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -191,7 +191,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             sortIcon = columnHeader.children('span.ui-sortable-column-icon'),
             sortOrder = null,
             columnId = null,
-            resolvedSortMetaIndex = null.
+            resolvedSortMetaIndex = null,
             ariaLabel = columnHeader.attr('aria-label');
 
             if(columnHeader.hasClass('ui-state-active')) {


### PR DESCRIPTION
On server side:
 - get the multi-sort-meta and convert it to a JS array of column client ids
 - add this array to the datatables widget config

On client side:
 - during ``bindSortEvents`` it resolves the index of the active column based on the id and so creates sort-meta that matches those on the server.
 - $.inArray is used instead of Array.indexOf, because IE 8 does not support it and I don't know the current minimal supported IE version.