### PR TITLE
Fix #5748: DatePicker: timeOnly causes infinite loop

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1523,8 +1523,10 @@
                 .on('mouseup.datePicker-time', timeSelector, null, function (event) {
                     $this.onTimePickerElementMouseUp(event);
                 })
-                .on('mouseleave.datePicker-time', timeSelector, null, function () {
-                    $this.clearTimePickerTimer();
+                .on('mouseleave.datePicker-time', timeSelector, null, function (event) {
+                    if (this.timePickerTimer) {
+                        $this.onTimePickerElementMouseUp(event);
+                    }
                 })
                 .on('click.datePicker-ampm', ampmSelector, null, function (event) {
                     $this.toggleAmPm(event);
@@ -1777,6 +1779,10 @@
         onTimePickerElementMouseUp: function (event) {
             if (!this.options.disabled) {
                 this.clearTimePickerTimer();
+
+                if (this.options.onSelect) {
+                    this.options.onSelect.call(this, event, this.value);
+                }
             }
         },
 
@@ -1816,6 +1822,7 @@
         clearTimePickerTimer: function () {
             if (this.timePickerTimer) {
                 clearTimeout(this.timePickerTimer);
+                this.timePickerTimer = null;
             }
         },
 
@@ -2233,7 +2240,8 @@
         },
 
         updateTime: function (event, hour, minute, second) {
-            var newDateTime = (this.value && this.value instanceof Date) ? new Date(this.value) : new Date();
+            var newDateTime = (this.value && this.value instanceof Date) ? new Date(this.value) : new Date(),
+                $this = this;
 
             newDateTime.setHours(hour);
             newDateTime.setMinutes(minute);
@@ -2243,9 +2251,13 @@
             this.updateModel(event, newDateTime);
 
             if (this.options.onSelect) {
-                this.options.onSelect.call(this, event, newDateTime);
+                if (this.timePickerTimer === 'undefined' || this.timePickerTimer === null) {
+                    this.options.onSelect.call(this, event, newDateTime);
+                }
             }
         },
+
+
 
         updateTimeAfterInput: function (event, newDateTime) {
             this.value = newDateTime;

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1524,7 +1524,7 @@
                     $this.onTimePickerElementMouseUp(event);
                 })
                 .on('mouseleave.datePicker-time', timeSelector, null, function (event) {
-                    if (this.timePickerTimer) {
+                    if ($this.timePickerTimer) {
                         $this.onTimePickerElementMouseUp(event);
                     }
                 })
@@ -1778,9 +1778,11 @@
 
         onTimePickerElementMouseUp: function (event) {
             if (!this.options.disabled) {
+                console.log('onTimePickerElementMouseUp');
                 this.clearTimePickerTimer();
 
                 if (this.options.onSelect) {
+                    console.log('...fire dateSelect');
                     this.options.onSelect.call(this, event, this.value);
                 }
             }
@@ -2240,8 +2242,7 @@
         },
 
         updateTime: function (event, hour, minute, second) {
-            var newDateTime = (this.value && this.value instanceof Date) ? new Date(this.value) : new Date(),
-                $this = this;
+            var newDateTime = (this.value && this.value instanceof Date) ? new Date(this.value) : new Date();
 
             newDateTime.setHours(hour);
             newDateTime.setMinutes(minute);
@@ -2256,7 +2257,6 @@
                 }
             }
         },
-
 
 
         updateTimeAfterInput: function (event, newDateTime) {

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1778,11 +1778,9 @@
 
         onTimePickerElementMouseUp: function (event) {
             if (!this.options.disabled) {
-                console.log('onTimePickerElementMouseUp');
                 this.clearTimePickerTimer();
 
                 if (this.options.onSelect) {
-                    console.log('...fire dateSelect');
                     this.options.onSelect.call(this, event, this.value);
                 }
             }
@@ -2257,7 +2255,6 @@
                 }
             }
         },
-
 
         updateTimeAfterInput: function (event, newDateTime) {
             this.value = newDateTime;


### PR DESCRIPTION
@melloware : I need your help!

I tried to fix this issue by triggering dateSelect at mouseUp instead after each increment.

But callBehavior fails because at this point there´s some other "this" object:
![grafik](https://user-images.githubusercontent.com/10461942/80243022-b0401f80-8666-11ea-87fb-e8514cef47b7.png)

One which does not have the dateSelect-Behavior.

This seems to be a trivial issue. Do you have a tip how to work arround this issue.