### PR TITLE
Fix #1964: Spinner prevent negative when min>=0

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -105,6 +105,11 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
                     //do nothing
                 break;
             }
+
+            /* Github #1964 do not allow minus */
+            if ($this.cfg.min >= 0 && event.key === "-") {
+                e.preventDefault();
+            }
         })
         .on('keyup.spinner', function (e) {
             $this.updateValue();


### PR DESCRIPTION
Tested in IE11, Firefox, Edge and Chrome.

`event.key === "-"` was the only thing that worked in all browsers for detecting the numpad or regular minus sign.  keycodes are not reliable because 189 is not negative in all languages in all browsers.