### PR TITLE
#4646: Timeline: move to java.time.LocalDateTime

### DIFF
--- a/docs/7_0/components/timeline.md
+++ b/docs/7_0/components/timeline.md
@@ -102,8 +102,6 @@ https://www.primefaces.org/showcase/ui/data/timeline/basic.xhtml
 
 | Event | Listener Parameter | Fired |
 | --- | --- | --- |
-page | org.primefaces.event.data.PageEvent | On pagination.
-sort | org.primefaces.event.data.SortEvent | When a column is sorted.
 add | org.primefaces.event.timeline.TimelineAddEvent | On event add.
 change | org.primefaces.event.timeline.TimelineModificationEvent | On event change.
 changed | org.primefaces.event.timeline.TimelineModificationEvent | On event change complete.

--- a/docs/7_1/components/timeline.md
+++ b/docs/7_1/components/timeline.md
@@ -28,7 +28,6 @@ value | null | TimelineModel | An instance of TimelineModel representing the bac
 varGroup | null | String | Name of the request-scoped variable for underlaying object in the TimelineGroup for each iteration.
 locale | null | Object | User locale for i18n messages. The attribute can be either a String or Locale object.
 timeZone | null | Object | Target time zone to convert start / end dates for displaying. This time zone is the time zone the user would like to see dates in UI. The attribute can be either a String or TimeZone object or null. If null, timeZone defaults to the server's time zone the application is running in.
-browserTimeZone | null | Object | Time zone the user's browser / PC is running in. This time zone allows to correct the conversion of start / end dates to the target timeZone for displaying. The attribute can be either a String or TimeZone object or null. Note: browserTimeZone should be provided if the target timeZone is provided. If null, browserTimeZone defaults to the server's timeZone.
 height | auto | String | The height of the timeline in pixels, as a percentage, or "auto". When the height is set to "auto", the height of the timeline is automatically adjusted to fit the contents. If not, it is possible that events get stacked so high, that they are not visible in the timeline. When height is set to "auto", a minimum height can be specified with the option minHeight. Default is "auto".
 minHeight | 0 | Integer | Specifies a minimum height for the Timeline in pixels. Useful when height is set to "auto".
 width | 100% | String | The width of the timeline in pixels or as a percentage.
@@ -40,10 +39,10 @@ selectable | true | Boolean | If true, events on the timeline are selectable. Se
 unselectable | true | Boolean | If true, you can unselect an item by clicking in the empty space of the timeline. If false, you cannot unselect an item, there will be always one item selected.
 zoomable | true | Boolean | If true, the timeline is zoomable. When the timeline is zoomed, AJAX "rangechange" events are fired.
 moveable | true | Boolean | If true, the timeline is movable. When the timeline is moved, AJAX "rangechange" events are fired.
-start | null | Date | The initial start date for the axis of the timeline. If not provided, the earliest date present in the events is taken as start date.
-end | null | Date | The initial end date for the axis of the timeline. If not provided, the latest date present in the events is taken as end date.
-min | null | Date | Set a minimum Date for the visible range. It will not be possible to move beyond this minimum.
-max | null | Date | Set a maximum Date for the visible range. It will not be possible to move beyond this maximum.
+start | null | LocalDateTime | The initial start date for the axis of the timeline. If not provided, the earliest date present in the events is taken as start date.
+end | null | LocalDateTime | The initial end date for the axis of the timeline. If not provided, the latest date present in the events is taken as end date.
+min | null | LocalDateTime | Set a minimum Date for the visible range. It will not be possible to move beyond this minimum.
+max | null | LocalDateTime | Set a maximum Date for the visible range. It will not be possible to move beyond this maximum.
 zoomMin | 10L | Long | Set a minimum zoom interval for the visible range in milliseconds. It will not be possible to zoom in further than this minimum.
 zoomMax | 315360000000000L | Long | Set a maximum zoom interval for the visible range in milliseconds. It will not be possible to zoom out further than this maximum. Default value equals 315360000000000 ms (about 10000 years).
 preloadFactor | 0.0f | Float | Preload factor is a positive float value or 0 which can be used for lazy loading of events. When the lazy loading feature is active, the calculated time range for preloading will be multiplicated by the preload factor. The result of this multiplication specifies the additional time range which will be considered for the preloading during moving / zooming too. For example, if the calculated time range for preloading is 5 days and the preload factor is 0.2, the result is 5 * 0.2 = 1 day. That means, 1 day backwards and / or 1 day onwards will be added to the original calculated time range. The event's area to be preloaded is wider then. This helps to avoid frequently, time-consuming fetching of events. Default value is 0.
