### PR TITLE
Avoiding NullPointerException on DefaultStreamedContent.getStream() when stream is null

### DIFF
--- a/src/main/java/org/primefaces/model/DefaultStreamedContent.java
+++ b/src/main/java/org/primefaces/model/DefaultStreamedContent.java
@@ -101,7 +101,11 @@ public class DefaultStreamedContent implements StreamedContent, Serializable {
 
     @Override
     public InputStream getStream() {
-        return stream.get();
+        InputStream result = null;
+        if (this.stream != null) {
+            result = stream.get();
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
The current implementation of `DefaultStreamedContent.getStream()` throws NullPointerException when the  `stream` attribute is null. This PR is intended to fix it.