### PR TITLE
Fix #5183: CSP .trigger('change') call native DOM event.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -3,6 +3,7 @@ if (!PrimeFaces.csp) {
     PrimeFaces.csp = {
 
         NONCE_INPUT : "primefaces.nonce",
+        TRIGGERS_HANDLED: false,
 
         init : function(nonce) {
 
@@ -18,6 +19,65 @@ if (!PrimeFaces.csp) {
                 }
                 input.setAttribute("value", nonce);
             }
+
+            // bind native DOM event handlers
+            if (!PrimeFaces.csp.TRIGGERS_HANDLED) {
+                PrimeFaces.csp.bindTriggerHandler();
+                PrimeFaces.csp.TRIGGERS_HANDLED = true;
+            }
+        },
+
+        /**
+         * First look for native Jquery events and call .trigger(). If no Jquery handler is found
+         * call the native DOM event handler.
+         * 
+         * @see https://stackoverflow.com/questions/21290775/jquery-el-triggerchange-doesnt-fire-native-listeners
+         */
+        bindTriggerHandler: function() {
+            // detect if an jquery object event has events attached
+            $.fn.hasHandlers = function(events,selector) {
+                var result = false;
+
+                this.each(function (i) {
+                    var elem = this;
+                    dEvents = $._data($(this).get(0), "events");
+                    if (!dEvents) {
+                        return false;
+                    }
+                    $.each(dEvents, function (name, handler) {
+                        if (events === name) {
+                            result = true;
+                        }
+                    });
+                });
+                return result;
+             };
+
+             // store off original jquery trigger handler
+             $.fn.triggerJquery = $.fn.trigger;
+
+             // trigger native DOM events 
+             $.fn.triggerNative = function(eventName) {
+                 return this.each(function() {
+                     var $this = $(this);
+                     var el = $this.get(0);
+                     var evt = document.createEvent('Events');
+                     evt.initEvent(eventName, true, false);
+                     el.dispatchEvent(evt);
+                 });
+             };
+
+             // override native Jquery trigger and call DOM event if no Jquery events found
+             $.fn.trigger = function(eventName) {
+                 return this.each(function() {
+                     var $this = $(this);
+                     if ($this.hasHandlers(eventName)) {
+                         $this.triggerJquery(eventName);
+                     } else {
+                         $this.triggerNative(eventName);
+                     }
+                 });
+             };
         },
 
         register: function(id, event, js){


### PR DESCRIPTION
There might be a better way to do this but here is what is happening.

First when `jq.trigger('change');` is being called that only looks for Jquery events to trigger or any registered "onChange=''" handlers on a DOM element. It does **NOT** call native DOM registered events.

So what this fix does is..

1. override the native .trigger() call in Jquery so we don't have to touch any code.

2. It detects whether there is a JQuery event registered for "focus" or "change" etc and will call the Jquery .trigger().

3. If no Jquery event is detected it then tries to call a Native DOM event using .triggerNative().

I am sure there might be a better way to do this but I have tested that this works so far to fix the CSP issue.