### PR TITLE
Fix #5100: Datagrid display expected number of items per page.

### DIFF
--- a/src/main/java/org/primefaces/component/datagrid/DataGridRenderer.java
+++ b/src/main/java/org/primefaces/component/datagrid/DataGridRenderer.java
@@ -158,6 +158,7 @@ public class DataGridRenderer extends DataRenderer {
         int rows = grid.getRows();
         int itemsToRender = rows != 0 ? rows : grid.getRowCount();
         int numberOfRowsToRender = (itemsToRender + columns - 1) / columns;
+        int displayedItemsToRender = rowIndex + itemsToRender;
         String columnClass = DataGrid.COLUMN_CLASS + " " + GridLayoutUtils.getColumnClass(columns);
 
         for (int i = 0; i < numberOfRowsToRender; i++) {
@@ -180,6 +181,10 @@ public class DataGridRenderer extends DataRenderer {
                 rowIndex++;
 
                 writer.endElement("div");
+
+                if (rowIndex >= displayedItemsToRender) {
+                    break;
+                }
             }
 
             writer.endElement("div");


### PR DESCRIPTION
Testing it now reveals the correct number of items per page.

![image](https://user-images.githubusercontent.com/4399574/63937974-bf1bf700-ca31-11e9-8dc2-72f74f4553f2.png)
