### PR TITLE
Fixes #5149 - Timeline: TimelineUpdater is null when javax.faces.PARTIAL_STATE_SAVING is false

### DIFF
--- a/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
+++ b/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
@@ -106,29 +106,22 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 
     @Override
     public void beforePhase(PhaseEvent event) {
-        if (event.getPhaseId().equals(PhaseId.RENDER_RESPONSE)) {
-            processCrudOperations(event.getFacesContext());
-        }
-        else if (event.getPhaseId().equals(PhaseId.APPLY_REQUEST_VALUES)) {
+        if (event.getPhaseId().equals(PhaseId.APPLY_REQUEST_VALUES)) {
             populateTimelineUpdater(event.getFacesContext());
+        }
+        else if (event.getPhaseId().equals(PhaseId.RENDER_RESPONSE)) {
+            processCrudOperations(event.getFacesContext());
         }
     }
 
     private void populateTimelineUpdater(FacesContext context) {
-        //This method assumes TimelineListener.processEvent(cse) was called before.
-        Map<String, TimelineUpdater> map
-                = (Map<String, TimelineUpdater>) context.getAttributes().get(TimelineUpdater.class.getName());
+        Map<String, TimelineUpdater> map = (Map<String, TimelineUpdater>) context.getAttributes().get(TimelineUpdater.class.getName());
         if (map == null) {
             map = new HashMap<>();
             context.getAttributes().put(TimelineUpdater.class.getName(), map);
         }
-        for (PhaseListener listener : context.getViewRoot().getPhaseListeners()) {
-            if (listener instanceof DefaultTimelineUpdater
-                    && ((DefaultTimelineUpdater) listener).getWidgetVar().equals(widgetVar)) {
-                if (!map.containsKey(widgetVar)) {
-                    map.put(widgetVar, (DefaultTimelineUpdater) listener);
-                }
-            }
+        if (!map.containsKey(widgetVar)) {
+            map.put(widgetVar, this);
         }
     }
 

--- a/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
+++ b/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
@@ -106,10 +106,10 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
 
     @Override
     public void beforePhase(PhaseEvent event) {
-        if (event.getPhaseId().equals(PhaseId.APPLY_REQUEST_VALUES)) {
+        if (PhaseId.APPLY_REQUEST_VALUES.equals(event.getPhaseId())) {
             populateTimelineUpdater(event.getFacesContext());
         }
-        else if (event.getPhaseId().equals(PhaseId.RENDER_RESPONSE)) {
+        else if (PhaseId.RENDER_RESPONSE.equals(event.getPhaseId())) {
             processCrudOperations(event.getFacesContext());
         }
     }

--- a/src/main/java/org/primefaces/component/timeline/TimelineListener.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineListener.java
@@ -23,8 +23,6 @@
  */
 package org.primefaces.component.timeline;
 
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.faces.context.FacesContext;
 import javax.faces.event.AbortProcessingException;
@@ -41,22 +39,10 @@ public class TimelineListener implements SystemEventListener {
         Timeline timeline = (Timeline) cse.getSource();
         String widgetVar = timeline.resolveWidgetVar(context);
 
-        Map<String, TimelineUpdater> map
-                = (Map<String, TimelineUpdater>) context.getAttributes().get(TimelineUpdater.class.getName());
-        if (map == null) {
-            map = new HashMap<>();
-            context.getAttributes().put(TimelineUpdater.class.getName(), map);
-        }
-
         boolean alreadyRegistred = false;
         for (PhaseListener listener : context.getViewRoot().getPhaseListeners()) {
             if (listener instanceof DefaultTimelineUpdater
                     && ((DefaultTimelineUpdater) listener).getWidgetVar().equals(widgetVar)) {
-
-                if (!map.containsKey(widgetVar)) {
-                    map.put(widgetVar, (DefaultTimelineUpdater) listener);
-                }
-
                 alreadyRegistred = true;
             }
         }
@@ -64,8 +50,6 @@ public class TimelineListener implements SystemEventListener {
         if (!alreadyRegistred) {
             DefaultTimelineUpdater timelineUpdater = new DefaultTimelineUpdater();
             timelineUpdater.setWidgetVar(widgetVar);
-            map.put(widgetVar, timelineUpdater);
-
             context.getViewRoot().addPhaseListener(timelineUpdater);
         }
     }


### PR DESCRIPTION
Fixes #5149 by moving the logic of setting the map of TimelineUpdaters in FacesContext attribute from `TimelineListener` to `DefaultTimelineUpdater` which is a phase listener, specifically before the APPLY_REQUEST_VALUES phase which it gets always executed no matter what value javax.faces.PARTIAL_STATE_SAVING property has.