### PR TITLE
Fix #4672 #2448: Removed NUMPAD_ENTER.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
@@ -22,7 +22,7 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
             var keyCode = $.ui.keyCode;
 
             data = data || e.data;
-            if (($this.scope && data.scopeEnter) || (!$this.scope && (e.which == keyCode.ENTER || e.which == keyCode.NUMPAD_ENTER))) {
+            if (($this.scope && data.scopeEnter) || (!$this.scope && (e.which == keyCode.ENTER))) {
                 //do not proceed if target is a textarea,button or link
                 if ($(e.target).is('textarea,button,input[type="submit"],a')) {
                     return true;
@@ -39,7 +39,7 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
         if (this.scope) {
             this.scope.off('keydown.' + this.id).on('keydown.' + this.id, function (e) {
                 var keyCode = $.ui.keyCode;
-                if (e.which == keyCode.ENTER || e.which == keyCode.NUMPAD_ENTER) {
+                if (e.which == keyCode.ENTER) {
                     closestForm.trigger('keydown.' + $this.id, {scopeEnter: true});
                     e.preventDefault();
                     e.stopPropagation();

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -362,7 +362,6 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
 
             switch(key) {
                 case keyCode.ENTER:
-                case keyCode.NUMPAD_ENTER:
                 case keyCode.SPACE:
                     if ($this.panel.is(":hidden"))
                         $this.show();

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.splitbutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.splitbutton.js
@@ -73,7 +73,6 @@ PrimeFaces.widget.SplitButton = PrimeFaces.widget.BaseWidget.extend({
                 break;
 
                 case keyCode.ENTER:
-                case keyCode.NUMPAD_ENTER:
                 case keyCode.SPACE:
                     $this.handleEnterKey(e);
                 break;
@@ -120,7 +119,6 @@ PrimeFaces.widget.SplitButton = PrimeFaces.widget.BaseWidget.extend({
                 case keyCode.DOWN:
                 case keyCode.RIGHT:
                 case keyCode.ENTER:
-                case keyCode.NUMPAD_ENTER:
                 case keyCode.TAB:
                 case keyCode.ESCAPE:
                 case keyCode.SPACE:
@@ -165,7 +163,6 @@ PrimeFaces.widget.SplitButton = PrimeFaces.widget.BaseWidget.extend({
                 break;
                 
                 case keyCode.ENTER:
-                case keyCode.NUMPAD_ENTER:
                     $this.handleEnterKey(e);
                 break;
                 


### PR DESCRIPTION
Because NUMPAD_ENTER is no longer defined as it shouldn't be it was now causing default command to evaluate to true in Chrome Auto Complete.

Because e.keycode == undefined and NUMPAD_ENTER is undefined ===true.

By remove the dead NUMPAD_ENTER resolves this issue.

@mertsincan this should probably be merged into ELITE 7.0.2