### PR TITLE
Fix #4629: Add escaping to showMessageInDialog.

### DIFF
--- a/src/main/java/org/primefaces/PrimeFaces.java
+++ b/src/main/java/org/primefaces/PrimeFaces.java
@@ -271,17 +271,28 @@ public class PrimeFaces {
         }
 
         /**
-         * Displays a message in a dynamic dialog.
+         * Displays a message in a dynamic dialog with any HTML escaped.
          *
          * @param message the {@link FacesMessage} to be displayed.
          */
         public void showMessageDynamic(FacesMessage message) {
+            showMessageDynamic(message, true);
+        }
+
+        /**
+         * Displays a message in a dynamic dialog with escape control.
+         *
+         * @param message the {@link FacesMessage} to be displayed.
+         * @param escape true to escape HTML content, false to display HTML content
+         */
+        public void showMessageDynamic(FacesMessage message, boolean escape) {
             String summary = EscapeUtils.forJavaScript(message.getSummary());
             String detail = EscapeUtils.forJavaScript(message.getDetail());
 
             executeScript("PrimeFaces.showMessageInDialog({severity:\"" + message.getSeverity()
                     + "\",summary:\"" + summary
-                    + "\",detail:\"" + detail + "\"});");
+                    + "\",detail:\"" + detail
+                    + "\",escape:" + escape + "});");
         }
     }
 

--- a/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
@@ -200,10 +200,11 @@ if (!PrimeFaces.dialog) {
                 this.messageDialog.titleContainer = this.messageDialog.titlebar.children('span.ui-dialog-title');
             }
 
-            var summaryHtml = msg.summary ? msg.summary.split(/\r\n|\n|\r/g).map(function(line) { return PrimeFaces.escapeHTML(line); }).join("<br>") : "";
+            var escape = msg.escape !== false;
+            var summaryHtml = msg.summary ? msg.summary.split(/\r\n|\n|\r/g).map(function(line) { return escape ? PrimeFaces.escapeHTML(line) : line; }).join("<br>") : "";
             this.messageDialog.titleContainer.html(summaryHtml);
 
-            var detailHtml = msg.detail ? msg.detail.split(/\r\n|\n|\r/g).map(function(line) { return PrimeFaces.escapeHTML(line); }).join("<br>") : "";
+            var detailHtml = msg.detail ? msg.detail.split(/\r\n|\n|\r/g).map(function(line) { return escape ? PrimeFaces.escapeHTML(line) : line; }).join("<br>") : "";
             this.messageDialog.content.html('').append('<span class="ui-dialog-message ui-messages-' + msg.severity.split(' ')[0].toLowerCase() + '-icon" />').append(detailHtml);
             this.messageDialog.show();
         },


### PR DESCRIPTION
Added an overloaded version with an escape flag.  The flag is of course TRUE by default in all cases because we want escaping.  You have to use the overridden method and pass it false.

```java
PrimeFaces.current().dialog().showMessageDynamic(new FacesMessage(FacesMessage.SEVERITY_INFO,
				"Auto de Apreensão", "<strong>test</strong>"), Boolean.FALSE);
```