### PR TITLE
SonarQube - Optimizing String indexOf() and lastIndexOf() for single char

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -701,7 +701,7 @@ public class DataTable extends DataTableBase {
         // new syntax is:
         // #{column.property} or even a method call
         if (expressionString.startsWith("#{" + getVar() + "[")) {
-            expressionString = expressionString.substring(expressionString.indexOf("[") + 1, expressionString.indexOf("]"));
+            expressionString = expressionString.substring(expressionString.indexOf('[') + 1, expressionString.indexOf(']'));
             expressionString = "#{" + expressionString + "}";
 
             ValueExpression dynaVE = context.getApplication()
@@ -1347,7 +1347,7 @@ public class DataTable extends DataTableBase {
                 String[] colsArr = togglableColumnsAsString.split(",");
                 for (int i = 0; i < colsArr.length; i++) {
                     String temp = colsArr[i];
-                    int sepIndex = temp.lastIndexOf("_");
+                    int sepIndex = temp.lastIndexOf('_');
                     togglableColsMap.put(temp.substring(0, sepIndex), Boolean.parseBoolean(temp.substring(sepIndex + 1, temp.length())));
                 }
             }
@@ -1383,7 +1383,7 @@ public class DataTable extends DataTableBase {
                 String[] colsArr = resizableColumnsAsString.split(",");
                 for (int i = 0; i < colsArr.length; i++) {
                     String temp = colsArr[i];
-                    int sepIndex = temp.lastIndexOf("_");
+                    int sepIndex = temp.lastIndexOf('_');
                     resizableColsMap.put(temp.substring(0, sepIndex), temp.substring(sepIndex + 1, temp.length()));
                 }
             }

--- a/src/main/java/org/primefaces/component/media/MediaRenderer.java
+++ b/src/main/java/org/primefaces/component/media/MediaRenderer.java
@@ -61,7 +61,7 @@ public class MediaRenderer extends CoreRenderer {
         if (value instanceof StreamedContent && player.getType().equals("application/pdf")) {
             StreamedContent streamedContent = (StreamedContent) value;
             if (streamedContent.getName() != null) {
-                int index = src.indexOf("?");
+                int index = src.indexOf('?');
                 src = src.substring(0, index) + ";/" + streamedContent.getName() + "" + src.substring(index, src.length());
             }
         }

--- a/src/main/java/org/primefaces/component/mindmap/Mindmap.java
+++ b/src/main/java/org/primefaces/component/mindmap/Mindmap.java
@@ -110,7 +110,7 @@ public class Mindmap extends MindmapBase {
             return searchRoot;
         }
         else {
-            String relativeRowKey = rowKey.substring(rowKey.indexOf("_") + 1);
+            String relativeRowKey = rowKey.substring(rowKey.indexOf('_') + 1);
 
             return findNode(searchRoot, relativeRowKey);
         }

--- a/src/main/java/org/primefaces/component/splitbutton/SplitButton.java
+++ b/src/main/java/org/primefaces/component/splitbutton/SplitButton.java
@@ -154,7 +154,7 @@ public class SplitButton extends SplitButtonBase {
                 return (MenuItem) childElement;
             }
             else {
-                String relativeIndex = id.substring(id.indexOf("_") + 1);
+                String relativeIndex = id.substring(id.indexOf('_') + 1);
 
                 return findMenuitem(((MenuGroup) childElement).getElements(), relativeIndex);
             }

--- a/src/main/java/org/primefaces/component/timeline/Timeline.java
+++ b/src/main/java/org/primefaces/component/timeline/Timeline.java
@@ -225,7 +225,7 @@ public class Timeline extends TimelineBase {
         int idx = groupParam.indexOf("</span>");
         if (idx > -1) {
             groupParam = groupParam.substring(0, idx);
-            int idxGroupOrder = groupParam.indexOf("#");
+            int idxGroupOrder = groupParam.indexOf('#');
             if (idxGroupOrder > -1) {
                 String groupOrder = groupParam.substring(idxGroupOrder + 1);
                 return groups.get(Integer.valueOf(groupOrder)).getId();

--- a/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -648,7 +648,7 @@ public class TreeTable extends TreeTableBase {
         if (columnTogglerParam != null) {
             String[] togglableColumns = columnTogglerParam.split(",");
             for (String togglableColumn : togglableColumns) {
-                int sepIndex = togglableColumn.lastIndexOf("_");
+                int sepIndex = togglableColumn.lastIndexOf('_');
                 UIColumn column = findColumn(togglableColumn.substring(0, sepIndex));
 
                 if (column != null) {


### PR DESCRIPTION
These methods calls can be more performant when called with a `char` argument instead of a single letter `String`.

Examples: Replacing `String.indexOf("[")` with `String.indexOf(']')`, and `String.lastIndexOf("_")` with `String.lastIndexOf('_')`.

This fixes SonarQube violations of the rule: [String function use should be optimized for single characters](https://rules.sonarsource.com/java/RSPEC-3027)