### PR TITLE
primefaces/primefaces#5856 prevent dynamic trees from loading the entire model of a partially collapsed tree

### DIFF
--- a/src/main/java/org/primefaces/component/api/UITree.java
+++ b/src/main/java/org/primefaces/component/api/UITree.java
@@ -257,29 +257,33 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
     }
 
     public void buildRowKeys(TreeNode node) {
-        int childCount = node.getChildCount();
-        if (childCount > 0) {
-            for (int i = 0; i < childCount; i++) {
-                TreeNode childNode = node.getChildren().get(i);
-                if (childNode.isSelected()) {
-                    addToPreselection(childNode);
-                }
+        if (node.isExpanded() || node.getParent() == null || node.getParent().isExpanded()) {
+            int childCount = node.getChildCount();
+            if (childCount > 0) {
+                for (int i = 0; i < childCount; i++) {
+                    TreeNode childNode = node.getChildren().get(i);
+                    if (childNode.isSelected()) {
+                        addToPreselection(childNode);
+                    }
 
-                String childRowKey = (node.getParent() == null) ? String.valueOf(i) : node.getRowKey() + "_" + i;
-                childNode.setRowKey(childRowKey);
-                buildRowKeys(childNode);
+                    String childRowKey = (node.getParent() == null) ? String.valueOf(i) : node.getRowKey() + "_" + i;
+                    childNode.setRowKey(childRowKey);
+                    buildRowKeys(childNode);
+                }
             }
         }
     }
 
     public void populateRowKeys(TreeNode node, List<String> keys) {
-        if (node != null) {
-            int childCount = node.getChildCount();
-            if (childCount > 0) {
-                for (int i = 0; i < childCount; i++) {
-                    TreeNode childNode = node.getChildren().get(i);
-                    keys.add(childNode.getRowKey());
-                    populateRowKeys(childNode, keys);
+        if (node.isExpanded() || node.getParent() == null || node.getParent().isExpanded()) {
+            if (node != null) {
+                int childCount = node.getChildCount();
+                if (childCount > 0) {
+                    for (int i = 0; i < childCount; i++) {
+                        TreeNode childNode = node.getChildren().get(i);
+                        keys.add(childNode.getRowKey());
+                        populateRowKeys(childNode, keys);
+                    }
                 }
             }
         }
@@ -293,7 +297,7 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
 
                 String childRowKey = (node.getParent() == null) ? String.valueOf(i) : node.getRowKey() + "_" + i;
                 childNode.setRowKey(childRowKey);
-                updateRowKeys(childNode);
+                updateRowKeys(childNode); // should we comment this to enable lazy loading?
             }
         }
     }

--- a/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -650,6 +650,10 @@ public class TreeRenderer extends CoreRenderer {
 
         //preselection
         String rowKey = node.getRowKey();
+        if (rowKey == null) {
+            tree.buildRowKeys(node.getParent());
+            rowKey = node.getRowKey();
+        }
         boolean selected = node.isSelected();
         boolean partialSelected = node.isPartialSelected();
         boolean filter = (tree.getValueExpression("filterBy") != null);


### PR DESCRIPTION
fixes primefaces/primefaces#5856

According to the documentation, `dynamic="true"` enables lazy loading. However, that's not entirely true. Since a couple of versions the entire data model is loaded, even if the tree is completely or partially collapsed.

This pull request fixes that. You can test it with the reproducer at https://github.com/stephanrauh/primefaces-test.