### PR TITLE
Fix #5084: IdleMonitor: support multiple on the same page

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/0-jquery.idletimer.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/0-jquery.idletimer.js
@@ -16,7 +16,7 @@
 */
 (function ($) {
 
-    $.idleTimer = function (firstParam, elem) {
+    $.idleTimer = function (firstParam, elem, uniqueId) {
         var opts;
         if ( typeof firstParam === "object" ) {
             opts = firstParam;
@@ -37,14 +37,14 @@
         }, opts);
 
         var jqElem = $(elem),
-            obj = jqElem.data("idleTimerObj") || {},
+            obj = jqElem.data("idleTimerObj" + uniqueId) || {},
 
             /* (intentionally not documented)
              * Toggles the idle state and fires an appropriate event.
              * @return {void}
              */
             toggleIdleState = function (e) {
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 // toggle the state
                 obj.idle = !obj.idle;
@@ -53,7 +53,7 @@
                 obj.olddate = +new Date();
 
                 // create a custom event, with state and name space
-                var event = $.Event((obj.idle ? "idle" : "active") + ".idleTimer");
+                var event = $.Event((obj.idle ? "idle" : "active") + ".idleTimer" + uniqueId);
 
                 // trigger event on object with elem and copy of obj
                 $(elem).trigger(event, [elem, $.extend({}, obj), e]);
@@ -65,7 +65,7 @@
              * @static
              */
             handleEvent = function (e) {
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 if (e.type === "storage" && e.originalEvent.key !== obj.timerSyncId) {
                     return;
@@ -129,7 +129,7 @@
              */
             reset = function () {
 
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 // reset settings
                 obj.idle = obj.idleBackup;
@@ -153,7 +153,7 @@
              */
             pause = function () {
 
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 // this is already paused
                 if ( obj.remaining != null ) { return; }
@@ -172,7 +172,7 @@
              */
             resume = function () {
 
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 // this isn't paused yet
                 if ( obj.remaining == null ) { return; }
@@ -194,16 +194,16 @@
              */
             destroy = function () {
 
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 //clear any pending timeouts
                 clearTimeout(obj.tId);
 
                 //Remove data
-                jqElem.removeData("idleTimerObj");
+                jqElem.removeData("idleTimerObj" + uniqueId);
 
                 //detach the event handlers
-                jqElem.off("._idleTimer");
+                jqElem.off("._idleTimer" + uniqueId);
             },
             /**
             * Returns the time until becoming idle
@@ -213,7 +213,7 @@
             */
             remainingtime = function () {
 
-                var obj = $.data(elem, "idleTimerObj") || {};
+                var obj = $.data(elem, "idleTimerObj" + uniqueId) || {};
 
                 //If idle there is no time remaining
                 if ( obj.idle ) { return 0; }
@@ -268,7 +268,7 @@
          * @param {Event} event A DOM2-normalized event object.
          * @return {void}
          */
-        jqElem.on($.trim((opts.events + " ").split(" ").join("._idleTimer ")), function (e) {
+        jqElem.on($.trim((opts.events + " ").split(" ").join("._idleTimer" + uniqueId + " ")), function (e) {
             handleEvent(e);
         });
 
@@ -297,15 +297,15 @@
         }
 
         // store our instance on the object
-        $.data(elem, "idleTimerObj", obj);
+        $.data(elem, "idleTimerObj" + uniqueId, obj);
 
         return jqElem;
     };
 
     // This allows binding to element
-    $.fn.idleTimer = function (firstParam) {
+    $.fn.idleTimer = function (firstParam, uniqueId) {
         if (this[0]) {
-            return $.idleTimer(firstParam, this[0]);
+            return $.idleTimer(firstParam, this[0], uniqueId);
         }
 
         return this;

--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
@@ -8,7 +8,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
 
         var $this = this;
 
-        $(document).on("idle.idleTimer", function(){
+        $(document).on("idle.idleTimer" + this.cfg.id, function(){
 
             if($this.cfg.onidle) {
                 $this.cfg.onidle.call($this);
@@ -16,7 +16,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
 
             $this.callBehavior('idle');
         })
-        .on("active.idleTimer", function(){
+        .on("active.idleTimer" + this.cfg.id, function(){
             if($this.cfg.onactive) {
                 $this.cfg.onactive.call(this);
             }
@@ -24,18 +24,18 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
             $this.callBehavior('active');
         });
 
-        $.idleTimer(this.cfg.timeout);
+        $.idleTimer(this.cfg.timeout, document, this.cfg.id);
 
 
         if (cfg.multiWindowSupport) {
             var globalLastActiveKey = $this.cfg.contextPath + '_idleMonitor_lastActive';
 
             // always reset with current time on init
-            localStorage.setItem(globalLastActiveKey, $(document).data('idleTimerObj').lastActive);
+            localStorage.setItem(globalLastActiveKey, $(document).data('idleTimerObj' + this.cfg.id).lastActive);
 
             $this.timer = setInterval(function() {
 
-                var idleTimerObj = $(document).data('idleTimerObj');
+                var idleTimerObj = $(document).data('idleTimerObj' + $this.cfg.id);
 
                 var globalLastActive = parseInt(localStorage.getItem(globalLastActiveKey));
                 var localLastActive = idleTimerObj.lastActive;

--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
@@ -43,7 +43,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
                 // reset local state
                 if (globalLastActive > localLastActive) {
                     // pause timer
-                    $.idleTimer('pause');
+                    $.idleTimer('pause', document, $this.cfg.id);
 
                     // overwrite real state
                     idleTimerObj.idle = false;
@@ -52,7 +52,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
                     idleTimerObj.remaining = $this.cfg.timeout;
 
                     // resume timer
-                    $.idleTimer('resume');
+                    $.idleTimer('resume', document, $this.cfg.id);
                 }
                 // update global state
                 else if (localLastActive > globalLastActive) {
@@ -73,15 +73,15 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
     },
 
     pause: function() {
-        $.idleTimer('pause');
+        $.idleTimer('pause', document, this.cfg.id);
     },
 
     resume: function() {
-        $.idleTimer('resume');
+        $.idleTimer('resume', document, this.cfg.id);
     },
 
     reset: function() {
-        $.idleTimer('reset');
+        $.idleTimer('reset', document, this.cfg.id);
     }
 
 });

--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
@@ -28,7 +28,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
 
 
         if (cfg.multiWindowSupport) {
-            var globalLastActiveKey = $this.cfg.contextPath + '_idleMonitor_lastActive';
+            var globalLastActiveKey = $this.cfg.contextPath + '_idleMonitor_lastActive' + this.cfg.id;
 
             // always reset with current time on init
             localStorage.setItem(globalLastActiveKey, $(document).data('idleTimerObj' + this.cfg.id).lastActive);


### PR DESCRIPTION
When using multiple idle monitor tags, they influence each other. I needed to use separate idle timers on the same page with different timeout times.

Client id is used to make several strings that are used as keys and event names unique.