### PR TITLE
#5554: ResolverStyle can be set for calendar and datepicker

### DIFF
--- a/docs/8_0/components/calendar.md
+++ b/docs/8_0/components/calendar.md
@@ -112,6 +112,7 @@ ajax selection and more.
 | defaultMinute | 0 | Integer | Default for minute selection, if no date is given. Default is 0.
 | defaultSecond | 0 | Integer | Default for second selection, if no date is given. Default is 0.
 | defaultMillisec | 0 | Integer | Default for millisecond selection, if no date is given. Default is 0.
+| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
 
 ## Getting Started with Calendar
 Value of the calendar should be a java.time.LocalDate.

--- a/docs/8_0/components/datepicker.md
+++ b/docs/8_0/components/datepicker.md
@@ -109,6 +109,7 @@ ajax selection and more.
 | tabindex | null | Integer | Position of the input element in the tabbing order.
 | title | null | String | Advisory tooltip informaton.
 | rangeSeparator | - | String | Separator for joining start and end dates on range selection mode.
+| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
 
 ## Getting Started with DatePicker
 Value of the DatePicker should be a java.time.LocalDate in single selection mode which is the default.

--- a/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -26,6 +26,7 @@ package org.primefaces.component.api;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
+import java.time.format.ResolverStyle;
 import java.util.Locale;
 
 import javax.faces.application.FacesMessage;
@@ -61,7 +62,8 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder {
         inputStyle,
         inputStyleClass,
         type,
-        rangeSeparator
+        rangeSeparator,
+        resolverStyle
     }
 
     public Object getLocale() {
@@ -234,6 +236,14 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder {
 
     public void setRangeSeparator(java.lang.String _rangeSeparator) {
         getStateHelper().put(PropertyKeys.rangeSeparator, _rangeSeparator);
+    }
+    
+    public String getResolverStyle() {
+        return (String) getStateHelper().eval(PropertyKeys.resolverStyle, ResolverStyle.SMART.name());
+    }
+
+    public void setResolverStyle(String resolverStyle) {
+        getStateHelper().put(PropertyKeys.resolverStyle, resolverStyle);
     }
 
     public enum ValidationResult {

--- a/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -237,7 +237,7 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder {
     public void setRangeSeparator(java.lang.String _rangeSeparator) {
         getStateHelper().put(PropertyKeys.rangeSeparator, _rangeSeparator);
     }
-    
+
     public String getResolverStyle() {
         return (String) getStateHelper().eval(PropertyKeys.resolverStyle, ResolverStyle.SMART.name());
     }

--- a/src/main/java/org/primefaces/component/calendar/BaseCalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/BaseCalendarRenderer.java
@@ -52,6 +52,7 @@ import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.Temporal;
 import java.util.Collection;
@@ -198,7 +199,8 @@ public abstract class BaseCalendarRenderer extends InputRenderer {
                     .appendPattern(calendar.calculatePattern())
                     .parseDefaulting(ChronoField.DAY_OF_MONTH, 1) //because of Month Picker which does not contain day of month
                     .toFormatter(calendar.calculateLocale(context))
-                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()));
+                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()))
+                    .withResolverStyle(resolveResolverStyle(calendar.getResolverStyle()));
 
             try {
                 return type == LocalDate.class
@@ -213,7 +215,8 @@ public abstract class BaseCalendarRenderer extends InputRenderer {
             String pattern = calendar instanceof Calendar ? calendar.calculatePattern() : calendar.calculateTimeOnlyPattern();
             DateTimeFormatter formatter = DateTimeFormatter
                     .ofPattern(pattern, calendar.calculateLocale(context))
-                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()));
+                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()))
+                    .withResolverStyle(resolveResolverStyle(calendar.getResolverStyle()));
 
             try {
                 return LocalTime.parse(submittedValue, formatter);
@@ -227,7 +230,8 @@ public abstract class BaseCalendarRenderer extends InputRenderer {
                     .parseCaseInsensitive()
                     .appendPattern(calendar.calculatePattern())
                     .toFormatter(calendar.calculateLocale(context))
-                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()));
+                    .withZone(CalendarUtils.calculateZoneId(calendar.getTimeZone()))
+                    .withResolverStyle(resolveResolverStyle(calendar.getResolverStyle()));
 
             try {
                 return LocalDateTime.parse(submittedValue, formatter);
@@ -240,6 +244,15 @@ public abstract class BaseCalendarRenderer extends InputRenderer {
         //TODO: implement if necessary
         FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_ERROR, type.getName() + " not supported", null);
         throw new ConverterException(message);
+    }
+
+    private ResolverStyle resolveResolverStyle(String passedResolverStyle) {
+        for (ResolverStyle resolverStyle : ResolverStyle.values()) {
+            if (resolverStyle.name().equalsIgnoreCase(passedResolverStyle)) {
+                return resolverStyle;
+            }
+        }
+        return ResolverStyle.SMART;
     }
 
     protected ConverterException createConverterException(FacesContext context,

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3141,6 +3141,14 @@
             <required>false</required>
             <type>java.lang.Integer</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[ResolverStyle for java.time.format.DateTimeFormatter, lenient, smart or strict, Default is smart.]]>
+            </description>
+            <name>resolverStyle</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -29772,6 +29780,14 @@
                 <![CDATA[Separator for joining start and end dates on range selection mode. Default value is "-".]]>
             </description>
             <name>rangeSeparator</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[ResolverStyle for java.time.format.DateTimeFormatter, lenient, smart or strict, Default is smart.]]>
+            </description>
+            <name>resolverStyle</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>


### PR DESCRIPTION
New attribute `resolverStyle` which defaults to SMART as at the moment. Wrote some tests and added the new attribute the the documentation of calendar and datepicker.