### PR TITLE
Fix #5675, 5695, 5801, 5429: Remove zoom/transform IE8 hack.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/accordion/accordion.css
+++ b/src/main/resources/META-INF/resources/primefaces/accordion/accordion.css
@@ -1,6 +1,6 @@
 .ui-accordion .ui-accordion-header { cursor: pointer; position: relative; margin-top: 1px; min-height: 0; padding: .5em .5em .5em 2.2em;}
 .ui-accordion .ui-accordion-header .ui-icon { position: absolute; left: .5em; top: 50%; margin-top: -8px; }
-.ui-accordion .ui-accordion-content { padding: 1em 2.2em; border-top: 0; margin-top: -2px; position: relative; top: 1px; margin-bottom: 2px; overflow: auto; -moz-transform: scale(1); -o-transform: scale(1); -webkit-transform: scale(1); transform: scale(1); }
+.ui-accordion .ui-accordion-content { padding: 1em 2.2em; border-top: 0; margin-top: -2px; position: relative; top: 1px; margin-bottom: 2px; overflow: auto; }
 .ui-accordion .ui-accordion-header.ui-state-disabled, .ui-accordion .ui-accordion-header.ui-state-disabled a { cursor: default; }
 
 /** RTL **/

--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.css
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.css
@@ -1,9 +1,5 @@
 .ui-autocomplete {
     width: auto;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
     cursor: pointer;
     -moz-box-shadow: none;
     -webkit-box-shadow: none;

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
@@ -3,7 +3,7 @@
 .ui-dialog.ui-overlay-hidden {display:block;}
 .ui-dialog .ui-dialog-titlebar { padding: .4em .4em .4em 1em; position: relative; border:0px; }
 .ui-dialog .ui-dialog-title { float: left; margin: .3em 16px .1em 0; } 
-.ui-dialog .ui-dialog-content {position: relative; border: 0; padding: .5em 1em; background: none; overflow: auto;  -moz-transform: scale(1); -o-transform: scale(1); -webkit-transform: scale(1); transform: scale(1); }
+.ui-dialog .ui-dialog-content {position: relative; border: 0; padding: .5em 1em; background: none; overflow: auto; }
 .ui-dialog .ui-dialog-content.ui-df-content {overflow: hidden; padding: 0;}
 .ui-dialog .ui-dialog-footer {padding: .4em 1em; border-width: 1px 0 0 0; text-align:left;}
 .ui-dialog .ui-dialog-buttonpane { text-align: left; background-image: none; margin: .5em 0 0 0; padding: .3em 1em .5em .4em; }

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -393,10 +393,6 @@ input[type=text]::-ms-clear {
     text-decoration: none !important;
     cursor: pointer;
     text-align: center;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
     overflow: visible; /* the overflow property removes extra width in IE */
 }
 
@@ -492,10 +488,6 @@ button.ui-button::-moz-focus-inner {
     display: inline-block;
     position: relative;
     width: auto;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
     cursor: pointer;
 }
 
@@ -741,10 +733,6 @@ button.ui-button::-moz-focus-inner {
 /** IE Hacks **/
 div.ui-button, .ui-splitbutton {
     display: inline-block;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
 }
 
 /** Password **/

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.css
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.css
@@ -349,10 +349,6 @@
     cursor: pointer; 
     position: relative; 
     margin: 0;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
 }
 
 .ui-panelmenu .ui-panelmenu-header a { 
@@ -374,10 +370,6 @@
     position: relative; 
     top: 1px; 
     overflow: auto; 
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1); 
     outline: none;
 }
 
@@ -444,10 +436,6 @@
 /** TabMenu **/
 .ui-tabmenu { 
     position: relative; 
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1); 
 }
 
 .ui-tabmenu .ui-tabmenu-nav { 

--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.css
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.css
@@ -37,10 +37,6 @@
 .ui-paginator .ui-paginator-current {
 	display: inline-block;
 	padding: 2px 6px;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
 	margin-left: 1px;
 	margin-right: 1px;
 	text-decoration: none;

--- a/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
+++ b/src/main/resources/META-INF/resources/primefaces/tabview/tabview.css
@@ -1,10 +1,6 @@
 .ui-tabs {
     position: relative;
     padding: .2em;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
 } /* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
 
 .ui-tabs .ui-tabs-nav {

--- a/src/main/resources/META-INF/resources/primefaces/tree/tree.css
+++ b/src/main/resources/META-INF/resources/primefaces/tree/tree.css
@@ -69,10 +69,6 @@
 
 .ui-tree .ui-chkbox {
     display: inline-block;
-    -moz-transform: scale(1);
-    -o-transform: scale(1);
-    -webkit-transform: scale(1);
-    transform: scale(1);
 }
 
 /** Horizontal Tree **/


### PR DESCRIPTION
These transforms were to fix an old IE8 issue.  This issue is no longer present in IE11.

Tested in Edge, IE11, Firefox and Chrome.