### PR TITLE
Fix #5086: Doc AJAX Behavior events.

### DIFF
--- a/docs/7_0/components/inputnumber.md
+++ b/docs/7_0/components/inputnumber.md
@@ -121,3 +121,13 @@ Here are some examples demonstrating various cases;
 <p:inputNumber id="Input8" value="1234.000000001" decimalPlaces="15" />
 ```
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_0/components/inputtext.md
+++ b/docs/7_0/components/inputtext.md
@@ -82,3 +82,14 @@ Widget: _PrimeFaces.widget.InputText_
 | --- | --- | --- | --- | 
 enable() | - | void | Enables the input field.
 disable() | - | void | Disables the input field.
+
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_0/components/inputtextarea.md
+++ b/docs/7_0/components/inputtextarea.md
@@ -134,3 +134,13 @@ list of structural style classes;
 
 As skinning style classes are global, see the main theming section for more information.
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, itemSelect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_0/components/selectonemenu.md
+++ b/docs/7_0/components/selectonemenu.md
@@ -120,6 +120,18 @@ function customFilter(itemLabel, filterValue) {
 In addition to the standard events like "change", custom "itemSelect" event is also available to
 invoke when an item is selected from dropdown.
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+In addition to the standard events like "change", custom "itemSelect" event is also available to invoke when an item is selected from dropdown.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, itemSelect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```
+
 ## Client Side API
 Widget: _PrimeFaces.widget.SelectOneMenu_
 

--- a/docs/7_1/components/inputnumber.md
+++ b/docs/7_1/components/inputnumber.md
@@ -121,3 +121,13 @@ Here are some examples demonstrating various cases;
 <p:inputNumber id="Input8" value="1234.000000001" decimalPlaces="15" />
 ```
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_1/components/inputtext.md
+++ b/docs/7_1/components/inputtext.md
@@ -82,3 +82,14 @@ Widget: _PrimeFaces.widget.InputText_
 | --- | --- | --- | --- | 
 enable() | - | void | Enables the input field.
 disable() | - | void | Disables the input field.
+
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_1/components/inputtextarea.md
+++ b/docs/7_1/components/inputtextarea.md
@@ -134,3 +134,13 @@ list of structural style classes;
 
 As skinning style classes are global, see the main theming section for more information.
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, itemSelect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/7_1/components/selectonemenu.md
+++ b/docs/7_1/components/selectonemenu.md
@@ -117,8 +117,16 @@ function customFilter(itemLabel, filterValue) {
 ```
 
 ## Ajax Behavior Events
-In addition to the standard events like "change", custom "itemSelect" event is also available to
-invoke when an item is selected from dropdown.
+
+The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+In addition to the standard events like "change", custom "itemSelect" event is also available to invoke when an item is selected from dropdown.  
+  
+**Default Event:** valueChange  
+**Available Events:** blur, change, click, dblclick, focus, itemSelect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```
 
 ## Client Side API
 Widget: _PrimeFaces.widget.SelectOneMenu_

--- a/src/test/java/org/primefaces/documentation/GenerateAjaxBehaviorDoc.java
+++ b/src/test/java/org/primefaces/documentation/GenerateAjaxBehaviorDoc.java
@@ -1,0 +1,75 @@
+/* 
+ * The MIT License
+ *
+ * Copyright (c) 2009-2019 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.documentation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.faces.component.UIComponentBase;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Utility class to scan a component and generated the Markdown information 
+ * for the AJAX behavior events the component supports.
+ * <p>
+ * Execute by passing component class to the command line argument.
+ * Example: org.primefaces.component.inputtext.InputText
+ */
+public class GenerateAjaxBehaviorDoc {
+
+    
+    public static void main(String[] args) {
+        try {
+            for (String className : args) {
+                Class<?> clazz = Class.forName(className);
+                generateMarkdown((UIComponentBase)clazz.newInstance());
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void generateMarkdown(UIComponentBase comp) {
+        String defaultEvent = comp.getDefaultEventName();
+        List<String> events = new ArrayList<>(comp.getEventNames());
+        Collections.sort(events);
+        String eventString = ArrayUtils.toString(events);
+        eventString = StringUtils.remove(eventString, "[");
+        eventString = StringUtils.remove(eventString, "]");
+        System.out.println("## Ajax Behavior Events");
+        System.out.println();
+        System.out.println("The following AJAX behavior events are available for this component. If no event is specific the default event is called.  ");
+        System.out.println("  ");
+        System.out.println("**Default Event:** " + defaultEvent + "  ");
+        System.out.println("**Available Events:** " + eventString + "  ");
+        System.out.println();
+        System.out.println("```xhtml");
+        System.out.println(String.format("<p:ajax event=\"%s\" listener=\"#{bean.handle%s}\" update=\"msgs\" />", defaultEvent,defaultEvent));
+        System.out.println("```");
+    }
+}


### PR DESCRIPTION
In the Test package wrote a little generator where you can just pass it a class name like "org.primefaces.component.inputtext.InputText" and it will generate the Markdown in the console to cut and paste.

I documented 4 really popular components that did not have Ajax Behavior docs InputText, InputTextArea, InputNumber, and SelectOneMenu.  

Any feedback on the format is welcome.