### PR TITLE
Fix for #4931: DataGrid and DataTable: rows- and first-attributes ignored after use of paginator

### DIFF
--- a/src/main/java/org/primefaces/component/api/UIData.java
+++ b/src/main/java/org/primefaces/component/api/UIData.java
@@ -293,24 +293,26 @@ public class UIData extends javax.faces.component.UIData {
             throw new IllegalArgumentException("Unsupported rows per page value: " + rowsParam);
         }
 
-        data.setFirst(Integer.valueOf(firstParam));
-
-        if ("*".equals(rowsParam)) {
-            data.setRows(getRowCount());
+        ValueExpression firstVe = data.getValueExpression("first");
+        if (isWriteable(elContext, firstVe)) {
+            firstVe.setValue(elContext, Integer.valueOf(firstParam));
         }
         else {
-            data.setRows(Integer.valueOf(rowsParam));
+            data.setFirst(Integer.valueOf(firstParam));
         }
 
-        ValueExpression firstVe = data.getValueExpression("first");
         ValueExpression rowsVe = data.getValueExpression("rows");
+        int newRowsValue = "*".equals(rowsParam) ? getRowCount() : Integer.valueOf(rowsParam);
+        if (isWriteable(elContext, rowsVe)) {
+            rowsVe.setValue(elContext, newRowsValue);
+        }
+        else {
+            data.setRows(newRowsValue);
+        }
+    }
 
-        if (firstVe != null && !firstVe.isReadOnly(elContext)) {
-            firstVe.setValue(context.getELContext(), data.getFirst());
-        }
-        if (rowsVe != null && !rowsVe.isReadOnly(elContext)) {
-            rowsVe.setValue(context.getELContext(), data.getRows());
-        }
+    private boolean isWriteable(ELContext elContext, ValueExpression ve) {
+        return ve != null && !ve.isReadOnly(elContext);
     }
 
     @Override


### PR DESCRIPTION
This PR is a successor to PR https://github.com/primefaces/primefaces/pull/4937 (which I unfortunately messed up with merging) and should fix issue https://github.com/primefaces/primefaces/issues/4931.
