### PR TITLE
Fix #4864: Float Label causing JS error when input undefined.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -121,7 +121,13 @@
          * @param the parent element of input
          */
         updateFilledState: function(input, parent) {
-            if (input.val().length) {
+            var value = input.val();
+            
+            if (typeof(value) == 'undefined') {
+                return;
+            }
+            
+            if (value.length) {
                 input.addClass('ui-state-filled');
                 
                 if(parent.is("span:not('.ui-float-label')")) {


### PR DESCRIPTION
If you go to the Showcase: https://www.primefaces.org/showcase/ui/misc/blockUI.xhtml

You will see this error

```
Uncaught TypeError: Cannot read property 'length' of undefined
    at Object.updateFilledState (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:124)
    at Object.skinInput (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:145)
    at Class.bindEvents (components.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:16468)
    at Class.init (components.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:16413)
    at new Class (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:2362)
    at Class.bindPaginator (components.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:3184)
    at Class.init (components.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:3037)
    at Class.prototype.<computed> [as init] (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:2349)
    at new Class (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:2362)
    at Object.createWidget (core.js.xhtml?ln=primefaces&v=7.1-SNAPSHOT:383)
```