### PR TITLE
Fix #5713: DatePicker Add showWeek and weekCalculator

### DIFF
--- a/docs/9_0/components/datepicker.md
+++ b/docs/9_0/components/datepicker.md
@@ -55,6 +55,8 @@ ajax selection and more.
 | stepMinute | 1 | Integer | Minute steps.
 | stepSecond | 1 | Integer | Second steps.
 | showButtonBar | false | Boolean | Whether to display buttons at the footer.
+| showWeek | false | Boolean | Displays the week number next to each week.
+| weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
 | panelStyleClass | null | String | Style class of the container element.
 | panelStyle | null | String | Inline style of the container element.
 | keepInvalid | false | Boolean | Whether to keep the invalid inputs in the field or not.

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -76,7 +76,9 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         disabledDays,
         onMonthChange,
         onYearChange,
-        timeInput
+        timeInput,
+        showWeek,
+        weekCalculator
     }
 
     public DatePickerBase() {
@@ -391,6 +393,22 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
 
     public void setTimeInput(boolean timeInput) {
         getStateHelper().put(PropertyKeys.timeInput, timeInput);
+    }
+
+    public boolean isShowWeek() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.showWeek, false);
+    }
+
+    public void setShowWeek(boolean showWeek) {
+        getStateHelper().put(PropertyKeys.showWeek, showWeek);
+    }
+
+    public String getWeekCalculator() {
+        return (String) getStateHelper().eval(PropertyKeys.weekCalculator, null);
+    }
+
+    public void setWeekCalculator(String weekCalculator) {
+        getStateHelper().put(PropertyKeys.weekCalculator, weekCalculator);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -113,6 +113,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("numberOfMonths", datepicker.getNumberOfMonths(), 1)
             .attr("view", datepicker.getView(), null)
             .attr("touchUI", datepicker.isTouchUI(), false)
+            .attr("showWeek", datepicker.isShowWeek(), false)
             .attr("appendTo", SearchExpressionFacade.resolveClientId(context, datepicker, datepicker.getAppendTo(),
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
             .attr("icon", datepicker.getTriggerButtonIcon(), null)
@@ -147,6 +148,11 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
         String onYearChange = datepicker.getOnYearChange();
         if (onYearChange != null) {
             wb.nativeAttr("onYearChange", onYearChange);
+        }
+
+        String weekCalculator = datepicker.getWeekCalculator();
+        if (weekCalculator != null) {
+            wb.nativeAttr("weekCalculator", weekCalculator);
         }
 
         if (datepicker.isShowOtherMonths()) {

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -29815,5 +29815,21 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Display the current calendar week infront of each row in the calendar panel.]]>
+            </description>
+            <name>showWeek</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[A javascript method that is used to calculate the calendar week. Default implementations are available if start of week is monday, sunday or saturday.]]>
+            </description>
+            <name>weekCalculator</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
 </facelet-taglib>

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -17,6 +17,12 @@
     }
 }(function ($) {
 
+    function calculateWeekNumber(d) {
+        var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+        var weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
+        return weekNo;
+    }
+
     $.widget("prime.datePicker", {
 
         options: {
@@ -116,7 +122,7 @@
                 var sundayIndex = this.getSundayIndex();
                 if(sundayIndex == 0) {
                     this.options.weekCalculator = this.calculateWeekNumber_sundayFirst;
-            	}
+                }
                 else if(sundayIndex == 1) {
                     this.options.weekCalculator = this.calculateWeekNumber_saturdayFirst;
                 }
@@ -1321,27 +1327,21 @@
         },
 
         calculateWeekNumber_iso8601: function(d) {
-        	d = new Date(Date.UTC(d.year, d.month, d.day));
+            d = new Date(Date.UTC(d.year, d.month, d.day));
             d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay()||7));
-            var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-            var weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
-            return weekNo;
+            return calculateWeekNumber(d);
         },
 
         calculateWeekNumber_sundayFirst: function (d) {
             d = new Date(Date.UTC(d.year, d.month, d.day));
             d.setUTCDate(d.getUTCDate() + 3 - d.getUTCDay());
-            var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-            var weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
-            return weekNo;
+            return calculateWeekNumber(d);
         },
 
         calculateWeekNumber_saturdayFirst: function (d) {
-        	d = new Date(Date.UTC(d.year, d.month, d.day));
+            d = new Date(Date.UTC(d.year, d.month, d.day));
             d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
-            var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
-            var weekNo = Math.ceil(( ( (d - yearStart) / 86400000) + 1)/7);
-            return weekNo;
+            return calculateWeekNumber(d);
         },
 
         renderWeek: function (weekDates) {


### PR DESCRIPTION
**Changes as of 2020-03-23:**
 - only a single default implementation is used for all possible `start of week` (`options.locale.firstDay` / `options.locale.firstDayOfWeek`)
 - additionally this implementation is based on the locale option `firstDayWeekOffset` which will be guessed based on `start of week` if not provided.
 - it will fix #1052

------------

`weekCalculator` internally defaults to one of three different implemetation.

- start of week = monday: calculateWeekNumber_iso8601 (like the jQuery based calendar)
- start of week = sunday: calculateWeekNumber_sundayFirst
- start of week = saturday: calculateWeekNumber_saturdayFirst

jQuery based calendar calculated wrong week numbers for sow=sunday|saturday