### PR TITLE
Fix #5726: ChartJS BarChart remove hardcoded offset=true

### DIFF
--- a/src/main/java/org/primefaces/component/charts/ChartRenderer.java
+++ b/src/main/java/org/primefaces/component/charts/ChartRenderer.java
@@ -217,10 +217,6 @@ public class ChartRenderer extends CoreRenderer {
         for (int i = 0; i < axes.size(); i++) {
             CartesianAxes data = axes.get(i);
 
-            if (chartName.equals("bar")) {
-                data.setOffset(true);
-            }
-
             if (i != 0) {
                 writer.write(",");
             }


### PR DESCRIPTION
- [x] Removed the hardcoding of offset=true for Bar Charts
- [x] Submit showcase update for this change
- [x] Update migration guide