### PR TITLE
Fix #5744: Touch support configuration

### DIFF
--- a/docs/9_0/components/calendar.md
+++ b/docs/9_0/components/calendar.md
@@ -115,6 +115,7 @@ ajax selection and more.
 | defaultSecond | 0 | Integer | Default for second selection, if no date is given. Default is 0.
 | defaultMillisec | 0 | Integer | Default for millisecond selection, if no date is given. Default is 0.
 | resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
+| touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting Started with Calendar
 Value of the calendar should be a java.time.LocalDate.

--- a/docs/9_0/components/carousel.md
+++ b/docs/9_0/components/carousel.md
@@ -43,6 +43,7 @@ Carousel is a multi purpose component to display a set of data or general conten
 | footerText | null | String | Label for footer.
 | responsive | false | Boolean | In responsive mode, carousel adjusts its content based on screen size.
 | breakpoint | 560 | Integer | Breakpoint value in pixels to switch between small and large viewport.
+| touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting Started with Carousel
 Carousel has two main use-cases; data and general content display. To begin with data iteration let’s

--- a/docs/9_0/components/contextmenu.md
+++ b/docs/9_0/components/contextmenu.md
@@ -32,6 +32,7 @@ ContextMenu provides an overlay menu displayed on mouse right-click event.
 | beforeShow | null | String | Client side callback to execute before showing.
 | selectionMode | multiple | String | Defines the selection behavior, e.g "single" or "multiple".
 | targetFilter | null | String | Selector to filter the elements to attach the menu.
+| touchable | true | Boolean | Enable touch support if browser detection supports it. For long press and hold to bring up menu.
 
 ## Getting started with ContextMenu
 ContextMenu is created with submenus and menuitems. Optional for attribute defines which

--- a/docs/9_0/components/datagrid.md
+++ b/docs/9_0/components/datagrid.md
@@ -44,6 +44,7 @@ lazy | false | Boolean | Defines if lazy loading is enabled for the data compone
 emptyMessage | No records found. | String | Text to display when there is no data to display.
 layout | tabular | String | Layout approach to use, valid values are "tabular" and "grid" for responsive grid.
 multiViewState | false | Boolean | Whether to keep DataGrid state across views, defaults to false.
+touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with the DataGrid
 A list of cars will be used throughout the datagrid, datalist and datatable examples.

--- a/docs/9_0/components/datalist.md
+++ b/docs/9_0/components/datalist.md
@@ -46,6 +46,7 @@ DataList presents a collection of data in list layout with several display types
 | emptyMessage | No records found. | String | Text to display when there is no data to display.
 | itemStyleClass | null | String | Style class of an item in list.
 | multiViewState | false | Boolean | Whether to keep list state across views, defaults to false.
+| touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with the DataList
 Since DataList is a data iteration component, it renders it’s children for each data represented with

--- a/docs/9_0/components/datatable.md
+++ b/docs/9_0/components/datatable.md
@@ -110,6 +110,7 @@ DataTable displays data in tabular format.
 | var                       | null               | String           | Name of the request-scoped variable used to refer each data.
 | virtualScroll             | false              | Boolean          | Loads data on demand as the scrollbar gets close to the bottom. Default is false.
 | widgetVar                 | null               | String           | Name of the client side widget.
+| touchable                 | true               | Boolean          | Enable touch support if browser detection supports it.
 
 ## Getting started with the DataTable
 We will be using the same Car and CarBean classes described in DataGrid section.

--- a/docs/9_0/components/dataview.md
+++ b/docs/9_0/components/dataview.md
@@ -44,6 +44,7 @@ layout | list | String | Layout strategy to use, valid values are "list" and "gr
 gridIcon | null | String | Icon of the grid layout button.
 listIcon | null | String | Icon of the list layout button.
 multiViewState | false | Boolean | Whether to keep DataView state across views, defaults to false.
+touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with the DataView
 A list of cars will be used throughout the examples.

--- a/docs/9_0/components/datepicker.md
+++ b/docs/9_0/components/datepicker.md
@@ -115,6 +115,7 @@ ajax selection and more.
 | rangeSeparator | - | String | Separator for joining start and end dates on range selection mode.
 | resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
 | timeInput | false | Boolean | Allows direct input in time field.
+| touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting Started with DatePicker
 Value of the DatePicker should be a java.time.LocalDate in single selection mode which is the default.

--- a/docs/9_0/components/galleria.md
+++ b/docs/9_0/components/galleria.md
@@ -38,6 +38,7 @@ Galleria is used to display a set of images.
 | transitionInterval | 4000 | Integer | Defines interval of slideshow.
 | autoPlay | true | Boolean | Images are displayed in a slideshow in autoPlay.
 | tabindex | 0 | String | Specifies the tab order of element in tab navigation.
+| touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting Started with Galleria
 Images to displayed are defined as children of galleria;

--- a/docs/9_0/components/selectonemenu.md
+++ b/docs/9_0/components/selectonemenu.md
@@ -60,6 +60,7 @@ autoWidth | true | Boolean | Calculates a fixed width based on the width of the 
 dynamic | false | Boolean | Defines if dynamic loading is enabled for the element's panel. If the value is "true", the overlay is not rendered on page load to improve performance.
 dir | ltr | String | Direction indication for text that does not inherit directionality. Valid values are LTR and RTL.
 hideNoSelectionOption | false | boolean  | Flag indicating that, if this component is activated by the user, The "no selection option", if any, must be hidden.
+touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with SelectOneMenu
 Basic SelectOneMenu usage is same as the standard one.

--- a/docs/9_0/components/slider.md
+++ b/docs/9_0/components/slider.md
@@ -38,6 +38,7 @@ onSlide | null | String | Client side callback to execute during sliding.
 onSlideEnd | null | String | Client side callback to execute when slide ends.
 range | false | Boolean | When enabled, two handles are provided for selection a range.
 displayTemplate | null | String | String template to use when updating the display. Valid placeholders are {value}, {min} and {max}.
+touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with Slider
 Slider requires an input component to work with, _for_ attribute is used to set the id of the input

--- a/docs/9_0/components/tabview.md
+++ b/docs/9_0/components/tabview.md
@@ -41,6 +41,7 @@ TabView is a container component to group content in tabs.
 | scrollable     | false   | Boolean    | When enabled, tab headers can be scrolled horizontally instead of wrapping.
 | prependId      | true    | Boolean    | TabView is a naming container thus prepends its id to its children by default, a false value turns this behavior off except for dynamic tabs.
 | tabindex       | 0       | String     | Position of the element in the tabbing order.
+| touchable      | true    | Boolean    | Enable touch support if browser detection supports it.
 
 ## Getting started with the TabView
 TabView requires one more child tab components to display. Titles can also be defined by using

--- a/docs/9_0/components/treetable.md
+++ b/docs/9_0/components/treetable.md
@@ -64,6 +64,7 @@ paginatorAlwaysVisible | true | Boolean | Defines if paginator should be hidden 
 rows | 0 | Integer | Number of rows to display per page. Default value is 0 meaning to display all data available.
 first | 0 | Integer | Index of the first data to display.
 disabledTextSelection | true | Boolean | Disables text selection on row click.
+touchable | true | Boolean | Enable touch support if browser detection supports it.
 
 ## Getting started with the TreeTable
 Similar to the Tree, TreeTable is populated with an _org.primefaces.model.TreeNode_ instance that

--- a/docs/9_0/core/responsive.md
+++ b/docs/9_0/core/responsive.md
@@ -58,3 +58,18 @@ For a detailed example of a responsive page that uses all of the parts above, vi
 http://www.primefaces.org/showcase/ui/misc/responsive.xhtml
 
 Source code is available at GitHub.
+
+## Touch Support
+Some components are mobile aware and support mobile concepts such as Swipe on TabView or Long Press to bring up the Context Menu.
+This can be disabled per component or globally using primefaces.TOUCHABLE global setting to `false` instructs PrimeFaces Touch aware 
+components such as datatable, galleria, tabview, carousel, context menu to disable touch support on browsers that support it.
+
+```xml
+<context-param>
+    <param-name>primefaces.TOUCHABLE</param-name>
+    <param-value>false</param-value>
+</context-param>
+```
+
+Parameter value can also be an EL expression for dynamic values.
+

--- a/src/main/java/org/primefaces/component/api/TouchAware.java
+++ b/src/main/java/org/primefaces/component/api/TouchAware.java
@@ -1,0 +1,46 @@
+/**
+ * The MIT License
+ *
+ * Copyright (c) 2009-2019 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.api;
+
+/**
+ * Even though touch support is detected in the browser a developer may wish
+ * to turn it off globally or per component that supports touch.
+ */
+public interface TouchAware {
+
+    /**
+     * Is this component touch enabled?
+     *
+     * @return false to disable
+     */
+    boolean isTouchable();
+
+    /**
+     * Enable/disable touch support for this component.
+     *
+     * @param touchable true for touch support
+     */
+    void setTouchable(boolean touchable);
+
+}

--- a/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -38,7 +38,7 @@ import org.primefaces.util.CalendarUtils;
 import org.primefaces.util.LocaleUtils;
 import org.primefaces.util.MessageFactory;
 
