### PR TITLE
Fix #5569: ConfirmDialog appendTo="@(body)" default

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -633,7 +633,7 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
         cfg.resizable = false;
         cfg.modal = true;
 
-        if (!cfg.appendTo && cfg.global) {
+        if (!cfg.appendTo || cfg.global) {
         	cfg.appendTo = '@(body)';
         }
 


### PR DESCRIPTION
Default to appendTo="@(body)" if either global="true" or if appendTo is not defined.