### PR TITLE
Fix #4857,#344,#349,#3314: TAB key will not select item if autoSelection="false"

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -316,10 +316,14 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                         break;
 
                     case keyCode.TAB:
-                        if(highlightedItem.length) {
+                        if(highlightedItem.length && $this.cfg.autoSelection) {
                             highlightedItem.trigger('click');
+                        } else {
+                            $this.hide();
+                            if ($this.timeout) {
+                                $this.deleteTimeout();
+                            }
                         }
-                        $this.hide();
                         $this.isTabPressed = true;
                         break;
                 }


### PR DESCRIPTION
If AutoComplete has  `autoSelection="false"` it makes the TAB key work like normal and just focus the next field.