### PR TITLE
Fix #5661: Repeat backward compatible with JSF2.2

### DIFF
--- a/src/main/java/org/primefaces/component/repeat/UIRepeat.java
+++ b/src/main/java/org/primefaces/component/repeat/UIRepeat.java
@@ -913,7 +913,7 @@ public class UIRepeat extends UINamingContainer {
             this.resetDataModel();
             int prevIndex = this.index;
             FacesEvent target = idxEvent.getTarget();
-            FacesContext ctx = target.getFacesContext();
+            FacesContext ctx = FacesContext.getCurrentInstance();
             UIComponent source = target.getComponent();
             UIComponent compositeParent = null;
             try {


### PR DESCRIPTION
Tested this fix with the reproducer and its working. Shoul be a safe Fix since FacesEvent.getFacesContext() says it returns the target context or if NULL returns `FacesContext.getCurrentInstance()`.