### PR TITLE
Fix #4868: Hide/Show all items at once

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -874,21 +874,29 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             this.itemsContainer.children('.ui-selectonemenu-item-group').show();
         }
         else {
+            var hide = [];
+            var show = [];
+
             for(var i = 0; i < this.options.length; i++) {
                 var option = this.options.eq(i),
                 itemLabel = this.cfg.caseSensitive ? option.text() : option.text().toLowerCase(),
                 item = this.items.eq(i);
 
                 if(item.hasClass('ui-noselection-option')) {
-                    item.hide();
+                    hide.push(item);
                 }
                 else {
                     if(this.filterMatcher(itemLabel, filterValue))
-                        item.show();
+                        show.push(item);
                     else
-                        item.hide();
+                        hide.push(item);
                 }
             }
+
+            $.each(hide, function(i, o) { o.hide() });
+            $.each(show, function(i, o) { o.show() });
+            hide = [];
+            show = [];
 
             //Toggle groups
             var groups = this.itemsContainer.children('.ui-selectonemenu-item-group');
@@ -897,17 +905,20 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
 
                 if(g === (groups.length - 1)) {
                     if(group.nextAll().filter(':visible').length === 0)
-                        group.hide();
+                        hide.push(group);
                     else
-                        group.show();
+                        show.push(group);
                 }
                 else {
                     if(group.nextUntil('.ui-selectonemenu-item-group').filter(':visible').length === 0)
-                        group.hide();
+                        hide.push(group);
                     else
-                        group.show();
+                        show.push(group);
                 }
             }
+
+            $.each(hide, function(i, o) { o.hide() });
+            $.each(show, function(i, o) { o.show() });
         }
 
         var firstVisibleItem = this.items.filter(':visible:not(.ui-state-disabled):first');


### PR DESCRIPTION
This improves the filter performance. A full refactoring might speed up this even more but requires way more testing than these minimal changes.

## Before
**Firefox:**
![FF_before](https://user-images.githubusercontent.com/5850477/59115796-4fbecb80-894a-11e9-9e07-68d9540fabfa.png)
**Internet Explorer:**
![IE_before](https://user-images.githubusercontent.com/5850477/59115759-3d449200-894a-11e9-87bb-26d9137f58fc.png)
## After
**Firefox:**
![FF_after](https://user-images.githubusercontent.com/5850477/59115830-65cc8c00-894a-11e9-9c18-6c0a0a51f1cb.png)
**Internet Explorer:**
![IE_after](https://user-images.githubusercontent.com/5850477/59115712-256d0e00-894a-11e9-8771-fa4ecb045bd6.png)

