### PR TITLE
Fix #5455: Only fire rangeChanged event if triggered by user.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -271,7 +271,10 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
                     properties: properties
                 };
 
-                this.getBehavior("rangechanged").call(this, options);
+                // #5455 only fire if initiated by user
+                if (properties.byUser) {
+                    this.getBehavior("rangechanged").call(this, options); 
+                }
             }, this));
         }
 


### PR DESCRIPTION
Timeline providers a "byUser" property to the RangeChanged event so we can now only fire it if the user actually changed the range and not when the page loads which is correct and prevents the CSP issue.