### PR TITLE
Fix #4639: ChartJS add common Scale options.

### DIFF
--- a/src/main/java/org/primefaces/component/charts/ChartRenderer.java
+++ b/src/main/java/org/primefaces/component/charts/ChartRenderer.java
@@ -33,6 +33,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.model.charts.ChartData;
 import org.primefaces.model.charts.ChartDataSet;
 import org.primefaces.model.charts.ChartModel;
+import org.primefaces.model.charts.axes.AxesScale;
 import org.primefaces.model.charts.axes.cartesian.CartesianAxes;
 import org.primefaces.model.charts.axes.cartesian.CartesianScales;
 import org.primefaces.model.charts.axes.radial.RadialScales;
@@ -41,6 +42,7 @@ import org.primefaces.model.charts.optionconfig.legend.Legend;
 import org.primefaces.model.charts.optionconfig.title.Title;
 import org.primefaces.model.charts.optionconfig.tooltip.Tooltip;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.ChartUtils;
 import org.primefaces.util.EscapeUtils;
 
 public class ChartRenderer extends CoreRenderer {
@@ -162,17 +164,16 @@ public class ChartRenderer extends CoreRenderer {
             if (scales instanceof CartesianScales) {
                 writer.write("\"scales\":{");
                 CartesianScales cScales = (CartesianScales) scales;
+                encodeScaleCommon(writer, cScales);
                 List<CartesianAxes> xAxes = cScales.getXAxes();
                 if (xAxes != null && !xAxes.isEmpty()) {
+                    writer.write(",");
                     encodeAxes(context, chartName, "xAxes", xAxes);
-                    hasComma = true;
                 }
 
                 List<CartesianAxes> yAxes = cScales.getYAxes();
                 if (yAxes != null && !yAxes.isEmpty()) {
-                    if (hasComma) {
-                        writer.write(",");
-                    }
+                    writer.write(",");
                     encodeAxes(context, chartName, "yAxes", yAxes);
                 }
 
@@ -181,32 +182,31 @@ public class ChartRenderer extends CoreRenderer {
             else if (scales instanceof RadialScales) {
                 writer.write("\"scale\":{");
                 RadialScales rScales = (RadialScales) scales;
-                String preString;
+                encodeScaleCommon(writer, rScales);
                 if (rScales.getAngelLines() != null) {
-                    writer.write("\"angleLines\":" + rScales.getAngelLines().encode());
-                    hasComma = true;
+                    writer.write(",\"angleLines\":" + rScales.getAngelLines().encode());
                 }
 
                 if (rScales.getGridLines() != null) {
-                    preString = hasComma ? "," : "";
-                    writer.write(preString + "\"gridLines\":" + rScales.getGridLines().encode());
-                    hasComma = true;
+                    writer.write(",\"gridLines\":" + rScales.getGridLines().encode());
                 }
 
                 if (rScales.getPointLabels() != null) {
-                    preString = hasComma ? "," : "";
-                    writer.write(preString + "\"pointLabels\":" + rScales.getPointLabels().encode());
-                    hasComma = true;
+                    writer.write(",\"pointLabels\":" + rScales.getPointLabels().encode());
                 }
 
                 if (rScales.getTicks() != null) {
-                    preString = hasComma ? "," : "";
-                    writer.write(preString + "\"ticks\":" + rScales.getTicks().encode());
+                    writer.write(",\"ticks\":" + rScales.getTicks().encode());
                 }
 
                 writer.write("}");
             }
         }
+    }
+
+    protected void encodeScaleCommon(ResponseWriter writer, AxesScale scale) throws IOException {
+        ChartUtils.writeDataValue(writer, "display", scale.isDisplay(), false);
+        ChartUtils.writeDataValue(writer, "weight", scale.getWeight(), true);
     }
 
     protected void encodeAxes(FacesContext context, String chartName, String name, List<CartesianAxes> axes) throws IOException {

--- a/src/main/java/org/primefaces/model/charts/axes/AxesScale.java
+++ b/src/main/java/org/primefaces/model/charts/axes/AxesScale.java
@@ -21,61 +21,54 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.model.charts.axes.cartesian;
+package org.primefaces.model.charts.axes;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.primefaces.model.charts.axes.AxesScale;
+import java.io.Serializable;
 
 /**
- * Used to provide scales option has cartesian type
+ * Base Scale configuration for common scale options.
  */
-public class CartesianScales extends AxesScale {
+public abstract class AxesScale implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private List<CartesianAxes> xAxes;
-    private List<CartesianAxes> yAxes;
+    private boolean display = true;
+    private Number weight;
 
-    public CartesianScales() {
-        xAxes = new ArrayList<>();
-        yAxes = new ArrayList<>();
+    /**
+     * Controls the axis global visibility (visible when true, hidden when false).
+     *
+     * @return display flag
+     */
+    public boolean isDisplay() {
+        return display;
     }
 
     /**
-     * Gets xAxes
+     * Controls the axis global visibility (visible when true, hidden when false).
      *
-     * @return xAxes List&#60;{@link CartesianAxes}&#62; list of x axes
+     * @param display true to display false to hide.
      */
-    public List<CartesianAxes> getXAxes() {
-        return xAxes;
+    public void setDisplay(boolean display) {
+        this.display = display;
     }
 
     /**
-     * Gets yAxes
+     * The weight used to sort the axis. Higher weights are further away from the chart area.
      *
-     * @return yAxes List&#60;{@link CartesianAxes}&#62; list of y axes
+     * @return the weight
      */
-    public List<CartesianAxes> getYAxes() {
-        return yAxes;
+    public Number getWeight() {
+        return weight;
     }
 
     /**
-     * Adds a new xAxes as {@link CartesianAxes} data to scales
+     * The weight used to sort the axis. Higher weights are further away from the chart area.
      *
-     * @param newXAxesData
+     * @param weight number to set to the weight to
      */
-    public void addXAxesData(CartesianAxes newXAxesData) {
-        xAxes.add(newXAxesData);
+    public void setWeight(Number weight) {
+        this.weight = weight;
     }
 
-    /**
-     * Adds a new yAxes as {@link CartesianAxes} data to scales
-     *
-     * @param newYAxesData
-     */
-    public void addYAxesData(CartesianAxes newYAxesData) {
-        yAxes.add(newYAxesData);
-    }
 }

--- a/src/main/java/org/primefaces/model/charts/axes/radial/RadialScales.java
+++ b/src/main/java/org/primefaces/model/charts/axes/radial/RadialScales.java
@@ -23,9 +23,8 @@
  */
 package org.primefaces.model.charts.axes.radial;
 
-import java.io.Serializable;
-
 import org.primefaces.model.charts.axes.AxesGridLines;
+import org.primefaces.model.charts.axes.AxesScale;
 import org.primefaces.model.charts.axes.radial.linear.RadialLinearAngleLines;
 import org.primefaces.model.charts.axes.radial.linear.RadialLinearPointLabels;
 import org.primefaces.model.charts.axes.radial.linear.RadialLinearTicks;
@@ -33,7 +32,7 @@ import org.primefaces.model.charts.axes.radial.linear.RadialLinearTicks;
 /**
  * Used to provide scales option has radial type
  */
-public class RadialScales implements Serializable {
+public class RadialScales extends AxesScale {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
- Added common Scale options
- Cleaned up Scale output code dealing with commas because there is now always a default disply="" flag so we can assume the comma's.