### PR TITLE
More fixes for Inneficient iteration of Maps (#5746)

### DIFF
--- a/src/main/java/org/primefaces/application/DialogNavigationHandler.java
+++ b/src/main/java/org/primefaces/application/DialogNavigationHandler.java
@@ -87,9 +87,10 @@ public class DialogNavigationHandler extends ConfigurableNavigationHandler {
 
             sb.append(",options:{");
             if (options != null && !options.isEmpty()) {
-                for (Iterator<String> it = options.keySet().iterator(); it.hasNext();) {
-                    String optionName = it.next();
-                    Object optionValue = options.get(optionName);
+                for (Iterator<Map.Entry<String, Object>> it = options.entrySet().iterator(); it.hasNext();) {
+                    Map.Entry<String, Object> entry = it.next();
+                    String optionName = entry.getKey();
+                    Object optionValue = entry.getValue();
 
                     sb.append(optionName).append(":");
                     if (optionValue instanceof String) {

--- a/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
+++ b/src/main/java/org/primefaces/component/chart/renderer/DonutRenderer.java
@@ -50,9 +50,10 @@ public class DonutRenderer extends BasePlotRenderer {
 
             writer.write("[");
             Map<String, Number> map = (Map) data.get(i);
-            for (Iterator<String> it = map.keySet().iterator(); it.hasNext(); ) {
-                String key = it.next();
-                Number value = map.get(key);
+            for (Iterator<Map.Entry<String, Number>> it = map.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<String, Number> entry = it.next();
+                String key = entry.getKey();
+                Number value = entry.getValue();
 
                 writer.write("[" + escapeChartData(key) + "," + value + "]");
 

--- a/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
+++ b/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
@@ -175,9 +175,10 @@ public class PrimePartialResponseWriter extends PartialResponseWriterWrapper {
             startExtension(CALLBACK_EXTENSION_PARAMS);
             getWrapped().write("{");
 
-            for (Iterator<String> it = params.keySet().iterator(); it.hasNext();) {
-                String paramName = it.next();
-                Object paramValue = params.get(paramName);
+            for (Iterator<Map.Entry<String, Object>> it = params.entrySet().iterator(); it.hasNext();) {
+                Map.Entry<String, Object> entry = it.next();
+                String paramName = entry.getKey();
+                Object paramValue = entry.getValue();
 
                 if (paramValue == null) {
                     encodeJSONValue(paramName, null);

--- a/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
+++ b/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
@@ -308,9 +308,11 @@ public class AjaxRequestBuilder {
         if (params != null && !params.isEmpty()) {
             buffer.append(",pa:[");
 
-            for (Iterator<String> it = params.keySet().iterator(); it.hasNext();) {
-                String name = it.next();
-                List<String> paramValues = params.get(name);
+            for (Iterator<Map.Entry<String, List<String>>> it = params.entrySet().iterator(); it.hasNext();) {
+                Map.Entry<String, List<String>> entry = it.next();
+                String name = entry.getKey();
+                List<String> paramValues = entry.getValue();
+
                 int size = paramValues.size();
                 for (int i = 0; i < size; i++) {
                     String paramValue = paramValues.get(i);


### PR DESCRIPTION
Sorry for revisiting Issue #5746, I overlooked other 4 violations.

The fixes here are different from https://github.com/primefaces/primefaces/pull/5747.
They introduce a `Map.Entry<K, V>` variable to preserve the original key and values variables.