### PR TITLE
Fix #5508: Firefox floating label fix

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -1007,3 +1007,8 @@ div.ui-button, .ui-splitbutton {
     top: -.75em;
     font-size: 12px;
 }
+
+/** Firefox: https://github.com/primefaces/primefaces/issues/5508 **/
+.ui-float-label > input.ui-state-focus ~ label {
+    top: -.75em;
+}

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -998,10 +998,8 @@ div.ui-button, .ui-splitbutton {
 
 .ui-float-label > input:focus ~ label,
 .ui-float-label > input.ui-state-filled ~ label,
-.ui-float-label > input:-webkit-autofill ~ label,
 .ui-float-label > textarea:focus ~ label,
 .ui-float-label > textarea.ui-state-filled ~ label,
-.ui-float-label > textarea:-webkit-autofill ~ label,
 .ui-float-label > .ui-inputwrapper-focus ~ label,
 .ui-float-label > .ui-inputwrapper-filled ~ label {
     top: -.75em;
@@ -1009,6 +1007,8 @@ div.ui-button, .ui-splitbutton {
 }
 
 /** Firefox: https://github.com/primefaces/primefaces/issues/5508 **/
-.ui-float-label > input.ui-state-focus ~ label {
+.ui-float-label > input:-webkit-autofill ~ label,
+.ui-float-label > textarea:-webkit-autofill ~ label {
     top: -.75em;
+    font-size: 12px;
 }


### PR DESCRIPTION
I don't know why but this has to be one its own line for Firefox to pick it up.  If I move this up to the block above it Firefox ignores it.