### PR TITLE
WebXmlParser: fix xpath-queries for namespace-aware XPath implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.9.0-2</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- will be included and relocated by shade plugin -->
         <dependency>
             <groupId>org.owasp.encoder</groupId>

--- a/src/test/java/org/primefaces/config/WebXmlParserTest.java
+++ b/src/test/java/org/primefaces/config/WebXmlParserTest.java
@@ -1,0 +1,78 @@
+package org.primefaces.config;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.xml.xpath.XPathFactory;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class WebXmlParserTest {
+    private static String XPATH_FACTORY_SYSTEM_PROPERTY = XPathFactory.DEFAULT_PROPERTY_NAME + ":" + XPathFactory.DEFAULT_OBJECT_MODEL_URI;
+
+    @Parameterized.Parameter
+    public String pathToWebXml;
+
+    private FacesContext context;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"web-namespaces.xml"},
+                {"web-empty-error-code.xml"},
+                {"web-no-namespace.xml"},
+        });
+    }
+
+    private void configureXpathFactory(Class<? extends XPathFactory> factoryClass) {
+        System.setProperty(XPATH_FACTORY_SYSTEM_PROPERTY, factoryClass.getName());
+        assertEquals("The XpathFactory implementations must match: " + factoryClass.getName(), factoryClass, XPathFactory.newInstance().getClass());
+    }
+
+    @Before
+    public void mockContext() throws Exception {
+        context = mock(FacesContext.class);
+        ExternalContext extContext = mock(ExternalContext.class);
+        when(context.getExternalContext()).thenReturn(extContext);
+        when(extContext.getResource(anyString())).thenReturn(this.getClass().getResource(pathToWebXml));
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(XPATH_FACTORY_SYSTEM_PROPERTY);
+    }
+
+
+    private void assertErrorPages(Map<String, String> errorPages) {
+        String viewExpiredClassName = "javax.faces.application.ViewExpiredException";
+        assertEquals("Parsing the web.xml should return 2 errors pages", 2, errorPages.size());
+        assertEquals("The key null should return the default location", "/default", errorPages.get(null));
+        assertEquals("The key " + viewExpiredClassName + "  should return the viewExpired location", "/viewExpired", errorPages.get(viewExpiredClassName));
+    }
+
+    @Test
+    public void testSaxon() {
+        configureXpathFactory(net.sf.saxon.xpath.XPathFactoryImpl.class);
+        Map<String, String> errorPages = WebXmlParser.getErrorPages(context);
+        assertErrorPages(errorPages);
+    }
+
+    @Test
+    public void testInternalJaxp() {
+        configureXpathFactory(com.sun.org.apache.xpath.internal.jaxp.XPathFactoryImpl.class);
+        Map<String, String> errorPages = WebXmlParser.getErrorPages(context);
+        assertErrorPages(errorPages);
+    }
+}

--- a/src/test/resources/org/primefaces/config/web-empty-error-code.xml
+++ b/src/test/resources/org/primefaces/config/web-empty-error-code.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <error-page>
+        <exception-type>javax.faces.application.ViewExpiredException</exception-type>
+        <location>/viewExpired</location>
+    </error-page>
+    <error-page>
+        <location>/default</location>
+    </error-page>
+</web-app>

--- a/src/test/resources/org/primefaces/config/web-namespaces.xml
+++ b/src/test/resources/org/primefaces/config/web-namespaces.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <error-page>
+        <exception-type>javax.faces.application.ViewExpiredException</exception-type>
+        <location>/viewExpired</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/default</location>
+    </error-page>
+</web-app>

--- a/src/test/resources/org/primefaces/config/web-no-namespace.xml
+++ b/src/test/resources/org/primefaces/config/web-no-namespace.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<web-app version="3.0">
+
+    <error-page>
+        <exception-type>javax.faces.application.ViewExpiredException</exception-type>
+        <location>/viewExpired</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/default</location>
+    </error-page>
+</web-app>


### PR DESCRIPTION
To get the error-pages from the web.xml the WebXmlParser uses the javax.xml.xpath.XPathFactory to create xpath-queries. Which implementation of the XPathFactory is actually used can be globally defined via system-properties or Java service provider configuration. If a namespace-aware XPathFactory-implementation such as the net.sf.saxon.xpath.XPathFactoryImpl is configured during runtime the xpath-queries for the error-pages fail and no error-pages are available when the PrimeExceptionHandler handles an exception. 
This pull request improves the xpath-queries so they will work on both namespace-aware and namespace-unaware XPath implementations and adds a unit test which verifies the fix.

