### PR TITLE
Fix #5189: CSP self directive.

### DIFF
--- a/src/main/java/org/primefaces/csp/CspPhaseListener.java
+++ b/src/main/java/org/primefaces/csp/CspPhaseListener.java
@@ -63,7 +63,7 @@ public class CspPhaseListener implements PhaseListener {
             CspState state = PrimeFacesContext.getCspState(context);
 
             HttpServletResponse response = (HttpServletResponse) externalContext.getResponse();
-            response.addHeader("Content-Security-Policy", "script-src 'nonce-" + state.getNonce() + "'");
+            response.addHeader("Content-Security-Policy", "script-src 'self' 'nonce-" + state.getNonce() + "'");
 
             PrimeFaces.current().executeScript("PrimeFaces.csp.init('" + Encode.forJavaScript(state.getNonce()) + "');");
         }


### PR DESCRIPTION
It turns out it does work with the latest Edge we were just missing the "self" directive to apply the nonce the page's own domain.

See: https://blogs.windows.com/msedgedev/2017/01/10/edge-csp-2/

I tested in IE11, Edge, Chrome, and Firefox and CSP is working correctly.