### PR TITLE
Fix #5618,#5619: DatePicker prev/next month button calculation

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1638,11 +1638,11 @@
 
             if (this.options.view === 'date') {
                 if (newViewDate.getMonth() === 0) {
-                    newViewDate.setMonth(11);
+                    newViewDate.setMonth(11, 1);
                     newViewDate.setFullYear(newViewDate.getFullYear() - 1);
                 }
                 else {
-                    newViewDate.setMonth(newViewDate.getMonth() - 1);
+                    newViewDate.setMonth(newViewDate.getMonth() - 1, 1);
                 }
 
                 if (this.options.onMonthChange) {
@@ -1683,11 +1683,11 @@
 
             if (this.options.view === 'date') {
                 if (newViewDate.getMonth() === 11) {
-                    newViewDate.setMonth(0);
+                    newViewDate.setMonth(0, 1);
                     newViewDate.setFullYear(newViewDate.getFullYear() + 1);
                 }
                 else {
-                    newViewDate.setMonth(newViewDate.getMonth() + 1);
+                    newViewDate.setMonth(newViewDate.getMonth() + 1, 1);
                 }
 
                 if (this.options.onMonthChange) {


### PR DESCRIPTION
The issue was the Javascript `setMonth(month-1)` to set to the previous or next month.

Date: March 31, 2020 if you clicked previous set the date to March 02, 2020.  This is because Feb doesn't have a 31st day so Javascript is confused.  Its the same issue for January 31st rolling next month goes to March.

The fix is simple use the overloaded `setMonth(month, day)` and always use day 1 since all months have a 1st day of the month.