### PR TITLE
Fix #5723: Dashboard disabled and reordering

### DIFF
--- a/docs/9_0/components/dashboard.md
+++ b/docs/9_0/components/dashboard.md
@@ -22,7 +22,8 @@ Dashboard provides a portal like layout with drag&drop based reorder capabilitie
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 | widgetVar | null | String | Name of the client side widget
 | model | null | DashboardModel | Dashboard model instance representing the layout of the UI.
-| disabled | false | Boolean | Disables reordering feature.
+| disabled | false | Boolean | Disables the component.
+| reordering | true | Boolean | Allow reordering of panels.
 | style | null | String | Inline style of the dashboard container
 | styleClass | null | String | Style class of the dashboard container
 
@@ -171,3 +172,11 @@ the default implementation)
 | void addWidget(String widgetId) | Adds a new widget with the given id
 | void addWidget(int index, String widgetId) | Adds a new widget at given index
 | void reorderWidget(int index, String widgetId) | Updates the index of widget in column
+
+## Client Side API
+Widget: _PrimeFaces.widget.Dashboard_
+
+| Method | Params | Return Type | Description | 
+| --- | --- | --- | --- | 
+| disable() | - | void | Disables dashboard
+| enable() | - | void | Enables dashboard

--- a/src/main/java/org/primefaces/component/dashboard/DashboardBase.java
+++ b/src/main/java/org/primefaces/component/dashboard/DashboardBase.java
@@ -40,6 +40,7 @@ public abstract class DashboardBase extends UIPanel implements Widget, ClientBeh
         widgetVar,
         model,
         disabled,
+        reordering,
         style,
         styleClass
     }
@@ -71,6 +72,14 @@ public abstract class DashboardBase extends UIPanel implements Widget, ClientBeh
 
     public boolean isDisabled() {
         return (Boolean) getStateHelper().eval(PropertyKeys.disabled, false);
+    }
+
+    public void setReordering(boolean disabled) {
+        getStateHelper().put(PropertyKeys.reordering, disabled);
+    }
+
+    public boolean isReordering() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.reordering, true);
     }
 
     public void setDisabled(boolean disabled) {

--- a/src/main/java/org/primefaces/component/dashboard/DashboardBase.java
+++ b/src/main/java/org/primefaces/component/dashboard/DashboardBase.java
@@ -74,8 +74,8 @@ public abstract class DashboardBase extends UIPanel implements Widget, ClientBeh
         return (Boolean) getStateHelper().eval(PropertyKeys.disabled, false);
     }
 
-    public void setReordering(boolean disabled) {
-        getStateHelper().put(PropertyKeys.reordering, disabled);
+    public void setReordering(boolean reordering) {
+        getStateHelper().put(PropertyKeys.reordering, reordering);
     }
 
     public boolean isReordering() {

--- a/src/main/java/org/primefaces/component/dashboard/DashboardRenderer.java
+++ b/src/main/java/org/primefaces/component/dashboard/DashboardRenderer.java
@@ -57,6 +57,9 @@ public class DashboardRenderer extends CoreRenderer {
         writer.startElement("div", dashboard);
         writer.writeAttribute("id", clientId, "id");
         String styleClass = dashboard.getStyleClass() != null ? Dashboard.CONTAINER_CLASS + " " + dashboard.getStyleClass() : Dashboard.CONTAINER_CLASS;
+        if (dashboard.isDisabled()) {
+            styleClass = styleClass + " ui-state-disabled";
+        }
         writer.writeAttribute("class", styleClass, "styleClass");
         if (dashboard.getStyle() != null) {
             writer.writeAttribute("style", dashboard.getStyle(), "style");
@@ -94,7 +97,7 @@ public class DashboardRenderer extends CoreRenderer {
         String clientId = dashboard.getClientId(context);
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("Dashboard", dashboard.resolveWidgetVar(context), clientId)
-                .attr("disabled", dashboard.isDisabled(), false);
+                .attr("disabled", !dashboard.isReordering(), false);
 
         encodeClientBehaviors(context, dashboard);
 

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -6355,9 +6355,17 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Disables reordering.]]>
+                <![CDATA[Disables the component.]]>
             </description>
             <name>disabled</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Allow reordering of panels. Default is true.]]>
+            </description>
+            <name>reordering</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>

--- a/src/main/resources/META-INF/resources/primefaces/dashboard/dashboard.js
+++ b/src/main/resources/META-INF/resources/primefaces/dashboard/dashboard.js
@@ -12,6 +12,12 @@ PrimeFaces.widget.Dashboard = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.revert=false;
         this.cfg.handle='.ui-panel-titlebar';
 
+        this.bindEvents();
+
+        $(this.jqId + ' .ui-dashboard-column').sortable(this.cfg);
+    },
+
+    bindEvents: function() {
         var $this = this;
 
         if(this.hasBehavior('reorder')) {
@@ -37,8 +43,14 @@ PrimeFaces.widget.Dashboard = PrimeFaces.widget.BaseWidget.extend({
                 }
             };
         }
+    },
 
-        $(this.jqId + ' .ui-dashboard-column').sortable(this.cfg);
+    disable: function () {
+        this.jq.addClass('ui-state-disabled');
+    },
+
+    enable: function () {
+        this.jq.removeClass('ui-state-disabled');
     }
 
 });


### PR DESCRIPTION
- [x] new property `reordering` which enables or disables reordering capability
- [x] `disabled` property now acts like it does for other components
- [x] Widget methods added for enable() disable()
- [x] Update migration guide