### PR TITLE
Fix #3153: Dock prevent document scroll by default.

### DIFF
--- a/docs/7_1/components/dock.md
+++ b/docs/7_1/components/dock.md
@@ -25,7 +25,8 @@ Dock component mimics the well known dock interface of Mac OS X.
 | itemWidth | 40 | Integer | Initial width of items.
 | maxWidth | 50 | Integer | Maximum width of items.
 | proximity | 90 | Integer | Distance to enlarge.
-| halign | center | String | Horizontal alignment,
+| halign | center | String | Horizontal alignment.
+| blockScroll | true | Boolean | Whether to block scrolling of the document.
 | widgetVar | null | String | Name of the client side widget.
 
 

--- a/src/main/java/org/primefaces/component/dock/DockBase.java
+++ b/src/main/java/org/primefaces/component/dock/DockBase.java
@@ -40,7 +40,8 @@ public abstract class DockBase extends AbstractMenu implements Widget {
         itemWidth,
         maxWidth,
         proximity,
-        halign
+        halign,
+        blockScroll
     }
 
     public DockBase() {
@@ -107,5 +108,13 @@ public abstract class DockBase extends AbstractMenu implements Widget {
 
     public void setHalign(String halign) {
         getStateHelper().put(PropertyKeys.halign, halign);
+    }
+
+    public boolean isBlockScroll() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.blockScroll, true);
+    }
+
+    public void setBlockScroll(boolean blockScroll) {
+        getStateHelper().put(PropertyKeys.blockScroll, blockScroll);
     }
 }

--- a/src/main/java/org/primefaces/component/dock/DockRenderer.java
+++ b/src/main/java/org/primefaces/component/dock/DockRenderer.java
@@ -49,7 +49,8 @@ public class DockRenderer extends BaseMenuRenderer {
                 .attr("maxWidth", dock.getMaxWidth())
                 .attr("itemWidth", dock.getItemWidth())
                 .attr("proximity", dock.getProximity())
-                .attr("halign", dock.getHalign());
+                .attr("halign", dock.getHalign())
+                .attr("blockScroll", dock.isBlockScroll());
 
         wb.finish();
     }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -8471,6 +8471,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Whether to block scrolling of the document. Default is true.]]>
+            </description>
+            <name>blockScroll</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/resources/primefaces/dock/dock.js
+++ b/src/main/resources/META-INF/resources/primefaces/dock/dock.js
@@ -449,7 +449,11 @@ PrimeFaces.widget.Dock = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.items = 'a';
         this.cfg.itemsText = 'span';
         this.cfg.container = '.ui-dock-container-' + this.cfg.position;
-        
+
+        if (widget.cfg.blockScroll) {
+            PrimeFaces.utils.preventScrolling();
+        }
+
         $(this.jqId).Fisheye(this.cfg);
     }
     


### PR DESCRIPTION
Similar to other components except I made the default true for this one because the body should really not be scrolling when using the dock.