### PR TITLE
Fix #52 - Dialog Framework: DialogReturn event for Menuitem

### DIFF
--- a/src/main/java/org/primefaces/application/DialogReturn.java
+++ b/src/main/java/org/primefaces/application/DialogReturn.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2009-2019 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.primefaces.application;
 
 import org.primefaces.component.api.PrimeClientBehaviorHolder;

--- a/src/main/java/org/primefaces/application/DialogReturn.java
+++ b/src/main/java/org/primefaces/application/DialogReturn.java
@@ -1,0 +1,72 @@
+package org.primefaces.application;
+
+import org.primefaces.component.api.PrimeClientBehaviorHolder;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.util.Constants;
+import org.primefaces.util.MapBuilder;
+
+import javax.faces.component.UIComponent;
+import javax.faces.component.behavior.ClientBehaviorHolder;
+import javax.faces.context.FacesContext;
+import javax.faces.event.AjaxBehaviorEvent;
+import javax.faces.event.BehaviorEvent;
+import javax.faces.event.FacesEvent;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public interface DialogReturn extends ClientBehaviorHolder, PrimeClientBehaviorHolder {
+
+    Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
+            .put("dialogReturn", SelectEvent.class)
+            .put("click", null)
+            .ibuild();
+
+    Collection<String> EVENT_NAMES = Collections.unmodifiableSet(BEHAVIOR_EVENT_MAPPING.keySet());
+
+    String DEFAULT_EVENT = "click";
+
+    @Override
+    default Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
+        return BEHAVIOR_EVENT_MAPPING;
+    }
+
+    @Override
+    default Collection<String> getEventNames() {
+        return EVENT_NAMES;
+    }
+
+    @Override
+    default String getDefaultEventName() {
+        return DEFAULT_EVENT;
+    }
+
+    void queueEvent(FacesEvent event);
+
+    default void handleEvent(FacesEvent event, UIComponent source, Consumer<FacesEvent> queueEvent) {
+        FacesContext context = event.getFacesContext();
+
+        if (event instanceof AjaxBehaviorEvent) {
+            Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+            String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
+
+            if (eventName.equals("dialogReturn")) {
+                AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
+                Map<String, Object> session = context.getExternalContext().getSessionMap();
+                String dcid = params.get(source.getClientId(context) + "_pfdlgcid");
+                Object selectedValue = session.get(dcid);
+                session.remove(dcid);
+
+                event = new SelectEvent(source, behaviorEvent.getBehavior(), selectedValue);
+                queueEvent.accept(event);
+            }
+            else if (eventName.equals("click")) {
+                queueEvent.accept(event);
+            }
+        }
+        else {
+            queueEvent.accept(event);
+        }
+    }
+}

--- a/src/main/java/org/primefaces/application/DialogReturnHolder.java
+++ b/src/main/java/org/primefaces/application/DialogReturnHolder.java
@@ -65,9 +65,7 @@ public interface DialogReturnHolder extends ClientBehaviorHolder, PrimeClientBeh
         return DEFAULT_EVENT;
     }
 
