### PR TITLE
Fix #4891, #2479, #1592: ColumnToggler use column label value if found.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
+++ b/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
@@ -58,7 +58,13 @@ PrimeFaces.widget.ColumnToggler = PrimeFaces.widget.DeferredWidget.extend({
             hidden = column.hasClass('ui-helper-hidden'),
             boxClass = hidden ? 'ui-chkbox-box ui-widget ui-corner-all ui-state-default' : 'ui-chkbox-box ui-widget ui-corner-all ui-state-default ui-state-active',
             iconClass = (hidden) ? 'ui-chkbox-icon ui-icon ui-icon-blank' : 'ui-chkbox-icon ui-icon ui-icon-check',
-            columnTitle = column.children('.ui-column-title').text();
+            columnChildren = column.children('.ui-column-title'),
+            columnTitle = columnChildren.text();
+            
+            var label = columnChildren.find('label');
+            if (label.length) {
+                columnTitle = label.text();
+            } 
 
             this.hasPriorityColumns = column.is('[class*="ui-column-p-"]');
 


### PR DESCRIPTION
If the column is using a facet for header check the contents of the facet for a "label" element such as <h:outputText/>.

This fixes the issues and makes the component more robust.