### PR TITLE
Fix #3268: ImageCropper potential path traversal mitigated.

### DIFF
--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -44,6 +44,8 @@ import org.apache.commons.io.input.BoundedInputStream;
 
 import org.primefaces.model.CroppedImage;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.Constants;
+import org.primefaces.util.FileUploadUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class ImageCropperRenderer extends CoreRenderer {
@@ -186,7 +188,10 @@ public class ImageCropperRenderer extends CoreRenderer {
                 }
                 else {
                     ExternalContext externalContext = context.getExternalContext();
-                    File file = new File(externalContext.getRealPath("") + imagePath);
+                    // GitHub #3268 OWASP Path Traversal
+                    imagePath = FileUploadUtils.checkPathTraversal(imagePath);
+                    String webRoot = externalContext.getRealPath(Constants.EMPTY_STRING);
+                    File file = new File(webRoot + imagePath);
                     inputStream = new FileInputStream(file);
                 }
             }

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -336,4 +336,36 @@ public class FileUploadUtils {
             throw new IllegalArgumentException("Unsupported UploadedFile type: " + file.getClass().getName());
         }
     }
+
+    /**
+     * OWASP prevent directory path traversal of "../../image.png".
+     *
+     * @see https://www.owasp.org/index.php/Path_Traversal
+     * @param relativePath the relative path to check for path traversal
+     * @return the relative path
+     * @throws FacesException if any error is detected
+     */
+    public static String checkPathTraversal(String relativePath) {
+        File file = new File(relativePath);
+
+        if (file.isAbsolute()) {
+            throw new FacesException("Path traversal attempt - absolute path not allowed.");
+        }
+
+        try  {
+            String pathUsingCanonical = file.getCanonicalPath();
+            String pathUsingAbsolute = file.getAbsolutePath();
+
+            // Require the absolute path and canonicalized path match.
+            // This is done to avoid directory traversal
+            // attacks, e.g. "1/../2/"
+            if (!pathUsingCanonical.equals(pathUsingAbsolute))  {
+                throw new FacesException("Path traversal attempt for path " + relativePath);
+            }
+        }
+        catch (IOException ex) {
+            throw new FacesException("Path traversal - unexpected exception.", ex);
+        }
+        return relativePath;
+    }
 }

--- a/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -36,6 +36,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -119,6 +121,50 @@ public class FileUploadUtilsTest {
         when(fileUpload.getAccept()).thenReturn("image/gif");
         Assert.assertFalse(FileUploadUtils.isValidType(fileUpload, createFile("test.gif", "image/gif", exe)));
         Assert.assertTrue(FileUploadUtils.isValidType(fileUpload, createFile("test.png", "image/png", gif)));
+    }
+    
+    @Test
+    public void checkPathTraversal_AbsoluteFile() {
+        // Arrange
+        String relativePath = FileUploadUtilsTest.class.getResource("/test.png").getFile();
+        
+        // Act
+        try {
+            FileUploadUtils.checkPathTraversal(relativePath);
+            fail("File was absolute path and should have failed");
+        }
+        catch (Exception e) {
+            // Assert
+            assertEquals("Path traversal attempt - absolute path not allowed.", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void checkPathTraversal_PathTraversal() {
+        // Arrange
+        String relativePath = "../../test.png";
+        
+        // Act
+        try {
+            FileUploadUtils.checkPathTraversal(relativePath);
+            fail("File was absolute path and should have failed");
+        }
+        catch (Exception e) {
+            // Assert
+            assertEquals("Path traversal attempt for path ../../test.png", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void checkPathTraversal_Valid() {
+        // Arrange
+        String relativePath = "test.png";
+        
+        // Act
+        String result = FileUploadUtils.checkPathTraversal(relativePath);
+
+        // Assert
+        assertEquals(relativePath, result);
     }
     
 }


### PR DESCRIPTION
Added unit tests.
Fixed following OWASP guidelines.