### PR TITLE
Fix #5869: InputText/InputTextArea validate maxlength

### DIFF
--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -51,6 +51,10 @@ public class InputTextRenderer extends InputRenderer {
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(clientId);
 
         if (submittedValue != null) {
+            int maxlength = inputText.getMaxlength();
+            if (maxlength > 0 && submittedValue.length() > maxlength) {
+                return;
+            }
             inputText.setSubmittedValue(submittedValue);
         }
     }
@@ -68,7 +72,7 @@ public class InputTextRenderer extends InputRenderer {
         String counter = inputText.getCounter();
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("InputText", inputText.resolveWidgetVar(context), clientId)
-                .attr("maxlength", inputText.getMaxlength(), Integer.MAX_VALUE);
+                .attr("maxlength", inputText.getMaxlength(), Integer.MIN_VALUE);
 
         if (counter != null) {
             UIComponent counterComponent = SearchExpressionFacade.resolveComponent(context, inputText, counter);

--- a/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -33,6 +33,7 @@ import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class InputTextRenderer extends InputRenderer {
@@ -53,7 +54,7 @@ public class InputTextRenderer extends InputRenderer {
         if (submittedValue != null) {
             int maxlength = inputText.getMaxlength();
             if (maxlength > 0 && submittedValue.length() > maxlength) {
-                return;
+                submittedValue = LangUtils.substring(submittedValue, 0, maxlength);
             }
             inputText.setSubmittedValue(submittedValue);
         }

--- a/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
+++ b/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
@@ -38,6 +38,7 @@ import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class InputTextareaRenderer extends InputRenderer {
@@ -59,8 +60,9 @@ public class InputTextareaRenderer extends InputRenderer {
         if (submittedValue != null) {
             // #5381: normalize new lines to match JavaScript
             submittedValue = submittedValue.replaceAll("\\r\\n?", "\n");
-            if (submittedValue.length() > inputTextarea.getMaxlength()) {
-                return;
+            int maxlength = inputTextarea.getMaxlength();
+            if (submittedValue.length() > maxlength) {
+                submittedValue = LangUtils.substring(submittedValue, 0, maxlength);
             }
         }
 

--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -61,6 +61,74 @@ public class LangUtils {
         return true;
     }
 
+    /**
+     * <p>Gets a substring from the specified String avoiding exceptions.</p>
+     *
+     * <p>A negative start position can be used to start/end {@code n}
+     * characters from the end of the String.</p>
+     *
+     * <p>The returned substring starts with the character in the {@code start}
+     * position and ends before the {@code end} position. All position counting is
+     * zero-based -- i.e., to start at the beginning of the string use
+     * {@code start = 0}. Negative start and end positions can be used to
+     * specify offsets relative to the end of the String.</p>
+     *
+     * <p>If {@code start} is not strictly to the left of {@code end}, ""
+     * is returned.</p>
+     *
+     * <pre>
+     * StringUtils.substring(null, *, *)    = null
+     * StringUtils.substring("", * ,  *)    = "";
+     * StringUtils.substring("abc", 0, 2)   = "ab"
+     * StringUtils.substring("abc", 2, 0)   = ""
+     * StringUtils.substring("abc", 2, 4)   = "c"
+     * StringUtils.substring("abc", 4, 6)   = ""
+     * StringUtils.substring("abc", 2, 2)   = ""
+     * StringUtils.substring("abc", -2, -1) = "b"
+     * StringUtils.substring("abc", -4, 2)  = "ab"
+     * </pre>
+     *
+     * @param str  the String to get the substring from, may be null
+     * @param start  the position to start from, negative means
+     *  count back from the end of the String by this many characters
+     * @param end  the position to end at (exclusive), negative means
+     *  count back from the end of the String by this many characters
+     * @return substring from start position to end position,
+     *  {@code null} if null String input
+     */
+    public static String substring(final String str, int start, int end) {
+        if (str == null) {
+            return null;
+        }
+
+        // handle negatives
+        if (end < 0) {
+            end = str.length() + end; // remember end is negative
+        }
+        if (start < 0) {
+            start = str.length() + start; // remember start is negative
+        }
+
+        // check length next
+        if (end > str.length()) {
+            end = str.length();
+        }
+
+        // if start is greater than end, return ""
+        if (start > end) {
+            return Constants.EMPTY_STRING;
+        }
+
+        if (start < 0) {
+            start = 0;
+        }
+        if (end < 0) {
+            end = 0;
+        }
+
+        return str.substring(start, end);
+    }
+
     public static boolean contains(Object[] array, Object object) {
         if (array == null || array.length == 0) {
             return false;

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtext.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtext.js
@@ -13,7 +13,8 @@
  * 
  * @prop {string} cfg.counter ID of the label component to display remaining and entered characters.
  * @prop {string} cfg.counterTemplate Template text to display in counter, default value is `{0}`.
- * @prop {number} cfg.maxlength Maximum number of characters that may be entered in this field.
+ * @prop {number} cfg.maxlength Maximum number of characters that may be entered in this field. Default to 
+ *                              Integer.MAX_VALUE (2147483648).
  */
 PrimeFaces.widget.InputText = PrimeFaces.widget.BaseWidget.extend({
 
@@ -24,6 +25,7 @@ PrimeFaces.widget.InputText = PrimeFaces.widget.BaseWidget.extend({
      */
     init: function(cfg) {
         this._super(cfg);
+        this.cfg.maxlength = (this.cfg.maxlength === undefined) ? 2147483648 : this.cfg.maxlength;
 
         PrimeFaces.skinInput(this.jq);
 

--- a/src/test/java/org/primefaces/util/LangUtilsTest.java
+++ b/src/test/java/org/primefaces/util/LangUtilsTest.java
@@ -28,8 +28,13 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 
 public class LangUtilsTest {
+    
+    private static final String FOO = "foo";
+    private static final String SENTENCE = "foo bar baz";
 
     @Test
     public void getTypeFromCollectionProperty_Simple() {
@@ -58,6 +63,28 @@ public class LangUtilsTest {
 
         assertEquals(String.class, type);
     }
+    
+
+
+    @Test
+    public void substring() {
+        assertNull(LangUtils.substring(null, 0, 0));
+        assertNull(LangUtils.substring(null, 1, 2));
+        assertEquals("", LangUtils.substring("", 0, 0));
+        assertEquals("", LangUtils.substring("", 1, 2));
+        assertEquals("", LangUtils.substring("", -2, -1));
+
+        assertEquals("", LangUtils.substring(SENTENCE, 8, 6));
+        assertEquals(FOO, LangUtils.substring(SENTENCE, 0, 3));
+        assertEquals("o", LangUtils.substring(SENTENCE, -9, 3));
+        assertEquals(FOO, LangUtils.substring(SENTENCE, 0, -8));
+        assertEquals("o", LangUtils.substring(SENTENCE, -9, -8));
+        assertEquals(SENTENCE, LangUtils.substring(SENTENCE, 0, 80));
+        assertEquals("", LangUtils.substring(SENTENCE, 2, 2));
+        assertEquals("b", LangUtils.substring("abc", -2, -1));
+    }
+
+   
 
     class SimpleClass {
         private List<String> strings;


### PR DESCRIPTION
@tandraschko this PR does two things. one issue while I was fixing the validation issue.

1. Validation: Fixes the input validation to respect the maxlength property similar to InputTextArea.

2. Performance: The maxlength property of inherited  `HtmlInputText` is actually set to Integer.MIN_VALUE. Our Widget code was doing `.attr("maxlength", inputText.getMaxlength(), Integer.MAX_VALUE)` so that means for every single input on the screen it was always sending maxlength like.
```javascript
pf.cw("InputText","widget_j_idt718_j_idt720",{id:"j_idt718:j_idt720",maxlength:-2147483648});
```

So now with this PR the maxlength property is ONLY sent if it is set by the user.
```javascript
pf.cw("InputText","widget_j_idt723_j_idt725",{id:"j_idt718:j_idt720"});
pf.cw("InputText","widget_j_idt723_j_idt727",{id:"j_idt723:j_idt727",maxlength:10});
```