### PR TITLE
FileUpload - close input streams to prevent file handlers leak

### DIFF
--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -139,9 +139,9 @@ public class FileUploadUtils {
      */
     public static boolean isValidType(PrimeApplicationContext context, FileUpload fileUpload, UploadedFile uploadedFile) {
         String fileName = uploadedFile.getFileName();
-        try {
+        try (InputStream input = uploadedFile.getInputStream()) {
             boolean validType = isValidFileName(fileUpload, uploadedFile)
-                        && isValidFileContent(context, fileUpload, fileName, uploadedFile.getInputStream());
+                        && isValidFileContent(context, fileUpload, fileName, input);
             if (validType) {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine(String.format("The uploaded file %s meets the filename and content type specifications", fileName));
@@ -298,8 +298,8 @@ public class FileUploadUtils {
         boolean valid = (sizeLimit == null || uploadedFile.getSize() <= sizeLimit)
                 && FileUploadUtils.isValidType(appContext, fileUpload, uploadedFile);
         if (valid) {
-            try {
-                FileUploadUtils.performVirusScan(context, fileUpload, uploadedFile.getInputStream());
+            try (InputStream input = uploadedFile.getInputStream()) {
+                FileUploadUtils.performVirusScan(context, fileUpload, input);
             }
             catch (VirusException ex) {
                 return false;


### PR DESCRIPTION
It happens that UploadedFile.getInputStream() points to a real temporary file (eg. under Undertow). Therefore if this InputStream is not being closed file handler leaks, which may eventually lead to "too many open files" error.