### PR TITLE
Fix #4712: SelectManyRenderer better defaults for empty array/list.

### DIFF
--- a/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
@@ -82,7 +82,7 @@ public abstract class SelectManyRenderer extends SelectRenderer {
     @Override
     protected boolean isSelected(FacesContext context, UIComponent component, Object itemValue, Object valueArray, Converter converter) {
         // GitHub #4712
-        if (itemValue == null && valueArray == null) {
+        if (valueArray == null) {
             return false;
         }
         return super.isSelected(context, component, itemValue, valueArray, converter);

--- a/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/SelectManyRenderer.java
@@ -30,6 +30,7 @@ import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UISelectMany;
 import javax.faces.context.FacesContext;
+import javax.faces.convert.Converter;
 
 public abstract class SelectManyRenderer extends SelectRenderer {
 
@@ -78,5 +79,16 @@ public abstract class SelectManyRenderer extends SelectRenderer {
         return (Object[]) select.getSubmittedValue();
     }
 
+    @Override
+    protected boolean isSelected(FacesContext context, UIComponent component, Object itemValue, Object valueArray, Converter converter) {
+        // GitHub #4712
+        if (itemValue == null && valueArray == null) {
+            return false;
+        }
+        return super.isSelected(context, component, itemValue, valueArray, converter);
+    }
+
     protected abstract String getSubmitParam(FacesContext context, UISelectMany selectMany);
+
+
 }


### PR DESCRIPTION
This was the cleanest way to fix it by overriding the method in SelectRenderer and just tweaking this check.  

The base method is used by SelectOne and some other non many selectors so that I believe is the correct behavior if both are null.