### PR TITLE
SonarQube - Using StringBuilder for concatenating String in for loops

### DIFF
--- a/src/main/java/org/primefaces/expression/impl/RowExpressionResolver.java
+++ b/src/main/java/org/primefaces/expression/impl/RowExpressionResolver.java
@@ -55,9 +55,9 @@ public class RowExpressionResolver implements SearchExpressionResolver, ClientId
 
         int row = validate(context, source, last, expression);
         UIData data = (UIData) last;
-        char seperatorChar = UINamingContainer.getSeparatorChar(context);
+        char separatorChar = UINamingContainer.getSeparatorChar(context);
 
-        String clientIds = "";
+        StringBuilder clientIds = new StringBuilder();
 
         for (UIComponent column : data.getChildren()) {
             // handle dynamic columns
@@ -69,11 +69,18 @@ public class RowExpressionResolver implements SearchExpressionResolver, ClientId
                     for (UIComponent comp : column.getChildren()) {
 
                         if (clientIds.length() > 0) {
-                            clientIds += " ";
+                            clientIds.append(" ");
                         }
 
-                        clientIds += data.getClientId(context) + seperatorChar + row + seperatorChar
-                                + dynamicColumn.getId() + seperatorChar + i + seperatorChar + comp.getId();
+                        clientIds.append(data.getClientId(context));
+                        clientIds.append(separatorChar);
+                        clientIds.append(row);
+                        clientIds.append(separatorChar);
+                        clientIds.append(dynamicColumn.getId());
+                        clientIds.append(separatorChar);
+                        clientIds.append(i);
+                        clientIds.append(separatorChar);
+                        clientIds.append(comp.getId());
                     }
                 }
             }
@@ -81,15 +88,19 @@ public class RowExpressionResolver implements SearchExpressionResolver, ClientId
                 for (UIComponent cell : column.getChildren()) {
 
                     if (clientIds.length() > 0) {
-                        clientIds += " ";
+                        clientIds.append(" ");
                     }
 
-                    clientIds += data.getClientId(context) + seperatorChar + row + seperatorChar + cell.getId();
+                    clientIds.append(data.getClientId(context));
+                    clientIds.append(separatorChar);
+                    clientIds.append(row);
+                    clientIds.append(separatorChar);
+                    clientIds.append(cell.getId());
                 }
             }
         }
 
-        return clientIds;
+        return clientIds.toString();
     }
 
     protected int validate(FacesContext context, UIComponent source, UIComponent last, String expression) {

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -138,19 +138,19 @@ public class CalendarUtils {
 
     public static final String getValueAsString(FacesContext context, UICalendar calendar, Object value, String pattern) {
         if (value instanceof List) {
-            String valuesAsString = "";
+            StringBuilder valuesAsString = new StringBuilder();
             String separator = "multiple".equals(calendar.getSelectionMode()) ? "," : " - ";
             List values = ((List) value);
 
             for (int i = 0; i < values.size(); i++) {
                 if (i != 0) {
-                    valuesAsString += separator;
+                    valuesAsString.append(separator);
                 }
 
-                valuesAsString += getValue(context, calendar, values.get(i), pattern);
+                valuesAsString.append(getValue(context, calendar, values.get(i), pattern));
             }
 
-            return valuesAsString;
+            return valuesAsString.toString();
         }
         else {
             return getValue(context, calendar, value, pattern);


### PR DESCRIPTION
This pull request fixes violations of the SonarQube rule [Strings should not be concatenated using '+' in a loop](https://rules.sonarsource.com/java/RSPEC-1643) that says:

> Strings are immutable objects, so concatenation doesn't simply add the new String to the end of the existing string. Instead, in each loop iteration, the first String is converted to an intermediate object type, the second string is appended, and then the intermediate object is converted back to a String. Further, performance of these intermediate operations degrades as the String gets longer. Therefore, the use of StringBuilder is preferred.