### PR TITLE
Fix #3078: TabView better mobile detection.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -69,23 +69,6 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
     bindEvents: function() {
         var $this = this;
 
-        // Touch Swipe Events
-        this.jq.swipe({
-            swipeLeft:function(event) {
-                var activeIndex = $this.getActiveIndex();
-                if (activeIndex < $this.getLength() - 1) {
-                    $this.select(activeIndex + 1);
-                }
-            },
-            swipeRight: function(event) {
-                var activeIndex = $this.getActiveIndex();
-                if (activeIndex > 0) {
-                    $this.select(activeIndex - 1);
-                }
-            },
-            excludedElements: PrimeFaces.utils.excludedSwipeElements()
-        });
-
         //Tab header events
         this.headerContainer
                 .on('mouseover.tabview', function(e) {
@@ -175,7 +158,33 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                             });
         }
 
+        this.bindSwipeEvents();
         this.bindKeyEvents();
+    },
+
+    /**
+     * Binds swipe events to this tabview.
+     */
+    bindSwipeEvents: function() {
+        if (!PrimeFaces.env.touch) {
+            return;
+        }
+        var $this = this;
+        this.jq.swipe({
+            swipeLeft:function(event) {
+                var activeIndex = $this.getActiveIndex();
+                if (activeIndex < $this.getLength() - 1) {
+                    $this.select(activeIndex + 1);
+                }
+            },
+            swipeRight: function(event) {
+                var activeIndex = $this.getActiveIndex();
+                if (activeIndex > 0) {
+                    $this.select(activeIndex - 1);
+                }
+            },
+            excludedElements: PrimeFaces.utils.excludedSwipeElements()
+        });
     },
 
     bindKeyEvents: function() {


### PR DESCRIPTION
Based on this forum post: https://forum.primefaces.org/viewtopic.php?f=3&t=60644

User in desktop browser held down both mouse buttons and it emulated a "swipe".  Added a check for PrimeFaces.env.touch before enabling.