### PR TITLE
Fix #3078: Swipe refactoring and exclude role=combobox.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
+++ b/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
@@ -159,7 +159,7 @@ PrimeFaces.widget.Carousel = PrimeFaces.widget.DeferredWidget.extend({
                     $this.setPage($this.page - 1);
                 }
             },
-            excludedElements: "button, input, select, textarea, a, .noSwipe"
+            excludedElements: PrimeFaces.utils.excludedSwipeElements()
         });
 
         if(this.pageLinks.length) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -344,6 +344,14 @@ if (!PrimeFaces.utils) {
                 return true;
             }
             return false;
+        },
+
+        /**
+         * Exclude elements such as buttons, links, inputs from being touch swiped. 
+         * Users can always add class="noSwipe" to any element to exclude it as well.
+         */
+        excludedSwipeElements: function() {
+            return ":button:enabled, :input:enabled, a, [role='combobox'], .noSwipe";
         }
 
     };

--- a/src/main/resources/META-INF/resources/primefaces/galleria/galleria.js
+++ b/src/main/resources/META-INF/resources/primefaces/galleria/galleria.js
@@ -117,7 +117,7 @@ PrimeFaces.widget.Galleria = PrimeFaces.widget.DeferredWidget.extend({
                 $this.stopSlideshow();
                 $this.next();
             },
-            excludedElements: "button, input, select, textarea, a, .noSwipe"
+            excludedElements: PrimeFaces.utils.excludedSwipeElements()
         });
 
         // Keyboard accessibility

--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -83,7 +83,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                     $this.select(activeIndex - 1);
                 }
             },
-            excludedElements: "button, input, select, textarea, a, .noSwipe"
+            excludedElements: PrimeFaces.utils.excludedSwipeElements()
         });
 
         //Tab header events


### PR DESCRIPTION
@fanste Please test this fix. I just tested in IE11 Phone mode and proved it was an issue and its fixed.

- It also allowed me to refactor this to common swiped exlcuded since that was cut and pasted.
- I chose role='combobox' so that will fix SelectOneMenu, SelectCheckBox menu and any others that are rendered with a DIV.
