### PR TITLE
Fix #5061: TouchPunch 1.0.5 and extensions.txt doc.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/extensions.txt
@@ -10,6 +10,7 @@ List of Plugins
 - Cursor Position (https://github.com/beviz/jquery-caret-position-getter)
 - Browser (https://github.com/gabceb/jquery-browser-plugin/releases)
 - Autosize (https://github.com/jackmoore/autosize)
+- Touch Punch (https://github.com/RWAP/jquery-ui-touch-punch custom fork of https://github.com/furf/jquery-ui-touch-punch)
 
 
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.touch-punch.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.touch-punch.js
@@ -11,10 +11,6 @@
  * Depends:
  * jquery.ui.widget.js
  * jquery.ui.mouse.js
- *
- * Depends:
- *  jquery.ui.widget.js
- *  jquery.ui.mouse.js
  */
 (function( factory ) {
     if ( typeof define === "function" && define.amd ) {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.touch-punch.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.touch-punch.js
@@ -1,16 +1,20 @@
 /*!
- * Query UI Touch Punch 1.0.3 as modified by RWAP Software (based on original touchpunch v0.2.3 which has not been updated since 2014)
+ * jQuery UI Touch Punch 1.0.5 as modified by RWAP Software (based on original touchpunch v0.2.3 which has not been updated since 2014)
  *
- *
- * Original jquery-ui-touch-punch Copyright 2011, Dave Furfero
+ * Updates to take account of various suggested changes on the original code issues
+ * Copyright 2011–2014, Dave Furfero
  * Dual licensed under the MIT or GPL Version 2 licenses.
- * 
+ *
  * Original: https://github.com/furf/jquery-ui-touch-punch
  * Fork: https://github.com/RWAP/jquery-ui-touch-punch
  *
  * Depends:
  * jquery.ui.widget.js
  * jquery.ui.mouse.js
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
  */
 (function( factory ) {
     if ( typeof define === "function" && define.amd ) {
@@ -25,7 +29,13 @@
 }(function ($) {
 
   // Detect touch support
-  $.support.touch = ('ontouchstart' in document || 'ontouchstart' in window || window.TouchEvent  || (window.DocumentTouch && document instanceof DocumentTouch) || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0);
+  $.support.touch = ( 'ontouchstart' in document 
+   	|| 'ontouchstart' in window 
+   	|| window.TouchEvent 
+   	|| (window.DocumentTouch && document instanceof DocumentTouch) 
+   	|| navigator.maxTouchPoints > 0 
+   	|| navigator.msMaxTouchPoints > 0
+  );	
 
   // Ignore browsers without touch or mouse support
   if (!$.support.touch || !$.ui.mouse) {


### PR DESCRIPTION
- Updated to 1.0.5 of RWAP's fork where he accepted my Lenovo TouchScreen patch
- Addded doc to extensions.txt to document this plugin and the fork URL we are using.
- Original Touch Punch has been inactive for 3+ years
- RWAP's fork has been keeping it modern and fixing issues like Apple Pencil and the original bug we had for #5061 