### PR TITLE
Fix #5075: SelectOneMenu fixed p:column rendered property

### DIFF
--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -429,19 +429,21 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             else {
                 for (int j = 0; j < columns.size(); j++) {
                     Column column = columns.get(j);
-                    String style = column.getStyle();
-                    String styleClass = column.getStyleClass();
+                    if (column.isRendered()) {
+                        String style = column.getStyle();
+                        String styleClass = column.getStyleClass();
 
-                    writer.startElement("td", null);
-                    if (style != null) {
-                        writer.writeAttribute("style", style, null);
-                    }
-                    if (styleClass != null) {
-                        writer.writeAttribute("class", styleClass, null);
-                    }
+                        writer.startElement("td", null);
+                        if (style != null) {
+                            writer.writeAttribute("style", style, null);
+                        }
+                        if (styleClass != null) {
+                            writer.writeAttribute("class", styleClass, null);
+                        }
 
-                    renderChildren(context, column);
-                    writer.endElement("td");
+                        renderChildren(context, column);
+                        writer.endElement("td");
+                    }
                 }
             }
 

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -429,21 +429,22 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             else {
                 for (int j = 0; j < columns.size(); j++) {
                     Column column = columns.get(j);
-                    if (column.isRendered()) {
-                        String style = column.getStyle();
-                        String styleClass = column.getStyleClass();
-
-                        writer.startElement("td", null);
-                        if (style != null) {
-                            writer.writeAttribute("style", style, null);
-                        }
-                        if (styleClass != null) {
-                            writer.writeAttribute("class", styleClass, null);
-                        }
-
-                        renderChildren(context, column);
-                        writer.endElement("td");
+                    if (!column.isRendered()) {
+                        continue;
                     }
+                    String style = column.getStyle();
+                    String styleClass = column.getStyleClass();
+
+                    writer.startElement("td", null);
+                    if (style != null) {
+                        writer.writeAttribute("style", style, null);
+                    }
+                    if (styleClass != null) {
+                        writer.writeAttribute("class", styleClass, null);
+                    }
+
+                    renderChildren(context, column);
+                    writer.endElement("td");
                 }
             }
 


### PR DESCRIPTION
When using advanced version of SelectOneMenu with a inner columns, the column rendered property is ignored.

This commit fix that issue.