### PR TITLE
Fix #5425: Autonumeric disable console warnings

### DIFF
--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -234,7 +234,8 @@ public class InputNumberRenderer extends InputRenderer {
             .attr("leadingZero", inputNumber.getLeadingZero(), "deny")
             .attr("allowDecimalPadding", inputNumber.isPadControl(), true)
             .attr("roundingMethod", inputNumber.getRoundMethod(), "S")
-            .attr("selectOnFocus", false, true);
+            .attr("selectOnFocus", false, true)
+            .attr("showWarnings", false, true);
 
         wb.finish();
     }


### PR DESCRIPTION

showWarnings | Defines if warnings should be shown. This is safe to disable in production. | true
-- | -- | --


