### PR TITLE
Fix #4834: Refactor CSV to be more flexible and add 2.0 validations.

### DIFF
--- a/src/main/java/org/primefaces/validate/bean/AssertFalseClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/AssertFalseClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.AssertFalse;
 import javax.validation.metadata.ConstraintDescriptor;
 
 public class AssertFalseClientValidationConstraint implements ClientValidationConstraint {
@@ -48,6 +47,6 @@ public class AssertFalseClientValidationConstraint implements ClientValidationCo
 
     @Override
     public String getValidatorId() {
-        return AssertFalse.class.getSimpleName();
+        return "AssertFalse";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/AssertTrueClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/AssertTrueClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.AssertTrue;
 import javax.validation.metadata.ConstraintDescriptor;
 
 public class AssertTrueClientValidationConstraint implements ClientValidationConstraint {
@@ -48,6 +47,6 @@ public class AssertTrueClientValidationConstraint implements ClientValidationCon
 
     @Override
     public String getValidatorId() {
-        return AssertTrue.class.getSimpleName();
+        return "AssertTrue";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/BeanValidationMetadataMapper.java
+++ b/src/main/java/org/primefaces/validate/bean/BeanValidationMetadataMapper.java
@@ -38,19 +38,6 @@ import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.validation.MessageInterpolator;
-import javax.validation.constraints.AssertFalse;
-import javax.validation.constraints.AssertTrue;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Future;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import javax.validation.constraints.Past;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.metadata.BeanValidationMetadataExtractor;
@@ -60,21 +47,30 @@ public class BeanValidationMetadataMapper {
 
     private static final Logger LOGGER = Logger.getLogger(BeanValidationMetadataMapper.class.getName());
 
-    private static final Map<Class<? extends Annotation>, ClientValidationConstraint> CONSTRAINT_MAPPING
-            = MapBuilder.<Class<? extends Annotation>, ClientValidationConstraint>builder()
-                    .put(NotNull.class, new NotNullClientValidationConstraint())
-                    .put(Null.class, new NullClientValidationConstraint())
-                    .put(Size.class, new SizeClientValidationConstraint())
-                    .put(Min.class, new MinClientValidationConstraint())
-                    .put(Max.class, new MaxClientValidationConstraint())
-                    .put(DecimalMin.class, new DecimalMinClientValidationConstraint())
-                    .put(DecimalMax.class, new DecimalMaxClientValidationConstraint())
-                    .put(AssertTrue.class, new AssertTrueClientValidationConstraint())
-                    .put(AssertFalse.class, new AssertFalseClientValidationConstraint())
-                    .put(Digits.class, new DigitsClientValidationConstraint())
-                    .put(Past.class, new PastClientValidationConstraint())
-                    .put(Future.class, new FutureClientValidationConstraint())
-                    .put(Pattern.class, new PatternClientValidationConstraint())
+    private static final Map<String, ClientValidationConstraint> CONSTRAINT_MAPPING
+            = MapBuilder.<String, ClientValidationConstraint>builder()
+                    .put("javax.validation.constraints.AssertFalse", new AssertFalseClientValidationConstraint())
+                    .put("javax.validation.constraints.AssertTrue", new AssertTrueClientValidationConstraint())
+                    .put("javax.validation.constraints.DecimalMax", new DecimalMaxClientValidationConstraint())
+                    .put("javax.validation.constraints.DecimalMin", new DecimalMinClientValidationConstraint())
+                    .put("javax.validation.constraints.Digits", new DigitsClientValidationConstraint())
+                    .put("javax.validation.constraints.Email", new EmailClientValidationConstraint())
+                    .put("javax.validation.constraints.Future", new FutureClientValidationConstraint())
+                    .put("javax.validation.constraints.FutureOrPresent", new FutureOrPresentClientValidationConstraint())
+                    .put("javax.validation.constraints.Max", new MaxClientValidationConstraint())
+                    .put("javax.validation.constraints.Min", new MinClientValidationConstraint())
+                    .put("javax.validation.constraints.Negative", new NegativeClientValidationConstraint())
+                    .put("javax.validation.constraints.NegativeOrZero", new NegativeOrZeroClientValidationConstraint())
+                    .put("javax.validation.constraints.NotBlank", new NotBlankClientValidationConstraint())
+                    .put("javax.validation.constraints.NotEmpty", new NotEmptyClientValidationConstraint())
+                    .put("javax.validation.constraints.NotNull", new NotNullClientValidationConstraint())
+                    .put("javax.validation.constraints.Null", new NullClientValidationConstraint())
+                    .put("javax.validation.constraints.Past", new PastClientValidationConstraint())
+                    .put("javax.validation.constraints.PastOrPresent", new PastOrPresentClientValidationConstraint())
+                    .put("javax.validation.constraints.Pattern", new PatternClientValidationConstraint())
+                    .put("javax.validation.constraints.Positive", new PositiveClientValidationConstraint())
+                    .put("javax.validation.constraints.PositiveOrZero", new PositiveOrZeroClientValidationConstraint())
+                    .put("javax.validation.constraints.Size", new SizeClientValidationConstraint())
                     .build();
 
     private BeanValidationMetadataMapper() {
@@ -106,7 +102,7 @@ public class BeanValidationMetadataMapper {
                     Class<?> annotationType = constraintDescriptor.getAnnotation().annotationType();
 
                     // lookup ClientValidationConstraint by constraint annotation (e.g. @NotNull)
-                    ClientValidationConstraint clientValidationConstraint = CONSTRAINT_MAPPING.get(annotationType);
+                    ClientValidationConstraint clientValidationConstraint = CONSTRAINT_MAPPING.get(annotationType.getName());
 
                     // mapping available? Otherwise try to lookup custom constraint
                     if (clientValidationConstraint == null) {
@@ -176,10 +172,10 @@ public class BeanValidationMetadataMapper {
     }
 
     public static void registerConstraintMapping(Class<? extends Annotation> constraint, ClientValidationConstraint clientValidationConstraint) {
-        CONSTRAINT_MAPPING.put(constraint, clientValidationConstraint);
+        CONSTRAINT_MAPPING.put(constraint.getName(), clientValidationConstraint);
     }
 
     public static ClientValidationConstraint removeConstraintMapping(Class<? extends Annotation> constraint) {
-        return CONSTRAINT_MAPPING.remove(constraint);
+        return CONSTRAINT_MAPPING.remove(constraint.getName());
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/DecimalMaxClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/DecimalMaxClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.DecimalMax;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -51,6 +50,6 @@ public class DecimalMaxClientValidationConstraint implements ClientValidationCon
 
     @Override
     public String getValidatorId() {
-        return DecimalMax.class.getSimpleName();
+        return "DecimalMax";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/DecimalMinClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/DecimalMinClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.DecimalMin;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -51,6 +50,6 @@ public class DecimalMinClientValidationConstraint implements ClientValidationCon
 
     @Override
     public String getValidatorId() {
-        return DecimalMin.class.getSimpleName();
+        return "DecimalMin";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/DigitsClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/DigitsClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Digits;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -52,6 +51,6 @@ public class DigitsClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return Digits.class.getSimpleName();
+        return "Digits";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/EmailClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/EmailClientValidationConstraint.java
@@ -27,10 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class EmailClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    private static final String MESSAGE_METADATA = "data-p-email-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.Email.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
@@ -47,6 +47,7 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "Email";
     }
+
 }

--- a/src/main/java/org/primefaces/validate/bean/FutureOrPresentClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/FutureOrPresentClientValidationConstraint.java
@@ -27,10 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class FutureOrPresentClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    private static final String MESSAGE_METADATA = "data-p-futureorpresent-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.FutureOrPresent.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
@@ -47,6 +47,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "FutureOrPresent";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/MaxClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/MaxClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Max;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -51,6 +50,6 @@ public class MaxClientValidationConstraint implements ClientValidationConstraint
 
     @Override
     public String getValidatorId() {
-        return Max.class.getSimpleName();
+        return "Max";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/MinClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/MinClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Min;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -51,6 +50,6 @@ public class MinClientValidationConstraint implements ClientValidationConstraint
 
     @Override
     public String getValidatorId() {
-        return Min.class.getSimpleName();
+        return "Min";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NegativeClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NegativeClientValidationConstraint.java
@@ -26,17 +26,21 @@ package org.primefaces.validate.bean;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
+import org.primefaces.util.HTML;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class NegativeClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    public static final String MESSAGE_METADATA = "data-p-negative-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.Negative.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
         Map<String, Object> metadata = new HashMap<>();
         Map attrs = constraintDescriptor.getAttributes();
         Object message = attrs.get(ATTR_MESSAGE);
+
+        // TODO not sure if this limit is correct
+        metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, -Double.MIN_VALUE);
 
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
@@ -47,6 +51,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "Negative";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NegativeOrZeroClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NegativeOrZeroClientValidationConstraint.java
@@ -26,17 +26,20 @@ package org.primefaces.validate.bean;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
+import org.primefaces.util.HTML;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class NegativeOrZeroClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    public static final String MESSAGE_METADATA = "data-p-negativeorzero-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.NegativeOrZero.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
         Map<String, Object> metadata = new HashMap<>();
         Map attrs = constraintDescriptor.getAttributes();
         Object message = attrs.get(ATTR_MESSAGE);
+
+        metadata.put(HTML.VALIDATION_METADATA.MAX_VALUE, 0);
 
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
@@ -47,6 +50,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "NegativeOrZero";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NotBlankClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotBlankClientValidationConstraint.java
@@ -27,10 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class NotBlankClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    private static final String MESSAGE_METADATA = "data-p-notblank-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.NotBlank.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
@@ -47,6 +47,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "NotBlank";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NotEmptyClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotEmptyClientValidationConstraint.java
@@ -27,10 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class NotEmptyClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    private static final String MESSAGE_METADATA = "data-p-notempty-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.NotEmpty.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
@@ -47,6 +47,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "NotEmpty";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NotNullClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.NotNull;
 import javax.validation.metadata.ConstraintDescriptor;
 
 public class NotNullClientValidationConstraint implements ClientValidationConstraint {
@@ -48,6 +47,6 @@ public class NotNullClientValidationConstraint implements ClientValidationConstr
 
     @Override
     public String getValidatorId() {
-        return NotNull.class.getSimpleName();
+        return "NotNull";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/NullClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/NullClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Null;
 import javax.validation.metadata.ConstraintDescriptor;
 
 public class NullClientValidationConstraint implements ClientValidationConstraint {
@@ -48,6 +47,6 @@ public class NullClientValidationConstraint implements ClientValidationConstrain
 
     @Override
     public String getValidatorId() {
-        return Null.class.getSimpleName();
+        return "Null";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/PastClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/PastClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Past;
 import javax.validation.metadata.ConstraintDescriptor;
 
 public class PastClientValidationConstraint implements ClientValidationConstraint {
@@ -48,6 +47,6 @@ public class PastClientValidationConstraint implements ClientValidationConstrain
 
     @Override
     public String getValidatorId() {
-        return Past.class.getSimpleName();
+        return "Past";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/PastOrPresentClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/PastOrPresentClientValidationConstraint.java
@@ -27,10 +27,10 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class PastOrPresentClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    private static final String MESSAGE_METADATA = "data-p-pastorpresent-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.PastOrPresent.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
@@ -47,6 +47,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "PastOrPresent";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/PatternClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/PatternClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Pattern;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -51,7 +50,7 @@ public class PatternClientValidationConstraint implements ClientValidationConstr
 
     @Override
     public String getValidatorId() {
-        return Pattern.class.getSimpleName();
+        return "Pattern";
     }
 
 }

--- a/src/main/java/org/primefaces/validate/bean/PositiveClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/PositiveClientValidationConstraint.java
@@ -26,17 +26,21 @@ package org.primefaces.validate.bean;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
+import org.primefaces.util.HTML;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class PositiveClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    public static final String MESSAGE_METADATA = "data-p-positive-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.Positive.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
         Map<String, Object> metadata = new HashMap<>();
         Map attrs = constraintDescriptor.getAttributes();
         Object message = attrs.get(ATTR_MESSAGE);
+
+        // TODO not sure if this limit is correct
+        metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, Double.MIN_VALUE);
 
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
@@ -47,6 +51,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "Positive";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/PositiveOrZeroClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/PositiveOrZeroClientValidationConstraint.java
@@ -26,17 +26,20 @@ package org.primefaces.validate.bean;
 import java.util.HashMap;
 import java.util.Map;
 import javax.validation.metadata.ConstraintDescriptor;
+import org.primefaces.util.HTML;
 
-public class FutureClientValidationConstraint implements ClientValidationConstraint {
+public class PositiveOrZeroClientValidationConstraint implements ClientValidationConstraint {
 
-    private static final String MESSAGE_METADATA = "data-p-future-msg";
-    private static final String MESSAGE_ID = "{javax.validation.constraints.Future.message}";
+    public static final String MESSAGE_METADATA = "data-p-positiveorzero-msg";
+    private static final String MESSAGE_ID = "{javax.validation.constraints.PositiveOrZero.message}";
 
     @Override
     public Map<String, Object> getMetadata(ConstraintDescriptor constraintDescriptor) {
         Map<String, Object> metadata = new HashMap<>();
         Map attrs = constraintDescriptor.getAttributes();
         Object message = attrs.get(ATTR_MESSAGE);
+
+        metadata.put(HTML.VALIDATION_METADATA.MIN_VALUE, 0);
 
         if (!message.equals(MESSAGE_ID)) {
             metadata.put(MESSAGE_METADATA, message);
@@ -47,6 +50,6 @@ public class FutureClientValidationConstraint implements ClientValidationConstra
 
     @Override
     public String getValidatorId() {
-        return "Future";
+        return "PositiveOrZero";
     }
 }

--- a/src/main/java/org/primefaces/validate/bean/SizeClientValidationConstraint.java
+++ b/src/main/java/org/primefaces/validate/bean/SizeClientValidationConstraint.java
@@ -25,7 +25,6 @@ package org.primefaces.validate.bean;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.validation.constraints.Size;
 import javax.validation.metadata.ConstraintDescriptor;
 import org.primefaces.util.HTML;
 
@@ -52,6 +51,6 @@ public class SizeClientValidationConstraint implements ClientValidationConstrain
 
     @Override
     public String getValidatorId() {
-        return Size.class.getSimpleName();
+        return "Size";
     }
 }

--- a/src/main/resources/META-INF/resources/primefaces/validation/beanvalidation.js
+++ b/src/main/resources/META-INF/resources/primefaces/validation/beanvalidation.js
@@ -11,101 +11,44 @@ if (window.PrimeFaces) {
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.DecimalMax.message'] = 'must be less than or equal to {0}';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.DecimalMin.message'] = 'must be greater than or equal to {0}';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Digits.message'] = 'numeric value out of bounds (<{0} digits>.<{1} digits> expected)';
-    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Future.message'] = 'must be in the future';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Email.message'] = 'must be a well-formed email address';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Future.message'] = 'must be a future date';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.FutureOrPresent.message'] = 'must be a date in the present or in the future';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Max.message'] = 'must be less than or equal to {0}';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Min.message'] = 'must be greater than or equal to {0}';
-    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.NotNull.message'] = 'may not be null';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Negative.message'] = 'must be less than 0';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.NegativeOrZero.message'] = 'must be less than or equal to 0';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.NotBlank.message'] = 'must not be blank';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.NotEmpty.message'] = 'must not be empty';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.NotNull.message'] = 'must not be null';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Null.message'] = 'must be null';
-    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Past.message'] = 'must be in the past';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Past.message'] = 'must be a past date';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.PastOrPresent.message'] = 'must be a date in the past or in the present';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Pattern.message'] = 'must match "{0}"';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Positive.message'] = 'must be greater than 0';
+    PrimeFaces.locales['en_US'].messages['javax.validation.constraints.PositiveOrZero.message'] = 'must be greater than or equal to 0';
     PrimeFaces.locales['en_US'].messages['javax.validation.constraints.Size.message'] = 'size must be between {0} and {1}';
 
-    PrimeFaces.validator['NotNull'] = {
+    PrimeFaces.validator['AssertFalse'] = {
 
-        MESSAGE_ID: 'javax.validation.constraints.NotNull.message',
+        MESSAGE_ID: 'javax.validation.constraints.AssertFalse.message',
 
         validate: function(element, value) {
-            if(value === null || value === undefined) {
+            if(value === true) {
                 var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-notnull-msg'));
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-afalse-msg'));
             }
         }
     };
 
-    PrimeFaces.validator['Null'] = {
+    PrimeFaces.validator['AssertTrue'] = {
 
-        MESSAGE_ID: 'javax.validation.constraints.Null.message',
+        MESSAGE_ID: 'javax.validation.constraints.AssertTrue.message',
 
         validate: function(element, value) {
-            if(value !== null) {
+            if(value === false) {
                 var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-null-msg'));
-            }
-        }
-    };
-
-    PrimeFaces.validator['Size'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Size.message',
-
-        validate: function(element, value) {
-            if(value !== null){
-                var length = element.val().length,
-                min = element.data('p-minlength'),
-                max = element.data('p-maxlength'),
-                vc = PrimeFaces.util.ValidationContext;
-
-                if(length < min || length > max) {
-                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-size-msg'), min, max);
-                }
-            }
-        }
-    };
-
-    PrimeFaces.validator['Min'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Min.message',
-
-        validate: function(element, value) {
-            if(value !== null) {
-                var min = element.data('p-minvalue'),
-                vc = PrimeFaces.util.ValidationContext;
-
-                if(value < min) {
-                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-min-msg'), min);
-                }
-            }
-        }
-    };
-
-    PrimeFaces.validator['Max'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Max.message',
-
-        validate: function(element, value) {
-            if(value !== null) {
-                var max = element.data('p-maxvalue'),
-                vc = PrimeFaces.util.ValidationContext;
-
-                if(value > max) {
-                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-max-msg'), max);
-                }
-            }
-        }
-    };
-
-    PrimeFaces.validator['DecimalMin'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.DecimalMin.message',
-
-        validate: function(element, value) {
-            if(value !== null) {
-                var min = element.data('p-minvalue'),
-                vc = PrimeFaces.util.ValidationContext;
-
-                if(value < min) {
-                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-decimalmin-msg'), min);
-                }
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-atrue-msg'));
             }
         }
     };
@@ -126,66 +69,17 @@ if (window.PrimeFaces) {
         }
     };
 
-    PrimeFaces.validator['AssertTrue'] = {
+    PrimeFaces.validator['DecimalMin'] = {
 
-        MESSAGE_ID: 'javax.validation.constraints.AssertTrue.message',
-
-        validate: function(element, value) {
-            if(value === false) {
-                var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-atrue-msg'));
-            }
-        }
-    };
-
-    PrimeFaces.validator['AssertFalse'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.AssertFalse.message',
-
-        validate: function(element, value) {
-            if(value === true) {
-                var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-afalse-msg'));
-            }
-        }
-    };
-
-    PrimeFaces.validator['Past'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Past.message',
-
-        validate: function(element, value) {
-            if(value !== null && value >= new Date()) {
-                var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-past-msg'));
-            }
-        }
-    };
-
-    PrimeFaces.validator['Future'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Future.message',
-
-        validate: function(element, value) {
-            if(value !== null && value <= new Date()) {
-                var vc = PrimeFaces.util.ValidationContext;
-                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-future-msg'));
-            }
-        }
-    };
-
-    PrimeFaces.validator['Pattern'] = {
-
-        MESSAGE_ID: 'javax.validation.constraints.Pattern.message',
+        MESSAGE_ID: 'javax.validation.constraints.DecimalMin.message',
 
         validate: function(element, value) {
             if(value !== null) {
-                var pattern = element.data('p-pattern'),
-                vc = PrimeFaces.util.ValidationContext,
-                regex = new RegExp(pattern);
+                var min = element.data('p-minvalue'),
+                vc = PrimeFaces.util.ValidationContext;
 
-                if(!regex.test(value)) {
-                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-pattern-msg'), pattern);
+                if(value < min) {
+                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-decimalmin-msg'), min);
                 }
             }
         }
@@ -213,7 +107,233 @@ if (window.PrimeFaces) {
             }
         }
     };
-    
+
+    PrimeFaces.validator['Email'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Email.message',
+
+        // source: https://stackoverflow.com/questions/13992403/regex-validation-of-email-addresses-according-to-rfc5321-rfc5322/26989421#26989421
+        EMAIL_ADDRESS_REGEX: /^([!#-'*+\/-9=?A-Z^-~-]+(\.[!#-'*+\/-9=?A-Z^-~-]+)*|"([]!#-[^-~ \t]|(\\[\t -~]))+")@([!#-'*+\/-9=?A-Z^-~-]+(\.[!#-'*+\/-9=?A-Z^-~-]+)*|\[[\t -Z^-~]*\])$/,
+
+        validate: function(element, value) {
+            if(value !== null && !EMAIL_ADDRESS_REGEX.test(value)) {
+                var vc = PrimeFaces.util.ValidationContext;
+                return vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-email-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['Future'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Future.message',
+
+        validate: function(element, value) {
+            if(value !== null && value <= new Date()) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-future-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['FutureOrPresent'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.FutureOrPresent.message',
+
+        validate: function(element, value) {
+            if(value !== null && value < new Date()) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-futureorpresent-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['Max'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Max.message',
+
+        validate: function(element, value) {
+            if(value !== null) {
+                var max = element.data('p-maxvalue'),
+                vc = PrimeFaces.util.ValidationContext;
+
+                if(value > max) {
+                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-max-msg'), max);
+                }
+            }
+        }
+    };
+
+    PrimeFaces.validator['Min'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Min.message',
+
+        validate: function(element, value) {
+            if(value !== null) {
+                var min = element.data('p-minvalue'),
+                vc = PrimeFaces.util.ValidationContext;
+
+                if(value < min) {
+                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-min-msg'), min);
+                }
+            }
+        }
+    };
+
+    PrimeFaces.validator['Negative'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Negative.message',
+
+        validate: function(element, value) {
+            if(value !== null && value >= 0) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-negative-msg'), min);
+            }
+        }
+    };
+
+    PrimeFaces.validator['NegativeOrZero'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.NegativeOrZero.message',
+
+        validate: function(element, value) {
+            if(value !== null && value > 0) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-negativeorzero-msg'), min);
+            }
+        }
+    };
+
+    PrimeFaces.validator['NotBlank'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.NotBlank.message',
+
+        validate: function(element, value) {
+            if(value === null || value === undefined || 0 === value.trim().length) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-notblank-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['NotEmpty'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.NotEmpty.message',
+
+        validate: function(element, value) {
+            if(value === null || value === undefined || 0 === value.length) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-notempty-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['NotNull'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.NotNull.message',
+
+        validate: function(element, value) {
+            if(value === null || value === undefined) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-notnull-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['Null'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Null.message',
+
+        validate: function(element, value) {
+            if(value !== null) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-null-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['Past'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Past.message',
+
+        validate: function(element, value) {
+            if(value !== null && value >= new Date()) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-past-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['PastOrPresent'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.PastOrPresent.message',
+
+        validate: function(element, value) {
+            if(value !== null && value > new Date()) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-pastorpresent-msg'));
+            }
+        }
+    };
+
+    PrimeFaces.validator['Pattern'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Pattern.message',
+
+        validate: function(element, value) {
+            if(value !== null) {
+                var pattern = element.data('p-pattern'),
+                vc = PrimeFaces.util.ValidationContext,
+                regex = new RegExp(pattern);
+
+                if(!regex.test(value)) {
+                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-pattern-msg'), pattern);
+                }
+            }
+        }
+    };
+
+    PrimeFaces.validator['Positive'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Positive.message',
+
+        validate: function(element, value) {
+            if(value !== null && value <= 0) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-positive-msg'), min);
+            }
+        }
+    };
+
+    PrimeFaces.validator['PositiveOrZero'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.PositiveOrZero.message',
+
+        validate: function(element, value) {
+            if(value !== null && value < 0) {
+                var vc = PrimeFaces.util.ValidationContext;
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-positiveorzero-msg'), min);
+            }
+        }
+    };
+
+    PrimeFaces.validator['Size'] = {
+
+        MESSAGE_ID: 'javax.validation.constraints.Size.message',
+
+        validate: function(element, value) {
+            if(value !== null){
+                var length = element.val().length,
+                min = element.data('p-minlength'),
+                max = element.data('p-maxlength'),
+                vc = PrimeFaces.util.ValidationContext;
+
+                if(length < min || length > max) {
+                    throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-size-msg'), min, max);
+                }
+            }
+        }
+    };
+
     PrimeFaces.util.ValidationContext.getMessageBV = function(element, defaultKey, msg) {
         if (msg && msg.charAt(0) !== '{') {
             return { summary : msg, detail : msg };
@@ -249,7 +369,7 @@ if (window.PrimeFaces) {
             }
         }
     };
-    
+
     PrimeFaces.util.ValidationContext.formatBV = function(str, params) {
         var s = str;
         for(var i = 3; i < params.length; i++) {       


### PR DESCRIPTION
Adds flexibility and doesn't tie PF to a specific validation api version.  Adds all the 2.0 validations.