### PR TITLE
Fix #1181: RemoteCommand add CSV support

### DIFF
--- a/docs/8_0/components/commandbutton.md
+++ b/docs/8_0/components/commandbutton.md
@@ -71,6 +71,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | widgetVar | null | String | Name of the client side widget.
 | form | null | String | Form to serialize for an ajax request. Default is the enclosing form.
 | renderDisabledClick | true | Boolean | When enabled, click event can be added to disabled button.
+| validateClient | false | Boolean | When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.
 
 
 ## Getting started with CommandButton

--- a/docs/8_0/components/commandlink.md
+++ b/docs/8_0/components/commandlink.md
@@ -67,6 +67,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | title | null | String | Advisory tooltip information.
 | type | null | String | Type of resource referenced by the link.
 | form | null | String | Form to serialize for an ajax request. Default is the enclosing form.
+| validateClient | false | Boolean | When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.
 
 ## Getting Started with CommandLink
 CommandLink is used just like the standard h:commandLink, difference is form is submitted with

--- a/docs/9_0/components/commandbutton.md
+++ b/docs/9_0/components/commandbutton.md
@@ -71,6 +71,7 @@ CommandButton is an extended version of standard commandButton with ajax and the
 | widgetVar | null | String | Name of the client side widget.
 | form | null | String | Form to serialize for an ajax request. Default is the enclosing form.
 | renderDisabledClick | true | Boolean | When enabled, click event can be added to disabled button.
+| validateClient | false | Boolean | When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.
 
 
 ## Getting started with CommandButton

--- a/docs/9_0/components/commandlink.md
+++ b/docs/9_0/components/commandlink.md
@@ -67,6 +67,7 @@ CommandLink extends standard JSF commandLink with Ajax capabilities.
 | title | null | String | Advisory tooltip information.
 | type | null | String | Type of resource referenced by the link.
 | form | null | String | Form to serialize for an ajax request. Default is the enclosing form.
+| validateClient | false | Boolean | When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.
 
 ## Getting Started with CommandLink
 CommandLink is used just like the standard h:commandLink, difference is form is submitted with

--- a/docs/9_0/components/remotecommand.md
+++ b/docs/9_0/components/remotecommand.md
@@ -40,6 +40,7 @@ resetValues | false | Boolean | If true, local values of input components to be 
 ignoreAutoUpdate | false | Boolean | If true, components which autoUpdate="true" will not be updated for this request. If not specified, or the value is false, no such indication is made.
 timeout | 0 | Integer | Timeout for the ajax request in milliseconds.
 form | null | String | Form to serialize for an ajax request. Default is the enclosing form.
+validateClient | false | Boolean | When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.
 
 ## Getting started with RemoteCommand
 RemoteCommand is used by invoking the command from your javascript code.

--- a/src/main/java/org/primefaces/component/remotecommand/RemoteCommandBase.java
+++ b/src/main/java/org/primefaces/component/remotecommand/RemoteCommandBase.java
@@ -52,7 +52,8 @@ public abstract class RemoteCommandBase extends UICommand implements AjaxSource 
         resetValues,
         ignoreAutoUpdate,
         partialSubmitFilter,
-        form
+        form,
+        validateClient
     }
 
     public RemoteCommandBase() {
@@ -213,6 +214,14 @@ public abstract class RemoteCommandBase extends UICommand implements AjaxSource 
 
     public void setForm(String form) {
         getStateHelper().put(PropertyKeys.form, form);
+    }
+
+    public boolean isValidateClient() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.validateClient, false);
+    }
+
+    public void setValidateClient(boolean validateClient) {
+        getStateHelper().put(PropertyKeys.validateClient, validateClient);
     }
 
 }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -19706,6 +19706,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.]]>
+            </description>
+            <name>validateClient</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>


### PR DESCRIPTION
Added CSV support to remote command.

Also realized the `validateClient` docs were missing from 8.0 and 9.0 for CommandButton and CommandLink.