### PR TITLE
Fix #5829: ColumnToggler add button to ignored overlay elements

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
+++ b/src/main/resources/META-INF/resources/primefaces/columntoggler/columntoggler.js
@@ -183,7 +183,8 @@ PrimeFaces.widget.ColumnToggler = PrimeFaces.widget.DeferredWidget.extend({
 
         this.bindKeyEvents();
 
-        PrimeFaces.utils.registerHideOverlayHandler(this, 'mousedown.' + this.id + '_hide', $this.panel, null,
+        PrimeFaces.utils.registerHideOverlayHandler(this, 'mousedown.' + this.id + '_hide', $this.panel, 
+            function() { return $this.trigger; },
             function(e, eventTarget) {
                 if(!($this.panel.is(eventTarget) || $this.panel.has(eventTarget).length > 0)) {
                     $this.hide();


### PR DESCRIPTION
Easy fix the registerOverlayHandler and button click were colliding. Simply needed to add the button to resolveIgnoredElementsCallback so they don't collide.  Tested and works in all browsers.