### PR TITLE
Support for  #4847:  DataTable: improve support for filterOptions in dynamicColumns

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -889,12 +889,18 @@ public class DataTableRenderer extends DataRenderer {
     protected void encodeFilterInput(UIColumn column, ResponseWriter writer, boolean disableTabbing,
         String filterId, String filterStyleClass, Object filterValue, String ariaLabelId) throws IOException {
 
-        if (column.getValueExpression(Column.PropertyKeys.filterOptions.toString()) == null) {
+        if (hasFilterOptions(column)) {
             encodeFilterInputText(column, writer, disableTabbing, filterId, filterStyleClass, filterValue, ariaLabelId);
         }
         else {
             encodeFilterInputSelect(column, writer, disableTabbing, filterId, filterStyleClass, filterValue, ariaLabelId);
         }
+    }
+
+    private boolean hasFilterOptions(UIColumn column) {
+        return column.getValueExpression(Column.PropertyKeys.filterOptions.toString()) == null
+            || getFilterOptions(column) == null
+            || getFilterOptions(column).length == 0;
     }
 
     protected void encodeFilterInputSelect(UIColumn column, ResponseWriter writer, boolean disableTabbing,

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -889,7 +889,7 @@ public class DataTableRenderer extends DataRenderer {
     protected void encodeFilterInput(UIColumn column, ResponseWriter writer, boolean disableTabbing,
         String filterId, String filterStyleClass, Object filterValue, String ariaLabelId) throws IOException {
 
-        if (hasFilterOptions(column)) {
+        if (!hasFilterOptions(column)) {
             encodeFilterInputText(column, writer, disableTabbing, filterId, filterStyleClass, filterValue, ariaLabelId);
         }
         else {
@@ -898,9 +898,13 @@ public class DataTableRenderer extends DataRenderer {
     }
 
     private boolean hasFilterOptions(UIColumn column) {
-        return column.getValueExpression(Column.PropertyKeys.filterOptions.toString()) == null
-            || getFilterOptions(column) == null
-            || getFilterOptions(column).length == 0;
+        boolean hasFilterOptionsVE = column.getValueExpression(Column.PropertyKeys.filterOptions.toString()) != null;
+        if (!hasFilterOptionsVE) {
+            return false;
+        }
+
+        SelectItem[] filterOptions = getFilterOptions(column);
+        return filterOptions != null && filterOptions.length != 0;
     }
 
     protected void encodeFilterInputSelect(UIColumn column, ResponseWriter writer, boolean disableTabbing,


### PR DESCRIPTION
This PR adds support for filterOptions EL that evaluates to null or empty array, as requested by #4847.