### PR TITLE
Add clear event details to autocomplete docs

### DIFF
--- a/docs/7_0/components/autocomplete.md
+++ b/docs/7_0/components/autocomplete.md
@@ -267,6 +267,7 @@ case _org.primefaces.event.Unselect_ instance is passed to a listener if defined
 | itemUnselect | org.primefaces.event.UnselectEvent | On item unselection. | 
 | query | - | On query. |
 | moreText | - | When moreText is clicked. |
+| clear | - | When all text is deleted. |
 
 ## ItemTip
 Itemtip is an advanced built-in tooltip when mouse is over on suggested items. Content of the

--- a/docs/7_1/components/autocomplete.md
+++ b/docs/7_1/components/autocomplete.md
@@ -268,6 +268,7 @@ case _org.primefaces.event.Unselect_ instance is passed to a listener if defined
 | itemUnselect | org.primefaces.event.UnselectEvent | On item unselection. |
 | query | - | On query. |
 | moreText | - | When moreText is clicked. |
+| clear | - | When all text is deleted. |
 
 ## ItemTip
 Itemtip is an advanced built-in tooltip when mouse is over on suggested items. Content of the


### PR DESCRIPTION
I didn't know this event existed until I dug into the code, was useful for me.