### PR TITLE
Fix #4882: ColumnToggler duplicate id's.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
+++ b/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
@@ -43,7 +43,7 @@ PrimeFaces.widget.ColumnToggler = PrimeFaces.widget.DeferredWidget.extend({
 
     render: function() {
         this.columns = this.thead.find('> tr > th:not(.ui-static-column)');
-        this.panel = $('<div></div>').attr('id', this.cfg.id).attr('role', 'dialog').addClass('ui-columntoggler ui-widget ui-widget-content ui-shadow ui-corner-all')
+        this.panel = $(PrimeFaces.escapeClientId(this.cfg.id)).attr('role', 'dialog').addClass('ui-columntoggler ui-widget ui-widget-content ui-shadow ui-corner-all')
                 .append('<ul class="ui-columntoggler-items" role="group"></ul>').appendTo(document.body);
         this.itemContainer = this.panel.children('ul');
 


### PR DESCRIPTION
The DIV was already created in the Renderer so instead of creating a new one simply find the existing one.