### PR TITLE
Fix #3078: TabView add swipe events

### DIFF
--- a/src/main/java/org/primefaces/component/tabview/TabView.java
+++ b/src/main/java/org/primefaces/component/tabview/TabView.java
@@ -46,7 +46,8 @@ import org.primefaces.util.MapBuilder;
         @ResourceDependency(library = "primefaces", name = "jquery/jquery.js"),
         @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js"),
         @ResourceDependency(library = "primefaces", name = "core.js"),
-        @ResourceDependency(library = "primefaces", name = "components.js")
+        @ResourceDependency(library = "primefaces", name = "components.js"),
+        @ResourceDependency(library = "primefaces", name = "touch/touchswipe.js")
 })
 public class TabView extends TabViewBase {
 

--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -69,6 +69,23 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
     bindEvents: function() {
         var $this = this;
 
+        // Touch Swipe Events
+        this.jq.swipe({
+            swipeLeft:function(event) {
+                var activeIndex = $this.getActiveIndex();
+                if (activeIndex < $this.getLength() - 1) {
+                    $this.select(activeIndex + 1);
+                }
+            },
+            swipeRight: function(event) {
+                var activeIndex = $this.getActiveIndex();
+                if (activeIndex > 0) {
+                    $this.select(activeIndex - 1);
+                }
+            },
+            excludedElements: "button, input, select, textarea, a, .noSwipe"
+        });
+
         //Tab header events
         this.headerContainer
                 .on('mouseover.tabview', function(e) {


### PR DESCRIPTION
Follow Carousel as the pattern for adding swipe events.

Test in Chrome mobile.