### PR TITLE
Schedule: Fix ScheduleRenderer bug - only LocalDateTime properties ar…

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -124,7 +124,9 @@ public class ScheduleRenderer extends CoreRenderer {
                     for (Map.Entry<String, Object> dynaProperty : event.getDynamicProperties().entrySet()) {
                         String key = dynaProperty.getKey();
                         Object value = dynaProperty.getValue();
-                        value = ((LocalDateTime) value).format(dateTimeFormatter);
+                        if (value instanceof LocalDateTime) {
+                            value = ((LocalDateTime) value).format(dateTimeFormatter);
+                        }
                         jsonObject.put(key, value);
                     }
                 }


### PR DESCRIPTION
After removing support for Date type in Schedule component, into ScheduleRenderer.encodeEventsAsJSON(), the dynamicProperties from ScheduleEvent are all handled as LocalDateTime.

I have readed the type check on putting those dynamic properties into the JSON object.