### PR TITLE
Fix #5163: TextEditor add secure attribute.

### DIFF
--- a/docs/7_1/components/texteditor.md
+++ b/docs/7_1/components/texteditor.md
@@ -36,6 +36,7 @@ style | null | String | Inline style of the editor container.
 styleClass | null | String | Style class of the editor container.
 placeholder | null | String | Placeholder text to show when editor is empty
 toolbarVisible | true | Boolean | Whether the toolbar of the editor is visible.
+secure | true | Boolean | Secure the component with the OWASP HTML Sanitizer library on the classpath.
 allowFormatting | true | Boolean | Whether to allow formatting to be included.
 allowBlocks | true | Boolean | Whether to allow blocks to be included.
 allowStyles | true | Boolean | Whether to allow styles to be included.

--- a/src/main/java/org/primefaces/component/texteditor/TextEditorBase.java
+++ b/src/main/java/org/primefaces/component/texteditor/TextEditorBase.java
@@ -49,7 +49,8 @@ public abstract class TextEditorBase extends UIInput implements Widget, ClientBe
         allowLinks,
         allowStyles,
         allowImages,
-        formats
+        formats,
+        secure
     }
 
     public TextEditorBase() {
@@ -163,5 +164,13 @@ public abstract class TextEditorBase extends UIInput implements Widget, ClientBe
 
     public void setFormats(List formats) {
         getStateHelper().put(PropertyKeys.formats, formats);
+    }
+
+    public boolean isSecure() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.secure, true);
+    }
+
+    public void setSecure(boolean secure) {
+        getStateHelper().put(PropertyKeys.secure, secure);
     }
 }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -25800,6 +25800,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Secure the component with the HTML Sanitizer library on the classpath. Default is true.]]>
+            </description>
+            <name>secure</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Whether to allow formatting to be included.]]>
             </description>
             <name>allowFormatting</name>


### PR DESCRIPTION
Makes the component secure by default with the ability to opt-opt of security.