### PR TITLE
Fix #4998: Allow custom animation duration for show/hide

### DIFF
--- a/docs/7_1/components/blockui.md
+++ b/docs/7_1/components/blockui.md
@@ -72,8 +72,8 @@ Widget: _PrimeFaces.widget.BlockUI_
 
 | Method | Params | Return Type | Description | 
 | --- | --- | --- | --- | 
-| show() | - | void Blocks the UI.
-| hide() | - | void Unblocks the UI
+| show(duration) | duration: (optional) duration of the animation | void | Blocks the UI.
+| hide(duration) | duration: (optional) duration of the animation | void | Unblocks the UI
 
 ## Skinning
 Following is the list of structural style classes;

--- a/docs/7_1/components/dialog.md
+++ b/docs/7_1/components/dialog.md
@@ -146,8 +146,8 @@ Widget: _PrimeFaces.widget.Dialog_
 
 | Method | Params | Return Type | Description | 
 | --- | --- | --- | --- | 
-| show() | - | void | Displays dialog.
-| hide() | - | void | Closes dialog.
+| show(duration) | duration: (optional) duration of the animation | void | Displays dialog.
+| hide(duration) | duration: (optional) duration of the animation | void | Closes dialog.
 | isVisible() | - | void | Returns visibility as a boolean.
 | resetPosition | - | void | Reset the dialog position based on the configured "position".
 

--- a/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -58,7 +58,14 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         });
     },
     
-    show: function() {
+    /**
+     * Show the component with optional duration animation.
+     * 
+     * @param [duration] Durations are given in milliseconds; higher values indicate slower animations, not faster ones. 
+     *                 The strings 'fast' and 'slow' can be supplied to indicate durations of 200 and 600 milliseconds, 
+     *                 respectively.
+     */
+    show: function(duration) {
         this.blocker.css('z-index', ++PrimeFaces.zindex);
         
         //center position of content
@@ -73,32 +80,42 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             });
         }
 
-        if(this.cfg.animate)
+        var animated = this.cfg.animate && typeof duration === 'undefined';
+        if(animated)
             this.blocker.fadeIn();    
         else
-            this.blocker.show();
+            this.blocker.show(duration);
 
         if(this.hasContent()) {
-            if(this.cfg.animate)
+            if(animated)
                 this.content.fadeIn();
             else
-                this.content.show();
+                this.content.show(duration);
         }
         
         this.block.attr('aria-busy', true);
     },
     
-    hide: function() {
-        if(this.cfg.animate)
+    /**
+     * Hide the component with optional duration animation.
+     * 
+     * @param [duration] Durations are given in milliseconds; higher values indicate slower animations, not faster ones. 
+     *                 The strings 'fast' and 'slow' can be supplied to indicate durations of 200 and 600 milliseconds, 
+     *                 respectively.
+     */
+    hide: function(duration) {
+        var animated = this.cfg.animate && typeof duration === 'undefined';
+
+        if(animated)
             this.blocker.fadeOut();
         else
-            this.blocker.hide();
+            this.blocker.hide(duration);
 
         if(this.hasContent()) {
-            if(this.cfg.animate)
+            if(animated)
                 this.content.fadeOut();
             else
-                this.content.hide();
+                this.content.hide(duration);
         }
         
         this.block.attr('aria-busy', false);

--- a/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -80,15 +80,15 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             });
         }
 
-        var animated = this.cfg.animate && typeof duration === 'undefined';
+        var animated = this.cfg.animate;
         if(animated)
-            this.blocker.fadeIn();    
+            this.blocker.fadeIn(duration);    
         else
             this.blocker.show(duration);
 
         if(this.hasContent()) {
             if(animated)
-                this.content.fadeIn();
+                this.content.fadeIn(duration);
             else
                 this.content.show(duration);
         }
@@ -104,16 +104,16 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      *                 respectively.
      */
     hide: function(duration) {
-        var animated = this.cfg.animate && typeof duration === 'undefined';
+        var animated = this.cfg.animate;
 
         if(animated)
-            this.blocker.fadeOut();
+            this.blocker.fadeOut(duration);
         else
             this.blocker.hide(duration);
 
         if(this.hasContent()) {
             if(animated)
-                this.content.fadeOut();
+                this.content.fadeOut(duration);
             else
                 this.content.hide(duration);
         }

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -111,7 +111,14 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         return this.jq.find(':tabbable').add(this.footer.find(':tabbable'));
     },
 
-    show: function() {
+    /**
+     * Show the dialog with optional animation duration.
+     * 
+     * @param [duration] Durations are given in milliseconds; higher values indicate slower animations, not faster ones. 
+     *                 The strings 'fast' and 'slow' can be supplied to indicate durations of 200 and 600 milliseconds, 
+     *                 respectively.
+     */
+    show: function(duration) {
         if(this.isVisible()) {
             return;
         }
@@ -128,11 +135,11 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
                 this.jqEl.style.visibility = "visible";
             }
 
-            this._show();
+            this._show(duration);
         }
     },
 
-    _show: function() {
+    _show: function(duration) {
         this.moveToTop();
 
         //offset
@@ -142,7 +149,8 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
             this.lastScrollTop = winScrollTop;
         }
 
-        if(this.cfg.showEffect) {
+        var animated = this.cfg.showEffect && typeof duration === 'undefined';
+        if(animated) {
             var $this = this;
 
             this.jq.show(this.cfg.showEffect, null, 'normal', function() {
@@ -151,7 +159,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         }
         else {
             //display dialog
-            this.jq.show();
+            this.jq.show(duration);
 
             this.postShow();
         }
@@ -183,12 +191,20 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.applyFocus();
     },
 
-    hide: function() {
+    /**
+     * Hide the dialog with optional duration animation.
+     * 
+     * @param [duration] Durations are given in milliseconds; higher values indicate slower animations, not faster ones. 
+     *                 The strings 'fast' and 'slow' can be supplied to indicate durations of 200 and 600 milliseconds, 
+     *                 respectively.
+     */
+    hide: function(duration) {
         if(!this.isVisible()) {
             return;
         }
 
-        if(this.cfg.hideEffect) {
+        var animated = this.cfg.showEffect && typeof duration === 'undefined';
+        if(animated) {
             var $this = this;
 
             this.jq.hide(this.cfg.hideEffect, null, 'normal', function() {
@@ -203,7 +219,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
             if(this.cfg.modal) {
                 this.disableModality();
             }
-            this.onHide();
+            this.onHide(duration);
         }
     },
 

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -149,11 +149,11 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
             this.lastScrollTop = winScrollTop;
         }
 
-        var animated = this.cfg.showEffect && typeof duration === 'undefined';
+        var animated = this.cfg.showEffect;
         if(animated) {
             var $this = this;
 
-            this.jq.show(this.cfg.showEffect, null, 'normal', function() {
+            this.jq.show(this.cfg.showEffect, duration, 'normal', function() {
                 $this.postShow();
             });
         }
@@ -203,11 +203,11 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
             return;
         }
 
-        var animated = this.cfg.showEffect && typeof duration === 'undefined';
+        var animated = this.cfg.showEffect;
         if(animated) {
             var $this = this;
 
-            this.jq.hide(this.cfg.hideEffect, null, 'normal', function() {
+            this.jq.hide(this.cfg.hideEffect, duration, 'normal', function() {
                 if($this.cfg.modal) {
                     $this.disableModality();
                 }


### PR DESCRIPTION
Added new optional param [duration] to .show and .hide function of dialog and block UI.

If the parameter is left off the component behaves like .show() and .hide() always have.
