### PR TITLE
Fix #5550: Tree context menu display with no ajax event

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
+++ b/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
@@ -227,6 +227,8 @@ PrimeFaces.widget.BaseTree = PrimeFaces.widget.BaseWidget.extend({
             };
 
             this.callBehavior('contextMenu', ext);
+        } else {
+            fnShowMenu();
         }
     },
 


### PR DESCRIPTION
The issue was it was only displaying the context menu if an AJAX event was bound to the component.  We needed to add a default case.