### PR TITLE
Fix #5230: Datatable livescroll duplicating records on refresh

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -721,6 +721,7 @@ public class DataTable extends DataTableBase {
         setSortField(null);
         setDefaultSort(true);
         setSortMeta(null);
+        setScrollOffset(0);
     }
 
     public boolean isFilteringEnabled() {

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -114,6 +114,10 @@ public class DataTableRenderer extends DataRenderer {
             table.setDefaultSortFunction(table.getSortFunction());
         }
 
+        if (table.isLiveScroll()) {
+            table.setScrollOffset(0);
+        }
+
         if (table.isLazy()) {
             if (table.isLiveScroll()) {
                 table.loadLazyScrollData(0, table.getScrollRows());

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -1324,15 +1324,16 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
         this.cloneHead();
 
-        this.restoreScrollState();
-
         if(this.cfg.liveScroll) {
+            this.clearScrollState();
             this.scrollOffset = 0;
             this.cfg.liveScrollBuffer = (100 - this.cfg.liveScrollBuffer) / 100;
             this.shouldLiveScroll = true;
             this.loadingLiveScroll = false;
             this.allLoadedLiveScroll = $this.cfg.scrollStep >= $this.cfg.scrollLimit;
         }
+
+        this.restoreScrollState();
 
         if(this.cfg.virtualScroll) {
             var row = this.bodyTable.children('tbody').children('tr.ui-widget-content');
@@ -4957,15 +4958,16 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
 
         this.cloneHead();
 
-        this.restoreScrollState();
-
         if(this.cfg.liveScroll) {
+            this.clearScrollState();
             this.scrollOffset = 0;
             this.cfg.liveScrollBuffer = (100 - this.cfg.liveScrollBuffer) / 100;
             this.shouldLiveScroll = true;
             this.loadingLiveScroll = false;
             this.allLoadedLiveScroll = $this.cfg.scrollStep >= $this.cfg.scrollLimit;
         }
+
+        this.restoreScrollState();
 
         if(this.cfg.virtualScroll) {
             var row = this.scrollTbody.children('tr.ui-widget-content');


### PR DESCRIPTION
- Must reset scrollOffset to 0
- When repainting the UI need to clearScrollState so the refreshed datatable starts back at the first row.