### PR TITLE
Fix #5105: InputMask validation enabled by default

### DIFF
--- a/src/main/java/org/primefaces/component/inputmask/InputMaskBase.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskBase.java
@@ -102,7 +102,7 @@ public abstract class InputMaskBase extends HtmlInputText implements Widget {
     }
 
     public boolean isValidateMask() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.validateMask, false);
+        return (Boolean) getStateHelper().eval(PropertyKeys.validateMask, true);
     }
 
     public void setValidateMask(boolean validateMask) {


### PR DESCRIPTION
Enables security by default and allows the user to opt-out rather than opt-in.