### PR TITLE
Fix #5604: SelectManyMenu change event when only 1 item

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectmanymenu.js
@@ -23,8 +23,7 @@ PrimeFaces.widget.SelectManyMenu = PrimeFaces.widget.SelectListbox.extend({
 
                 var item = $(this),
                 selectedItems = $this.items.filter('.ui-state-highlight'),
-                metaKey = (e.metaKey||e.ctrlKey),
-                unchanged = (!metaKey && selectedItems.length === 1 && selectedItems.index() === item.index());
+                metaKey = (e.metaKey||e.ctrlKey);
 
                 if(!e.shiftKey) {
                     if(!metaKey && !$this.cfg.showCheckbox) {
@@ -63,10 +62,7 @@ PrimeFaces.widget.SelectManyMenu = PrimeFaces.widget.SelectListbox.extend({
                     }
                 }
 
-                if(!unchanged) {
-                    $this.input.trigger('change');
-                }
-
+                $this.input.trigger('change');
                 $this.input.trigger('click');
                 PrimeFaces.clearSelection();
                 e.preventDefault();


### PR DESCRIPTION
I tested this with showCheckbox="false" and showCheckbox="true" and it now works.

I looked through the code history and its been there since before 2013 but maybe at one point the way the boxes worked they weren't selected yet,  but this code definitely did not make sense and was causing the issue described in the ticket.