### PR TITLE
Fix #688: Paginator allow disabling of focus.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
@@ -304,7 +304,7 @@ PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
             this.pagesContainer.append('<a class="' + styleClass + '" aria-label="' + ariaLabel + '" tabindex="0" href="#">' + (i + 1) + '</a>');
         }
 
-        if(focusContainer) {
+        if(focusContainer && this.allowRefocus()) {
             focusContainer.children().filter('.ui-state-active').trigger('focus');
         }
 
@@ -406,5 +406,13 @@ PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
 
     prev: function() {
         this.setPage(this.cfg.page - 1);
+    },
+    
+    /**
+     * Override this widget method if you don't want the paginator to refocus after paging.
+     * @see GitHub #688
+     */
+    allowRefocus: function() {
+        return true;
     }
 });


### PR DESCRIPTION
By default the behavior is not changing as it defaults to refocusing the paginator as it always has.  This just creates a widget method to give downstream users the ability to turn off refocus with...

```javascript
PrimeFaces.widget.Paginator.prototype.allowRefocus =  function() {
        return false;
 };
```