### PR TITLE
Fixes #2702 - TimelineGroup without events not shown

### DIFF
--- a/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
@@ -207,7 +207,12 @@ public class TimelineRenderer extends CoreRenderer {
                               Map<String, String> groupsContent, TimelineEvent event) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
 
-        fsw.write("{\"start\":" + encodeDate(browserTZ, targetTZ, event.getStartDate()));
+        if (event.getStartDate() != null) {
+            fsw.write("{\"start\":" + encodeDate(browserTZ, targetTZ, event.getStartDate()));
+        }
+        else {
+            fsw.write("{\"start\":null");
+        }
 
         if (event.getEndDate() != null) {
             fsw.write(",\"end\":" + encodeDate(browserTZ, targetTZ, event.getEndDate()));


### PR DESCRIPTION
This allow to register a TimelineEvent without start nor end date in order to show groups without events in timeline component. Ref: https://github.com/primefaces/primefaces/issues/2702#issuecomment-509756534