@@ -85,11 +84,8 @@ public class BasicTimelineView implements Serializable {
     @PostConstruct
     protected void initialize() {
         model = new TimelineModel();
-        Calendar cal = Calendar.getInstance();
-        cal.set(2014, Calendar.JUNE, 12, 0, 0, 0);
-        model.add(new TimelineEvent("PrimeUI 1.1", cal.getTime()));
-        cal.set(2014, Calendar.OCTOBER, 11, 0, 0, 0);
-        model.add(new TimelineEvent("PrimeFaces 5.1.3", cal.getTime()));
+        model.add(new TimelineEvent("PrimeUI 1.1", LocalDate.of(2014, 6, 12)));
+        model.add(new TimelineEvent("PrimeFaces 5.1.3", LocalDate.of(2014, 10, 11)));
     }
 }
 ```

--- a/docs/7_1/components/timeline.md
+++ b/docs/7_1/components/timeline.md
@@ -98,8 +98,6 @@ https://www.primefaces.org/showcase/ui/data/timeline/basic.xhtml
 
 | Event | Listener Parameter | Fired |
 | --- | --- | --- |
-page | org.primefaces.event.data.PageEvent | On pagination.
-sort | org.primefaces.event.data.SortEvent | When a column is sorted.
 add | org.primefaces.event.timeline.TimelineAddEvent | On event add.
 change | org.primefaces.event.timeline.TimelineModificationEvent | On event change.
 changed | org.primefaces.event.timeline.TimelineModificationEvent | On event change complete.

--- a/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
+++ b/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
@@ -25,6 +25,7 @@ package org.primefaces.component.timeline;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -38,6 +39,7 @@ import javax.faces.event.PhaseListener;
 import org.primefaces.PrimeFaces;
 import org.primefaces.model.timeline.TimelineEvent;
 import org.primefaces.model.timeline.TimelineGroup;
+import org.primefaces.util.CalendarUtils;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.FastStringWriter;
 
@@ -127,8 +129,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
             groupsContent = new HashMap<>();
         }
 
-        TimeZone targetTZ = ComponentUtils.resolveTimeZone(timeline.getTimeZone());
-        TimeZone browserTZ = ComponentUtils.resolveTimeZone(timeline.getBrowserTimeZone());
+        ZoneId zoneId = CalendarUtils.calculateZoneId(timeline.getTimeZone());
 
         try (FastStringWriter fsw = new FastStringWriter();
              FastStringWriter fswHtml = new FastStringWriter()) {
@@ -141,7 +142,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
                         sb.append(";PF('");
                         sb.append(widgetVar);
                         sb.append("').addEvent(");
-                        sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, browserTZ, targetTZ,
+                        sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, zoneId,
                                 groups, groupFacet, groupsContent, crudOperationData.getEvent()));
                         sb.append(", " + PREVENT_RENDER + ")");
                         renderComponent = true;
@@ -154,7 +155,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
                         sb.append("').changeEvent(");
                         sb.append(crudOperationData.getIndex());
                         sb.append(",");
-                        sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, browserTZ, targetTZ,
+                        sb.append(timelineRenderer.encodeEvent(fc, fsw, fswHtml, timeline, zoneId,
                                 groups, groupFacet, groupsContent, crudOperationData.getEvent()));
                         sb.append(", " + PREVENT_RENDER + ")");
                         renderComponent = true;

--- a/src/main/java/org/primefaces/component/timeline/Timeline.java
+++ b/src/main/java/org/primefaces/component/timeline/Timeline.java
@@ -23,9 +23,7 @@
  */
 package org.primefaces.component.timeline;
 
-import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import javax.faces.application.ResourceDependencies;
@@ -91,14 +89,13 @@ public class Timeline extends TimelineBase {
             AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
 
             ZoneId zoneId = CalendarUtils.calculateZoneId(getTimeZone());
-            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME.withZone(zoneId);
 
             if ("add".equals(eventName)) {
                 // preset start / end date and the group
                 TimelineAddEvent te =
                         new TimelineAddEvent(this, behaviorEvent.getBehavior(),
-                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDate")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDate")),
                                 getGroup(params.get(clientId + "_group")));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
@@ -116,8 +113,8 @@ public class Timeline extends TimelineBase {
                     clonedEvent.setStyleClass(timelineEvent.getStyleClass());
 
                     // update start / end date and the group
-                    clonedEvent.setStartDate(LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter));
-                    clonedEvent.setEndDate(LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter));
+                    clonedEvent.setStartDate(DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDate")));
+                    clonedEvent.setEndDate(DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDate")));
                     clonedEvent.setGroup(getGroup(params.get(clientId + "_group")));
                 }
 
@@ -158,8 +155,8 @@ public class Timeline extends TimelineBase {
             else if ("rangechange".equals(eventName) || "rangechanged".equals(eventName)) {
                 TimelineRangeEvent te =
                         new TimelineRangeEvent(this, behaviorEvent.getBehavior(),
-                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter));
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDate")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDate")));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
 
@@ -168,10 +165,10 @@ public class Timeline extends TimelineBase {
             else if ("lazyload".equals(eventName)) {
                 TimelineLazyLoadEvent te =
                         new TimelineLazyLoadEvent(this, behaviorEvent.getBehavior(),
-                                LocalDateTime.parse(params.get(clientId + "_startDateFirst"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_endDateFirst"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_startDateSecond"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_endDateSecond"), dateTimeFormatter));
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDateFirst")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDateFirst")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDateSecond")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDateSecond")));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
 
@@ -192,8 +189,8 @@ public class Timeline extends TimelineBase {
                 // preset start / end date, group, dragId and data object
                 TimelineDragDropEvent te =
                         new TimelineDragDropEvent(this, behaviorEvent.getBehavior(),
-                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
-                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_startDate")),
+                                DateUtils.toLocalDateTime(zoneId, params.get(clientId + "_endDate")),
                                 getGroup(params.get(clientId + "_group")), dragId, data);
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
@@ -229,6 +226,5 @@ public class Timeline extends TimelineBase {
                 .equals(context.getExternalContext().getRequestParameterMap().get(
                         Constants.RequestParams.PARTIAL_SOURCE_PARAM));
     }
-
 
 }

--- a/src/main/java/org/primefaces/component/timeline/Timeline.java
+++ b/src/main/java/org/primefaces/component/timeline/Timeline.java
@@ -23,6 +23,9 @@
  */
 package org.primefaces.component.timeline;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import javax.faces.application.ResourceDependencies;
@@ -35,10 +38,7 @@ import javax.faces.event.FacesEvent;
 import org.primefaces.event.timeline.*;
 import org.primefaces.model.timeline.TimelineEvent;
 import org.primefaces.model.timeline.TimelineGroup;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
-import org.primefaces.util.DateUtils;
-import org.primefaces.util.MapBuilder;
+import org.primefaces.util.*;
 import org.primefaces.visit.UIDataContextCallback;
 
 @ResourceDependencies({
@@ -90,15 +90,15 @@ public class Timeline extends TimelineBase {
 
             AjaxBehaviorEvent behaviorEvent = (AjaxBehaviorEvent) event;
 
+            ZoneId zoneId = CalendarUtils.calculateZoneId(getTimeZone());
+            DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME.withZone(zoneId);
+
             if ("add".equals(eventName)) {
                 // preset start / end date and the group
-                TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
-                TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTimeZone());
-
                 TimelineAddEvent te =
                         new TimelineAddEvent(this, behaviorEvent.getBehavior(),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")),
+                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter),
                                 getGroup(params.get(clientId + "_group")));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
@@ -116,10 +116,8 @@ public class Timeline extends TimelineBase {
                     clonedEvent.setStyleClass(timelineEvent.getStyleClass());
 
                     // update start / end date and the group
-                    TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
-                    TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTimeZone());
-                    clonedEvent.setStartDate(DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")));
-                    clonedEvent.setEndDate(DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")));
+                    clonedEvent.setStartDate(LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter));
+                    clonedEvent.setEndDate(LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter));
                     clonedEvent.setGroup(getGroup(params.get(clientId + "_group")));
                 }
 
@@ -136,8 +134,8 @@ public class Timeline extends TimelineBase {
                 if (timelineEvent != null) {
                     clonedEvent = new TimelineEvent();
                     clonedEvent.setData(timelineEvent.getData());
-                    clonedEvent.setStartDate((Date) timelineEvent.getStartDate().clone());
-                    clonedEvent.setEndDate(timelineEvent.getEndDate() != null ? (Date) timelineEvent.getEndDate().clone() : null);
+                    clonedEvent.setStartDate(timelineEvent.getStartDate());
+                    clonedEvent.setEndDate(timelineEvent.getEndDate());
                     clonedEvent.setEditable(timelineEvent.isEditable());
                     clonedEvent.setGroup(timelineEvent.getGroup());
                     clonedEvent.setStyleClass(timelineEvent.getStyleClass());
@@ -158,28 +156,22 @@ public class Timeline extends TimelineBase {
                 return;
             }
             else if ("rangechange".equals(eventName) || "rangechanged".equals(eventName)) {
-                TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
-                TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTimeZone());
-
                 TimelineRangeEvent te =
                         new TimelineRangeEvent(this, behaviorEvent.getBehavior(),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")));
+                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
 
                 return;
             }
             else if ("lazyload".equals(eventName)) {
-                TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
-                TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTimeZone());
-
                 TimelineLazyLoadEvent te =
                         new TimelineLazyLoadEvent(this, behaviorEvent.getBehavior(),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDateFirst")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDateFirst")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDateSecond")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDateSecond")));
+                                LocalDateTime.parse(params.get(clientId + "_startDateFirst"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_endDateFirst"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_startDateSecond"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_endDateSecond"), dateTimeFormatter));
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);
 
@@ -198,13 +190,10 @@ public class Timeline extends TimelineBase {
                 }
 
                 // preset start / end date, group, dragId and data object
-                TimeZone targetTZ = ComponentUtils.resolveTimeZone(getTimeZone());
-                TimeZone browserTZ = ComponentUtils.resolveTimeZone(getBrowserTimeZone());
-
                 TimelineDragDropEvent te =
                         new TimelineDragDropEvent(this, behaviorEvent.getBehavior(),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_startDate")),
-                                DateUtils.toUtcDate(browserTZ, targetTZ, params.get(clientId + "_endDate")),
+                                LocalDateTime.parse(params.get(clientId + "_startDate"), dateTimeFormatter),
+                                LocalDateTime.parse(params.get(clientId + "_endDate"), dateTimeFormatter),
                                 getGroup(params.get(clientId + "_group")), dragId, data);
                 te.setPhaseId(behaviorEvent.getPhaseId());
                 super.queueEvent(te);

--- a/src/main/java/org/primefaces/component/timeline/TimelineBase.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineBase.java
@@ -30,6 +30,8 @@ import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.Widget;
 import org.primefaces.util.ComponentUtils;
 
+import java.time.LocalDateTime;
+
 
 public abstract class TimelineBase extends UIComponentBase implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
@@ -259,35 +261,35 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, Cl
         getStateHelper().put(PropertyKeys.moveable, moveable);
     }
 
-    public java.util.Date getStart() {
-        return (java.util.Date) getStateHelper().eval(PropertyKeys.start, null);
+    public LocalDateTime getStart() {
+        return (LocalDateTime) getStateHelper().eval(PropertyKeys.start, null);
     }
 
-    public void setStart(java.util.Date start) {
+    public void setStart(LocalDateTime start) {
         getStateHelper().put(PropertyKeys.start, start);
     }
 
-    public java.util.Date getEnd() {
-        return (java.util.Date) getStateHelper().eval(PropertyKeys.end, null);
+    public LocalDateTime getEnd() {
+        return (LocalDateTime) getStateHelper().eval(PropertyKeys.end, null);
     }
 
-    public void setEnd(java.util.Date end) {
+    public void setEnd(LocalDateTime end) {
         getStateHelper().put(PropertyKeys.end, end);
     }
 
-    public java.util.Date getMin() {
-        return (java.util.Date) getStateHelper().eval(PropertyKeys.min, null);
+    public LocalDateTime getMin() {
+        return (LocalDateTime) getStateHelper().eval(PropertyKeys.min, null);
     }
 
-    public void setMin(java.util.Date min) {
+    public void setMin(LocalDateTime min) {
         getStateHelper().put(PropertyKeys.min, min);
     }
 
-    public java.util.Date getMax() {
-        return (java.util.Date) getStateHelper().eval(PropertyKeys.max, null);
+    public LocalDateTime getMax() {
+        return (LocalDateTime) getStateHelper().eval(PropertyKeys.max, null);
     }
 
-    public void setMax(java.util.Date max) {
+    public void setMax(LocalDateTime max) {
         getStateHelper().put(PropertyKeys.max, max);
     }
 

--- a/src/main/java/org/primefaces/component/timeline/TimelineBase.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineBase.java
@@ -49,7 +49,6 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, Cl
         varGroup,
         locale,
         timeZone,
-        browserTimeZone,
         height,
         minHeight,
         width,
@@ -163,14 +162,6 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, Cl
 
     public void setTimeZone(Object timeZone) {
         getStateHelper().put(PropertyKeys.timeZone, timeZone);
-    }
-
-    public Object getBrowserTimeZone() {
-        return getStateHelper().eval(PropertyKeys.browserTimeZone, null);
-    }
-
-    public void setBrowserTimeZone(Object browserTimeZone) {
-        getStateHelper().put(PropertyKeys.browserTimeZone, browserTimeZone);
     }
 
     public String getHeight() {

--- a/src/main/java/org/primefaces/event/timeline/TimelineAddEvent.java
+++ b/src/main/java/org/primefaces/event/timeline/TimelineAddEvent.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.event.timeline;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
@@ -34,22 +34,22 @@ public class TimelineAddEvent extends AbstractAjaxBehaviorEvent {
 
     private static final long serialVersionUID = 1L;
 
-    private Date startDate;
-    private Date endDate;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
     private String group;
 
-    public TimelineAddEvent(UIComponent component, Behavior behavior, Date startDate, Date endDate, String group) {
+    public TimelineAddEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate, String group) {
         super(component, behavior);
         this.startDate = startDate;
         this.endDate = endDate;
         this.group = group;
     }
 
-    public Date getStartDate() {
+    public LocalDateTime getStartDate() {
         return startDate;
     }
 
-    public Date getEndDate() {
+    public LocalDateTime getEndDate() {
         return endDate;
     }
 

--- a/src/main/java/org/primefaces/event/timeline/TimelineDragDropEvent.java
+++ b/src/main/java/org/primefaces/event/timeline/TimelineDragDropEvent.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.event.timeline;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
@@ -42,8 +42,8 @@ public class TimelineDragDropEvent<T> extends TimelineAddEvent {
      */
     private T data;
 
-    public TimelineDragDropEvent(UIComponent component, Behavior behavior, Date startDate, Date endDate, String group,
-            String dragId, T data) {
+    public TimelineDragDropEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate, String group,
+                                 String dragId, T data) {
         super(component, behavior, startDate, endDate, group);
         this.dragId = dragId;
         this.data = data;

--- a/src/main/java/org/primefaces/event/timeline/TimelineEventComparator.java
+++ b/src/main/java/org/primefaces/event/timeline/TimelineEventComparator.java
@@ -44,11 +44,11 @@ public class TimelineEventComparator implements Comparator<TimelineEvent>, Seria
                 return 1;
             }
             else {
-                return (a.getEndDate().before(b.getEndDate()) ? -1 : 1);
+                return (a.getEndDate().isBefore(b.getEndDate()) ? -1 : 1);
             }
         }
         else {
-            return (a.getStartDate().before(b.getStartDate()) ? -1 : 1);
+            return (a.getStartDate().isBefore(b.getStartDate()) ? -1 : 1);
         }
     }
 }

--- a/src/main/java/org/primefaces/event/timeline/TimelineLazyLoadEvent.java
+++ b/src/main/java/org/primefaces/event/timeline/TimelineLazyLoadEvent.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.event.timeline;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
@@ -37,25 +37,25 @@ public class TimelineLazyLoadEvent extends AbstractAjaxBehaviorEvent {
     /**
      * start time of the first time range for lazy loading
      */
-    private Date startDateFirst;
+    private LocalDateTime startDateFirst;
 
     /**
      * end time of the first time range for lazy loading
      */
-    private Date endDateFirst;
+    private LocalDateTime endDateFirst;
 
     /**
      * start time of the second time range for lazy loading (if any)
      */
-    private Date startDateSecond;
+    private LocalDateTime startDateSecond;
 
     /**
      * end time of the second time range for lazy loading (if any)
      */
-    private Date endDateSecond;
+    private LocalDateTime endDateSecond;
 
-    public TimelineLazyLoadEvent(UIComponent component, Behavior behavior, Date startDateFirst, Date endDateFirst,
-            Date startDateSecond, Date endDateSecond) {
+    public TimelineLazyLoadEvent(UIComponent component, Behavior behavior, LocalDateTime startDateFirst, LocalDateTime endDateFirst,
+                                 LocalDateTime startDateSecond, LocalDateTime endDateSecond) {
         super(component, behavior);
         this.startDateFirst = startDateFirst;
         this.endDateFirst = endDateFirst;
@@ -63,27 +63,27 @@ public class TimelineLazyLoadEvent extends AbstractAjaxBehaviorEvent {
         this.endDateSecond = endDateSecond;
     }
 
-    public Date getStartDate() { // alias for getStartDateFirst()
+    public LocalDateTime getStartDate() { // alias for getStartDateFirst()
         return startDateFirst;
     }
 
-    public Date getEndDate() { // alias for getEndDateFirst()
+    public LocalDateTime getEndDate() { // alias for getEndDateFirst()
         return endDateFirst;
     }
 
-    public Date getStartDateFirst() {
+    public LocalDateTime getStartDateFirst() {
         return startDateFirst;
     }
 
-    public Date getEndDateFirst() {
+    public LocalDateTime getEndDateFirst() {
         return endDateFirst;
     }
 
-    public Date getStartDateSecond() {
+    public LocalDateTime getStartDateSecond() {
         return startDateSecond;
     }
 
-    public Date getEndDateSecond() {
+    public LocalDateTime getEndDateSecond() {
         return endDateSecond;
     }
 

--- a/src/main/java/org/primefaces/event/timeline/TimelineRangeEvent.java
+++ b/src/main/java/org/primefaces/event/timeline/TimelineRangeEvent.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.event.timeline;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
@@ -37,24 +37,24 @@ public class TimelineRangeEvent extends AbstractAjaxBehaviorEvent {
     /**
      * new start time of the visible range
      */
-    private Date startDate;
+    private LocalDateTime startDate;
 
     /**
      * new end time of the visible range
      */
-    private Date endDate;
+    private LocalDateTime endDate;
 
-    public TimelineRangeEvent(UIComponent component, Behavior behavior, Date startDate, Date endDate) {
+    public TimelineRangeEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate) {
         super(component, behavior);
         this.startDate = startDate;
         this.endDate = endDate;
     }
 
-    public Date getStartDate() {
+    public LocalDateTime getStartDate() {
         return startDate;
     }
 
-    public Date getEndDate() {
+    public LocalDateTime getEndDate() {
         return endDate;
     }
 }

--- a/src/main/java/org/primefaces/model/timeline/TimelineEvent.java
+++ b/src/main/java/org/primefaces/model/timeline/TimelineEvent.java
@@ -24,26 +24,28 @@
 package org.primefaces.model.timeline;
 
 import java.io.Serializable;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
 
-public class TimelineEvent implements Serializable {
+public class TimelineEvent<T> implements Serializable {
 
     private static final long serialVersionUID = 20130316L;
 
     /**
      * any custom data object (required to show content of the event)
      */
-    private Object data;
+    private T data;
 
     /**
      * event's start date (required)
      */
-    private Date startDate;
+    private LocalDateTime startDate;
 
     /**
      * event's end date (optional)
      */
-    private Date endDate;
+    private LocalDateTime endDate;
 
     /**
      * is this event editable? (optional. if null, see the timeline's attribute "editable"
@@ -63,91 +65,107 @@ public class TimelineEvent implements Serializable {
     public TimelineEvent() {
     }
 
-    public TimelineEvent(Object data, Date startDate) {
+    public TimelineEvent(T data, LocalDateTime startDate) {
         checkStartDate(startDate);
         this.data = data;
         this.startDate = startDate;
     }
 
-    public TimelineEvent(Object data, Date startDate, Boolean editable) {
+    public TimelineEvent(T data, LocalDate startDate) {
+        checkStartDate(startDate);
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        this.data = data;
+        this.startDate = startDateTime;
+    }
+
+    public TimelineEvent(T data, LocalDateTime startDate, Boolean editable) {
         checkStartDate(startDate);
         this.data = data;
         this.startDate = startDate;
         this.editable = editable;
     }
 
-    public TimelineEvent(Object data, Date startDate, Boolean editable, String group) {
+    public TimelineEvent(T data, LocalDateTime startDate, Boolean editable, String group) {
         checkStartDate(startDate);
         this.data = data;
         this.startDate = startDate;
-        this.editable = editable;
-        this.group = group;
-    }
-
-    public TimelineEvent(Object data, Date startDate, Boolean editable, String group, String styleClass) {
-        checkStartDate(startDate);
-        this.data = data;
-        this.startDate = startDate;
-        this.editable = editable;
-        this.group = group;
-        this.styleClass = styleClass;
-    }
-
-    public TimelineEvent(Object data, Date startDate, Date endDate) {
-        checkStartDate(startDate);
-        this.data = data;
-        this.startDate = startDate;
-        this.endDate = endDate;
-    }
-
-    public TimelineEvent(Object data, Date startDate, Date endDate, Boolean editable) {
-        checkStartDate(startDate);
-        this.data = data;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.editable = editable;
-    }
-
-    public TimelineEvent(Object data, Date startDate, Date endDate, Boolean editable, String group) {
-        checkStartDate(startDate);
-        this.data = data;
-        this.startDate = startDate;
-        this.endDate = endDate;
         this.editable = editable;
         this.group = group;
     }
 
-    public TimelineEvent(Object data, Date startDate, Date endDate, Boolean editable, String group, String styleClass) {
+    public TimelineEvent(T data, LocalDateTime startDate, Boolean editable, String group, String styleClass) {
         checkStartDate(startDate);
         this.data = data;
         this.startDate = startDate;
-        this.endDate = endDate;
         this.editable = editable;
         this.group = group;
         this.styleClass = styleClass;
     }
 
-    public Object getData() {
+    public TimelineEvent(T data, LocalDateTime startDate, LocalDateTime endDate) {
+        checkStartDate(startDate);
+        this.data = data;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public TimelineEvent(T data, LocalDate startDate, LocalDate endDate) {
+        checkStartDate(startDate);
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atStartOfDay();
+        this.data = data;
+        this.startDate = startDateTime;
+        this.endDate = endDateTime;
+    }
+
+    public TimelineEvent(T data, LocalDateTime startDate, LocalDateTime endDate, Boolean editable) {
+        checkStartDate(startDate);
+        this.data = data;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.editable = editable;
+    }
+
+    public TimelineEvent(T data, LocalDateTime startDate, LocalDateTime endDate, Boolean editable, String group) {
+        checkStartDate(startDate);
+        this.data = data;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.editable = editable;
+        this.group = group;
+    }
+
+    public TimelineEvent(T data, LocalDateTime startDate, LocalDateTime endDate, Boolean editable, String group, String styleClass) {
+        checkStartDate(startDate);
+        this.data = data;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.editable = editable;
+        this.group = group;
+        this.styleClass = styleClass;
+    }
+
+    public T getData() {
         return data;
     }
 
-    public void setData(Object data) {
+    public void setData(T data) {
         this.data = data;
     }
 
-    public Date getStartDate() {
+    public LocalDateTime getStartDate() {
         return startDate;
     }
 
-    public void setStartDate(Date startDate) {
+    public void setStartDate(LocalDateTime startDate) {
         this.startDate = startDate;
     }
 
-    public Date getEndDate() {
+    public LocalDateTime getEndDate() {
         return endDate;
     }
 
-    public void setEndDate(Date endDate) {
+    public void setEndDate(LocalDateTime endDate) {
         this.endDate = endDate;
     }
 
@@ -187,7 +205,7 @@ public class TimelineEvent implements Serializable {
 
         TimelineEvent that = (TimelineEvent) o;
 
-        if (data != null ? !data.equals(that.data) : that.data != null) {
+        if (!Objects.equals(data, that.data)) {
             return false;
         }
 
@@ -211,7 +229,13 @@ public class TimelineEvent implements Serializable {
                 + '}';
     }
 
-    private void checkStartDate(Date startDate) {
+    private void checkStartDate(LocalDate startDate) {
+        if (startDate == null) {
+            throw new IllegalArgumentException("Event start date can not be null!");
+        }
+    }
+
+    private void checkStartDate(LocalDateTime startDate) {
         if (startDate == null) {
             throw new IllegalArgumentException("Event start date can not be null!");
         }

--- a/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
+++ b/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
@@ -25,7 +25,7 @@ package org.primefaces.model.timeline;
 
 import java.io.Serializable;
 
-public class TimelineGroup implements Serializable {
+public class TimelineGroup<T> implements Serializable {
 
     private static final long serialVersionUID = 20140413L;
 
@@ -37,12 +37,12 @@ public class TimelineGroup implements Serializable {
     /**
      * any custom data object (required to show content of the group)
      */
-    private Object data;
+    private T data;
 
     public TimelineGroup() {
     }
 
-    public TimelineGroup(String id, Object data) {
+    public TimelineGroup(String id, T data) {
         this.id = id;
         this.data = data;
     }
@@ -55,11 +55,11 @@ public class TimelineGroup implements Serializable {
         this.id = id;
     }
 
-    public Object getData() {
+    public T getData() {
         return data;
     }
 
-    public void setData(Object data) {
+    public void setData(T data) {
         this.data = data;
     }
 

--- a/src/main/java/org/primefaces/model/timeline/TimelineModel.java
+++ b/src/main/java/org/primefaces/model/timeline/TimelineModel.java
@@ -24,9 +24,9 @@
 package org.primefaces.model.timeline;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.TreeSet;
 import org.primefaces.component.timeline.TimelineUpdater;
@@ -370,12 +370,12 @@ public class TimelineModel implements Serializable {
         orderedEvents.addAll(events);
 
         // find the largest end date
-        Date endDate = null;
+        LocalDateTime endDate = null;
         for (TimelineEvent e : orderedEvents) {
             if (endDate == null && e.getEndDate() != null) {
                 endDate = e.getEndDate();
             }
-            else if (endDate != null && e.getEndDate() != null && endDate.before(e.getEndDate())) {
+            else if (endDate != null && e.getEndDate() != null && endDate.isBefore(e.getEndDate())) {
                 endDate = e.getEndDate();
             }
         }
@@ -479,11 +479,11 @@ public class TimelineModel implements Serializable {
         }
         else if (event1.getEndDate() == null && event2.getEndDate() != null) {
             return (event1.getStartDate().equals(event2.getStartDate()) || event1.getStartDate().equals(event2.getEndDate())
-                    || (event1.getStartDate().after(event2.getStartDate()) && event1.getStartDate().before(event2.getEndDate())));
+                    || (event1.getStartDate().isAfter(event2.getStartDate()) && event1.getStartDate().isBefore(event2.getEndDate())));
         }
         else if (event1.getEndDate() != null && event2.getEndDate() == null) {
             return (event2.getStartDate().equals(event1.getStartDate()) || event2.getStartDate().equals(event1.getEndDate())
-                    || (event2.getStartDate().after(event1.getStartDate()) && event2.getStartDate().before(event1.getEndDate())));
+                    || (event2.getStartDate().isAfter(event1.getStartDate()) && event2.getStartDate().isBefore(event1.getEndDate())));
         }
         else {
             // check with ODER if
@@ -491,10 +491,10 @@ public class TimelineModel implements Serializable {
             // 2. end date of the event 1 is within the event 2
             // 3. event 2 is completely strong within the event 1
             return (event1.getStartDate().equals(event2.getStartDate()) || event1.getStartDate().equals(event2.getEndDate())
-                    || (event1.getStartDate().after(event2.getStartDate()) && event1.getStartDate().before(event2.getEndDate())))
+                    || (event1.getStartDate().isAfter(event2.getStartDate()) && event1.getStartDate().isBefore(event2.getEndDate())))
                     || (event1.getEndDate().equals(event2.getStartDate()) || event1.getEndDate().equals(event2.getEndDate())
-                    || (event1.getEndDate().after(event2.getStartDate()) && event1.getEndDate().before(event2.getEndDate())))
-                    || (event1.getStartDate().before(event2.getStartDate()) && event1.getEndDate().after(event2.getEndDate()));
+                    || (event1.getEndDate().isAfter(event2.getStartDate()) && event1.getEndDate().isBefore(event2.getEndDate())))
+                    || (event1.getStartDate().isBefore(event2.getStartDate()) && event1.getEndDate().isAfter(event2.getEndDate()));
         }
     }
 }

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -36,7 +36,6 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 import java.io.IOException;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -47,7 +46,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 /**
- * Utility class for calendar component
+ * Utility class for calendar- and datepicker-component
  */
 public class CalendarUtils {
 
@@ -67,73 +66,13 @@ public class CalendarUtils {
     }
 
     /**
-     * Try to convert the given value to {@link Date} or return <code>null</code> if there is no appropriate converter for doing so.
+     * Try to convert the given value to {@link LocalDate} or return <code>null</code> if there is no appropriate converter for doing so.
      * @param context the faces context
      * @param calendar the calendar component
      * @param value the value to convert
-     * @return the {@link Date} object or <code>null</code>
-     * @deprecated Use eg {@link CalendarUtils#getObjectAsLocalDate(FacesContext, UICalendar, Object)} instead.
-     */
-    @Deprecated
-    public static Date getObjectAsDate(FacesContext context, UICalendar calendar, Object value) {
-        if (value == null) {
-            return null;
-        }
-
-        if (value instanceof Date) {
-            return (Date) value;
-        }
-
-        String pattern = calendar.calculatePattern();
-        if (pattern != null) {
-            Locale locale = calendar.calculateLocale(context);
-            if (locale != null) {
-                SimpleDateFormat dateFormat = new SimpleDateFormat(pattern, locale);
-                try {
-                    return dateFormat.parse(value.toString());
-                }
-                catch (ParseException ex) {
-                    // NO-OP
-                }
-            }
-        }
-
-        if (calendar.getConverter() != null) {
-            try {
-                Object obj = calendar.getConverter().getAsObject(context, calendar, value.toString());
-                if (obj instanceof Date) {
-                    return (Date) obj;
-                }
-            }
-            catch (ConverterException ex) {
-                // NO-OP
-            }
-        }
-
-        Converter converter = context.getApplication().createConverter(value.getClass());
-        if (converter != null) {
-            Object obj = converter.getAsObject(context, calendar, value.toString());
-            if (obj instanceof Date) {
-                return (Date) obj;
-            }
-        }
-
-        // TODO Currently we do not support conversion of jquery datepicker's special dates like 'today' or '+1m +7d'
-        // See http://api.jqueryui.com/datepicker/#option-maxDate, https://github.com/primefaces/primefaces/issues/4621
-
-        return null;
-    }
-
-    /**
-     * Try to convert the given value to {@link Date} or return <code>null</code> if there is no appropriate converter for doing so.
-     * @param context the faces context
-     * @param calendar the calendar component
-     * @param value the value to convert
-     * @return the {@link Date} object or <code>null</code>
+     * @return the {@link LocalDate} object or <code>null</code>
      */
     public static LocalDate getObjectAsLocalDate(FacesContext context, UICalendar calendar, Object value) {
-        //TODO: do we need getObjectAsLocalDateTime additional or instead?
-
         if (value == null) {
             return null;
         }

--- a/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -423,24 +423,6 @@ public class ComponentUtils {
         return ComponentTraversalUtils.closestForm(context, component);
     }
 
-    /**
-     * Gets a {@link TimeZone} instance by the parameter "timeZone" which can be String or {@link TimeZone} or null.
-     *
-     * @param timeZone given time zone
-     * @return resolved TimeZone
-     */
-    public static TimeZone resolveTimeZone(Object timeZone) {
-        if (timeZone instanceof String) {
-            return TimeZone.getTimeZone((String) timeZone);
-        }
-        else if (timeZone instanceof TimeZone) {
-            return (TimeZone) timeZone;
-        }
-        else {
-            return TimeZone.getDefault();
-        }
-    }
-
     public static <T extends Renderer> T getUnwrappedRenderer(FacesContext context, String family, String rendererType) {
         Renderer renderer = context.getRenderKit().getRenderer(family, rendererType);
 

--- a/src/main/java/org/primefaces/util/DateUtils.java
+++ b/src/main/java/org/primefaces/util/DateUtils.java
@@ -28,16 +28,11 @@ import java.util.TimeZone;
 
 public class DateUtils {
 
+    /*
+    Only used by Timeline-Component
+     */
+
     private DateUtils() {
-    }
-
-    // convert from local date to UTC
-    public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, String localDate) {
-        if (localDate == null) {
-            return null;
-        }
-
-        return toUtcDate(browserTZ, targetTZ, Long.valueOf(localDate));
     }
 
     // convert from local date to UTC

--- a/src/main/java/org/primefaces/util/DateUtils.java
+++ b/src/main/java/org/primefaces/util/DateUtils.java
@@ -23,42 +23,33 @@
  */
 package org.primefaces.util;
 
-import java.util.Date;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public class DateUtils {
 
     /*
     Only used by Timeline-Component
+    TODO: Maybe we should move this to CalendarUtils.
      */
 
     private DateUtils() {
     }
 
-    // convert from local date to UTC
-    public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, long localDate) {
-        return toUtcDate(browserTZ, targetTZ, new Date(localDate));
-    }
-
-    // convert from local date to UTC
-    public static Date toUtcDate(TimeZone browserTZ, TimeZone targetTZ, Date localDate) {
-        if (localDate == null) {
+    /**
+     * Convert ISO-String (@see <a href="https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString">https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString</a>)
+     * to LocalDateTime.
+     * @param isoDateString
+     * @return
+     */
+    public static LocalDateTime toLocalDateTime(ZoneId zoneId, String isoDateString) {
+        if (isoDateString == null) {
             return null;
         }
 
-        long local = localDate.getTime();
-        int targetOffsetFromUTC = targetTZ.getOffset(local);
-        int browserOffsetFromUTC = browserTZ.getOffset(local);
-
-        return new Date(local - targetOffsetFromUTC + browserOffsetFromUTC);
-    }
-
-    // convert from UTC to local date
-    public static long toLocalDate(TimeZone browserTZ, TimeZone targetTZ, Date utcDate) {
-        long utc = utcDate.getTime();
-        int targetOffsetFromUTC = targetTZ.getOffset(utc);
-        int browserOffsetFromUTC = browserTZ.getOffset(utc);
-
-        return utc + targetOffsetFromUTC - browserOffsetFromUTC;
+        Instant instant = Instant.parse(isoDateString);
+        LocalDateTime result = LocalDateTime.ofInstant(instant, zoneId);
+        return result;
     }
 }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -26228,15 +26228,6 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Time zone the user's browser / PC is running in. This time zone allows to correct the conversion of start / end dates to the target timeZone for displaying.
-                The attribute can be either a String or TimeZone object or null. Note: browserTimeZone should be provided if the target timeZone is provided. If null, browserTimeZone defaults to the server's timeZone.]]>
-            </description>
-            <name>browserTimeZone</name>
-            <required>false</required>
-            <type>java.lang.Object</type>
-        </attribute>
-        <attribute>
-            <description>
                 <![CDATA[The height of the timeline in pixels, as a percentage, or "auto". When the height is set to "auto", the height of the timeline is automatically adjusted to fit the contents.
                 If not, it is possible that events get stacked so high, that they are not visible in the timeline. When height is set to "auto", a minimum height can be specified with the option minHeight. Default is "auto".]]>
             </description>
@@ -26333,7 +26324,7 @@
             </description>
             <name>start</name>
             <required>false</required>
-            <type>java.util.Date</type>
+            <type>java.time.LocalDateTime</type>
         </attribute>
         <attribute>
             <description>
@@ -26341,7 +26332,7 @@
             </description>
             <name>end</name>
             <required>false</required>
-            <type>java.util.Date</type>
+            <type>java.time.LocalDateTime</type>
         </attribute>
         <attribute>
             <description>
@@ -26349,7 +26340,7 @@
             </description>
             <name>min</name>
             <required>false</required>
-            <type>java.util.Date</type>
+            <type>java.time.LocalDateTime</type>
         </attribute>
         <attribute>
             <description>
@@ -26357,7 +26348,7 @@
             </description>
             <name>max</name>
             <required>false</required>
-            <type>java.util.Date</type>
+            <type>java.time.LocalDateTime</type>
         </attribute>
         <attribute>
             <description>

--- a/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -445,13 +445,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
         };
 
         if (range.startFirst != null && range.endFirst != null) {
-            options.params[0] = {name: this.id + '_startDateFirst', value: range.startFirst.toISOString()};
-            options.params[1] = {name: this.id + '_endDateFirst', value: range.endFirst.toISOString()};
+            options.params[0] = {name: this.id + '_startDateFirst', value: new Date(range.startFirst).toISOString()};
+            options.params[1] = {name: this.id + '_endDateFirst', value: new Date(range.endFirst).toISOString()};
         }
 
         if (range.startSecond != null && range.endSecond != null) {
-            options.params[2] = {name: this.id + '_startDateSecond', value: range.startSecond.toISOString()};
-            options.params[3] = {name: this.id + '_endDateSecond', value: range.endSecond.toISOString()};
+            options.params[2] = {name: this.id + '_startDateSecond', value: new Date(range.startSecond).toISOString()};
+            options.params[3] = {name: this.id + '_endDateSecond', value: new Date(range.endSecond).toISOString()};
         }
 
         this.getBehavior("lazyload").call(this, options);

--- a/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -101,13 +101,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
                 var params = [];
                 params.push({
                     name: this.id + '_startDate',
-                    value: event.start.getTime()
+                    value: event.start.toISOString()
                 });
 
                 if (event.end) {
                     params.push({
                         name: this.id + '_endDate',
-                        value: event.end.getTime()
+                        value: event.end.toISOString()
                     });
                 }
 
@@ -148,13 +148,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                 params.push({
                     name: this.id + '_startDate',
-                    value: event.start.getTime()
+                    value: event.start.toISOString()
                 });
 
                 if (event.end) {
                     params.push({
                         name: this.id + '_endDate',
-                        value: event.end.getTime()
+                        value: event.end.toISOString()
                     });
                 }
 
@@ -195,13 +195,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                 params.push({
                     name: this.id + '_startDate',
-                    value: event.start.getTime()
+                    value: event.start.toISOString()
                 });
 
                 if (event.end) {
                     params.push({
                         name: this.id + '_endDate',
-                        value: event.end.getTime()
+                        value: event.end.toISOString()
                     });
                 }
 
@@ -269,8 +269,8 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                 var options = {
                     params: [
-                        {name: this.id + '_startDate', value: range.start.getTime()},
-                        {name: this.id + '_endDate', value: range.end.getTime()}
+                        {name: this.id + '_startDate', value: range.start.toISOString()},
+                        {name: this.id + '_endDate', value: range.end.toISOString()}
                     ]
                 };
 
@@ -285,8 +285,8 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                 var options = {
                     params: [
-                        {name: this.id + '_startDate', value: range.start.getTime()},
-                        {name: this.id + '_endDate', value: range.end.getTime()}
+                        {name: this.id + '_startDate', value: range.start.toISOString()},
+                        {name: this.id + '_endDate', value: range.end.toISOString()}
                     ]
                 };
 
@@ -341,12 +341,12 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
                 var params = [];
                 params.push({
                     name: this.id + '_startDate',
-                    value: xstart.getTime()
+                    value: xstart.toISOString()
                 });
 
                 params.push({
                     name: this.id + '_endDate',
-                    value: xend.getTime()
+                    value: xend.toISOString()
                 });
 
                 var group = inst.getGroupFromHeight(y); // (group may be undefined)
@@ -445,13 +445,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
         };
 
         if (range.startFirst != null && range.endFirst != null) {
-            options.params[0] = {name: this.id + '_startDateFirst', value: range.startFirst};
-            options.params[1] = {name: this.id + '_endDateFirst', value: range.endFirst};
+            options.params[0] = {name: this.id + '_startDateFirst', value: range.startFirst.toISOString()};
+            options.params[1] = {name: this.id + '_endDateFirst', value: range.endFirst.toISOString()};
         }
 
         if (range.startSecond != null && range.endSecond != null) {
-            options.params[2] = {name: this.id + '_startDateSecond', value: range.startSecond};
-            options.params[3] = {name: this.id + '_endDateSecond', value: range.endSecond};
+            options.params[2] = {name: this.id + '_startDateSecond', value: range.startSecond.toISOString()};
+            options.params[3] = {name: this.id + '_endDateSecond', value: range.endSecond.toISOString()};
         }
 
         this.getBehavior("lazyload").call(this, options);


### PR DESCRIPTION
Some kind of "preview". I´ll have to rebase/update/redo this PR after https://github.com/primefaces/primefaces/pull/5113 is merged.

Showcase-PR: https://github.com/primefaces/showcase-facelift/pull/59

Noteable:
- Changed Client-JS to send toISOString() instead of getTime() to Server
- so browserTimeZone-attribute should not be necessary any more
- maybe we should merge DateUtils with CalendarUtils (DateUtils is only used by Timeline; there is left only one method)