-public abstract class UICalendar extends HtmlInputText implements InputHolder {
+public abstract class UICalendar extends HtmlInputText implements InputHolder, TouchAware {
 
     public static final String CONTAINER_CLASS = "ui-calendar";
     public static final String INPUT_STYLE_CLASS = "ui-inputfield ui-widget ui-state-default ui-corner-all";
@@ -64,7 +64,8 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder {
         inputStyleClass,
         type,
         rangeSeparator,
-        resolverStyle
+        resolverStyle,
+        touchable
     }
 
     public Object getLocale() {
@@ -249,6 +250,16 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder {
 
     public void setResolverStyle(String resolverStyle) {
         getStateHelper().put(PropertyKeys.resolverStyle, resolverStyle);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 
     public enum ValidationResult {

--- a/src/main/java/org/primefaces/component/api/UIData.java
+++ b/src/main/java/org/primefaces/component/api/UIData.java
@@ -61,7 +61,7 @@ import org.primefaces.util.SharedStringBuilder;
  * It also contains some methods of the Mojarra impl (e.g. setRowIndexRowStatePreserved), maybe can remove it in the future.
  */
 @SuppressWarnings("unchecked")
-public class UIData extends javax.faces.component.UIData {
+public class UIData extends javax.faces.component.UIData implements TouchAware {
 
     public static final String PAGINATOR_TOP_CONTAINER_CLASS = "ui-paginator ui-paginator-top ui-widget-header";
     public static final String PAGINATOR_BOTTOM_CONTAINER_CLASS = "ui-paginator ui-paginator-bottom ui-widget-header";
@@ -117,7 +117,8 @@ public class UIData extends javax.faces.component.UIData {
         rowIndexVar,
         saved,
         lazy,
-        rowStatePreserved;
+        rowStatePreserved,
+        touchable;
     }
 
     public boolean isPaginator() {
@@ -135,6 +136,16 @@ public class UIData extends javax.faces.component.UIData {
 
     public void setPaginatorTemplate(java.lang.String _paginatorTemplate) {
         getStateHelper().put(PropertyKeys.paginatorTemplate, _paginatorTemplate);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -31,6 +31,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.api.UICalendar;
 import org.primefaces.util.CalendarUtils;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class CalendarRenderer extends BaseCalendarRenderer {
@@ -106,7 +107,8 @@ public class CalendarRenderer extends BaseCalendarRenderer {
                 .attr("disabledWeekends", calendar.isDisabledWeekends(), false)
                 .attr("disabled", calendar.isDisabled(), false)
                 .attr("yearRange", calendar.getYearRange(), null)
-                .attr("focusOnSelect", calendar.isFocusOnSelect(), false);
+                .attr("focusOnSelect", calendar.isFocusOnSelect(), false)
+                .attr("touchable", ComponentUtils.isTouchable(context, calendar),  true);
 
         if (calendar.isNavigator()) {
             wb.attr("changeMonth", true).attr("changeYear", true);

--- a/src/main/java/org/primefaces/component/carousel/CarouselBase.java
+++ b/src/main/java/org/primefaces/component/carousel/CarouselBase.java
@@ -23,10 +23,11 @@
  */
 package org.primefaces.component.carousel;
 
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.UIData;
 import org.primefaces.component.api.Widget;
 
-public abstract class CarouselBase extends UIData implements Widget {
+public abstract class CarouselBase extends UIData implements Widget, TouchAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -56,7 +57,8 @@ public abstract class CarouselBase extends UIData implements Widget {
         toggleable,
         toggleSpeed,
         collapsed,
-        stateful
+        stateful,
+        touchable
     }
 
     public CarouselBase() {
@@ -252,5 +254,15 @@ public abstract class CarouselBase extends UIData implements Widget {
 
     public void setStateful(boolean stateful) {
         getStateHelper().put(PropertyKeys.stateful, stateful);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/carousel/CarouselBase.java
+++ b/src/main/java/org/primefaces/component/carousel/CarouselBase.java
@@ -23,11 +23,10 @@
  */
 package org.primefaces.component.carousel;
 
-import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.UIData;
 import org.primefaces.component.api.Widget;
 
-public abstract class CarouselBase extends UIData implements Widget, TouchAware {
+public abstract class CarouselBase extends UIData implements Widget {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -57,8 +56,7 @@ public abstract class CarouselBase extends UIData implements Widget, TouchAware 
         toggleable,
         toggleSpeed,
         collapsed,
-        stateful,
-        touchable
+        stateful
     }
 
     public CarouselBase() {
@@ -254,15 +252,5 @@ public abstract class CarouselBase extends UIData implements Widget, TouchAware 
 
     public void setStateful(boolean stateful) {
         getStateHelper().put(PropertyKeys.stateful, stateful);
-    }
-
-    @Override
-    public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
-    }
-
-    @Override
-    public void setTouchable(boolean touchable) {
-        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/carousel/CarouselRenderer.java
+++ b/src/main/java/org/primefaces/component/carousel/CarouselRenderer.java
@@ -77,7 +77,8 @@ public class CarouselRenderer extends CoreRenderer {
                 .attr("easing", carousel.getEasing(), null)
                 .attr("responsive", carousel.isResponsive(), false)
                 .attr("breakpoint", carousel.getBreakpoint(), 560)
-                .attr("stateful", carousel.isStateful());
+                .attr("stateful", carousel.isStateful())
+                .attr("touchable", ComponentUtils.isTouchable(context, carousel),  true);
 
         if (carousel.isToggleable()) {
             wb.attr("toggleable", true)

--- a/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
+++ b/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
@@ -23,10 +23,11 @@
  */
 package org.primefaces.component.contextmenu;
 
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.Widget;
 import org.primefaces.component.menu.AbstractMenu;
 
-public abstract class ContextMenuBase extends AbstractMenu implements Widget {
+public abstract class ContextMenuBase extends AbstractMenu implements Widget, TouchAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -43,7 +44,8 @@ public abstract class ContextMenuBase extends AbstractMenu implements Widget {
         event,
         beforeShow,
         selectionMode,
-        targetFilter;
+        targetFilter,
+        touchable;
 
         private String toString;
 
@@ -148,5 +150,15 @@ public abstract class ContextMenuBase extends AbstractMenu implements Widget {
 
     public void setTargetFilter(String targetFilter) {
         getStateHelper().put(PropertyKeys.targetFilter, targetFilter);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
@@ -33,6 +33,7 @@ import org.primefaces.component.menu.AbstractMenu;
 import org.primefaces.component.tieredmenu.TieredMenuRenderer;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.util.HTML;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class ContextMenuRenderer extends TieredMenuRenderer {
@@ -60,7 +61,8 @@ public class ContextMenuRenderer extends TieredMenuRenderer {
                 .attr("event", menu.getEvent(), null)
                 .attr("selectionMode", menu.getSelectionMode(), "multiple")
                 .callback("beforeShow", "function(event)", menu.getBeforeShow())
-                .attr("targetFilter", menu.getTargetFilter(), null);
+                .attr("targetFilter", menu.getTargetFilter(), null)
+                .attr("touchable", ComponentUtils.isTouchable(context, menu),  true);
 
         wb.finish();
     }

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -252,7 +252,12 @@ public class DataTableRenderer extends DataRenderer {
                     .attr("scrollHeight", table.getScrollHeight(), null)
                     .attr("frozenColumns", table.getFrozenColumns(), 0)
                     .attr("liveScrollBuffer", table.getLiveScrollBuffer())
-                    .attr("virtualScroll", table.isVirtualScroll());
+                    .attr("virtualScroll", table.isVirtualScroll())
+                    .attr("touchable", false,  true);
+        }
+        else {
+            // only allow swipe if not scrollable
+            wb.attr("touchable", ComponentUtils.isTouchable(context, table),  true);
         }
 
         //Resizable/Draggable Columns
@@ -296,7 +301,6 @@ public class DataTableRenderer extends DataRenderer {
                 .callback("onRowClick", "function(row)", table.getOnRowClick());
 
         wb.attr("disableContextMenuIfEmpty", table.isDisableContextMenuIfEmpty());
-        wb.attr("touchable", ComponentUtils.isTouchable(context, table),  true);
 
         //Behaviors
         encodeClientBehaviors(context, table);

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -296,6 +296,7 @@ public class DataTableRenderer extends DataRenderer {
                 .callback("onRowClick", "function(row)", table.getOnRowClick());
 
         wb.attr("disableContextMenuIfEmpty", table.isDisableContextMenuIfEmpty());
+        wb.attr("touchable", ComponentUtils.isTouchable(context, table),  true);
 
         //Behaviors
         encodeClientBehaviors(context, table);

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -41,6 +41,7 @@ import org.primefaces.component.calendar.BaseCalendarRenderer;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.expression.SearchExpressionUtils;
 import org.primefaces.util.CalendarUtils;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class DatePickerRenderer extends BaseCalendarRenderer {
@@ -146,7 +147,8 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
             .attr("icon", datepicker.getTriggerButtonIcon(), null)
             .attr("rangeSeparator", datepicker.getRangeSeparator(), null)
-            .attr("timeInput", datepicker.isTimeInput());
+            .attr("timeInput", datepicker.isTimeInput())
+            .attr("touchable", ComponentUtils.isTouchable(context, datepicker),  true);
 
         List<Integer> disabledDays = datepicker.getDisabledDays();
         if (disabledDays != null) {

--- a/src/main/java/org/primefaces/component/galleria/GalleriaBase.java
+++ b/src/main/java/org/primefaces/component/galleria/GalleriaBase.java
@@ -25,9 +25,10 @@ package org.primefaces.component.galleria;
 
 import javax.faces.component.UIOutput;
 
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.Widget;
 
-public abstract class GalleriaBase extends UIOutput implements Widget {
+public abstract class GalleriaBase extends UIOutput implements Widget, TouchAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -50,7 +51,8 @@ public abstract class GalleriaBase extends UIOutput implements Widget {
         transitionInterval,
         panelWidth,
         panelHeight,
-        showCaption
+        showCaption,
+        touchable
     }
 
     public GalleriaBase() {
@@ -190,5 +192,15 @@ public abstract class GalleriaBase extends UIOutput implements Widget {
 
     public void setTabindex(String tabindex) {
         getStateHelper().put(PropertyKeys.tabindex, tabindex);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/galleria/GalleriaRenderer.java
+++ b/src/main/java/org/primefaces/component/galleria/GalleriaRenderer.java
@@ -136,7 +136,8 @@ public class GalleriaRenderer extends CoreRenderer {
                 .attr("showCaption", galleria.isShowCaption(), false)
                 .attr("panelWidth", galleria.getPanelWidth(), Integer.MIN_VALUE)
                 .attr("panelHeight", galleria.getPanelHeight(), Integer.MIN_VALUE)
-                .attr("custom", (galleria.getFacet("content") != null));
+                .attr("custom", (galleria.getFacet("content") != null))
+                .attr("touchable", ComponentUtils.isTouchable(context, galleria),  true);
 
         wb.finish();
     }

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
@@ -27,9 +27,10 @@ import javax.faces.component.html.HtmlSelectOneMenu;
 
 import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.RTLAware;
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.Widget;
 
-public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Widget, InputHolder, RTLAware {
+public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Widget, InputHolder, RTLAware, TouchAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -58,7 +59,8 @@ public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Wid
         placeholder,
         autoWidth,
         dynamic,
-        dir
+        dir,
+        touchable
     }
 
     public SelectOneMenuBase() {
@@ -248,5 +250,15 @@ public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Wid
     @Override
     public void setDir(String dir) {
         getStateHelper().put(PropertyKeys.dir, dir);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -539,7 +539,8 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                 .attr("syncTooltip", menu.isSyncTooltip(), false)
                 .attr("labelTemplate", menu.getLabelTemplate(), null)
                 .attr("autoWidth", menu.isAutoWidth(), true)
-                .attr("dynamic", menu.isDynamic(), false);
+                .attr("dynamic", menu.isDynamic(), false)
+                .attr("touchable", ComponentUtils.isTouchable(context, menu),  true);
 
         if (menu.isFilter()) {
             wb.attr("filter", true)

--- a/src/main/java/org/primefaces/component/slider/SliderBase.java
+++ b/src/main/java/org/primefaces/component/slider/SliderBase.java
@@ -27,9 +27,10 @@ import javax.faces.component.UIInput;
 import javax.faces.component.behavior.ClientBehaviorHolder;
 
 import org.primefaces.component.api.PrimeClientBehaviorHolder;
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.Widget;
 
-public abstract class SliderBase extends UIInput implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder {
+public abstract class SliderBase extends UIInput implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder, TouchAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -52,7 +53,8 @@ public abstract class SliderBase extends UIInput implements Widget, ClientBehavi
         onSlide,
         onSlideEnd,
         range,
-        displayTemplate;
+        displayTemplate,
+        touchable;
 
         private String toString;
 
@@ -204,5 +206,15 @@ public abstract class SliderBase extends UIInput implements Widget, ClientBehavi
 
     public void setDisplayTemplate(String displayTemplate) {
         getStateHelper().put(PropertyKeys.displayTemplate, displayTemplate);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/slider/SliderRenderer.java
+++ b/src/main/java/org/primefaces/component/slider/SliderRenderer.java
@@ -109,6 +109,7 @@ public class SliderRenderer extends CoreRenderer {
                 .attr("disabled", slider.isDisabled(), false)
                 .attr("range", range)
                 .attr("displayTemplate", slider.getDisplayTemplate(), null)
+                .attr("touchable", ComponentUtils.isTouchable(context, slider),  true)
                 .callback("onSlideStart", "function(event,ui)", slider.getOnSlideStart())
                 .callback("onSlide", "function(event,ui)", slider.getOnSlide())
                 .callback("onSlideEnd", "function(event,ui)", slider.getOnSlideEnd());

--- a/src/main/java/org/primefaces/component/tabview/TabViewBase.java
+++ b/src/main/java/org/primefaces/component/tabview/TabViewBase.java
@@ -27,10 +27,11 @@ import javax.faces.component.behavior.ClientBehaviorHolder;
 
 import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.RTLAware;
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.UITabPanel;
 import org.primefaces.component.api.Widget;
 
-public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware, ClientBehaviorHolder, PrimeClientBehaviorHolder {
+public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware, TouchAware, ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -51,7 +52,8 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
         onTabClose,
         dir,
         scrollable,
-        tabindex
+        tabindex,
+        touchable
     }
 
     public TabViewBase() {
@@ -173,5 +175,15 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
 
     public void setTabindex(String tabindex) {
         getStateHelper().put(PropertyKeys.tabindex, tabindex);
+    }
+
+    @Override
+    public boolean isTouchable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+    }
+
+    @Override
+    public void setTouchable(boolean touchable) {
+        getStateHelper().put(PropertyKeys.touchable, touchable);
     }
 }

--- a/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -103,7 +103,8 @@ public class TabViewRenderer extends CoreRenderer {
         wb.attr("effect", tabView.getEffect(), null)
                 .attr("effectDuration", tabView.getEffectDuration(), null)
                 .attr("scrollable", tabView.isScrollable())
-                .attr("tabindex", tabView.getTabindex(), null);
+                .attr("tabindex", tabView.getTabindex(), null)
+                .attr("touchable", ComponentUtils.isTouchable(context, tabView),  true);
 
         encodeClientBehaviors(context, tabView);
 

--- a/src/main/java/org/primefaces/context/PrimeRequestContext.java
+++ b/src/main/java/org/primefaces/context/PrimeRequestContext.java
@@ -63,6 +63,7 @@ public class PrimeRequestContext {
     private PrimeApplicationContext applicationContext;
     private Boolean ignoreAutoUpdate;
     private Boolean rtl;
+    private Boolean touchable;
 
     public PrimeRequestContext(FacesContext context) {
         this.context = context;
@@ -253,5 +254,23 @@ public class PrimeRequestContext {
         }
 
         return rtl;
+    }
+
+    public boolean isTouchable() {
+        if (touchable == null) {
+            String param = context.getExternalContext().getInitParameter(Constants.ContextParams.TOUCHABLE);
+            if (param == null) {
+                touchable = true;
+            }
+            else {
+                ELContext elContext = context.getELContext();
+                ExpressionFactory expressionFactory = context.getApplication().getExpressionFactory();
+                ValueExpression expression = expressionFactory.createValueExpression(elContext, param, String.class);
+                String expressionValue = (String) expression.getValue(elContext);
+                touchable = expressionValue == null || Boolean.parseBoolean(expressionValue);
+            }
+        }
+
+        return touchable;
     }
 }

--- a/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -24,6 +24,7 @@
 package org.primefaces.util;
 
 import org.primefaces.component.api.RTLAware;
+import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.UITabPanel;
 import org.primefaces.component.api.Widget;
 import org.primefaces.config.PrimeConfiguration;
@@ -222,6 +223,12 @@ public class ComponentUtils {
         boolean globalValue = PrimeRequestContext.getCurrentInstance(context).isRTL();
 
         return globalValue || component.isRTL();
+    }
+
+    public static boolean isTouchable(FacesContext context, TouchAware component) {
+        boolean globalValue = PrimeRequestContext.getCurrentInstance(context).isTouchable();
+
+        return globalValue || component.isTouchable();
     }
 
     public static void processDecodesOfFacetsAndChilds(UIComponent component, FacesContext context) {

--- a/src/main/java/org/primefaces/util/Constants.java
+++ b/src/main/java/org/primefaces/util/Constants.java
@@ -35,6 +35,7 @@ public class Constants {
         public static final String FONT_AWESOME = "primefaces.FONT_AWESOME";
         public static final String SUBMIT = "primefaces.SUBMIT";
         public static final String DIRECTION = "primefaces.DIR";
+        public static final String TOUCHABLE = "primefaces.TOUCHABLE";
         public static final String RESET_VALUES = "primefaces.RESET_VALUES";
         public static final String PFV_KEY = "primefaces.CLIENT_SIDE_VALIDATION";
         public static final String UPLOADER = "primefaces.UPLOADER";

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3524,6 +3524,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Makes panel toggleable. Default is false.]]>
             </description>
             <name>toggleable</name>

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3524,19 +3524,19 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Breakpoint value in pixels to switch between small and large viewport. Default is 640]]>
-            </description>
-            <name>breakpoint</name>
-            <required>false</required>
-            <type>java.lang.Integer</type>
-        </attribute>
-        <attribute>
-            <description>
                 <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Breakpoint value in pixels to switch between small and large viewport. Default is 640]]>
+            </description>
+            <name>breakpoint</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
         </attribute>
         <attribute>
             <description>
@@ -30198,6 +30198,22 @@
             <name>touchable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Display the current calendar week infront of each row in the calendar panel.]]>
+            </description>
+            <name>showWeek</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[A javascript method that is used to calculate the calendar week. Default implementations are available if start of week is monday, sunday or saturday.]]>
+            </description>
+            <name>weekCalculator</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
     </tag>
 </facelet-taglib>

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3157,6 +3157,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -6343,6 +6351,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -6635,6 +6651,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -6859,6 +6883,14 @@
                 <![CDATA[Whether to keep list state across views, defaults to false.]]>
             </description>
             <name>multiViewState</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
@@ -7758,6 +7790,14 @@
             <required>false</required>
             <type>javax.el.MethodExpression</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -7949,6 +7989,14 @@
                 <![CDATA[Whether to keep DataView state across views, defaults to false.]]>
             </description>
             <name>multiViewState</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
@@ -10050,6 +10098,14 @@
                 <![CDATA[Displays information retrieved from title and alt attributes of images in content caption.]]>
             </description>
             <name>showCaption</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
@@ -23069,6 +23125,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -23947,6 +24011,14 @@
             <name>displayTemplate</name>
             <required>false</required>
             <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
         </attribute>
     </tag>
     <tag>
@@ -25833,6 +25905,14 @@
             <name>tabindex</name>
             <required>false</required>
             <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
         </attribute>
     </tag>
     <tag>
@@ -28401,6 +28481,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -30102,6 +30190,14 @@
             <name>weekCalculator</name>
             <required>false</required>
             <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+            </description>
+            <name>touchable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
         </attribute>
     </tag>
 </facelet-taglib>

--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -134,6 +134,9 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
         if(hasTimePicker) {
             this.configureTimePicker();
         }
+        
+        // is touch support enabled
+        var touchEnabled = PrimeFaces.env.isTouchable(this.cfg) && !this.input.attr("readonly") && this.cfg.showOn && this.cfg.showOn === 'button';
 
         //Client behaviors, input skinning and z-index
         if(this.cfg.popup) {
@@ -161,7 +164,7 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
                 }, 1);
 
                 // touch support - prevents keyboard popup
-                if(PrimeFaces.env.touch && !$this.input.attr("readonly") && $this.cfg.showOn && $this.cfg.showOn === 'button') {
+                if(touchEnabled) {
                     $(this).prop("readonly", true);
                 }
 
@@ -178,7 +181,7 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
         }
 
         // touch support - prevents keyboard popup
-        if (PrimeFaces.env.touch && !this.input.attr("readonly") && this.cfg.showOn && this.cfg.showOn === 'button') {
+        if (touchEnabled) {
             var fireCloseEvent = this.cfg.onClose;
             this.cfg.onClose = function(dateText, inst) {
                 $(this).attr("readonly", false);

--- a/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
+++ b/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
@@ -225,27 +225,29 @@ PrimeFaces.widget.Carousel = PrimeFaces.widget.DeferredWidget.extend({
             }
         });
 
-        this.itemsContainer.swipe({
-            swipeLeft:function(event) {
-                if($this.page === ($this.totalPages - 1)) {
-                    if($this.cfg.circular)
-                        $this.setPage(0);
-                }
-                else {
-                    $this.setPage($this.page + 1);
-                }
-            },
-            swipeRight: function(event) {
-            	if($this.page === 0) {
-                    if($this.cfg.circular)
-                        $this.setPage($this.totalPages - 1);
-                }
-                else {
-                    $this.setPage($this.page - 1);
-                }
-            },
-            excludedElements: PrimeFaces.utils.excludedSwipeElements()
-        });
+        if (PrimeFaces.env.isTouchable(this.cfg)) {
+            this.itemsContainer.swipe({
+                swipeLeft:function(event) {
+                    if($this.page === ($this.totalPages - 1)) {
+                        if($this.cfg.circular)
+                            $this.setPage(0);
+                    }
+                    else {
+                        $this.setPage($this.page + 1);
+                    }
+                },
+                swipeRight: function(event) {
+                    if($this.page === 0) {
+                        if($this.cfg.circular)
+                            $this.setPage($this.totalPages - 1);
+                    }
+                    else {
+                        $this.setPage($this.page - 1);
+                    }
+                },
+                excludedElements: PrimeFaces.utils.excludedSwipeElements()
+            });
+        }
 
         if(this.pageLinks.length) {
             this.pageLinks.on('click', function(e) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -64,7 +64,7 @@ if (!PrimeFaces.env) {
          * A widget is touch enabled if the browser supports touch AND the widget has the touchable property enabled.
          * The default will be true if it widget status can't be determined.
          * 
-         * @param cfg the widget configuration
+         * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg the widget configuration
          */
         isTouchable: function(cfg) {
             var widgetTouchable = (cfg == undefined) || (cfg.touchable != undefined ? cfg.touchable : true);

--- a/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -65,6 +65,7 @@ if (!PrimeFaces.env) {
          * The default will be true if it widget status can't be determined.
          * 
          * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg the widget configuration
+         * @return {boolean} true if touch is enabled, false if disabled
          */
         isTouchable: function(cfg) {
             var widgetTouchable = (cfg == undefined) || (cfg.touchable != undefined ? cfg.touchable : true);

--- a/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -64,7 +64,7 @@ if (!PrimeFaces.env) {
          * A widget is touch enabled if the browser supports touch AND the widget has the touchable property enabled.
          * The default will be true if it widget status can't be determined.
          * 
-         * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg the widget configuration
+         * @param {PrimeFaces.widget.BaseWidgetCfg} cfg the widget configuration
          * @return {boolean} true if touch is enabled, false if disabled
          */
         isTouchable: function(cfg) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -58,6 +58,17 @@ if (!PrimeFaces.env) {
          */
         isLtIE: function(version) {
             return (this.browser.msie) ? parseInt(this.browser.version, 10) < version : false;
+        },
+
+        /**
+         * A widget is touch enabled if the browser supports touch AND the widget has the touchable property enabled.
+         * The default will be true if it widget status can't be determined.
+         * 
+         * @param cfg the widget configuration
+         */
+        isTouchable: function(cfg) {
+            var widgetTouchable = (cfg == undefined) || (cfg.touchable != undefined ? cfg.touchable : true);
+            return PrimeFaces.env.touch && widgetTouchable;
         }
     };
 

--- a/src/main/resources/META-INF/resources/primefaces/datagrid/datagrid.js
+++ b/src/main/resources/META-INF/resources/primefaces/datagrid/datagrid.js
@@ -49,6 +49,7 @@ PrimeFaces.widget.DataGrid = PrimeFaces.widget.BaseWidget.extend({
         };
 
         this.paginator = new PrimeFaces.widget.Paginator(this.cfg.paginator);
+        this.paginator.bindSwipeEvents(this.jq, this.cfg);
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/datalist/datalist.js
+++ b/src/main/resources/META-INF/resources/primefaces/datalist/datalist.js
@@ -49,6 +49,7 @@ PrimeFaces.widget.DataList = PrimeFaces.widget.BaseWidget.extend({
         };
 
         this.paginator = new PrimeFaces.widget.Paginator(this.cfg.paginator);
+        this.paginator.bindSwipeEvents(this.jq, this.cfg);
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -400,9 +400,8 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         };
 
         this.paginator = new PrimeFaces.widget.Paginator(this.cfg.paginator);
-        this.paginator.bindSwipeEvents(this.jq);
+        this.paginator.bindSwipeEvents(this.jq, this.cfg);
         
-
         if(this.cfg.clientCache) {
             this.cacheRows = this.paginator.getRows();
             var newState = {

--- a/src/main/resources/META-INF/resources/primefaces/dataview/dataview.js
+++ b/src/main/resources/META-INF/resources/primefaces/dataview/dataview.js
@@ -56,6 +56,7 @@ PrimeFaces.widget.DataView = PrimeFaces.widget.BaseWidget.extend({
         };
 
         this.paginator = new PrimeFaces.widget.Paginator(this.cfg.paginator);
+        this.paginator.bindSwipeEvents(this.jq, this.cfg);
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -63,6 +63,9 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         this.bindDateSelectListener();
         this.bindViewChangeListener();
         this.bindCloseListener();
+        
+        // is touch support enabled
+        var touchEnabled = PrimeFaces.env.isTouchable(this.cfg) && !this.input.attr("readonly") && this.cfg.showIcon;
 
         //Client behaviors, input skinning and z-index
         if(!this.cfg.inline) {
@@ -83,7 +86,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
                 var inst = this; // the instance of prime.datePicker API
 
                 // touch support - prevents keyboard popup
-                if(PrimeFaces.env.touch && !inst.inputfield.attr("readonly") && _self.cfg.showIcon) {
+                if(touchEnabled) {
                     _self.jqEl.prop("readonly", true);
                 }
 
@@ -96,7 +99,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         }
 
         // touch support - prevents keyboard popup
-        if (PrimeFaces.env.touch && !this.input.attr("readonly") && this.cfg.showIcon) {
+        if (touchEnabled) {
             this.cfg.onBeforeHide = function() {
                 _self.jqEl.attr("readonly", false);
             };

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -128,7 +128,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         }
 
         // see #7602
-        if (PrimeFaces.env.touch) {
+        if (PrimeFaces.env.isTouchable(this.cfg)) {
             this.focusInput.attr('readonly', true);
         }
 

--- a/src/main/resources/META-INF/resources/primefaces/galleria/galleria.js
+++ b/src/main/resources/META-INF/resources/primefaces/galleria/galleria.js
@@ -156,17 +156,19 @@ PrimeFaces.widget.Galleria = PrimeFaces.widget.DeferredWidget.extend({
         });
 
         // Touch Swipe Events
-        this.jq.swipe({
-            swipeLeft:function(event) {
-                $this.stopSlideshow();
-                $this.prev();
-            },
-            swipeRight: function(event) {
-                $this.stopSlideshow();
-                $this.next();
-            },
-            excludedElements: PrimeFaces.utils.excludedSwipeElements()
-        });
+        if (PrimeFaces.env.isTouchable(this.cfg)) {
+            this.jq.swipe({
+                swipeLeft:function(event) {
+                    $this.stopSlideshow();
+                    $this.prev();
+                },
+                swipeRight: function(event) {
+                    $this.stopSlideshow();
+                    $this.next();
+                },
+                excludedElements: PrimeFaces.utils.excludedSwipeElements()
+            });
+        }
 
         // Keyboard accessibility
         this.jq.on('keydown.galleria', function(e) {

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
@@ -81,7 +81,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                 $this.show(e);
             });
 
-            if (PrimeFaces.env.touch) {
+            if (PrimeFaces.env.isTouchable(this.cfg)) {
                 $(document).swipe({
                     longTap:function(e, target) {
                        $this.show(e);
@@ -113,7 +113,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                     $this.show(e);
                 });
 
-                if (PrimeFaces.env.touch) {
+                if (PrimeFaces.env.isTouchable(this.cfg)) {
                     $(this.jqTargetId).swipe({
                         longTap:function(e, target) {
                            $this.show(e);

--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
@@ -259,9 +259,9 @@ PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
 
     /**
      * Binds swipe events to this paginator to the JQ element passed in.
-     *
+     * @private
      * @param {JQuery} owner the owner JQ element of the paginator
-     * @param ownerConfig the owner configuration to check if touch enabled or not
+     * @param {PrimeFaces.PartialWidgetCfg<TCfg>} ownerConfig the owner configuration to check if touch enabled or not
      */
     bindSwipeEvents: function(owner, ownerConfig) {
         if (!PrimeFaces.env.isTouchable(ownerConfig)) {

--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
@@ -259,11 +259,12 @@ PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
 
     /**
      * Binds swipe events to this paginator to the JQ element passed in.
-     * 
-     * @param {JQuery} owner The owner of the paginator
+     *
+     * @param {JQuery} owner the owner JQ element of the paginator
+     * @param ownerConfig the owner configuration to check if touch enabled or not
      */
-    bindSwipeEvents: function(owner) {
-        if (!PrimeFaces.env.touch) {
+    bindSwipeEvents: function(owner, ownerConfig) {
+        if (!PrimeFaces.env.isTouchable(ownerConfig)) {
             return;
         }
         var $this = this;

--- a/src/main/resources/META-INF/resources/primefaces/slider/slider.js
+++ b/src/main/resources/META-INF/resources/primefaces/slider/slider.js
@@ -65,7 +65,7 @@ PrimeFaces.widget.Slider = PrimeFaces.widget.BaseWidget.extend({
 
         this.bindEvents();
 
-        if (PrimeFaces.env.touch) {
+        if (PrimeFaces.env.isTouchable(this.cfg)) {
             this.bindTouchEvents();
         }
     },

--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -245,7 +245,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
      * @private
      */
     bindSwipeEvents: function() {
-        if (!PrimeFaces.env.touch) {
+        if (!PrimeFaces.env.isTouchable(this.cfg)) {
             return;
         }
         var $this = this;

--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -196,6 +196,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
             };
 
             this.paginator = new PrimeFaces.widget.Paginator(this.cfg.paginator);
+            this.paginator.bindSwipeEvents(this.jq, this.cfg);
         }
     },
 


### PR DESCRIPTION
Modeled this after Right to Left support RTLAware.  I just did Carousel for review before I implement the others.

- [x] TouchAware interface
- [x] Context param in web.xml `primefaces.TOUCHABLE` to globally disable touch support
- [x] Pass value as widget cfg param default is TRUE if it can't be determined
- [x] `PrimeFaces.env.isTouchable` reusable JS function to be used in all components
- [x] Wrap call to binding touchable events in new `PrimeFaces.env.isTouchable` method
- [x] Calendar
- [x] Carousel
- [x] ContextMenu
- [x] DataGrid
- [x] DataList
- [x] DataTable
- [x] DataView
- [x] DatePicker
- [x] Galleria
- [x] SelectOneMenu
- [x] Slider
- [x] TabView
- [x] TreeTable