### PR TITLE
Correct documentation for chart extender

### DIFF
--- a/docs/8_0/components/charts.md
+++ b/docs/8_0/components/charts.md
@@ -1014,11 +1014,9 @@ Charts are canvas based and can be exported as static images with client side ap
 ```
 
 ## Extender
-Extender function allows access to the underlying chart.js api using the setExtender method of the model.
+Extender function allows access to the underlying chart.js api using the setExtender method of the model. The exstender function needs to be defined before the chart component, otherwise it could happen that on the first model load, the script isn't found.
 
 ```xhtml
-<p:radarChart model="#{bean.radarModel2}" />
-
 <h:outputScript>
         function chartExtender() {
            //copy the config options into a variable
@@ -1059,6 +1057,8 @@ Extender function allows access to the underlying chart.js api using the setExte
            $.extend(true, this.cfg.config, options);
         };
 </h:outputScript>
+
+<p:radarChart model="#{bean.radarModel2}" />
 ```
 
 ```java


### PR DESCRIPTION
The chartExtender() script needs to be defined before the chart component. Otherwise the script won't be found on the first model load (It will be found on subsequent loads).
At least that's the way chromium reacts.