### PR TITLE
Fix #752: Tabview overflow:hidden CSS

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
@@ -90,8 +90,7 @@
 }
 
 .ui-tabs-left > .ui-tabs-panels {
-    float:right;
-    width:75%;
+    overflow: hidden;
 }
 
 .ui-tabs.ui-tabs-left > .ui-tabs-nav li,


### PR DESCRIPTION
Verified this works in IE, Edge, Chrome, and Firefox