### PR TITLE
Fix #5614: Datatable sorting taglib and docs

### DIFF
--- a/docs/8_0/components/datatable.md
+++ b/docs/8_0/components/datatable.md
@@ -2,6 +2,8 @@
 
 DataTable displays data in tabular format.
 
+[See this widget in the JavaScript API Docs.](../jsdocs/classes/primefaces.widget.datatable.html)
+
 ## Info
 
 | Name | Value |
@@ -41,7 +43,6 @@ DataTable displays data in tabular format.
 | expandableRowGroups       | false              | Boolean          | Makes row groups toggleable, default is false.
 | expandedRow               | false              | Boolean          | Defines if row should be rendered as expanded by default.
 | filterBy                  | null               | Map              | Map of filters; This also allows to filter the table by default.
-| sortMeta                  | null               | Map              | Map of sort infrmations; This also allows to sort the table by default.
 | filterDelay               | 300                | Integer          | Delay in milliseconds before sending an ajax filter query.
 | filterEvent               | keyup              | String           | Event to invoke filtering for input filters.
 | filteredValue             | null               | List             | List to keep filtered data.
@@ -90,11 +91,13 @@ DataTable displays data in tabular format.
 | scrollable                | false              | Boolean          | Makes data scrollable with fixed header.
 | selection                 | null               | Object           | Reference to the selection data.
 | selectionMode             | null               | String           | Enables row selection, valid values are “single” and “multiple”.
-| skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.
-| sortBy                    | null               | Object           | Property to be used for default sorting.
-| sortField                 | null               | String           | Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.
 | sortMode                  | single             | String           | Defines sorting mode, valid values are _single_ and _multiple_.
-| sortOrder                 | ascending          | String           | “ascending” or “descending”.
+| sortMeta                  | null               | Map              | Ordered map of sort information in _multiple_ sortMode; This also allows to sort the table by default.
+| sortBy                    | null               | Object           | Property to be used for default sorting in _single_ sortMode.
+| sortField                 | null               | String           | Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.
+| sortOrder                 | ascending          | String           | Sets sorting order in 'single' sortMode. Default is "ascending"
+| sortFunction              | null               |                  | Custom pluggable sortFunction for default sorting in 'single' sortMode.
+| skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.
 | stickyHeader              | false              | Boolean          | Sticky header stays in window viewport during scrolling.
 | stickyTopAt               | null               | String           | Selector to position on the page according to other fixing elements on the top of the table. Default is null.
 | style                     | null               | String           | Inline style of the component.

--- a/docs/9_0/components/datatable.md
+++ b/docs/9_0/components/datatable.md
@@ -95,7 +95,8 @@ DataTable displays data in tabular format.
 | sortMeta                  | null               | Map              | Ordered map of sort information in _multiple_ sortMode; This also allows to sort the table by default.
 | sortBy                    | null               | Object           | Property to be used for default sorting in _single_ sortMode.
 | sortField                 | null               | String           | Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.
-| sortOrder                 | ascending          | String           | “ascending” or “descending”.
+| sortOrder                 | ascending          | String           | Sets sorting order in 'single' sortMode. Default is "ascending"
+| sortFunction              | null               |                  | Custom pluggable sortFunction for default sorting in 'single' sortMode.
 | skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.
 | stickyHeader              | false              | Boolean          | Sticky header stays in window viewport during scrolling.
 | stickyTopAt               | null               | String           | Selector to position on the page according to other fixing elements on the top of the table. Default is null.

--- a/docs/9_0/components/datatable.md
+++ b/docs/9_0/components/datatable.md
@@ -43,7 +43,6 @@ DataTable displays data in tabular format.
 | expandableRowGroups       | false              | Boolean          | Makes row groups toggleable, default is false.
 | expandedRow               | false              | Boolean          | Defines if row should be rendered as expanded by default.
 | filterBy                  | null               | Map              | Map of filters; This also allows to filter the table by default.
-| sortMeta                  | null               | Map              | Map of sort infrmations; This also allows to sort the table by default.
 | filterDelay               | 300                | Integer          | Delay in milliseconds before sending an ajax filter query.
 | filterEvent               | keyup              | String           | Event to invoke filtering for input filters.
 | filteredValue             | null               | List             | List to keep filtered data.
