### PR TITLE
Fix #5594 - FileUpload: Improve VirusScanner Interface

### DIFF
--- a/src/main/java/org/primefaces/component/fileupload/CommonsFileUploadDecoder.java
+++ b/src/main/java/org/primefaces/component/fileupload/CommonsFileUploadDecoder.java
@@ -24,10 +24,7 @@
 package org.primefaces.component.fileupload;
 
 import org.apache.commons.fileupload.FileItem;
-import org.primefaces.event.FileUploadEvent;
-import org.primefaces.model.file.CommonsUploadedFile;
-import org.primefaces.model.file.UploadedFileWrapper;
-import org.primefaces.util.FileUploadUtils;
+import org.primefaces.model.file.*;
 import org.primefaces.webapp.MultipartRequest;
 
 import javax.faces.FacesException;
@@ -36,9 +33,6 @@ import javax.servlet.ServletRequestWrapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.primefaces.model.file.UploadedFile;
-import org.primefaces.model.file.UploadedFiles;
-import org.primefaces.model.file.UploadedFilesWrapper;
 
 public class CommonsFileUploadDecoder {
 
@@ -75,14 +69,13 @@ public class CommonsFileUploadDecoder {
     }
 
     private static void decodeSimple(FacesContext context, FileUpload fileUpload, MultipartRequest request, String inputToDecodeId) throws IOException {
-
         if (fileUpload.isMultiple()) {
             Long sizeLimit = fileUpload.getSizeLimit();
             List<UploadedFile> files = request.getFileItems(inputToDecodeId).stream()
                     .map(p -> new CommonsUploadedFile(p, sizeLimit))
                     .collect(Collectors.toList());
 
-            if (!files.isEmpty() && FileUploadUtils.areValidFiles(context, fileUpload, files)) {
+            if (!files.isEmpty()) {
                 UploadedFiles uploadedFiles = new UploadedFiles(files);
                 fileUpload.setSubmittedValue(new UploadedFilesWrapper(uploadedFiles));
             }
@@ -92,15 +85,9 @@ public class CommonsFileUploadDecoder {
         }
         else {
             FileItem file = request.getFileItem(inputToDecodeId);
-
             if (file != null && !file.getName().isEmpty()) {
                 UploadedFile uploadedFile = new CommonsUploadedFile(file, fileUpload.getSizeLimit());
-                if (FileUploadUtils.isValidFile(context, fileUpload, uploadedFile)) {
-                    fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
-                }
-                else {
-                    fileUpload.setSubmittedValue("");
-                }
+                fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
             }
         }
     }
@@ -111,9 +98,7 @@ public class CommonsFileUploadDecoder {
 
         if (file != null) {
             UploadedFile uploadedFile = new CommonsUploadedFile(file, fileUpload.getSizeLimit());
-            if (FileUploadUtils.isValidFile(context, fileUpload, uploadedFile)) {
-                fileUpload.queueEvent(new FileUploadEvent(fileUpload, uploadedFile));
-            }
+            fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
         }
     }
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUpload.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUpload.java
@@ -23,10 +23,20 @@
  */
 package org.primefaces.component.fileupload;
 
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.file.UploadedFile;
+import org.primefaces.model.file.UploadedFiles;
+import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.FileUploadUtils;
+import org.primefaces.virusscan.VirusException;
+
 import javax.el.MethodExpression;
+import javax.faces.FacesException;
+import javax.faces.application.FacesMessage;
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;
 import javax.faces.context.FacesContext;
+import javax.faces.validator.ValidatorException;
 
 @ResourceDependencies({
         @ResourceDependency(library = "primefaces", name = "components.css"),
@@ -61,6 +71,33 @@ public class FileUpload extends FileUploadBase {
 
         if (me != null && event instanceof org.primefaces.event.FileUploadEvent) {
             me.invoke(facesContext.getELContext(), new Object[]{event});
+        }
+    }
+
+    @Override
+    protected void validateValue(FacesContext context, Object newValue) {
+        super.validateValue(context, newValue);
+
+        if (isValid() && ComponentUtils.isRequestSource(this, context)) {
+            try {
+                if (newValue instanceof UploadedFile) {
+                    FileUploadUtils.tryValidateFile(context, this, (UploadedFile) newValue);
+                }
+                else if (newValue instanceof UploadedFiles) {
+                    FileUploadUtils.tryValidateFiles(context, this, ((UploadedFiles) newValue).getFiles());
+                }
+                else {
+                    throw new IllegalArgumentException("Argument of type '" + newValue.getClass().getName() + "' not supported");
+                }
+
+                if ("advanced".equals(getMode())) {
+                    queueEvent(new FileUploadEvent(this, (UploadedFile) newValue));
+                }
+            }
+            catch (VirusException | ValidatorException e) {
+                setValid(false);
+                context.addMessage(getClientId(context), new FacesMessage(FacesMessage.SEVERITY_ERROR, e.getMessage(), null));
+            }
         }
     }
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUpload.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUpload.java
@@ -31,7 +31,6 @@ import org.primefaces.util.FileUploadUtils;
 import org.primefaces.virusscan.VirusException;
 
 import javax.el.MethodExpression;
-import javax.faces.FacesException;
 import javax.faces.application.FacesMessage;
 import javax.faces.application.ResourceDependencies;
 import javax.faces.application.ResourceDependency;

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
@@ -69,7 +69,7 @@ public abstract class FileUploadBase extends UIInput implements Widget {
         cancelIcon,
         onAdd,
         validateContentType,
-        performVirusScan
+        virusScan
     }
 
     public FileUploadBase() {
@@ -353,11 +353,11 @@ public abstract class FileUploadBase extends UIInput implements Widget {
         getStateHelper().put(PropertyKeys.validateContentType, validateContentType);
     }
 
-    public boolean isPerformVirusScan() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.performVirusScan, false);
+    public boolean isVirusScan() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.virusScan, false);
     }
 
-    public void setPerformVirusScan(boolean performVirusScan) {
-        getStateHelper().put(PropertyKeys.performVirusScan, performVirusScan);
+    public void setVirusScan(boolean virusScan) {
+        getStateHelper().put(PropertyKeys.virusScan, virusScan);
     }
 }

--- a/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
+++ b/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
@@ -23,9 +23,7 @@
  */
 package org.primefaces.component.fileupload;
 
-import org.primefaces.event.FileUploadEvent;
 import org.primefaces.model.file.*;
-import org.primefaces.util.FileUploadUtils;
 
 import javax.faces.FacesException;
 import javax.faces.context.FacesContext;
@@ -69,7 +67,7 @@ public class NativeFileUploadDecoder {
                     .map(p -> new NativeUploadedFile(p, sizeLimit))
                     .collect(Collectors.toList());
 
-            if (!files.isEmpty() && FileUploadUtils.areValidFiles(context, fileUpload, files)) {
+            if (!files.isEmpty()) {
                 UploadedFiles uploadedFiles = new UploadedFiles(files);
                 fileUpload.setSubmittedValue(new UploadedFilesWrapper(uploadedFiles));
             }
@@ -79,12 +77,9 @@ public class NativeFileUploadDecoder {
         }
         else {
             Part part = request.getPart(inputToDecodeId);
-
             if (part != null) {
                 NativeUploadedFile uploadedFile = new NativeUploadedFile(part, fileUpload.getSizeLimit());
-                if (FileUploadUtils.isValidFile(context, fileUpload, uploadedFile)) {
-                    fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
-                }
+                fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
             }
             else {
                 fileUpload.setSubmittedValue("");
@@ -98,9 +93,7 @@ public class NativeFileUploadDecoder {
 
         if (part != null) {
             NativeUploadedFile uploadedFile = new NativeUploadedFile(part, fileUpload.getSizeLimit());
-            if (FileUploadUtils.isValidFile(context, fileUpload, uploadedFile)) {
-                fileUpload.queueEvent(new FileUploadEvent(fileUpload, uploadedFile));
-            }
+            fileUpload.setSubmittedValue(new UploadedFileWrapper(uploadedFile));
         }
     }
 }

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -23,13 +23,23 @@
  */
 package org.primefaces.util;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PushbackInputStream;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.primefaces.component.fileupload.FileUpload;
+import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.model.file.UploadedFile;
+import org.primefaces.shaded.owasp.SafeFile;
+import org.primefaces.shaded.owasp.ValidationException;
+import org.primefaces.virusscan.VirusException;
+
+import javax.faces.FacesException;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.validator.ValidatorException;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -37,20 +47,6 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import javax.faces.FacesException;
-import javax.faces.context.FacesContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.primefaces.component.fileupload.FileUpload;
-import org.primefaces.context.PrimeApplicationContext;
-import org.primefaces.shaded.owasp.SafeFile;
-import org.primefaces.shaded.owasp.ValidationException;
-import org.primefaces.virusscan.VirusException;
-import org.primefaces.model.file.UploadedFile;
 
 /**
  * Utilities for FileUpload components.
@@ -286,37 +282,38 @@ public class FileUploadUtils {
         return true;
     }
 
-    public static void performVirusScan(FacesContext facesContext, InputStream inputStream) throws VirusException {
-        PrimeApplicationContext.getCurrentInstance(facesContext).getVirusScannerService().performVirusScan(inputStream);
+    public static void performVirusScan(FacesContext facesContext, UploadedFile file) throws VirusException {
+        PrimeApplicationContext.getCurrentInstance(facesContext).getVirusScannerService().performVirusScan(file);
     }
 
-    public static boolean isValidFile(FacesContext context, FileUpload fileUpload, UploadedFile uploadedFile) throws IOException {
+    public static void tryValidateFile(FacesContext context, FileUpload fileUpload, UploadedFile uploadedFile) throws ValidatorException {
         Long sizeLimit = fileUpload.getSizeLimit();
         PrimeApplicationContext appContext = PrimeApplicationContext.getCurrentInstance(context);
-        boolean valid = (sizeLimit == null || uploadedFile.getSize() <= sizeLimit)
-                && isValidType(appContext, fileUpload, uploadedFile);
-        if (valid && fileUpload.isPerformVirusScan()) {
-            try (InputStream input = uploadedFile.getInputStream()) {
-                performVirusScan(context, input);
-            }
-            catch (VirusException ex) {
-                return false;
-            }
+
+        if (sizeLimit != null && uploadedFile.getSize() > sizeLimit) {
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
         }
-        return valid;
+
+        if (!isValidType(appContext, fileUpload, uploadedFile)) {
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
+        }
+
+        if (fileUpload.isVirusScan()) {
+            performVirusScan(context, uploadedFile);
+        }
     }
 
-    public static boolean areValidFiles(FacesContext context, FileUpload fileUpload, List<UploadedFile> files) throws IOException {
+    public static void tryValidateFiles(FacesContext context, FileUpload fileUpload, List<UploadedFile> files) {
         long totalPartSize = 0;
         Long sizeLimit = fileUpload.getSizeLimit();
         for (UploadedFile file : files) {
             totalPartSize += file.getSize();
-            if (!isValidFile(context, fileUpload, file)) {
-                return false;
-            }
+            tryValidateFile(context, fileUpload, file);
         }
 
-        return sizeLimit == null || totalPartSize <= sizeLimit;
+        if (sizeLimit != null && totalPartSize > sizeLimit) {
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
+        }
     }
 
     /**

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -208,6 +208,7 @@ public class FileUploadUtils {
         String tempFileSuffix = tika ? null : "." + FilenameUtils.getExtension(fileName);
         String tempFilePrefix = UUID.randomUUID().toString();
         Path tempFile = Files.createTempFile(tempFilePrefix, tempFileSuffix);
+
         try {
             try (InputStream in = new PushbackInputStream(new BufferedInputStream(stream))) {
                 try (OutputStream out = new FileOutputStream(tempFile.toFile())) {
@@ -230,6 +231,7 @@ public class FileUploadUtils {
                 }
                 return false;
             }
+
             //Comma-separated values: file_extension|audio/*|video/*|image/*|media_type (see https://www.w3schools.com/tags/att_input_accept.asp)
             String[] accepts = fileUpload.getAccept().split(",");
             boolean accepted = false;
@@ -291,11 +293,11 @@ public class FileUploadUtils {
         PrimeApplicationContext appContext = PrimeApplicationContext.getCurrentInstance(context);
 
         if (sizeLimit != null && uploadedFile.getSize() > sizeLimit) {
-            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, fileUpload.getInvalidSizeMessage(), ""));
         }
 
         if (!isValidType(appContext, fileUpload, uploadedFile)) {
-            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, fileUpload.getInvalidFileMessage(), ""));
         }
 
         if (fileUpload.isVirusScan()) {
@@ -312,7 +314,7 @@ public class FileUploadUtils {
         }
 
         if (sizeLimit != null && totalPartSize > sizeLimit) {
-            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, "", ""));
+            throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, fileUpload.getInvalidFileMessage(), ""));
         }
     }
 

--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -23,6 +23,10 @@
  */
 package org.primefaces.util;
 
+import javax.faces.FacesException;
+import javax.xml.bind.DatatypeConverter;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -180,5 +184,15 @@ public class LangUtils {
 
         return currentClass.getName().startsWith(currentClass.getSuperclass().getName())
                 && currentClass.getName().contains("$$");
+    }
+
+    public static String md5Hex(byte[] bytes) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            md.update(bytes);
+            return DatatypeConverter.printHexBinary(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new FacesException(e);
+        }
     }
 }

--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -191,7 +191,8 @@ public class LangUtils {
             MessageDigest md = MessageDigest.getInstance("MD5");
             md.update(bytes);
             return DatatypeConverter.printHexBinary(md.digest());
-        } catch (NoSuchAlgorithmException e) {
+        }
+        catch (NoSuchAlgorithmException e) {
             throw new FacesException(e);
         }
     }

--- a/src/main/java/org/primefaces/virusscan/VirusException.java
+++ b/src/main/java/org/primefaces/virusscan/VirusException.java
@@ -23,8 +23,23 @@
  */
 package org.primefaces.virusscan;
 
-public class VirusException extends Exception {
+import javax.faces.FacesException;
 
-    private static final long serialVersionUID = 1L;
+public class VirusException extends FacesException {
 
+    public VirusException() {
+        // NOOP
+    }
+
+    public VirusException(String message) {
+        super(message);
+    }
+
+    public VirusException(Throwable cause) {
+        super(cause);
+    }
+
+    public VirusException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/org/primefaces/virusscan/VirusScanner.java
+++ b/src/main/java/org/primefaces/virusscan/VirusScanner.java
@@ -39,9 +39,8 @@ public interface VirusScanner {
 
     /**
      * Perform virus scan and throw exception if a virus has been detected.
-     * @param file input stream to perform virus scan on
-     * @throws VirusException if a virus has been detected by the scanner
+     * @param file file to perform virus scan on
      */
-    void scan(UploadedFile file) throws VirusException;
+    void scan(UploadedFile file);
 
 }

--- a/src/main/java/org/primefaces/virusscan/VirusScanner.java
+++ b/src/main/java/org/primefaces/virusscan/VirusScanner.java
@@ -23,7 +23,7 @@
  */
 package org.primefaces.virusscan;
 
-import java.io.InputStream;
+import org.primefaces.model.file.UploadedFile;
 
 /**
  * Service provider interface for virus scanning that might be used in file upload component for example when dealing with untrusted files.
@@ -39,9 +39,9 @@ public interface VirusScanner {
 
     /**
      * Perform virus scan and throw exception if a virus has been detected.
-     * @param inputStream input stream to perform virus scan on
+     * @param file input stream to perform virus scan on
      * @throws VirusException if a virus has been detected by the scanner
      */
-    void performVirusScan(InputStream inputStream) throws VirusException;
+    void scan(UploadedFile file) throws VirusException;
 
 }

--- a/src/main/java/org/primefaces/virusscan/VirusScannerService.java
+++ b/src/main/java/org/primefaces/virusscan/VirusScannerService.java
@@ -23,8 +23,8 @@
  */
 package org.primefaces.virusscan;
 
-import java.io.InputStream;
-import java.io.PushbackInputStream;
+import org.primefaces.model.file.UploadedFile;
+
 import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
@@ -45,10 +45,10 @@ public class VirusScannerService {
 
     /**
      * Perform virus scan and throw exception if at least one registered {@link VirusScanner} provider has detected a virus.
-     * @param inputStream input stream to perform virus scan on
+     * @param file input stream to perform virus scan on
      * @throws VirusException if at least one {@link VirusScanner} provider has detected a virus
      */
-    public void performVirusScan(InputStream inputStream) throws VirusException {
+    public void performVirusScan(UploadedFile file) throws VirusException {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.fine("Performing virus scan...");
         }
@@ -69,7 +69,7 @@ public class VirusScannerService {
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine(String.format("Performing virus scan with %s provider", clazz));
                 }
-                scanner.performVirusScan(new PushbackInputStream(inputStream));
+                scanner.scan(file);
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.fine(String.format("No virus detected with %s provider", clazz));
                 }

--- a/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
+++ b/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -63,10 +64,14 @@ public class VirusTotalReportScanner implements VirusScanner {
         return ctx.getInitParameter(CONTEXT_PARAM_KEY) != null;
     }
 
+    /**
+     * Scan file using "/file/report" endpoint
+     * @throws VirusException if a virus has been detected by the scanner
+     */
     @Override
-    public void scan(UploadedFile file) throws VirusException {
+    public void scan(UploadedFile file) {
         try {
-            HttpURLConnection connection = openConnection(file);
+            URLConnection connection = openConnection(file);
             try (InputStream response = connection.getInputStream()) {
                 JSONObject json = new JSONObject(IOUtils.toString(response, StandardCharsets.UTF_8));
                 handleBodyResponse(file, json);
@@ -103,7 +108,7 @@ public class VirusTotalReportScanner implements VirusScanner {
         return MessageFactory.getMessage("primefaces.fileupload.VIRUS_TOTAL_FILE", new Object[]{file.getFileName()});
     }
 
-    protected HttpURLConnection openConnection(UploadedFile file) throws IOException {
+    protected URLConnection openConnection(UploadedFile file) throws IOException {
         HttpURLConnection connection;
 
         try {

--- a/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
+++ b/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
@@ -115,7 +115,8 @@ public class VirusTotalReportScanner implements VirusScanner {
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
             connection.connect();
-        } catch (IOException e) {
+        }
+        catch (IOException e) {
             throw new FacesException(e);
         }
 

--- a/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
+++ b/src/main/java/org/primefaces/virusscan/impl/VirusTotalReportScanner.java
@@ -26,31 +26,32 @@ package org.primefaces.virusscan.impl;
 import org.apache.commons.io.IOUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.primefaces.model.file.UploadedFile;
 import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
+import org.primefaces.util.MessageFactory;
 import org.primefaces.virusscan.VirusException;
 import org.primefaces.virusscan.VirusScanner;
 
+import javax.faces.FacesException;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
-import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.faces.FacesException;
 
 /**
  * This is the default {@link VirusScanner} provider bundled with PrimeFaces.
- * The implementation makes use of the <a href="https://www.virustotal.com/de/documentation/public-api/">VirusTotal Public API v2.0</a>.
+ * The implementation makes use of the <a href="https://developers.virustotal.com/reference">VirusTotal Public API v2.0</a>.
  * It requires {@link #CONTEXT_PARAM_KEY} to be specified.
  */
-public class VirusTotalVirusScanner implements VirusScanner {
+public class VirusTotalReportScanner implements VirusScanner {
 
-    private static final Logger LOGGER = Logger.getLogger(VirusTotalVirusScanner.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(VirusTotalReportScanner.class.getName());
 
     private static final String CONTEXT_PARAM_KEY = "primefaces.virusscan.VIRUSTOTAL_KEY";
 
@@ -63,39 +64,15 @@ public class VirusTotalVirusScanner implements VirusScanner {
     }
 
     @Override
-    public void performVirusScan(InputStream inputStream) throws VirusException {
-        ExternalContext ctx = FacesContext.getCurrentInstance().getExternalContext();
-        String key = ctx.getInitParameter(CONTEXT_PARAM_KEY);
+    public void scan(UploadedFile file) throws VirusException {
         try {
-            byte[] content = IOUtils.toByteArray(inputStream);
-            MessageDigest md = MessageDigest.getInstance("MD5");
-            md.update(content);
-            String hash = DatatypeConverter.printHexBinary(md.digest());
-            URL url = new URL(String.format(API_ENDPOINT, EscapeUtils.forUriComponent(key), EscapeUtils.forUriComponent(hash)));
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.connect();
-            checkResponseCode(connection.getResponseCode());
-
+            HttpURLConnection connection = openConnection(file);
             try (InputStream response = connection.getInputStream()) {
-                JSONObject json = new JSONObject(IOUtils.toString(response, "UTF-8"));
-                int responseCode = json.getInt("response_code");
-                if (LOGGER.isLoggable(Level.FINE)) {
-                    LOGGER.fine(String.format("Retrieved response code %d.", responseCode));
-                }
-                if (responseCode == 1) {
-                    // present
-                    int positives = json.getInt("positives");
-                    if (LOGGER.isLoggable(Level.FINE)) {
-                        LOGGER.fine(String.format("Retrieved %d positives.", positives));
-                    }
-                    if (positives > 0) {
-                        throw new VirusException();
-                    }
-                }
+                JSONObject json = new JSONObject(IOUtils.toString(response, StandardCharsets.UTF_8));
+                handleBodyResponse(file, json);
             }
         }
-        catch (JSONException | IOException | NoSuchAlgorithmException ex) {
+        catch (JSONException | IOException ex) {
             if (LOGGER.isLoggable(Level.WARNING)) {
                 LOGGER.log(Level.WARNING, "Cannot perform virus scan", ex);
             }
@@ -103,7 +80,46 @@ public class VirusTotalVirusScanner implements VirusScanner {
         }
     }
 
-    protected void checkResponseCode(int code) {
+    protected void handleBodyResponse(UploadedFile file, JSONObject json) {
+        int responseCode = json.getInt("response_code");
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine(String.format("Retrieved response code %d.", responseCode));
+        }
+
+        if (responseCode == 1) {
+            // present
+            int positives = json.getInt("positives");
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Retrieved %d positives.", positives));
+            }
+            if (positives > 0) {
+                String message = createErrorMessage(file, json);
+                throw new VirusException(message);
+            }
+        }
+    }
+
+    protected String createErrorMessage(UploadedFile file, JSONObject json) {
+        return MessageFactory.getMessage("primefaces.fileupload.VIRUS_TOTAL_FILE", new Object[]{file.getFileName()});
+    }
+
+    protected HttpURLConnection openConnection(UploadedFile file) throws IOException {
+        HttpURLConnection connection;
+
+        try {
+            ExternalContext ctx = FacesContext.getCurrentInstance().getExternalContext();
+            String key = ctx.getInitParameter(CONTEXT_PARAM_KEY);
+
+            String hash = LangUtils.md5Hex(file.getContent());
+            URL url = new URL(String.format(API_ENDPOINT, EscapeUtils.forUriComponent(key), EscapeUtils.forUriComponent(hash)));
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+        } catch (IOException e) {
+            throw new FacesException(e);
+        }
+
+        int code = connection.getResponseCode();
         switch (code) {
             case 200:
                 // OK
@@ -121,6 +137,8 @@ public class VirusTotalVirusScanner implements VirusScanner {
             default:
                 throw new FacesException("Unexpected HTTP code " + code + " calling Virus Total web service.");
         }
+
+        return connection;
     }
 
 }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -9707,7 +9707,7 @@
             <description>
                 <![CDATA[Whether virus scan should be performed. Default is false.]]>
             </description>
-            <name>performVirusScan</name>
+            <name>virusScan</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>

--- a/src/main/resources/META-INF/services/org.primefaces.virusscan.VirusScanner
+++ b/src/main/resources/META-INF/services/org.primefaces.virusscan.VirusScanner
@@ -1,1 +1,1 @@
-org.primefaces.virusscan.impl.VirusTotalVirusScanner
+org.primefaces.virusscan.impl.VirusTotalReportScanner

--- a/src/main/resources/org/primefaces/Messages.properties
+++ b/src/main/resources/org/primefaces/Messages.properties
@@ -31,3 +31,4 @@ primefaces.calendar.INVALID = {0}: Validation Error: Value is not valid.
 primefaces.calendar.DATE_INVALID_RANGE_MESSAGE_ID = {0}: Validation Error: Start date is greater than the end date.
 primefaces.panel.aria.TOGGLE = Toggle Panel
 primefaces.panel.aria.OPTIONS_MENU = Toggle Options Menu
+primefaces.fileupload.VIRUS_TOTAL_FILE = Virus Total has identified file '{0}' potentially dangerous

--- a/src/main/resources/org/primefaces/Messages_en.properties
+++ b/src/main/resources/org/primefaces/Messages_en.properties
@@ -31,3 +31,4 @@ primefaces.calendar.INVALID = {0}: Validation Error: Value is not valid.
 primefaces.calendar.DATE_INVALID_RANGE_MESSAGE_ID = {0}: Validation Error: Start date is greater than the end date.
 primefaces.panel.aria.TOGGLE = Toggle Panel
 primefaces.panel.aria.OPTIONS_MENU = Toggle Options Menu
+primefaces.fileupload.VIRUS_TOTAL_FILE = Virus Total has identified file '{0}' potentially dangerous


### PR DESCRIPTION
* Rename `Fileupload#performVirusScan` into `Fileupload#virusScan`
* Uploaded file validation moved to `FileUpload#validateValue`
* Refactor VirusTotalReportScanner

@Thomas-Schindler I changed `VirusTotalReportScanner` class so you can add your own error message. See `VirusTotalReportScanner#createErrorMessage`

This PR should be merged on top of #5608