### PR TITLE
Fix #5263: Ignore partial process for @none

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -400,7 +400,7 @@ if (!PrimeFaces.ajax) {
                         processIds = '@all';
                     }
                 }
-                if (processIds !== '@none') {
+                if (!processIds.includes('@none')) {
                     PrimeFaces.ajax.Request.addParam(postParams, PrimeFaces.PARTIAL_PROCESS_PARAM, processIds, parameterPrefix);
                 }
 

--- a/src/main/resources/META-INF/resources/primefaces/core/core.polyfills.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.polyfills.js
@@ -14,3 +14,15 @@ if (!Element.prototype.closest) {
         return null;
     };
 }
+
+if (!String.prototype.includes) {
+    String.prototype.includes = function(search, start) {
+      'use strict';
+
+      if (search instanceof RegExp) {
+        throw TypeError('first argument must not be a RegExp');
+      } 
+      if (start === undefined) { start = 0; }
+      return this.indexOf(search, start) !== -1;
+    };
+}


### PR DESCRIPTION
@tandraschko @Rapster I took another look at this one and would like your comments on this PR.

Basically if a user says the following:
```xml
<p:ajax process="@none" partialSubmit="true" />
```
They are requesting that NOTHING be partially processed. But if for some reason any PF widget is always including "@this" or "this.id" the resulting AJAX call looks like this...
```
javax.faces.partial.execute: @none j_idt6:tblData
```

This makes no sense and it processes the tblData.   This PR detects if "@none" is anywhere in the process it will make it send no partial processing.  So even if someone did this...
```xml
<p:ajax process="@this @none @form" partialSubmit="true" />
```
Once we detect @none in the chain none of the other processing makes sense so the whole thing should be @none.

Thoughts?
