### PR TITLE
Fix #5571: CSP Eval with return result

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
+++ b/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
@@ -312,7 +312,7 @@ PrimeFaces.widget.Carousel = PrimeFaces.widget.DeferredWidget.extend({
 
     restoreState: function() {
         var carouselStateAsString = PrimeFaces.getCookie(this.stateKey) || "first: null, collapsed: null";
-        this.carouselState = PrimeFaces.csp.eval('({' + carouselStateAsString + '})');
+        this.carouselState = PrimeFaces.csp.evalResult('({' + carouselStateAsString + '})');
 
         this.first = this.carouselState.first||this.first;
         this.page = parseInt(this.first/this.columns);

--- a/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -58,6 +58,18 @@ if (!PrimeFaces.csp) {
             // evaluate the script
             $.globalEval(js, options);
         },
+        
+        /**
+         * Perform a CSP safe eval() with a return result value.
+         *
+         * @param js the Javascript to evaluate
+         * @see https://stackoverflow.com/a/33945236/502366
+         */
+        evalResult: function (js) {
+            var executeJs = "var cspResult = " + js;
+            PrimeFaces.csp.eval(executeJs);
+            return cspResult;
+        },
 
         /**
          * CSP won't allow  string-to-JavaScript methods like eval() and new Function().


### PR DESCRIPTION
The error was reproted on PF Extensions here: https://github.com/primefaces-extensions/primefaces-extensions.github.com/issues/759

For eval() that need to return a result the JQuery globalEval does not return a result.  So based on this Stack overflow had to create a new method.
https://stackoverflow.com/a/33945236/502366
