### PR TITLE
Implement #5859: PrimeFaces.ajax.Request.handle returns promise-like

### DIFF
--- a/docs/9_0/components/remotecommand.md
+++ b/docs/9_0/components/remotecommand.md
@@ -57,14 +57,74 @@ RemoteCommand is used by invoking the command from your javascript code.
     }
 </script>
 ```
+
 That’s it whenever you execute your custom javascript function(eg customfunction()), a remote call
 will be made, actionListener is processed and output text is updated. Note that remoteCommand
 must be nested inside a form.
 
 
-## Passing Parameters
+## Passing parameters
+
 Remote command can send dynamic parameters in the following way;
 
 ```js
 increment([{name:'x', value:10}, {name:'y', value:20}]);
 ```
+
+To access these parameters in a bean method:
+
+```java
+    public void execute() {
+        String param1 = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("x");
+        String param2 = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("y");
+        // Do something with the parameters
+        FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Executed", "x: " + param1 + ", y: " + param2));
+    }
+```
+
+## Receiving parameters
+
+You can receive parameters from the server in the following way.
+
+First, in your bean method, add a callback parameter:
+
+```java
+    public void execute() {
+        // Do something interesting when the remote command is called
+        // ...
+
+        // Return data to the client
+        PrimeFaces.current().ajax().addCallbackParam("serverTime", System.currentTimeMillis());
+    }
+```
+
+Then access the parameter on the client:
+
+```xhtml
+<p:remoteCommand name="rc" update="msgs" action="#{remoteCommandView.execute}"
+    oncomplete="alert('Return value from server: ' + args.serverTime)"/>
+```
+
+## Using promises
+
+You can add also add callbacks for when the remote succeeds or fails via the
+promise returned by the remote command. Compared with adding a callback via
+`oncomplete`, this lets you register as many callbacks as you want, and also
+register different callbacks dynamically from the calling JavaScript code:
+
+Using `async` JavaScript functions (check browser support!), this would look as follows:
+
+```javascript
+async function main(param1, param2) {
+    const responseData = await rc([
+        {name: 'x', value: param1},
+        {name: 'y', value: param2},
+    ]);
+    
+    const serverTime = responseData.jqXHR.pfArgs.serverTime;
+}
+
+main("foo", "bar");
+```
+
+Without support for async function, use `rc().then(...).catch(...)` instead.

--- a/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
+++ b/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
@@ -75,7 +75,11 @@ public class RemoteCommandRenderer extends CoreRenderer {
                         .ajax(true)
                         .process(command, command.getProcess())
                         .update(command, command.getUpdate())
-                        .command(request).build();
+                        .command("return " + request)
+                        .build();
+        }
+        else {
+            request = "return " + request;
         }
 
         //script

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -36,6 +36,10 @@ if (!PrimeFaces.ajax) {
      * options. The individual options are documented in `PrimeFaces.ajax.Configuration`. 
      * @param {Partial<PrimeFaces.ajax.ConfigurationExtender>} [ext] Optional extender with additional options that
      * overwrite the options given in `cfg`.
+     * @return {Promise<PrimeFaces.ajax.ResponseData>} A promise that resolves once the AJAX requests is done. Use this
+     * to run custom JavaScript logic. When the AJAX request succeeds, the promise is fulfilled. Otherwise, when the
+     * AJAX request fails, the promise is rejected. If the promise is rejected, the rejection handler receives an object
+     * of type {@link PrimeFaces.ajax.FailedRequestData}. 
      */
     PrimeFaces.ab = function(cfg, ext) {
         for (var option in cfg) {
@@ -50,7 +54,7 @@ if (!PrimeFaces.ajax) {
             }
         }
 
-        PrimeFaces.ajax.Request.handle(cfg, ext);
+        return PrimeFaces.ajax.Request.handle(cfg, ext);
     };
 
     /**
@@ -381,9 +385,14 @@ if (!PrimeFaces.ajax) {
              * the HTTP method, the URL, and the content of the request. 
              * @param {Partial<PrimeFaces.ajax.ConfigurationExtender>} [ext] Optional extender with additional options
              * that overwrite the options given in `cfg`.
+             * @return {Promise<PrimeFaces.ajax.ResponseData>} A promise that resolves once the AJAX requests is done.
+             * Use this to run custom JavaScript logic. When the AJAX request succeeds, the promise is fulfilled.
+             * Otherwise, when the AJAX request fails, the promise is rejected. If the promise is rejected, the
+             * rejection handler receives an object of type {@link PrimeFaces.ajax.FailedRequestData}.
              */
             handle: function(cfg, ext) {
                 cfg.ext = ext;
+                cfg.promise = cfg.promise || $.Deferred();
 
                 if (PrimeFaces.settings.earlyPostParamEvaluation) {
                     cfg.earlyPostParams = PrimeFaces.ajax.Request.collectEarlyPostParams(cfg);
@@ -395,6 +404,8 @@ if (!PrimeFaces.ajax) {
                 else {
                     PrimeFaces.ajax.Queue.offer(cfg);
                 }
+
+                return cfg.promise.promise();
             },
 
             /**
@@ -463,11 +474,15 @@ if (!PrimeFaces.ajax) {
                 }
 
                 if(retVal === false) {
-                    PrimeFaces.debug('Ajax request cancelled by onstart callback.');
+                    PrimeFaces.debug('AJAX request cancelled by onstart callback.');
 
                     //remove from queue
                     if(!cfg.async) {
                         PrimeFaces.ajax.Queue.poll();
+                    }
+
+                    if (cfg.promise) {
+                        cfg.promise.reject({ textStatus: 'error', errorThrown: 'AJAX request cancelled by onstart callback.' });
                     }
 
                     return false;  //cancel request
@@ -695,6 +710,10 @@ if (!PrimeFaces.ajax) {
 
                 var jqXhr = $.ajax(xhrOptions)
                     .fail(function(xhr, status, errorThrown) {
+                        if (cfg.promise) {
+                            cfg.promise.reject({jqXHR: xhr, textStatus: status, errorThrown: errorThrown});
+                        }
+
                         var location = xhr.getResponseHeader("Location");
                         if (xhr.status == 401 && location) {
                             PrimeFaces.debug('Unauthorized status received. Redirecting to ' + location);
@@ -713,10 +732,15 @@ if (!PrimeFaces.ajax) {
                         PrimeFaces.error('Request return with error:' + status + '.');
                     })
                     .done(function(data, status, xhr) {
-                        PrimeFaces.debug('Response received succesfully.');
-
+                        PrimeFaces.debug('Response received successfully.');
                         try {
                             var parsed;
+
+                            // Resolve promise for custom JavaScript handler
+                            // Promise handlers are called asynchronously so they are run after the response was handled
+                            if (cfg.promise) {
+                                cfg.promise.resolve({document: data, textStatus: status, jqXHR: xhr});
+                            }
 
                             //call user callback
                             if(cfg.onsuccess) {
@@ -752,7 +776,7 @@ if (!PrimeFaces.ajax) {
                             cfg.ext.oncomplete.call(this, xhr, status, xhr.pfArgs, data);
                         }
 
-                        // after that, call the endusers callback, which should be called when everything is ready
+                        // after that, call the end user's callback, which should be called when everything is ready
                         if(cfg.oncomplete) {
                             cfg.oncomplete.call(this, xhr, status, xhr.pfArgs, data);
                         }


### PR DESCRIPTION
This implements #5859.

* I changed the method `PrimeFaces.ajax.Request.handle`. It now create a `$.Deferred` object and saves it in the `cfg` object, and returns it. Later, when the AJAX request is done, that promise is resolved, or rejected when the request failed.
* I also modified the `RemoteCommandRenderer` so that calling a remote command from the client now also returns that promise.
* I also updated the docs, see `remoteCommand.md` for an example.
* See also primefaces/primefaces-showcase#145

I also made sure this works when client-side validation is enabled (`PrimeFaces.vb` instead of `PrimeFaces.ab`). Currently, when csv is enabled, the remote command returns `false` when validation fails. In order not to break things, I left that as is and return the Promise only when validation succeeded.  Or do you think that we can change this - and return a rejected promise when validation fails? That is, change

```javascript
rc = function() {
        if (PrimeFaces.vb({
            s: this,
            a: true,
            p: 'j_idt720:name j_idt720:number',
            u: 'j_idt720:grid'
        })) {
            return pf.ab({
                s: "j_idt720:j_idt759",
                f: "j_idt720",
                p: "j_idt720:name j_idt720:number",
                u: "j_idt720:grid",
                pa: arguments[0]
            });
        } else {
            return false;
        }
    }
```

to this:

```javascript
rc = function() {
        if (PrimeFaces.vb({
            s: this,
            a: true,
            p: 'j_idt720:name j_idt720:number',
            u: 'j_idt720:grid'
        })) {
            return pf.ab({
                s: "j_idt720:j_idt759",
                f: "j_idt720",
                p: "j_idt720:name j_idt720:number",
                u: "j_idt720:grid",
                pa: arguments[0]
            });
        } else {
            return $.Deferred().reject({textStatus: 'error', errorThrown: 'Client-side validation failed.'});
        }
    }
```

