### PR TITLE
Fix #433: Allow ENTER/ESC to submit/cancel row editor.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2340,16 +2340,16 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
             // GitHub #433 Allow ENTER to submit ESC to cancel row editor
             $(document).on("keydown", "tr.ui-row-editing", function(e) {
-                var key = e.which,
                 keyCode = $.ui.keyCode;
-
-                if (key === keyCode.ENTER) { 
+                switch (e.which) {
+                case keyCode.ENTER:
                     $(this).closest("tr").find(".ui-row-editor-check").click();
                     return false; // prevents executing other event handlers (adding new row to the table)
-                }
-                if (key === keyCode.ESCAPE) {
+                case keyCode.ESCAPE:
                     $(this).closest("tr").find(".ui-row-editor-close").click();
                     return false;
+                default:
+                    break;
                 }
             });
         }

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2337,6 +2337,21 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                         .on('blur.datatable', rowEditorSelector, null, function(e) {
                             $(this).removeClass('ui-row-editor-outline');
                         });
+
+            // GitHub #433 Allow ENTER to submit ESC to cancel row editor
+            $(document).on("keydown", ".ui-cell-editor-input :input", function(e) {
+                var key = e.which,
+                keyCode = $.ui.keyCode;
+
+                if (key === keyCode.ENTER) { 
+                    $(this).closest("tr").find(".ui-row-editor-check").click();
+                    return false; // prevents executing other event handlers (adding new row to the table)
+                }
+                if (key === keyCode.ESCAPE) {
+                    $(this).closest("tr").find(".ui-row-editor-close").click();
+                    return false;
+                }
+            });
         }
         else if(this.cfg.editMode === 'cell') {
             var cellSelector = '> tr > td.ui-editable-column',

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2339,7 +2339,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                         });
 
             // GitHub #433 Allow ENTER to submit ESC to cancel row editor
-            $(document).on("keydown", ".ui-cell-editor-input :input", function(e) {
+            $(document).on("keydown", "tr.ui-row-editing", function(e) {
                 var key = e.which,
                 keyCode = $.ui.keyCode;
 

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2339,17 +2339,18 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                         });
 
             // GitHub #433 Allow ENTER to submit ESC to cancel row editor
-            $(document).on("keydown", "tr.ui-row-editing", function(e) {
-                keyCode = $.ui.keyCode;
-                switch (e.which) {
-                case keyCode.ENTER:
-                    $(this).closest("tr").find(".ui-row-editor-check").click();
-                    return false; // prevents executing other event handlers (adding new row to the table)
-                case keyCode.ESCAPE:
-                    $(this).closest("tr").find(".ui-row-editor-close").click();
-                    return false;
-                default:
-                    break;
+            $(document).off("keydown", "tr.ui-row-editing")
+                        .on("keydown", "tr.ui-row-editing", function(e) {
+                            var keyCode = $.ui.keyCode;
+                            switch (e.which) {
+                                case keyCode.ENTER:
+                                    $(this).closest("tr").find(".ui-row-editor-check").click();
+                                    return false; // prevents executing other event handlers (adding new row to the table)
+                                case keyCode.ESCAPE:
+                                    $(this).closest("tr").find(".ui-row-editor-close").click();
+                                    return false;
+                                default:
+                                    break;
                 }
             });
         }


### PR DESCRIPTION
1. Use `:input` instead of `input` so if you are are a select dropdown you can still press ENTER or ESC.  Previously it would only work if you were in an input box.

2. Modified the ROW finder to use the more specific styles `.ui-row-editor-check` and `.ui-row-editor-close` instead of `.ui-row-editor .ui-icon-close`

3. used Jquery constants for ENTER and ESC.