### PR TITLE
Fix #5504, Formatting of decimal values for AutoNumeric in InputNumber

### DIFF
--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -12128,7 +12128,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Number of decimal places. Default are taken from minValue and MaxValue.]]>
+                <![CDATA[Number of decimal places. Default is 2.]]>
             </description>
             <name>decimalPlaces</name>
             <required>false</required>

--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -127,11 +127,6 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
     },
 
     getValue: function () {
-        var val = this.autonumeric.getNumericString();
-        if (val && this.cfg.decimalPlaces) {
-            return parseFloat(val).toFixed(this.cfg.decimalPlaces);
-        }
-
-        return val;
+        return this.autonumeric.getNumericString();
     }
 });

--- a/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
+++ b/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
@@ -141,6 +141,20 @@ public class InputNumberTest {
     }
 
     @Test
+    public void testDecodeNegativeBelowDefaultRange() {
+        setupValues("-90000000000000", false, null, null, false);
+        renderer.decode(context, inputNumber);
+        Assertions.assertEquals("-10000000000000", inputNumber.getSubmittedValue());
+    }
+
+    @Test
+    public void testDecodePositiveAboveDefaultRange() {
+        setupValues("90000000000000", false, null, null, false);
+        renderer.decode(context, inputNumber);
+        Assertions.assertEquals("10000000000000", inputNumber.getSubmittedValue());
+    }
+
+    @Test
     public void testDecodeInvalidNumber() {
         setupValues("crash", false, null, null, false);
         


### PR DESCRIPTION
These changes should resolve the problems with the number formatting in InputNumber:

- Always use BigDecimal for internal value representation, so no digits are lost on conversion to double
- Format `minValue`/`maxValue` as plain decimal number without exponential notation
- Coerce the value inside the effective min/max range, even if the range is not explicitly given and the default minValue/maxValue of AutoNumeric are used
- render the formatted value also for the input / hidden input, so AutoNumeric never encounters a value in improper numeric format (with exponentials)
- No `parseFloat(val).toFixed(this.cfg.decimalPlaces)` in JavaScript, because autoNumeric already takes care of the decimal places and this would reduce the precision for large-precision decimal numbers
- Use `BigDecimal#toPlainString()` for decimal formatting instead of NumberFormat with fixed integer/decimal places