### PR TITLE
Fix #5861: ImageCropper file path issues on Unix

### DIFF
--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -207,7 +207,8 @@ public class ImageCropperRenderer extends CoreRenderer {
 
                     String webRoot = externalContext.getRealPath(Constants.EMPTY_STRING);
                     String fileSeparator = Constants.EMPTY_STRING;
-                    if (webRoot.charAt(webRoot.length() - 1) != File.separatorChar) {
+                    if (webRoot.charAt(webRoot.length() - 1) != File.separatorChar &&
+                                imagePath.charAt(0) != File.separatorChar) {
                         fileSeparator = File.separator;
                     }
 

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -207,8 +207,9 @@ public class ImageCropperRenderer extends CoreRenderer {
 
                     String webRoot = externalContext.getRealPath(Constants.EMPTY_STRING);
                     String fileSeparator = Constants.EMPTY_STRING;
-                    if (!webRoot.endsWith(File.separator) && !imagePath.startsWith(File.separator)) {
-                        fileSeparator = File.separator;
+                    if (!(webRoot.endsWith("\\") || webRoot.endsWith("/")) &&
+                                !(imagePath.endsWith("\\") || imagePath.endsWith("/"))) {
+                        fileSeparator = "/";
                     }
 
                     File file = new File(webRoot + fileSeparator + imagePath);

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -207,8 +207,7 @@ public class ImageCropperRenderer extends CoreRenderer {
 
                     String webRoot = externalContext.getRealPath(Constants.EMPTY_STRING);
                     String fileSeparator = Constants.EMPTY_STRING;
-                    if (webRoot.charAt(webRoot.length() - 1) != File.separatorChar &&
-                                imagePath.charAt(0) != File.separatorChar) {
+                    if (!webRoot.endsWith(File.separator) && !imagePath.startsWith(File.separator)) {
                         fileSeparator = File.separator;
                     }
 

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -204,8 +204,14 @@ public class ImageCropperRenderer extends CoreRenderer {
                     ExternalContext externalContext = context.getExternalContext();
                     // GitHub #3268 OWASP Path Traversal
                     imagePath = FileUploadUtils.checkPathTraversal(imagePath);
+
                     String webRoot = externalContext.getRealPath(Constants.EMPTY_STRING);
-                    File file = new File(webRoot + imagePath);
+                    String fileSeparator = Constants.EMPTY_STRING;
+                    if (webRoot.charAt(webRoot.length() - 1) != File.separatorChar) {
+                        fileSeparator = File.separator;
+                    }
+
+                    File file = new File(webRoot + fileSeparator + imagePath);
                     inputStream = new FileInputStream(file);
                 }
             }
@@ -234,6 +240,7 @@ public class ImageCropperRenderer extends CoreRenderer {
             return new CroppedImage(cropper.getImage(), croppedOutImage.toByteArray(), x, y, w, h);
         }
         catch (IOException e) {
+            LOGGER.severe(e.getMessage());
             throw new ConverterException(e);
         }
         finally {


### PR DESCRIPTION
Checks if the last character of webroot is a file separator "/" and if not appends it.