### PR TITLE
Fix #5790: CSP with DefaultCommand click

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -94,7 +94,7 @@ if (!PrimeFaces.csp) {
          * GitHub #5790: When using jQuery to trigger a click event on a button while using CSP
          * we must set preventDefault or else it will trigger a non-ajax button click.
          * 
-         * @return {JQuery} the JQuery click event
+         * @return {JQuery.Event} the JQuery click event
          */
         clickEvent: function() {
             var clickEvent = $.Event( "click" );

--- a/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -93,6 +93,8 @@ if (!PrimeFaces.csp) {
         /**
          * GitHub #5790: When using jQuery to trigger a click event on a button while using CSP
          * we must set preventDefault or else it will trigger a non-ajax button click.
+         * 
+         * @return {JQuery} the JQuery click event
          */
         clickEvent: function() {
             var clickEvent = $.Event( "click" );

--- a/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -24,9 +24,9 @@ if (!PrimeFaces.csp) {
 
         register: function(id, event, js){
             if (event) {
-                var shortenedEvent = event.substring(2, event.length);
-
-                var element = document.getElementById(id);
+                var shortenedEvent = event.substring(2, event.length),
+                    element = document.getElementById(id),
+                    jqEvent = shortenedEvent + '.' + id;
 
                 // if the eventhandler return false, we must use preventDefault
                 var jsWrapper = function(event) {
@@ -36,7 +36,7 @@ if (!PrimeFaces.csp) {
                     }
                 };
 
-                $(element).on(shortenedEvent, jsWrapper);
+                $(element).off(jqEvent).on(jqEvent, jsWrapper);
             }
         },
 
@@ -88,6 +88,18 @@ if (!PrimeFaces.csp) {
 
             // call the function
             cspFunction.call(id, e);
+        },
+
+        /**
+         * GitHub #5790: When using jQuery to trigger a click event on a button while using CSP
+         * we must set preventDefault or else it will trigger a non-ajax button click.
+         */
+        clickEvent: function() {
+            var clickEvent = $.Event( "click" );
+            if (PrimeFaces.csp.NONCE_VALUE) {
+                clickEvent.preventDefault();
+            }
+            return clickEvent;
         }
 
     };

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.defaultcommand.js
@@ -30,7 +30,7 @@ PrimeFaces.widget.DefaultCommand = PrimeFaces.widget.BaseWidget.extend({
                 }
 
                 if (!$this.jqTarget.is(':disabled, .ui-state-disabled')) {
-                    $this.jqTarget.click();
+                    $this.jqTarget.trigger(PrimeFaces.csp.clickEvent());
                 }
                 e.preventDefault();
                 e.stopImmediatePropagation();


### PR DESCRIPTION
I debugged the problem and it is because preventDefault is not set.

Clicking with the mouse the generated event is:
```
originalEvent: MouseEvent {isTrusted: true, screenX: 991, screenY: 349, clientX: 991, clientY: 246, …}
type: "click"
isDefaultPrevented: ƒ Se()
target: span.ui-button-text.ui-c
currentTarget: button#form1:btn2.ui-button.ui-widget.ui-state-default.ui-corner-all.ui-button-text-only.ui-state-focus.ui-state-hover
relatedTarget: null
timeStamp: 7779.6999999991385
jQuery341020872048982204006: true
delegateTarget: button#form1:btn2.ui-button.ui-widget.ui-state-default.ui-corner-all.ui-button-text-only.ui-state-focus.ui-state-hover
handleObj: {type: "click", origType: "click", data: undefined, guid: 78, handler: ƒ, …}
data: undefined
__proto__: Object
```

Presssing ENTER key which triggers the Default Command to execute a Jquery trigger click was generating this:
```
type: "click"
timeStamp: 1586968566959
jQuery341020872048982204006: true
isTrigger: 3
namespace: ""
rnamespace: null
result: undefined
target: button#form1:btn2.ui-button.ui-widget.ui-state-default.ui-corner-all.ui-button-text-only
delegateTarget: button#form1:btn2.ui-button.ui-widget.ui-state-default.ui-corner-all.ui-button-text-only
currentTarget: button#form1:btn2.ui-button.ui-widget.ui-state-default.ui-corner-all.ui-button-text-only
handleObj: {type: "click", origType: "click", data: undefined, guid: 78, handler: ƒ, …}
data: undefined
__proto__: Object
```

Notice `isDefaultPrevented` is missing so the button click was trigger a "Form Submit" non AJAX call on the button.