### PR TITLE
 Fix #4953, #5024; DatePicker Overlay-issue

### DIFF
--- a/docs/8_0/components/datepicker.md
+++ b/docs/8_0/components/datepicker.md
@@ -64,7 +64,7 @@ ajax selection and more.
 | view | date | String | Defines the view mode, valid values are "date" for datepicker and "month" for month picker.
 | touchUI | false | Boolean | Activates touch friendly mode
 | dateTemplate | null | Function | Javascript function that takes a date object and returns the content for the date cell.
-| appendTo | null | String | Appends the dialog to the element defined by the given search expression.
+| appendTo | @(body) | String | Appends the dialog to the element defined by the given search expression.
 | triggerButtonIcon | null | String | Icon of the datepicker element that toggles the visibility in popup mode.
 | disabledDates | null | List<java.time.LocalDate>, List<java.util.Date> (deprecated) | List of dates that should be disabled.
 | disabledDays | null | List<int> | List of week day indexes that should be disabled.

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -336,7 +336,7 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
     }
 
     public String getAppendTo() {
-        return (String) getStateHelper().eval(PropertyKeys.appendTo, null);
+        return (String) getStateHelper().eval(PropertyKeys.appendTo, "@(body)");
     }
 
     public void setAppendTo(String appendTo) {


### PR DESCRIPTION
Think it would help to default appendTo to "@(body)". So DatePicker should work OOTB within containers like DateTable, Tab, Dialog, ...