### PR TITLE
Fix #5584: Reflow must remove column title span from draggable

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3515,7 +3515,10 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 helperCells = helperRow.children();
 
                 for(var i = 0; i < helperCells.length; i++) {
-                    helperCells.eq(i).width(cells.eq(i).width());
+                    var helperCell = helperCells.eq(i);
+                    helperCell.width(cells.eq(i).width());
+                    // #5584 reflow must remove column title span
+                    helperCell.children().remove('.ui-column-title');
                 }
 
                 helperRow.appendTo(helper.find('tbody'));


### PR DESCRIPTION
Tested with reflow="true" and reflow="false" and now the draggable row text is properly the row only.