### PR TITLE
Fix #3787: AjaxStatus add delay attribute.

### DIFF
--- a/docs/7_1/components/ajaxstatus.md
+++ b/docs/7_1/components/ajaxstatus.md
@@ -24,6 +24,7 @@ AjaxStatus is a global notifier for ajax requests.
 | oncomplete | null | String | Client side callback to execute after ajax requests complete. |
 | onsuccess | null | String | Client side callback to execute after ajax requests completed succesfully. |
 | onerror | null | String | Client side callback to execute when an ajax request fails. |
+| delay | 0 | int | Delay in milliseconds before displaying the ajax status. Default is 0 meaning immediate. |
 | style | null | String | Inline style of the component. |
 | styleClass | null | String | Style class of the component. |
 | widgetVar | null | String | Name of the client side widget. |

--- a/src/main/java/org/primefaces/component/ajaxstatus/AjaxStatusBase.java
+++ b/src/main/java/org/primefaces/component/ajaxstatus/AjaxStatusBase.java
@@ -36,6 +36,7 @@ public abstract class AjaxStatusBase extends UIComponentBase implements Widget {
     public enum PropertyKeys {
 
         widgetVar,
+        delay,
         onstart,
         oncomplete,
         onsuccess,
@@ -59,6 +60,14 @@ public abstract class AjaxStatusBase extends UIComponentBase implements Widget {
 
     public void setWidgetVar(String widgetVar) {
         getStateHelper().put(PropertyKeys.widgetVar, widgetVar);
+    }
+
+    public int getDelay() {
+        return (Integer) getStateHelper().eval(PropertyKeys.delay, 0);
+    }
+
+    public void setDelay(int delay) {
+        getStateHelper().put(PropertyKeys.delay, delay);
     }
 
     public String getOnstart() {

--- a/src/main/java/org/primefaces/component/ajaxstatus/AjaxStatusRenderer.java
+++ b/src/main/java/org/primefaces/component/ajaxstatus/AjaxStatusRenderer.java
@@ -46,6 +46,7 @@ public class AjaxStatusRenderer extends CoreRenderer {
         String clientId = status.getClientId(context);
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("AjaxStatus", status.resolveWidgetVar(context), clientId);
+        wb.attr("delay", status.getDelay());
 
         wb.callback(AjaxStatus.START, AjaxStatus.CALLBACK_SIGNATURE, status.getOnstart())
                 .callback(AjaxStatus.ERROR, AjaxStatus.CALLBACK_SIGNATURE, status.getOnerror())

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -831,6 +831,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Delay in milliseconds before displaying the ajax status. Default is 0 meaning immediate.]]>
+            </description>
+            <name>delay</name>
+            <required>false</required>
+            <type>int</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Client side callback to execute after ajax requests start.]]>
             </description>
             <name>onstart</name>

--- a/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
+++ b/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
@@ -14,7 +14,10 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
         $this = this;
 
         doc.on('pfAjaxStart', function() {
-            $this.trigger('start', arguments);
+            var delay = $this.cfg.delay;
+            $this.timeout = setTimeout(function () {
+                $this.trigger('start', arguments);
+            }, delay);
         })
         .on('pfAjaxError', function() {
             $this.trigger('error', arguments);
@@ -23,6 +26,9 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
             $this.trigger('success', arguments);
         })
         .on('pfAjaxComplete', function() {
+            if($this.timeout) {
+                $this.deleteTimeout();
+            }
             $this.trigger('complete', arguments);
         });
 
@@ -64,6 +70,11 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
                 doc.trigger('pfAjaxError', arguments);
             });
         }
+    },
+
+    deleteTimeout: function() {
+        clearTimeout(this.timeout);
+        this.timeout = null;
     }
 
 });

--- a/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
+++ b/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
@@ -15,9 +15,13 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
 
         doc.on('pfAjaxStart', function() {
             var delay = $this.cfg.delay;
-            $this.timeout = setTimeout(function () {
+            if (delay > 0 ) {
+                $this.timeout = setTimeout(function () {
+                    $this.trigger('start', arguments);
+                }, delay);
+            } else {
                 $this.trigger('start', arguments);
-            }, delay);
+            }
         })
         .on('pfAjaxError', function() {
             $this.trigger('error', arguments);


### PR DESCRIPTION
Modeled after how AutoComplete handles the delay.
Tested in IE, Chrome, Firefox, and Edge.
Default is 0 ms which is identical to current behavior.