### PR TITLE
Fix #4787: CSP replaced illegal use of new Function()

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -833,18 +833,11 @@ if (!PrimeFaces.ajax) {
             doEval : function(node, xhr) {
                 var textContent = node.textContent || node.innerText || node.text;
 
+                var nonce;
                 if (xhr && xhr.pfSettings && xhr.pfSettings.nonce) {
-                    // $.globalEval doesn't support nonce currently
-                    // and the internal used DOMEval can't be used from outside?
-                    var script = document.createElement('script');
-                    script.nonce = xhr.pfSettings.nonce;
-                    script.setAttribute('nonce', xhr.pfSettings.nonce);
-                    script.innerHTML = textContent;
-                    document.head.appendChild(script);
+                    nonce = xhr.pfSettings.nonce;
                 }
-                else {
-                    $.globalEval(textContent);
-                }
+                PrimeFaces.csp.eval(textContent, nonce);
             },
 
             doExtension : function(node, xhr) {

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -650,9 +650,11 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
                 var el = $(this);
 
                 if(el.hasClass('ui-confirmdialog-yes') && PrimeFaces.confirmSource) {
-                    var fn = new Function('event',PrimeFaces.confirmSource.data('pfconfirmcommand'));
+                    var id = PrimeFaces.confirmSource.get(0);
+                    var js = PrimeFaces.confirmSource.data('pfconfirmcommand');
 
-                    fn.call(PrimeFaces.confirmSource.get(0),e);
+                    PrimeFaces.csp.executeEvent(id, js, e);
+
                     PrimeFaces.confirmDialog.hide();
                     PrimeFaces.confirmSource = null;
                 }


### PR DESCRIPTION
Tested with CSP enabled and disabled.  ConfirmDialog is working exactly as it was before and CSP violation is now fixed.