### PR TITLE
Fix #5827 Inverted order of method resolution in AjaxBehaviorListenerImpl

### DIFF
--- a/src/main/java/org/primefaces/behavior/ajax/AjaxBehaviorListenerImpl.java
+++ b/src/main/java/org/primefaces/behavior/ajax/AjaxBehaviorListenerImpl.java
@@ -69,22 +69,10 @@ public class AjaxBehaviorListenerImpl implements AjaxBehaviorListener, Serializa
         }
 
         try {
+            processArgListener(context, elContext, event);
+        }
+        catch (MethodNotFoundException | IllegalArgumentException | ArrayIndexOutOfBoundsException e) {
             listener.invoke(elContext, new Object[]{});
-        }
-        catch (MethodNotFoundException | IllegalArgumentException e) {
-            processArgListener(context, elContext, event);
-        }
-        // JBoss hack, see #1375
-        catch (ArrayIndexOutOfBoundsException e) {
-            processArgListener(context, elContext, event);
-        }
-        // it's wrapped in a ELException since newer Payara versions
-        catch (ELException e) {
-            if (e.getCause() instanceof MethodNotFoundException || e.getCause() instanceof IllegalArgumentException) {
-                processArgListener(context, elContext, event);
-                return;
-            }
-            throw e;
         }
     }
 


### PR DESCRIPTION
- first try to call method with parameters we have
- if it fails, try to call method with parameters
  - then EL implementation fills missing parameters with nulls
  - if the method has no parameters, behavior is still correct
- see also OverloadedMethodTest in EL library