### PR TITLE
SonarQube - Iterating on entrySet() instead of keySet() when key and value are needed

### DIFF
--- a/src/main/java/org/primefaces/webapp/MultipartRequest.java
+++ b/src/main/java/org/primefaces/webapp/MultipartRequest.java
@@ -35,13 +35,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import java.util.Map.Entry;
 
 public class MultipartRequest extends HttpServletRequestWrapper {
 
@@ -134,8 +133,8 @@ public class MultipartRequest extends HttpServletRequestWrapper {
         if (parameterMap == null) {
             Map<String, String[]> map = new LinkedHashMap<>();
 
-            for (String formParam : formParams.keySet()) {
-                map.put(formParam, formParams.get(formParam).toArray(new String[0]));
+            for (Entry<String, List<String>> entry : formParams.entrySet()) {
+                map.put(entry.getKey(), entry.getValue().toArray(new String[0]));
             }
 
             map.putAll(super.getParameterMap());


### PR DESCRIPTION
Iterating on a Map using `entrySet()`, when both key and value are needed, is more performant.

Fix a SonarQube violation of the rule: ["entrySet()" should be iterated when both the key and value are needed](https://rules.sonarsource.com/java/RSPEC-2864) (#4886)