### PR TITLE
Fix #4697 Negative CSS text indent causes outline wrapping text in Firefox

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -359,6 +359,7 @@
 
 .ui-button-icon-only {
     width: 2.4em;
+    overflow: hidden;
 }
 
 /*button text element */
@@ -373,8 +374,8 @@
 
 .ui-button-icon-only .ui-button-text {
     padding: .3em;
-    letter-spacing: -8px;
-    color: transparent;
+    white-space: nowrap;
+    visibility: hidden;
 }
 
 .ui-button-text-icon-left .ui-button-text {

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -373,7 +373,8 @@
 
 .ui-button-icon-only .ui-button-text {
     padding: .3em;
-    text-indent: -9999999px;
+    letter-spacing: -8px;
+    color: transparent;
 }
 
 .ui-button-text-icon-left .ui-button-text {


### PR DESCRIPTION
Firefox does not like `text-indent: -9999999px;`