### PR TITLE
Fix #4727: Dialog only use aria-labelledby is showHeader=true.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -561,8 +561,8 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         });
         
         // GitHub #4727
-        var title = '#' + this.id + '_title';
-        if ($(title).length) {
+        var title = this.id + '_title';
+        if ($('#' +title).length) {
             this.jq.attr('aria-labelledby', title);
         }
 

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -555,11 +555,16 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
     applyARIA: function() {
         this.jq.attr({
             'role': 'dialog'
-            ,'aria-labelledby': this.id + '_title'
             ,'aria-describedby': this.id + '_content'
             ,'aria-hidden': !this.cfg.visible
             ,'aria-modal': this.cfg.modal
         });
+        
+        // GitHub #4727
+        var title = this.id + '_title';
+        if ($(title).length) {
+            this.jq.attr('aria-labelledby', title);
+        }
 
         this.titlebar.children('a.ui-dialog-titlebar-icon').attr('role', 'button');
     },

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -562,7 +562,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         
         // GitHub #4727
         var title = this.id + '_title';
-        if ($('#' +title).length) {
+        if ($(PrimeFaces.escapeClientId(title)).length) {
             this.jq.attr('aria-labelledby', title);
         }
 

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -561,7 +561,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         });
         
         // GitHub #4727
-        var title = this.id + '_title';
+        var title = '#' + this.id + '_title';
         if ($(title).length) {
             this.jq.attr('aria-labelledby', title);
         }


### PR DESCRIPTION
I simply check for the existence of the title element and only set aria-labelledBy if the title is found.