### PR TITLE
Fix #4333: OWASP Dependency Checker

### DIFF
--- a/docs/7_1/gettingstarted/dependencies.md
+++ b/docs/7_1/gettingstarted/dependencies.md
@@ -14,7 +14,7 @@ any 3rd part work incorporated are compatible with the PrimeFaces Licenses.
 | commons-io | 2.4 | Optional | FileUpload |
 | barcode4j-light | 2.1 | Optional | Barcode |
 | qrgen |  1.4 | Optional | QR Code support for Barcode |
-| owasp-java-html-sanitizer |  20181114.1 | Optional | TextEditor |
+| owasp-java-html-sanitizer |  20190503.1 | Optional | TextEditor |
 
 *Listed versions are tested and known to be working with PrimeFaces, other versions of these
 dependencies may also work but not tested.

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.9.2</version>
+            <version>3.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
-            <version>3.0.2</version>
+            <version>3.7.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>20181114.1</version>
+            <version>20190503.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -459,6 +459,24 @@
                                 </resource>
                             </resources>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>5.0.0-M3</version>
+                <configuration>
+                    <skipProvidedScope>false</skipProvidedScope>
+                    <skipRuntimeScope>false</skipRuntimeScope>
+                    <failBuildOnCVSS>5</failBuildOnCVSS>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Added the checker to break build on vulnerability score 5 or higher.

The build was breaking due to CVE's so I updated the following dependencies...

- Upgraded HazelCast 3.12
- Upgraded EHCache 3.7.1
- OWASP Sanitizer 20190503.1