-    default void handleEvent(FacesEvent event, UIComponent source, Consumer<FacesEvent> queueEvent) {
-        FacesContext context = event.getFacesContext();
-
+    default void handleEvent(FacesEvent event, FacesContext context, UIComponent source, Consumer<FacesEvent> queueEvent) {
         if (event instanceof AjaxBehaviorEvent) {
             Map<String, String> params = context.getExternalContext().getRequestParameterMap();
             String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);

--- a/src/main/java/org/primefaces/application/DialogReturnHolder.java
+++ b/src/main/java/org/primefaces/application/DialogReturnHolder.java
@@ -39,7 +39,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public interface DialogReturn extends ClientBehaviorHolder, PrimeClientBehaviorHolder {
+public interface DialogReturnHolder extends ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
     Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
             .put("dialogReturn", SelectEvent.class)
@@ -65,8 +65,6 @@ public interface DialogReturn extends ClientBehaviorHolder, PrimeClientBehaviorH
         return DEFAULT_EVENT;
     }
 
-    void queueEvent(FacesEvent event);
-
     default void handleEvent(FacesEvent event, UIComponent source, Consumer<FacesEvent> queueEvent) {
         FacesContext context = event.getFacesContext();
 
@@ -74,7 +72,7 @@ public interface DialogReturn extends ClientBehaviorHolder, PrimeClientBehaviorH
             Map<String, String> params = context.getExternalContext().getRequestParameterMap();
             String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
 
-            if (eventName.equals("dialogReturn")) {
+            if ("dialogReturn".equals(eventName)) {
                 AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
                 Map<String, Object> session = context.getExternalContext().getSessionMap();
                 String dcid = params.get(source.getClientId(context) + "_pfdlgcid");
@@ -84,7 +82,7 @@ public interface DialogReturn extends ClientBehaviorHolder, PrimeClientBehaviorH
                 event = new SelectEvent(source, behaviorEvent.getBehavior(), selectedValue);
                 queueEvent.accept(event);
             }
-            else if (eventName.equals("click")) {
+            else if (DEFAULT_EVENT.equals(eventName)) {
                 queueEvent.accept(event);
             }
         }

--- a/src/main/java/org/primefaces/application/DialogReturnHolder.java
+++ b/src/main/java/org/primefaces/application/DialogReturnHolder.java
@@ -41,14 +41,14 @@ import java.util.function.Consumer;
 
 public interface DialogReturnHolder extends ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
+    String DEFAULT_EVENT = "click";
+
     Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
             .put("dialogReturn", SelectEvent.class)
-            .put("click", null)
+            .put(DEFAULT_EVENT, null)
             .ibuild();
 
     Collection<String> EVENT_NAMES = Collections.unmodifiableSet(BEHAVIOR_EVENT_MAPPING.keySet());
-
-    String DEFAULT_EVENT = "click";
 
     @Override
     default Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {

--- a/src/main/java/org/primefaces/application/DialogReturnHolder.java
+++ b/src/main/java/org/primefaces/application/DialogReturnHolder.java
@@ -65,7 +65,7 @@ public interface DialogReturnHolder extends ClientBehaviorHolder, PrimeClientBeh
         return DEFAULT_EVENT;
     }
 
-    default void handleEvent(FacesEvent event, FacesContext context, UIComponent source, Consumer<FacesEvent> queueEvent) {
+    default void handleQueueEvent(FacesEvent event, FacesContext context, UIComponent source, Consumer<FacesEvent> queueEvent) {
         if (event instanceof AjaxBehaviorEvent) {
             Map<String, String> params = context.getExternalContext().getRequestParameterMap();
             String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.component.commandbutton;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.util.HTML;
 import org.primefaces.util.LangUtils;
 
@@ -52,17 +52,17 @@ public class CommandButton extends CommandButtonBase {
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
+        return DialogReturnHolder.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return DialogReturn.EVENT_NAMES;
+        return DialogReturnHolder.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return DialogReturn.DEFAULT_EVENT;
+        return DialogReturnHolder.DEFAULT_EVENT;
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
@@ -23,22 +23,17 @@
  */
 package org.primefaces.component.commandbutton;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.logging.Logger;
+import org.primefaces.application.DialogReturn;
+import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
-import javax.faces.context.FacesContext;
-import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.BehaviorEvent;
 import javax.faces.event.FacesEvent;
-
-import org.primefaces.event.SelectEvent;
-import org.primefaces.util.Constants;
-import org.primefaces.util.HTML;
-import org.primefaces.util.LangUtils;
-import org.primefaces.util.MapBuilder;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
 
 @ResourceDependencies({
         @ResourceDependency(library = "primefaces", name = "components.css"),
@@ -53,53 +48,26 @@ public class CommandButton extends CommandButtonBase {
 
     private static final Logger LOGGER = Logger.getLogger(CommandButton.class.getName());
 
-    private static final Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
-            .put("click", null)
-            .put("dialogReturn", SelectEvent.class)
-            .build();
-    private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
     private String confirmationScript;
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return BEHAVIOR_EVENT_MAPPING;
+        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return EVENT_NAMES;
+        return DialogReturn.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return "click";
+        return DialogReturn.DEFAULT_EVENT;
     }
 
     @Override
     public void queueEvent(FacesEvent event) {
-        FacesContext context = getFacesContext();
-
-        if (event instanceof AjaxBehaviorEvent) {
-            Map<String, String> params = context.getExternalContext().getRequestParameterMap();
-            String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
-
-            if (eventName.equals("dialogReturn")) {
-                AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
-                Map<String, Object> session = context.getExternalContext().getSessionMap();
-                String dcid = params.get(getClientId(context) + "_pfdlgcid");
-                Object selectedValue = session.get(dcid);
-                session.remove(dcid);
-
-                event = new SelectEvent(this, behaviorEvent.getBehavior(), selectedValue);
-                super.queueEvent(event);
-            }
-            else if (eventName.equals("click")) {
-                super.queueEvent(event);
-            }
-        }
-        else {
-            super.queueEvent(event);
-        }
+        handleEvent(event, this, super::queueEvent);
     }
 
     public String resolveStyleClass() {

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
@@ -67,7 +67,7 @@ public class CommandButton extends CommandButtonBase {
 
     @Override
     public void queueEvent(FacesEvent event) {
-        handleEvent(event, getFacesContext(), this, super::queueEvent);
+        handleQueueEvent(event, getFacesContext(), this, super::queueEvent);
     }
 
     public String resolveStyleClass() {

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButton.java
@@ -67,7 +67,7 @@ public class CommandButton extends CommandButtonBase {
 
     @Override
     public void queueEvent(FacesEvent event) {
-        handleEvent(event, this, super::queueEvent);
+        handleEvent(event, getFacesContext(), this, super::queueEvent);
     }
 
     public String resolveStyleClass() {

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButtonBase.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButtonBase.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.component.commandbutton;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
 import org.primefaces.component.api.Widget;
@@ -32,7 +32,7 @@ import org.primefaces.util.ComponentUtils;
 import javax.faces.component.html.HtmlCommandButton;
 
 
-public abstract class CommandButtonBase extends HtmlCommandButton implements AjaxSource, Widget, Confirmable, DialogReturn {
+public abstract class CommandButtonBase extends HtmlCommandButton implements AjaxSource, Widget, Confirmable, DialogReturnHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/component/commandbutton/CommandButtonBase.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButtonBase.java
@@ -23,16 +23,16 @@
  */
 package org.primefaces.component.commandbutton;
 
-import javax.faces.component.html.HtmlCommandButton;
-
+import org.primefaces.application.DialogReturn;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
-import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.Widget;
 import org.primefaces.util.ComponentUtils;
 
+import javax.faces.component.html.HtmlCommandButton;
 
-public abstract class CommandButtonBase extends HtmlCommandButton implements AjaxSource, Widget, Confirmable, PrimeClientBehaviorHolder {
+
+public abstract class CommandButtonBase extends HtmlCommandButton implements AjaxSource, Widget, Confirmable, DialogReturn {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/component/commandlink/CommandLink.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLink.java
@@ -63,7 +63,7 @@ public class CommandLink extends CommandLinkBase {
 
     @Override
     public void queueEvent(FacesEvent event) {
-        handleEvent(event, this, super::queueEvent);
+        handleEvent(event, getFacesContext(), this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/commandlink/CommandLink.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLink.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.component.commandlink;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
@@ -48,17 +48,17 @@ public class CommandLink extends CommandLinkBase {
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
+        return DialogReturnHolder.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return DialogReturn.EVENT_NAMES;
+        return DialogReturnHolder.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return DialogReturn.DEFAULT_EVENT;
+        return DialogReturnHolder.DEFAULT_EVENT;
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/commandlink/CommandLink.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLink.java
@@ -23,19 +23,14 @@
  */
 package org.primefaces.component.commandlink;
 
-import java.util.Collection;
-import java.util.Map;
+import org.primefaces.application.DialogReturn;
 
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
-import javax.faces.context.FacesContext;
-import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.BehaviorEvent;
 import javax.faces.event.FacesEvent;
-
-import org.primefaces.event.SelectEvent;
-import org.primefaces.util.Constants;
-import org.primefaces.util.MapBuilder;
+import java.util.Collection;
+import java.util.Map;
 
 @ResourceDependencies({
         @ResourceDependency(library = "primefaces", name = "jquery/jquery.js"),
@@ -49,55 +44,26 @@ public class CommandLink extends CommandLinkBase {
 
     public static final String STYLE_CLASS = "ui-commandlink ui-widget";
     public static final String DISABLED_STYLE_CLASS = "ui-commandlink ui-widget ui-state-disabled";
-
-    private static final Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
-            .put("click", null)
-            .put("dialogReturn", SelectEvent.class)
-            .build();
-
-    private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
     private String confirmationScript;
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return BEHAVIOR_EVENT_MAPPING;
+        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return EVENT_NAMES;
+        return DialogReturn.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return "click";
+        return DialogReturn.DEFAULT_EVENT;
     }
 
     @Override
     public void queueEvent(FacesEvent event) {
-        FacesContext context = getFacesContext();
-
-        if (event instanceof AjaxBehaviorEvent) {
-            Map<String, String> params = context.getExternalContext().getRequestParameterMap();
-            String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
-
-            if (eventName.equals("dialogReturn")) {
-                AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
-                Map<String, Object> session = context.getExternalContext().getSessionMap();
-                String dcid = params.get(getClientId(context) + "_pfdlgcid");
-                Object selectedValue = session.get(dcid);
-                session.remove(dcid);
-
-                event = new SelectEvent(this, behaviorEvent.getBehavior(), selectedValue);
-                super.queueEvent(event);
-            }
-            else if (eventName.equals("click")) {
-                super.queueEvent(event);
-            }
-        }
-        else {
-            super.queueEvent(event);
-        }
+        handleEvent(event, this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/commandlink/CommandLink.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLink.java
@@ -63,7 +63,7 @@ public class CommandLink extends CommandLinkBase {
 
     @Override
     public void queueEvent(FacesEvent event) {
-        handleEvent(event, getFacesContext(), this, super::queueEvent);
+        handleQueueEvent(event, getFacesContext(), this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
@@ -23,14 +23,14 @@
  */
 package org.primefaces.component.commandlink;
 
-import javax.faces.component.html.HtmlCommandLink;
-
+import org.primefaces.application.DialogReturn;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
-import org.primefaces.component.api.PrimeClientBehaviorHolder;
+
+import javax.faces.component.html.HtmlCommandLink;
 
 
-public abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Confirmable, PrimeClientBehaviorHolder {
+public abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Confirmable, DialogReturn {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
+++ b/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
@@ -23,14 +23,14 @@
  */
 package org.primefaces.component.commandlink;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
 
 import javax.faces.component.html.HtmlCommandLink;
 
 
-public abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Confirmable, DialogReturn {
+public abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSource, Confirmable, DialogReturnHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.component.menuitem;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.ComponentUtils;
 
@@ -47,22 +47,22 @@ public class UIMenuItem extends UIMenuItemBase {
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
+        return DialogReturnHolder.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return DialogReturn.EVENT_NAMES;
+        return DialogReturnHolder.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return DialogReturn.DEFAULT_EVENT;
+        return DialogReturnHolder.DEFAULT_EVENT;
     }
 
     @Override
-    public void queueEvent(FacesEvent event) {
-        handleEvent(event, this, super::queueEvent);
+    public void queueEvent(FacesEvent e) {
+        handleEvent(e, this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
@@ -62,7 +62,7 @@ public class UIMenuItem extends UIMenuItemBase {
 
     @Override
     public void queueEvent(FacesEvent e) {
-        handleEvent(e, this, super::queueEvent);
+        handleEvent(e, getFacesContext(), this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
@@ -62,7 +62,7 @@ public class UIMenuItem extends UIMenuItemBase {
 
     @Override
     public void queueEvent(FacesEvent e) {
-        handleEvent(e, getFacesContext(), this, super::queueEvent);
+        handleQueueEvent(e, getFacesContext(), this, super::queueEvent);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItem.java
@@ -23,9 +23,9 @@
  */
 package org.primefaces.component.menuitem;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import org.primefaces.application.DialogReturn;
+import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.ComponentUtils;
 
 import javax.el.MethodExpression;
 import javax.faces.component.UIComponent;
@@ -33,37 +33,36 @@ import javax.faces.component.UIParameter;
 import javax.faces.context.FacesContext;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.BehaviorEvent;
-
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.MapBuilder;
+import javax.faces.event.FacesEvent;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 
 public class UIMenuItem extends UIMenuItemBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.component.UIMenuItem";
 
-    private static final String DEFAULT_EVENT = "click";
-
-    private static final Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
-            .put("click", null)
-            .build();
-
-    private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
     private String confirmationScript;
 
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
-        return BEHAVIOR_EVENT_MAPPING;
+        return DialogReturn.BEHAVIOR_EVENT_MAPPING;
     }
 
     @Override
     public Collection<String> getEventNames() {
-        return EVENT_NAMES;
+        return DialogReturn.EVENT_NAMES;
     }
 
     @Override
     public String getDefaultEventName() {
-        return DEFAULT_EVENT;
+        return DialogReturn.DEFAULT_EVENT;
+    }
+
+    @Override
+    public void queueEvent(FacesEvent event) {
+        handleEvent(event, this, super::queueEvent);
     }
 
     @Override
@@ -74,6 +73,8 @@ public class UIMenuItem extends UIMenuItemBase {
         if (params.containsKey(clientId)) {
             queueEvent(new ActionEvent(this));
         }
+
+        CoreRenderer.decodeBehaviors(facesContext, this);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItemBase.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItemBase.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.component.menuitem;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
 import org.primefaces.component.api.UIOutcomeTarget;
@@ -33,7 +33,7 @@ import org.primefaces.util.SerializableFunction;
 import javax.faces.component.UICommand;
 
 
-public abstract class UIMenuItemBase extends UICommand implements AjaxSource, UIOutcomeTarget, MenuItem, Confirmable, DialogReturn {
+public abstract class UIMenuItemBase extends UICommand implements AjaxSource, UIOutcomeTarget, MenuItem, Confirmable, DialogReturnHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/component/menuitem/UIMenuItemBase.java
+++ b/src/main/java/org/primefaces/component/menuitem/UIMenuItemBase.java
@@ -23,19 +23,17 @@
  */
 package org.primefaces.component.menuitem;
 
-import javax.faces.component.UICommand;
-import javax.faces.component.behavior.ClientBehaviorHolder;
-
+import org.primefaces.application.DialogReturn;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.Confirmable;
-import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.UIOutcomeTarget;
 import org.primefaces.model.menu.MenuItem;
 import org.primefaces.util.SerializableFunction;
 
+import javax.faces.component.UICommand;
 
-public abstract class UIMenuItemBase extends UICommand implements AjaxSource, UIOutcomeTarget, MenuItem, Confirmable,
-        ClientBehaviorHolder, PrimeClientBehaviorHolder {
+
+public abstract class UIMenuItemBase extends UICommand implements AjaxSource, UIOutcomeTarget, MenuItem, Confirmable, DialogReturn {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -574,7 +574,7 @@ public abstract class CoreRenderer extends Renderer {
         }
     }
 
-    protected void decodeBehaviors(FacesContext context, UIComponent component) {
+    public static void decodeBehaviors(FacesContext context, UIComponent component) {
         if (!(component instanceof ClientBehaviorHolder)) {
             return;
         }

--- a/src/main/java/org/primefaces/renderkit/OutcomeTargetRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/OutcomeTargetRenderer.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.renderkit;
 
-import org.primefaces.application.DialogReturn;
+import org.primefaces.application.DialogReturnHolder;
 import org.primefaces.behavior.confirm.ConfirmBehavior;
 import org.primefaces.component.api.AjaxSource;
 import org.primefaces.component.api.ClientBehaviorRenderingMode;
@@ -272,7 +272,7 @@ public class OutcomeTargetRenderer extends CoreRenderer {
             }
         }
 
-        if (menuitem instanceof DialogReturn) {
+        if (menuitem instanceof DialogReturnHolder) {
             List<ClientBehaviorContext.Parameter> behaviorParams = new ArrayList<>();
             behaviorParams.add(new ClientBehaviorContext.Parameter(Constants.CLIENT_BEHAVIOR_RENDERING_MODE, ClientBehaviorRenderingMode.UNOBSTRUSIVE));
             String dialogReturnBehavior = getEventBehaviors(context, (ClientBehaviorHolder) menuitem, "dialogReturn", behaviorParams);

--- a/src/main/java/org/primefaces/renderkit/OutcomeTargetRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/OutcomeTargetRenderer.java
@@ -23,12 +23,15 @@
  */
 package org.primefaces.renderkit;
 
+import org.primefaces.application.DialogReturn;
 import org.primefaces.behavior.confirm.ConfirmBehavior;
 import org.primefaces.component.api.AjaxSource;
+import org.primefaces.component.api.ClientBehaviorRenderingMode;
 import org.primefaces.component.api.UIOutcomeTarget;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.model.menu.MenuItem;
 import org.primefaces.util.ComponentTraversalUtils;
+import org.primefaces.util.Constants;
 
 import javax.faces.FacesException;
 import javax.faces.application.ConfigurableNavigationHandler;
@@ -266,6 +269,15 @@ public class OutcomeTargetRenderer extends CoreRenderer {
             }
             else {
                 writer.writeAttribute("onclick", onclick, null);
+            }
+        }
+
+        if (menuitem instanceof DialogReturn) {
+            List<ClientBehaviorContext.Parameter> behaviorParams = new ArrayList<>();
+            behaviorParams.add(new ClientBehaviorContext.Parameter(Constants.CLIENT_BEHAVIOR_RENDERING_MODE, ClientBehaviorRenderingMode.UNOBSTRUSIVE));
+            String dialogReturnBehavior = getEventBehaviors(context, (ClientBehaviorHolder) menuitem, "dialogReturn", behaviorParams);
+            if (dialogReturnBehavior != null) {
+                writer.writeAttribute("data-dialogreturn", dialogReturnBehavior, null);
             }
         }
     }

--- a/src/main/java/org/primefaces/util/MapBuilder.java
+++ b/src/main/java/org/primefaces/util/MapBuilder.java
@@ -23,6 +23,7 @@
  */
 package org.primefaces.util;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,5 +56,9 @@ public final class MapBuilder<K, V> {
 
     public Map<K, V> build() {
         return map;
+    }
+
+    public Map<K, V> ibuild() {
+        return Collections.unmodifiableMap(map);
     }
 }

--- a/src/main/java/org/primefaces/util/MapBuilder.java
+++ b/src/main/java/org/primefaces/util/MapBuilder.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Fluent builder for {@link Map}'s
+ * Fluent builder for {@link Map}
  *
  * @param <K> key type
  * @param <V> value type
@@ -54,10 +54,18 @@ public final class MapBuilder<K, V> {
         return this;
     }
 
+    /**
+     * Returns a mutable map.
+     * @return a mutable map.
+     */
     public Map<K, V> build() {
         return map;
     }
 
+    /**
+     * Returns a newly-created immutable map.
+     * @return a newly-created immutable map.
+     */
     public Map<K, V> ibuild() {
         return Collections.unmodifiableMap(map);
     }


### PR DESCRIPTION
To sum up:
- Fix #52 hopefully 😄 
- Refactoring to avoid copy/paste using default interface
    - `DialogReturnHolder` contains all the common stuff after analysing which component supporting `dialogReturn` event
    - Most of default methods might look useless, but having these just make sense to me as it implements `ClientBehaviorHolder` (FYI, I think `PrimeClientBehaviorHolder `should extend `ClientBehaviorHolder`)

One thing I don't like is the call of `CoreRenderer#decodeBehaviors` in `UIMenuItem#decode`, see my long comment here #3542

Feedbacks are welcome 😉 