### PR TITLE
resolve #5787: Use this._super in #init method of widgets

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -4,9 +4,8 @@
 PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
+
         this.block = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.block);
         this.content = $(this.jqId);
         this.cfg.animate = (this.cfg.animate === false)? false : true;
@@ -21,8 +20,6 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         if(this.cfg.blocked) {
             this.show();
         }
-
-        this.removeScriptElement(this.id);
     },
             
     refresh: function(cfg) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -74,14 +74,21 @@ if (!PrimeFaces.widget) {
         init: function(cfg) {
             this.cfg = cfg;
             this.id = cfg.id;
-            this.jqId = PrimeFaces.escapeClientId(this.id);
+            if ($.isArray(this.id)) {
+                this.jqId = $.map(this.id, function(id) {
+                    return PrimeFaces.escapeClientId(id);
+                }).join(",");
+            }
+            else {
+                this.jqId = PrimeFaces.escapeClientId(this.id);
+            }
             this.jq = $(this.jqId);
             this.widgetVar = cfg.widgetVar;
             this.destroyListeners = [];
             this.refreshListeners = [];
 
             //remove script tag
-            $(this.jqId + '_s').remove();
+            this.removeScriptElement(this.id);
 
             if (this.widgetVar) {
                 var $this = this;
@@ -137,10 +144,17 @@ if (!PrimeFaces.widget) {
         /**
          * Removes the widget's script block from the DOM.
          *
-         * @param {string} clientId The id of the widget.
+         * @param {string | string[]} clientId The id of the widget.
          */
         removeScriptElement: function(clientId) {
-            $(PrimeFaces.escapeClientId(clientId) + '_s').remove();
+            if ($.isArray(clientId)) {
+                $.each(clientId, function(_, id) {
+                    $(PrimeFaces.escapeClientId(id) + '_s').remove();
+                });
+            }
+            else {
+                $(PrimeFaces.escapeClientId(clientId) + '_s').remove();
+            }
         },
 
         hasBehavior: function(event) {

--- a/src/main/resources/META-INF/resources/primefaces/dragdrop/dragdrop.js
+++ b/src/main/resources/META-INF/resources/primefaces/dragdrop/dragdrop.js
@@ -4,10 +4,9 @@
 PrimeFaces.widget.Draggable = PrimeFaces.widget.BaseWidget.extend({
     
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
-        this.jq = $(PrimeFaces.escapeClientId(this.cfg.target));
+        this._super(cfg);
+
+        this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));
         this.cfg.cancel = this.cfg.cancel || "input,textarea,button,select,option";
 
         if(this.cfg.appendTo) {
@@ -28,9 +27,7 @@ PrimeFaces.widget.Draggable = PrimeFaces.widget.BaseWidget.extend({
             }
         };
         
-        this.jq.draggable(this.cfg);
-        
-        this.removeScriptElement(this.id);
+        this.jqTarget.draggable(this.cfg);
     }
     
 });
@@ -41,16 +38,12 @@ PrimeFaces.widget.Draggable = PrimeFaces.widget.BaseWidget.extend({
 PrimeFaces.widget.Droppable = PrimeFaces.widget.BaseWidget.extend({
     
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
-        this.jq = $(PrimeFaces.escapeClientId(this.cfg.target));
+        this._super(cfg);
+        this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));
 
         this.bindDropListener();
 
-        this.jq.droppable(this.cfg);
-        
-        this.removeScriptElement(this.id);
+        this.jqTarget.droppable(this.cfg);
     },
     
     bindDropListener: function() {

--- a/src/main/resources/META-INF/resources/primefaces/effect/effect.js
+++ b/src/main/resources/META-INF/resources/primefaces/effect/effect.js
@@ -4,9 +4,8 @@
 PrimeFaces.widget.Effect = PrimeFaces.widget.BaseWidget.extend({
     
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
+
         this.source = $(PrimeFaces.escapeClientId(this.cfg.source));
         var _self = this;
 
@@ -25,8 +24,6 @@ PrimeFaces.widget.Effect = PrimeFaces.widget.BaseWidget.extend({
         else {
             this.source.on(this.cfg.event, this.runner);
         }
-        
-        this.removeScriptElement(this.id);
     }
     
 });

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
@@ -4,9 +4,7 @@
 PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
         this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));
         this.scope = this.cfg.scope ? $(PrimeFaces.escapeClientId(this.cfg.scope)) : null;
         var $this = this;
@@ -47,7 +45,5 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
                 }
             });
         }
-
-        this.removeScriptElement(this.id);
     }
 });

