### PR TITLE
Fix #3378: DialogFramework allow widgetVar option.

### DIFF
--- a/docs/7_1/core/dialogframework.md
+++ b/docs/7_1/core/dialogframework.md
@@ -99,7 +99,7 @@ Here is the full list of configuration options;
 
 | Name | Default | Type | Description | 
 | --- | --- | --- | --- |
-widgetVar | null | String | Custom widgetVar of the dialog, if not declared it will be automatically created as id+'_dlgWidget'.
+widgetVar | null | String | Custom widgetVar of the dialog, if not declared it will be automatically created as "id+dlgWidget".
 modal | false | Boolean | Controls modality of the dialog.
 resizable | true | Boolean | When enabled, makes dialog resizable.
 draggable | true | Boolean | When enabled, makes dialog draggable.

--- a/docs/7_1/core/dialogframework.md
+++ b/docs/7_1/core/dialogframework.md
@@ -99,6 +99,7 @@ Here is the full list of configuration options;
 
 | Name | Default | Type | Description | 
 | --- | --- | --- | --- |
+widgetVar | null | String | Custom widgetVar of the dialog, if not declared it will be automatically created as id+'_dlgWidget'.
 modal | false | Boolean | Controls modality of the dialog.
 resizable | true | Boolean | When enabled, makes dialog resizable.
 draggable | true | Boolean | When enabled, makes dialog draggable.

--- a/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
@@ -12,8 +12,12 @@ if (!PrimeFaces.dialog) {
                 return;
             }
 
-            var dialogWidgetVar = cfg.sourceComponentId.replace(/:/g, '_') + '_dlgwidget',
-            styleClass = cfg.options.styleClass||'',
+            var dialogWidgetVar = cfg.options.widgetVar;
+            if (!dialogWidgetVar) {
+                dialogWidgetVar = cfg.sourceComponentId.replace(/:/g, '_') + '_dlgwidget';
+            }
+
+            var styleClass = cfg.options.styleClass||'',
             dialogDOM = $('<div id="' + dialogId + '" class="ui-dialog ui-widget ui-widget-content ui-corner-all ui-shadow ui-hidden-container ui-overlay-hidden ' + styleClass + '"' +
                     ' data-pfdlgcid="' + PrimeFaces.escapeHTML(cfg.pfdlgcid) + '" data-widget="' + dialogWidgetVar + '"></div>')
                     .append('<div class="ui-dialog-titlebar ui-widget-header ui-helper-clearfix ui-corner-top"><span id="' + dialogId + '_title" class="ui-dialog-title"></span></div>');


### PR DESCRIPTION
Tested and if widgetVar is not assigned it defaults to current behavior of auto assignment.

Other than that a widget var can be assigned with...

```java
options.put("widgetVar", "wgtChooseDialog");
```