### PR TITLE
Fix #5784: Move licenses out of META-INF/resources so they cannot be served

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,9 @@
                 </executions>
                 <configuration>
                     <excludedScopes>test,provided</excludedScopes>
+                    <outputDirectory>${project.basedir}/target/classes/META-INF/licenses/</outputDirectory>
+                    <licensesOutputFile>${project.basedir}/target/classes/META-INF/licenses/licenses-generated.xml</licensesOutputFile>
+                    <licensesOutputDirectory>${project.basedir}/target/classes/META-INF/licenses/</licensesOutputDirectory>
                     <licenseUrlReplacements>
                         <licenseUrlReplacement>
                             <regexp>.*BSD-3.*</regexp>


### PR DESCRIPTION
Current location let the licenses be served out of the web server which to me is not the right place for licenses.

Current location: /META-INF/resources/licenses/

New Location: /META-INF/licenses