### PR TITLE
Fix #5455: CSP initialized before PF scripts.

### DIFF
--- a/src/main/java/org/primefaces/PrimeFaces.java
+++ b/src/main/java/org/primefaces/PrimeFaces.java
@@ -106,6 +106,16 @@ public class PrimeFaces {
     }
 
     /**
+     * Executes a JavaScript statement before all other PrimeFaces scripts are executed.
+     * Useful when you need to do some initialization.
+     *
+     * @param statement the JavaScript statement.
+     */
+    public void initializeScript(String statement) {
+        getRequestContext().getInitializationScriptsToExecute().add(statement);
+    }
+
+    /**
      * Scrolls to a component with the given clientId.
      *
      * @param clientId clientId of the target component.

--- a/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
+++ b/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
@@ -208,9 +208,15 @@ public class PrimePartialResponseWriter extends PartialResponseWriterWrapper {
     }
 
     protected void encodeScripts(PrimeRequestContext requestContext) throws IOException {
-        List<String> scripts = requestContext.getScriptsToExecute();
-        if (!scripts.isEmpty()) {
+        List<String> initScripts = requestContext.getInitializationScriptsToExecute();
+        List<String> execScripts = requestContext.getScriptsToExecute();
+
+        if (!initScripts.isEmpty() || !execScripts.isEmpty()) {
             startEval();
+
+            List<String> scripts = new ArrayList<>();
+            scripts.addAll(initScripts);
+            scripts.addAll(execScripts);
 
             for (int i = 0; i < scripts.size(); i++) {
                 getWrapped().write(scripts.get(i));

--- a/src/main/java/org/primefaces/context/PrimeRequestContext.java
+++ b/src/main/java/org/primefaces/context/PrimeRequestContext.java
@@ -52,6 +52,7 @@ public class PrimeRequestContext {
     public static final String INSTANCE_KEY = PrimeRequestContext.class.getName();
 
     private static final String CALLBACK_PARAMS_KEY = "CALLBACK_PARAMS";
+    private static final String INIT_SCRIPT_KEY = "INITIALIZE_SCRIPT";
     private static final String EXECUTE_SCRIPT_KEY = "EXECUTE_SCRIPT";
     private static final Class<?>[] EMPTY_PARAMS = new Class<?>[0];
 
@@ -111,6 +112,22 @@ public class PrimeRequestContext {
         }
 
         return callbackParams;
+    }
+
+    /**
+     * @return all scripts added in the current request and called first before other scripts are executed.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> getInitializationScriptsToExecute() {
+        List<String> initToExecute =
+            (List<String>) context.getAttributes().get(INIT_SCRIPT_KEY);
+
+        if (initToExecute == null) {
+            initToExecute = new ArrayList<>();
+            context.getAttributes().put(INIT_SCRIPT_KEY, initToExecute);
+        }
+
+        return initToExecute;
     }
 
     /**

--- a/src/main/java/org/primefaces/csp/CspPhaseListener.java
+++ b/src/main/java/org/primefaces/csp/CspPhaseListener.java
@@ -72,7 +72,7 @@ public class CspPhaseListener implements PhaseListener {
             String policy = LangUtils.isValueBlank(customPolicy.get()) ? "script-src 'self'" : customPolicy.get();
             response.addHeader("Content-Security-Policy", policy + " 'nonce-" + state.getNonce() + "'");
 
-            PrimeFaces.current().executeScript("PrimeFaces.csp.init('" + Encode.forJavaScript(state.getNonce()) + "');");
+            PrimeFaces.current().initializeScript("PrimeFaces.csp.init('" + Encode.forJavaScript(state.getNonce()) + "');");
         }
     }
 

--- a/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -38,6 +38,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.render.Renderer;
 import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.LocaleUtils;
 
@@ -50,6 +51,7 @@ import org.primefaces.util.LocaleUtils;
  * - Registered Resources
  * - Client Validation Scripts
  * - PF Client Side Settings
+ * - PF Initialization Scripts
  * - Head Content
  * - Last Facet
  */
@@ -141,6 +143,9 @@ public class HeadRenderer extends Renderer {
 
         writer.write("}");
         writer.endElement("script");
+
+        // encode initialization scripts
+        encodeInitScripts(writer);
     }
 
     @Override
@@ -192,6 +197,22 @@ public class HeadRenderer extends Renderer {
                 writer.writeAttribute("src", resource.getRequestPath(), null);
                 writer.endElement("script");
             }
+        }
+    }
+
+    protected void encodeInitScripts(ResponseWriter writer) throws IOException {
+        List<String> scripts = PrimeRequestContext.getCurrentInstance().getInitializationScriptsToExecute();
+
+        if (!scripts.isEmpty()) {
+            writer.startElement("script", null);
+            writer.writeAttribute("type", "text/javascript", null);
+
+            for (int i = 0; i < scripts.size(); i++) {
+                writer.write(scripts.get(i));
+                writer.write(';');
+            }
+
+            writer.endElement("script");
         }
     }
 }

--- a/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -207,9 +207,19 @@ public class HeadRenderer extends Renderer {
             writer.startElement("script", null);
             writer.writeAttribute("type", "text/javascript", null);
 
+            boolean moveScriptsToBottom = PrimeRequestContext.getCurrentInstance().getApplicationContext().getConfig().isMoveScriptsToBottom();
+
+            if (!moveScriptsToBottom) {
+                writer.write("$(function(){");
+            }
+
             for (int i = 0; i < scripts.size(); i++) {
                 writer.write(scripts.get(i));
                 writer.write(';');
+            }
+
+            if (!moveScriptsToBottom) {
+                writer.write("});");
             }
 
             writer.endElement("script");


### PR DESCRIPTION
@tandraschko @Rapster  Our QA team keeps intermittenly getting the "Missing CSP Nonce" issue when they click a button or an Ajax script runs before the CSP Init script has run.    I am able to reproduce it every time using the Timeline All Events example.

This PR is for your review where I basically move that CSP Init script to the top so it executes before any other PF widget script.   This fixes the issue and I have noticed we are no longer getting those Missing CSP Nonce errors.

This PR is for your review or if you think of a better way to do it I am listening....but I think this is something we absolutely need to fix to allow adoption of CSP.