--- a/src/main/resources/META-INF/resources/primefaces/growl/growl.js
+++ b/src/main/resources/META-INF/resources/primefaces/growl/growl.js
@@ -4,13 +4,9 @@
 PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
 
         this.render();
-
-        this.removeScriptElement(this.id);
     },
 
     //Override

--- a/src/main/resources/META-INF/resources/primefaces/keyfilter/1-keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyfilter/1-keyfilter.js
@@ -6,8 +6,8 @@ PrimeFaces.widget.KeyFilter = PrimeFaces.widget.BaseWidget.extend({
      * @param {object} cfg The widget configuration.
      */
     init : function(cfg) {
-        this.id = cfg.id;
-        this.cfg = cfg;
+        this._super(cfg);
+
         this.target = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.target);
 
         if (this.target.is(':input')) {
@@ -16,8 +16,6 @@ PrimeFaces.widget.KeyFilter = PrimeFaces.widget.BaseWidget.extend({
             var nestedInput = $(':not(:submit):not(:button):input:visible:enabled:first', this.target);
             this.applyKeyFilter(nestedInput, cfg);
         }
-
-        this.removeScriptElement(this.id);
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
@@ -1,13 +1,7 @@
 PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.jq = $();
-
-        var _self = this;
-        $.each(this.cfg.id, function(index, id){
-            _self.jq = _self.jq.add($(PrimeFaces.escapeClientId(id)));
-        });
+        this._super(cfg);
 
         //elements
         this.pagesContainer = this.jq.children('.ui-paginator-pages');

--- a/src/main/resources/META-INF/resources/primefaces/poll/poll.js
+++ b/src/main/resources/META-INF/resources/primefaces/poll/poll.js
@@ -4,8 +4,8 @@
 PrimeFaces.widget.Poll = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
+        this._super(cfg);
+
         this.active = false;
 
         if(this.cfg.autoStart) {

--- a/src/main/resources/META-INF/resources/primefaces/resizable/resizable.js
+++ b/src/main/resources/META-INF/resources/primefaces/resizable/resizable.js
@@ -4,9 +4,8 @@
 PrimeFaces.widget.Resizable = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
+
         this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));
 
         this.renderDeferred();

--- a/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -4,8 +4,8 @@
 PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
+        this._super(cfg);
+
         this.cfg.showEvent = this.cfg.showEvent ? this.cfg.showEvent + '.tooltip' : 'mouseover.tooltip';
         this.cfg.hideEvent = this.cfg.hideEvent ? this.cfg.hideEvent + '.tooltip' : 'mouseout.tooltip';
         this.cfg.showEffect = this.cfg.showEffect ? this.cfg.showEffect : 'fade';
@@ -20,8 +20,6 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
             this.bindTarget();
         else
             this.bindGlobal();
-
-        this.removeScriptElement(this.id);
     },
 
     //@override

--- a/src/main/resources/META-INF/resources/primefaces/watermark/watermark.js
+++ b/src/main/resources/META-INF/resources/primefaces/watermark/watermark.js
@@ -4,9 +4,8 @@
 PrimeFaces.widget.Watermark = PrimeFaces.widget.BaseWidget.extend({
 
     init: function(cfg) {
-        this.cfg = cfg;
-        this.id = this.cfg.id;
-        this.jqId = PrimeFaces.escapeClientId(this.id);
+        this._super(cfg);
+
         this.target = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.target);
 
         if(this.target.is(':not(:input)')) {
@@ -14,8 +13,6 @@ PrimeFaces.widget.Watermark = PrimeFaces.widget.BaseWidget.extend({
         }
 
         this.target.attr('placeholder', this.cfg.value);
-
-        this.removeScriptElement(this.id);
     }
 
 });


### PR DESCRIPTION
See #5787

* Added `this._super(cfg)` to the init method of the widgets mentioned in the issue above
* Removed the following lines from the individual widgets as it's done by `BaseWidget#init`:
    * `this.removeScriptElement(this.id)`
    * `this.cfg = cfg;`
    * `this.id = cfg.id;`
    * `this.jqId = PrimeFaces.escapeClientId(this.id); `
* Draggable & Resize
    * For consistency, `BaseWidget#jq` should be the element with the id `BaseWidget#jqId`
    * But these two widgets set `this.jqId = PrimeFaces.escapeClientId(this.id);` and `this.jq = $(PrimeFaces.escapeClientId(this.cfg.target));`
    * :point_right: I changed that to `this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));`
 * Paginator: `cfg.id` is an array of IDs
    * :point_right: I modified `BaseWidget#init` so that it works regardless of whether `cfg.id` is a `string` or `string[]`