### PR TITLE
Fix #5645: Docu: make sure up-to-date versions are delivered to the client

### DIFF
--- a/docs/7_0/index.html
+++ b/docs/7_0/index.html
@@ -33,9 +33,6 @@
       plugins: [
         function(hook, vm) {
           hook.ready(function () {
-            console.log("Mein Docsify-Plugin; Init");
-
-            //let el = document.querySelector("h1.app-name");
             let h1Elt = document.querySelector("main aside h1.app-name");
             let versionElt = document.createElement("div");
             versionElt.setAttribute("class", "PF-version")

--- a/docs/8_0/index.html
+++ b/docs/8_0/index.html
@@ -35,9 +35,6 @@
       plugins: [
         function(hook, vm) {
           hook.ready(function () {
-            console.log("Mein Docsify-Plugin; Init");
-
-            //let el = document.querySelector("h1.app-name");
             let h1Elt = document.querySelector("main aside h1.app-name");
             let versionElt = document.createElement("div");
             versionElt.setAttribute("class", "PF-version")

--- a/docs/8_0/sw.js
+++ b/docs/8_0/sw.js
@@ -59,6 +59,9 @@ self.addEventListener('fetch', event => {
     // similar to HTTP's stale-while-revalidate: https://www.mnot.net/blog/2007/12/12/stale
     // Upgrade from Jake's to Surma's: https://gist.github.com/surma/eb441223daaedf880801ad80006389f1
     const cached = caches.match(event.request)
+    const cachedDelayed = new Promise(function(resolve, reject) {
+      setTimeout(resolve, 500, cached);
+    });
     const fixedUrl = getFixedUrl(event.request)
     const fetched = fetch(fixedUrl, { cache: 'no-store' })
     const fetchedCopy = fetched.then(resp => resp.clone())
@@ -68,7 +71,7 @@ self.addEventListener('fetch', event => {
     // If there’s nothing in cache, wait for the fetch.
     // If neither yields a response, return offline pages.
     event.respondWith(
-      Promise.race([fetched.catch(_ => cached), cached])
+      Promise.race([fetched.catch(_ => cached), cachedDelayed])
         .then(resp => resp || fetched)
         .catch(_ => { /* eat any errors */ })
     )

--- a/docs/8_0/sw.js
+++ b/docs/8_0/sw.js
@@ -66,15 +66,24 @@ self.addEventListener('fetch', event => {
     const fetched = fetch(fixedUrl, { cache: 'no-store' })
     const fetchedCopy = fetched.then(resp => resp.clone())
 
-    // Call respondWith() with whatever we get first.
-    // If the fetch fails (e.g disconnected), wait for the cache.
-    // If there’s nothing in cache, wait for the fetch.
-    // If neither yields a response, return offline pages.
-    event.respondWith(
-      Promise.race([fetched.catch(_ => cached), cachedDelayed])
-        .then(resp => resp || fetched)
-        .catch(_ => { /* eat any errors */ })
-    )
+    if (navigator.onLine) {
+      // Call respondWith() with whatever we get first.
+      // If the fetch fails (e.g disconnected), wait for the cache.
+      // If there’s nothing in cache, wait for the fetch.
+      // If neither yields a response, return offline pages.
+      event.respondWith(
+          Promise.race([fetched.catch(_ => cached), cachedDelayed])
+              .then(resp => resp || fetched)
+              .catch(_ => { /* eat any errors */ })
+      )
+    }
+    else { // offline
+      event.respondWith(
+          Promise.resolve(cached)
+              .then(resp => resp)
+              .catch(_ => { /* eat any errors */ })
+      )
+    }
 
     // Update the cache with the version we fetched (only for ok status)
     event.waitUntil(

--- a/docs/9_0/index.html
+++ b/docs/9_0/index.html
@@ -35,9 +35,6 @@
       plugins: [
         function(hook, vm) {
           hook.ready(function () {
-            console.log("Mein Docsify-Plugin; Init");
-
-            //let el = document.querySelector("h1.app-name");
             let h1Elt = document.querySelector("main aside h1.app-name");
             let versionElt = document.createElement("div");
             versionElt.setAttribute("class", "PF-version")

--- a/docs/9_0/sw.js
+++ b/docs/9_0/sw.js
@@ -59,6 +59,9 @@ self.addEventListener('fetch', event => {
     // similar to HTTP's stale-while-revalidate: https://www.mnot.net/blog/2007/12/12/stale
     // Upgrade from Jake's to Surma's: https://gist.github.com/surma/eb441223daaedf880801ad80006389f1
     const cached = caches.match(event.request)
+    const cachedDelayed = new Promise(function(resolve, reject) {
+      setTimeout(resolve, 500, cached);
+    });
     const fixedUrl = getFixedUrl(event.request)
     const fetched = fetch(fixedUrl, { cache: 'no-store' })
     const fetchedCopy = fetched.then(resp => resp.clone())
@@ -68,7 +71,7 @@ self.addEventListener('fetch', event => {
     // If there’s nothing in cache, wait for the fetch.
     // If neither yields a response, return offline pages.
     event.respondWith(
-      Promise.race([fetched.catch(_ => cached), cached])
+      Promise.race([fetched.catch(_ => cached), cachedDelayed])
         .then(resp => resp || fetched)
         .catch(_ => { /* eat any errors */ })
     )

--- a/docs/9_0/sw.js
+++ b/docs/9_0/sw.js
@@ -66,15 +66,24 @@ self.addEventListener('fetch', event => {
     const fetched = fetch(fixedUrl, { cache: 'no-store' })
     const fetchedCopy = fetched.then(resp => resp.clone())
 
-    // Call respondWith() with whatever we get first.
-    // If the fetch fails (e.g disconnected), wait for the cache.
-    // If there’s nothing in cache, wait for the fetch.
-    // If neither yields a response, return offline pages.
-    event.respondWith(
-      Promise.race([fetched.catch(_ => cached), cachedDelayed])
-        .then(resp => resp || fetched)
-        .catch(_ => { /* eat any errors */ })
-    )
+    if (navigator.onLine) {
+      // Call respondWith() with whatever we get first.
+      // If the fetch fails (e.g disconnected), wait for the cache.
+      // If there’s nothing in cache, wait for the fetch.
+      // If neither yields a response, return offline pages.
+      event.respondWith(
+          Promise.race([fetched.catch(_ => cached), cachedDelayed])
+              .then(resp => resp || fetched)
+              .catch(_ => { /* eat any errors */ })
+      )
+    }
+    else { // offline
+      event.respondWith(
+          Promise.resolve(cached)
+              .then(resp => resp)
+              .catch(_ => { /* eat any errors */ })
+      )
+    }
 
     // Update the cache with the version we fetched (only for ok status)
     event.waitUntil(


### PR DESCRIPTION
... and some minor cleanup

Browser online:
I modified the ServiceWorker by delaying the load (of the perhaps outdated version) from Cache Storage by 500ms. So the fetch of die up-to-date-version of the docu has higher priority.

Browser offline:
We only look into the Cache Storage.

Notes:
- We have to look how "fast" the browser updates sw.js. Maybe it takes a day or two. (Should not be an issue.)
- Serviceworker seems to fetch content only once within a "session". When a docu-file is modified after Serviceworker fetched it once within the "session" (browser-tab) it does not refetch this file.