### PR TITLE
Fix #5064: Do not increase z-index on every AJAX request.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -524,7 +524,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                         .css({
                             'left':'',
                             'top':'',
-                            'z-index': ++PrimeFaces.zindex,
+                            'z-index': PrimeFaces.getZindex(),
                             'width': content.outerWidth()
                         })
                         .position({
@@ -850,7 +850,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         this.panel.css({'left':'',
                         'top':'',
                         'width': panelWidth,
-                        'z-index': ++PrimeFaces.zindex
+                        'z-index': PrimeFaces.getZindex()
                 });
 
         if(this.panel.parent().is(this.jq)) {

--- a/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -59,7 +59,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     },
     
     show: function() {
-        this.blocker.css('z-index', ++PrimeFaces.zindex);
+        this.blocker.css('z-index', PrimeFaces.getZindex());
         
         //center position of content
         for(var i = 0; i < this.block.length; i++) {
@@ -69,7 +69,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             content.css({
                 'left': (blocker.width() - content.outerWidth()) / 2,
                 'top': (blocker.height() - content.outerHeight()) / 2,
-                'z-index': ++PrimeFaces.zindex
+                'z-index': PrimeFaces.getZindex()
             });
         }
 

--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -53,7 +53,7 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
 
                 //display on top
                 setTimeout(function() {
-                    $('#ui-datepicker-div').addClass('ui-input-overlay').css('z-index', ++PrimeFaces.zindex);
+                    $('#ui-datepicker-div').addClass('ui-input-overlay').css('z-index', PrimeFaces.getZindex());
 
                     if ($this.cfg.showTodayButton === false) {
                         $(input).datepicker("widget").find(".ui-datepicker-current").hide();

--- a/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
@@ -49,7 +49,7 @@
         this.cfg.onShow = function() {
             if($this.cfg.popup) {
                 $this.overlay.css({
-                    'z-index': ++PrimeFaces.zindex,
+                    'z-index': PrimeFaces.getZindex(),
                     'display':'block', 
                     'opacity':0, 
                     'pointer-events': 'none'
@@ -79,7 +79,7 @@
         };
 
         this.cfg.onHide = function(cp) {
-            $this.overlay.css('z-index', ++PrimeFaces.zindex);
+            $this.overlay.css('z-index', PrimeFaces.getZindex());
             $(cp).fadeOut('fast');
             return false;
         };

--- a/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
+++ b/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
@@ -342,7 +342,7 @@ PrimeFaces.widget.ColumnToggler = PrimeFaces.widget.DeferredWidget.extend({
     },
 
     alignPanel: function() {
-        this.panel.css({'left':'', 'top':'', 'z-index': ++PrimeFaces.zindex}).position({
+        this.panel.css({'left':'', 'top':'', 'z-index': PrimeFaces.getZindex()}).position({
                             my: 'left top'
                             ,at: 'left bottom'
                             ,of: this.trigger

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -292,6 +292,7 @@ if (!PrimeFaces.ajax) {
                 PrimeFaces.debug('Initiating ajax request.');
 
                 PrimeFaces.customFocus = false;
+                PrimeFaces.isAjaxRequest = true;
 
                 var global = (cfg.global === true || cfg.global === undefined) ? true : false,
                 form = null,
@@ -596,6 +597,8 @@ if (!PrimeFaces.ajax) {
                         if(!cfg.async && !PrimeFaces.nonAjaxPosted) {
                             PrimeFaces.ajax.Queue.poll();
                         }
+
+                        PrimeFaces.isAjaxRequest = false;
                     });
 
                 PrimeFaces.ajax.Queue.addXHR(jqXhr);

--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -654,11 +654,21 @@
               lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
               lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
               lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
+        },
+
+        /**
+         * AJAX request: returns the current zIndex.
+         * Non AJAX request: returns current zIndex + 1.
+         */
+        getZindex: function() {
+            return PrimeFaces.isAjaxRequest ? PrimeFaces.zindex : ++PrimeFaces.zindex;
         }, 
 
         zindex : 1000,
 
         customFocus : false,
+
+        isAjaxRequest : false,
 
         detachedWidgets : [],
 

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3289,7 +3289,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             scope: this.id,
             cancel: ':input,.ui-column-resizer',
             start: function(event, ui) {
-                ui.helper.css('z-index', ++PrimeFaces.zindex);
+                ui.helper.css('z-index', PrimeFaces.getZindex());
             },
             drag: function(event, ui) {
                 var droppable = ui.helper.data('droppable-column');
@@ -3458,7 +3458,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             handle: draggableHandle,
             appendTo: document.body,
             start: function(event, ui) {
-                ui.helper.css('z-index', ++PrimeFaces.zindex);
+                ui.helper.css('z-index', PrimeFaces.getZindex());
             },
             helper: function(event, ui) {
                 var cells = ui.children(),
@@ -3626,7 +3626,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             width: table.outerWidth(),
             top: offset.top,
             left: offset.left,
-            'z-index': ++PrimeFaces.zindex
+            'z-index': PrimeFaces.getZindex()
         });
 
         this.jq.prepend(this.stickyContainer);

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -32,7 +32,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
                     return false;
                 }
                 
-                this.panel.css('z-index', ++PrimeFaces.zindex);
+                this.panel.css('z-index', PrimeFaces.getZindex());
                 
                 var inst = this; // the instance of prime.datePicker API
 

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -398,7 +398,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
     },
 
     moveToTop: function() {
-        this.jq.css('z-index', ++PrimeFaces.zindex);
+        this.jq.css('z-index', PrimeFaces.getZindex());
     },
 
     toggleMaximize: function() {

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
@@ -365,7 +365,7 @@ PrimeFaces.widget.InputTextarea = PrimeFaces.widget.DeferredWidget.extend({
 
     show: function() {
         this.panel.css({
-            'z-index': ++PrimeFaces.zindex,
+            'z-index': PrimeFaces.getZindex(),
             'width': this.jq.innerWidth(),
             'visibility': 'hidden'
         }).show();

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.password.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.password.js
@@ -136,7 +136,7 @@ PrimeFaces.widget.Password = PrimeFaces.widget.BaseWidget.extend({
         this.panel.css({
             left:'',
             top:'',
-            'z-index': ++PrimeFaces.zindex
+            'z-index': PrimeFaces.getZindex()
         })
         .position({
             my: 'left top',

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -772,7 +772,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
         this.panel.css({
                 'left':'',
                 'top':'',
-                'z-index': ++PrimeFaces.zindex
+                'z-index': PrimeFaces.getZindex()
         });
 
         if(this.panel.parent().attr('id') === this.id) {

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -678,7 +678,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
 
         this.alignPanel();
 
-        this.panel.css({'display':'none', 'opacity':'', 'pointer-events': '', 'z-index': ++PrimeFaces.zindex});
+        this.panel.css({'display':'none', 'opacity':'', 'pointer-events': '', 'z-index': PrimeFaces.getZindex()});
 
         if($.browser.msie && /^[6,7]\.[0-9]+/.test($.browser.version)) {
             this.panel.parent().css('z-index', PrimeFaces.zindex - 1);

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.splitbutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.splitbutton.js
@@ -338,7 +338,7 @@ PrimeFaces.widget.SplitButton = PrimeFaces.widget.BaseWidget.extend({
     },
 
     alignPanel: function() {
-        this.menu.css({left:'', top:'','z-index': ++PrimeFaces.zindex});
+        this.menu.css({left:'', top:'','z-index': PrimeFaces.getZindex()});
 
         if(this.menu.parent().is(this.jq)) {
             this.menu.css({

--- a/src/main/resources/META-INF/resources/primefaces/growl/growl.js
+++ b/src/main/resources/META-INF/resources/primefaces/growl/growl.js
@@ -24,7 +24,7 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
     show: function(msgs) {
         var _self = this;
         
-        this.jq.css('z-index', ++PrimeFaces.zindex);
+        this.jq.css('z-index', PrimeFaces.getZindex());
 
         if(!this.cfg.keepAlive) {
             //clear previous messages

--- a/src/main/resources/META-INF/resources/primefaces/keyboard/1-keyboard.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyboard/1-keyboard.js
@@ -13,7 +13,7 @@
             this.cfg.layout = PrimeFaces.widget.KeyboardUtils.getPresetLayout(this.cfg.layoutName);
 
         this.cfg.beforeShow = function(div, inst) {
-            $(div).addClass('ui-input-overlay').css('z-index', ++PrimeFaces.zindex);
+            $(div).addClass('ui-input-overlay').css('z-index', PrimeFaces.getZindex());
         };
 
         this.jq.keypad(this.cfg);

--- a/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
@@ -269,7 +269,7 @@ PrimeFaces.widget.LightBox = PrimeFaces.widget.BaseWidget.extend({
     show: function() {
         this.center();
 
-        this.panel.css('z-index', ++PrimeFaces.zindex).show();
+        this.panel.css('z-index', PrimeFaces.getZindex()).show();
 
         if(!PrimeFaces.utils.isModalActive(this.id)) {
             this.enableModality();

--- a/src/main/resources/META-INF/resources/primefaces/log/log.js
+++ b/src/main/resources/META-INF/resources/primefaces/log/log.js
@@ -17,9 +17,9 @@ PrimeFaces.widget.Log = PrimeFaces.widget.BaseWidget.extend({
         this.jq.draggable({handle:this.header});
         
         //z-index
-        this.jq.zIndex(++PrimeFaces.zindex);
+        this.jq.zIndex(PrimeFaces.getZindex());
         this.header.mousedown(function() {
-            _self.jq.zIndex(++PrimeFaces.zindex);
+            _self.jq.zIndex(PrimeFaces.getZindex());
         });
 
         //attach events

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
@@ -91,7 +91,7 @@ PrimeFaces.widget.Menu = PrimeFaces.widget.BaseWidget.extend({
 
     show: function() {
         this.jq.css({
-            'z-index': ++PrimeFaces.zindex,
+            'z-index': PrimeFaces.getZindex(),
             'visibility': 'hidden'
         }).show();
 

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
@@ -119,7 +119,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
         this.jq.css({
             'left': left,
             'top': top,
-            'z-index': ++PrimeFaces.zindex
+            'z-index': PrimeFaces.getZindex()
         }).show();
 
         e.preventDefault();

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.megamenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.megamenu.js
@@ -352,7 +352,7 @@ PrimeFaces.widget.MegaMenu = PrimeFaces.widget.BaseWidget.extend({
             };
         }
 
-        submenu.css('z-index', ++PrimeFaces.zindex)
+        submenu.css('z-index', PrimeFaces.getZindex())
                 .show()
                 .position(pos);
     }

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
@@ -20,7 +20,7 @@ PrimeFaces.widget.Menubar = PrimeFaces.widget.TieredMenu.extend({
             };
         }
 
-        submenu.css('z-index', ++PrimeFaces.zindex)
+        submenu.css('z-index', PrimeFaces.getZindex())
                 .show()
                 .position(pos);
     },

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -149,7 +149,7 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.BaseWidget.extend({
     },
 
     alignPanel: function() {
-        this.menu.css({left:'', top:'','z-index': ++PrimeFaces.zindex});
+        this.menu.css({left:'', top:'','z-index': PrimeFaces.getZindex()});
 
         if(this.menu.parent().is(this.jq)) {
             this.menu.css({

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.slidemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.slidemenu.js
@@ -127,7 +127,7 @@ PrimeFaces.widget.SlideMenu = PrimeFaces.widget.Menu.extend({
 
     show: function() {
         this.align();
-        this.jq.css('z-index', ++PrimeFaces.zindex).show();
+        this.jq.css('z-index', PrimeFaces.getZindex()).show();
 
         if(!this.rendered) {
             this.render();

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
@@ -196,7 +196,7 @@ PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
             collision: 'flipfit'
         };
 
-        submenu.css('z-index', ++PrimeFaces.zindex)
+        submenu.css('z-index', PrimeFaces.getZindex())
             .show()
             .position(pos);
     },

--- a/src/main/resources/META-INF/resources/primefaces/mindmap/mindmap.js
+++ b/src/main/resources/META-INF/resources/primefaces/mindmap/mindmap.js
@@ -128,7 +128,7 @@ PrimeFaces.widget.Mindmap = PrimeFaces.widget.DeferredWidget.extend({
                             {
                                 'left': offset.left + node.attr('cx') + 20,
                                 'top':offset.top + node.attr('cy') + 10,
-                                'z-index': ++PrimeFaces.zindex
+                                'z-index': PrimeFaces.getZindex()
                             })
                         .show();
         }

--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -218,7 +218,7 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
             this.targetZindex = this.targetElement.zIndex();
         }
 
-        this.jq.css({'left':'', 'top':'', 'z-index': ++PrimeFaces.zindex})
+        this.jq.css({'left':'', 'top':'', 'z-index': PrimeFaces.getZindex()})
                 .position({
                     my: this.cfg.my
                     ,at: this.cfg.at

--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -131,7 +131,7 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
                         $this.tip.css({
                             'left': jsEvent.pageX,
                             'top': jsEvent.pageY + 15,
-                            'z-index': ++PrimeFaces.zindex
+                            'z-index': PrimeFaces.getZindex()
                         });
                         $this.tip[0].innerHTML = event.description;
                         $this.tip.show();

--- a/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
+++ b/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
@@ -42,7 +42,7 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
         }
 
         this.jq.addClass('ui-sidebar-active');
-        this.jq.css('z-index', this.cfg.baseZIndex + (++PrimeFaces.zindex));
+        this.jq.css('z-index', this.cfg.baseZIndex + (PrimeFaces.getZindex()));
 
         this.postShow();
         this.enableModality();

--- a/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
+++ b/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
@@ -69,7 +69,7 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
     bindEvents: function() {
         var $this = this;
 
-        this.target.data('zindex',this.target.zIndex()).css('z-index', ++PrimeFaces.zindex);
+        this.target.data('zindex',this.target.zIndex()).css('z-index', PrimeFaces.getZindex());
 
         if (this.cfg.blockScroll) {
             PrimeFaces.utils.preventScrolling();

--- a/src/main/resources/META-INF/resources/primefaces/sticky/sticky.js
+++ b/src/main/resources/META-INF/resources/primefaces/sticky/sticky.js
@@ -51,7 +51,7 @@ PrimeFaces.widget.Sticky = PrimeFaces.widget.BaseWidget.extend({
             this.target.css({
                 'position': 'fixed',
                 'top': this.cfg.margin,
-                'z-index': ++PrimeFaces.zindex
+                'z-index': PrimeFaces.getZindex()
             })
             .addClass('ui-shadow ui-sticky');
 

--- a/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -192,7 +192,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
          this.jq.css({
             left:'',
             top:'',
-            'z-index': ++PrimeFaces.zindex
+            'z-index': PrimeFaces.getZindex()
         });
 
         if(this.cfg.trackMouse && this.mouseEvent) {

--- a/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
+++ b/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
@@ -550,7 +550,7 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
                 return el;
             },
             appendTo: document.body,
-            zIndex: ++PrimeFaces.zindex,
+            zIndex: PrimeFaces.getZindex(),
             revert: true,
             scope: dragdropScope,
             containment: 'document'

--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -379,7 +379,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
             width: table.outerWidth(),
             top: offset.top,
             left: offset.left,
-            'z-index': ++PrimeFaces.zindex
+            'z-index': PrimeFaces.getZindex()
         });
 
         this.jq.prepend(this.stickyContainer);


### PR DESCRIPTION
What I did to fix this was the following:

1. Use global boolean variable Primefaces.isAjaxRequest to track whether or not this code is executing inside an ajax request or not.

2. Changed all ++zIndex calls to use a function PrimeFaces.getZindex(); which will return either the same index inside AJAX requests or +1 if loading the page for the first time to assign zIndexes.
