### PR TITLE
Fix #5656: BaseCalendarRenderer improve reflection of Lists

### DIFF
--- a/src/main/java/org/primefaces/component/calendar/BaseCalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/BaseCalendarRenderer.java
@@ -309,14 +309,18 @@ public abstract class BaseCalendarRenderer extends InputRenderer {
             Object base = valueReference.getBase();
             Object property = valueReference.getProperty();
 
-            try {
-                Field field = LangUtils.getUnproxiedClass(base.getClass()).getDeclaredField((String) property);
-                ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
-                Type listType = parameterizedType.getActualTypeArguments()[0];
-                type = Class.forName(listType.getTypeName());
-            }
-            catch (ReflectiveOperationException ex) {
-                //NOOP
+            Class<?> unproxiedClass = LangUtils.getUnproxiedClass(base.getClass());
+            while (unproxiedClass != null) {
+                try {
+                    Field field = unproxiedClass.getDeclaredField((String) property);
+                    ParameterizedType parameterizedType = (ParameterizedType) field.getGenericType();
+                    Type listType = parameterizedType.getActualTypeArguments()[0];
+                    type = Class.forName(listType.getTypeName());
+                    unproxiedClass = null;
+                }
+                catch (ReflectiveOperationException ex) {
+                    unproxiedClass = unproxiedClass.getSuperclass();
+                }
             }
         }
 


### PR DESCRIPTION
@christophs78 @tandraschko would like your eyes on this.  Had to test the main class if it had the Declared Field and then walk the superclass until it is found or not found.

I didn't want to modify LangUtils.getUnproxiedClass as that is from DeltaSpike and looks like its doing the right thing.