### PR TITLE
Fix #5414 and #5415: DatePicker: usability-improvements

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1491,7 +1491,11 @@
 
         onInputKeyDown: function (event) {
             this.isKeydown = true;
-            if (event.keyCode === 9) {
+            if (event.keyCode === 27) {
+                //put the focus back to the inputfield
+                this.inputfield.focus();
+            }
+            if (event.keyCode === 9 || event.keyCode === 27) {
                 if (this.options.touchUI) {
                     this.disableModality();
                 }
@@ -1840,6 +1844,9 @@
             }
 
             if (!this.options.inline && this.isSingleSelection() && (!this.options.showTime || this.options.hideOnDateTimeSelect)) {
+                //put the focus back to the inputfield
+                this.inputfield.focus();
+
                 setTimeout(function () {
                     $this.hideOverlay();
                 }, 100);


### PR DESCRIPTION
1) close popup with esc-key
2) put focus back to the input field after date-selection