@@ -92,11 +91,12 @@ DataTable displays data in tabular format.
 | scrollable                | false              | Boolean          | Makes data scrollable with fixed header.
 | selection                 | null               | Object           | Reference to the selection data.
 | selectionMode             | null               | String           | Enables row selection, valid values are “single” and “multiple”.
-| skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.
-| sortBy                    | null               | Object           | Property to be used for default sorting.
-| sortField                 | null               | String           | Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.
 | sortMode                  | single             | String           | Defines sorting mode, valid values are _single_ and _multiple_.
+| sortMeta                  | null               | Map              | Ordered map of sort information in _multiple_ sortMode; This also allows to sort the table by default.
+| sortBy                    | null               | Object           | Property to be used for default sorting in _single_ sortMode.
+| sortField                 | null               | String           | Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.
 | sortOrder                 | ascending          | String           | “ascending” or “descending”.
+| skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.
 | stickyHeader              | false              | Boolean          | Sticky header stays in window viewport during scrolling.
 | stickyTopAt               | null               | String           | Selector to position on the page according to other fixing elements on the top of the table. Default is null.
 | style                     | null               | String           | Inline style of the component.

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -7254,7 +7254,23 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Property to be used for default sorting.]]>
+                <![CDATA[Defines sorting mode, valid values are "single" (default) and "multiple".]]>
+            </description>
+            <name>sortMode</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Ordered map of sort information in "multiple" sortMode; This also allows to sort the table by default.]]>
+            </description>
+            <name>sortMeta</name>
+            <required>false</required>
+            <type>java.util.Map</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Property to be used for default sorting in "single" sortMode.]]>
             </description>
             <name>sortBy</name>
             <required>false</required>
@@ -7262,7 +7278,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Sets sorting order. Default is "ascending"]]>
+                <![CDATA[Sets sorting order in "single" sortMode. Default is "ascending"]]>
             </description>
             <name>sortOrder</name>
             <required>false</required>
@@ -7270,11 +7286,28 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Custom pluggable sortFunction for default sorting.]]>
+                <![CDATA[Custom pluggable sortFunction for default sorting in "single" sortMode.]]>
             </description>
             <name>sortFunction</name>
             <required>false</required>
             <type>javax.el.MethodExpression</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Name of the field to pass lazy load method for sorting in "single" sortMode. If not specified, sortBy expression is used to extract the name.]]>
+            </description>
+            <name>sortField</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and
+                at beginning in descending mode. Set to "-1" for the opposite behavior.]]>
+            </description>
+            <name>nullSortOrder</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
         </attribute>
         <attribute>
             <description>
@@ -7355,14 +7388,6 @@
             <name>filteredValue</name>
             <required>false</required>
             <type>java.util.List</type>
-        </attribute>
-        <attribute>
-            <description>
-                <![CDATA[Defines sorting mode, valid values are "single" (default) and "multiple".]]>
-            </description>
-            <name>sortMode</name>
-            <required>false</required>
-            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>
@@ -7518,28 +7543,11 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Name of the field to pass lazy load method for sorting. If not specified, sortBy expression is used to extract the name.]]>
-            </description>
-            <name>sortField</name>
-            <required>false</required>
-            <type>java.lang.String</type>
-        </attribute>
-        <attribute>
-            <description>
                 <![CDATA[Defines when the datatable is initiated at client side, valid values are "load" (default) and "immediate".]]>
             </description>
             <name>initMode</name>
             <required>false</required>
             <type>java.lang.String</type>
-        </attribute>
-        <attribute>
-            <description>
-                <![CDATA[Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and
-                at beginning in descending mode. Set to "-1" for the opposite behavior.]]>
-            </description>
-            <name>nullSortOrder</name>
-            <required>false</required>
-            <type>java.lang.Integer</type>
         </attribute>
         <attribute>
             <description>


### PR DESCRIPTION
- add `sortMeta` to taglib
- updated all sort fields docs