### PR TITLE
Fix #4752: NativeUpload can only accept a file name not a full path.

### DIFF
--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -24,6 +24,7 @@
 package org.primefaces.model;
 
 import org.primefaces.component.fileupload.FileUpload;
+import org.primefaces.shaded.owasp.SafeFile;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -130,7 +131,8 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
 
     @Override
     public void write(String filePath) throws Exception {
-        String validFileName = FileUploadUtils.getValidFilename(FilenameUtils.getName(filePath));
+        SafeFile file = new SafeFile(filePath);
+        String validFileName = FileUploadUtils.getValidFilename(FilenameUtils.getName(file.getPath()));
 
         if (parts != null) {
             for (int i = 0; i < parts.size(); i++) {

--- a/src/main/java/org/primefaces/model/NativeUploadedFile.java
+++ b/src/main/java/org/primefaces/model/NativeUploadedFile.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.faces.FacesException;
 import javax.servlet.http.Part;
+
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.util.FileUploadUtils;
 
@@ -128,16 +130,16 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
 
     @Override
     public void write(String filePath) throws Exception {
-        String validFilePath = FileUploadUtils.getValidFilePath(filePath);
+        String validFileName = FileUploadUtils.getValidFilename(FilenameUtils.getName(filePath));
 
         if (parts != null) {
             for (int i = 0; i < parts.size(); i++) {
                 Part p = parts.get(i);
-                p.write(validFilePath);
+                p.write(validFileName);
             }
         }
         else {
-            part.write(validFilePath);
+            part.write(validFileName);
         }
     }
 


### PR DESCRIPTION
@tandraschko @mertsincan can you review this.  I tested it heavily using the Tester provided by the user and it seems Part must not take a full path it can only accept a file name and it determines where to save the file.