### PR TITLE
Fix #5579: Spinner prevent bad input, default decimalPlaces to 0 for certain types

### DIFF
--- a/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -24,6 +24,8 @@
 package org.primefaces.component.spinner;
 
 import java.io.IOException;
+import java.math.BigInteger;
+
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
@@ -77,6 +79,16 @@ public class SpinnerRenderer extends InputRenderer {
     protected void encodeScript(FacesContext context, Spinner spinner) throws IOException {
         String clientId = spinner.getClientId(context);
         WidgetBuilder wb = getWidgetBuilder(context);
+
+        Object value = spinner.getValue();
+        String defaultDecimalPlaces = null;
+        if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof BigInteger) {
+            defaultDecimalPlaces = "0";
+        }
+        String decimalPlaces = isValueBlank(spinner.getDecimalPlaces())
+                ? defaultDecimalPlaces
+                : spinner.getDecimalPlaces();
+
         wb.init("Spinner", spinner.resolveWidgetVar(context), clientId)
                 .attr("step", spinner.getStepFactor(), 1.0)
                 .attr("min", spinner.getMin(), Double.MIN_VALUE)
@@ -85,7 +97,7 @@ public class SpinnerRenderer extends InputRenderer {
                 .attr("suffix", spinner.getSuffix(), null)
                 .attr("required", spinner.isRequired(), false)
                 .attr("rotate", spinner.isRotate(), false)
-                .attr("decimalPlaces", spinner.getDecimalPlaces(), null)
+                .attr("decimalPlaces", decimalPlaces, null)
                 .attr(SpinnerBase.PropertyKeys.thousandSeparator.name(), spinner.getThousandSeparator())
                 .attr(SpinnerBase.PropertyKeys.decimalSeparator.name(), spinner.getDecimalSeparator());
 

--- a/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -110,6 +110,12 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
             if ($this.cfg.min >= 0 && event.key === "-") {
                 e.preventDefault();
             }
+
+            /* GitHub #5579 prevent multiple '-' '.' */
+            var value = $(this).val();
+            if ((event.key === '-' && value.indexOf('-') != -1) || (event.key === '.' && value.indexOf('.')!= -1)) {
+                e.preventDefault();
+            }
         })
         .on('keyup.spinner', function (e) {
             $this.updateValue();


### PR DESCRIPTION
Addresses both issues listed in the ticket.