### PR TITLE
Inneficient iteration of a Map (#5746)

### DIFF
--- a/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -818,9 +818,7 @@ public class TreeRenderer extends CoreRenderer {
         wb.append(",iconStates:{");
 
         boolean firstWritten = false;
-        for (Iterator<String> it = nodes.keySet().iterator(); it.hasNext(); ) {
-            String type = it.next();
-            UITreeNode node = nodes.get(type);
+        for (UITreeNode node : nodes.values()) {
             String expandedIcon = node.getExpandedIcon();
             String collapsedIcon = node.getCollapsedIcon();
 


### PR DESCRIPTION
The fix here is slightly different than https://github.com/primefaces/primefaces/pull/4887, as in this case the key `String type` is only used within the loop to retrieve the value `UiTreeNode node`. 
So, I just iterated directly on `nodes.values()` (the Map's values Collection).