### PR TITLE
Fix #5038: DatePicker time picker only respect left click.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1658,6 +1658,10 @@
         },
 
         repeat: function (event, interval, type, direction) {
+            // GitHub #5038 only allow left click
+            if (event.which !== 1) {
+                return;
+            }
             var i = interval || 500,
                 $this = this;
 


### PR DESCRIPTION
Tested in IE11, Edge, Chrome, Firefox.

@mertsincan this is a fix in core datepicker code which probably needs to go to PrimeReact, Vue, etc.