### PR TITLE
Fix #5914: Schedule/Timeline toIsoString keep offset

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1027,6 +1027,18 @@
         },
 
         /**
+         * Converts a date into an ISO-8601 date without using the browser timezone offset.
+         * 
+         * See https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
+         * 
+         * @param {Date} date the date to convert
+         * @return {string} ISO-8601 version of the date
+         */
+        toISOString: function(date) {
+            return new Date(date.getTime() - (date.getTimezoneOffset() * 60000)).toISOString();
+        },
+
+        /**
          * Logs the current PrimeFaces and jQuery version to console.
          */
         version: function() {

--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -92,7 +92,7 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
             if($this.hasBehavior('dateSelect')) {
                 var ext = {
                     params: [
-                        {name: $this.id + '_selectedDate', value: dateClickInfo.date.toISOString()}
+                        {name: $this.id + '_selectedDate', value: PrimeFaces.toISOString(dateClickInfo.date)}
                     ]
                 };
 
@@ -206,8 +206,8 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
                 update: $this.id,
                 formId: $this.cfg.formId,
                 params: [
-                    {name: $this.id + '_start', value: fetchInfo.start.toISOString()},
-                    {name: $this.id + '_end', value: fetchInfo.end.toISOString()}
+                    {name: $this.id + '_start', value: PrimeFaces.toISOString(fetchInfo.start)},
+                    {name: $this.id + '_end', value: PrimeFaces.toISOString(fetchInfo.end)}
                 ],
                 onsuccess: function(responseXML, status, xhr) {
                     PrimeFaces.ajax.Response.handle(responseXML, status, xhr, {

--- a/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -186,13 +186,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                     params.push({
                         name: this.id + '_startDate',
-                        value: item.start.toISOString()
+                        value: PrimeFaces.toISOString(item.start)
                     });
 
                     if (item.end) {
                         params.push({
                             name: this.id + '_endDate',
-                            value: item.end.toISOString()
+                            value: PrimeFaces.toISOString(item.end)
                         });
                     }
 
@@ -226,13 +226,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                     params.push({
                         name: this.id + '_startDate',
-                        value: item.start.toISOString()
+                        value: PrimeFaces.toISOString(item.start)
                     });
 
                     if (item.end) {
                         params.push({
                             name: this.id + '_endDate',
-                            value: item.end.toISOString()
+                            value: PrimeFaces.toISOString(item.end)
                         });
                     }
 
@@ -260,13 +260,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
 
                     params.push({
                         name: this.id + '_startDate',
-                        value: item.start.toISOString()
+                        value: PrimeFaces.toISOString(item.start)
                     });
 
                     if (item.end) {
                         params.push({
                             name: this.id + '_endDate',
-                            value: item.end.toISOString()
+                            value: PrimeFaces.toISOString(item.end)
                         });
                     }
 
@@ -358,8 +358,8 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
             this.instance.on('rangechange', $.proxy(function (properties) {
                 var options = {
                     params: [
-                        {name: this.id + '_startDate', value: properties.start.toISOString()},
-                        {name: this.id + '_endDate', value: properties.end.toISOString()}
+                        {name: this.id + '_startDate', value: PrimeFaces.toISOString(properties.start)},
+                        {name: this.id + '_endDate', value: PrimeFaces.toISOString(properties.end)}
                     ],
                     properties: properties
                 };
@@ -373,8 +373,8 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
             this.instance.on('rangechanged', $.proxy(function (properties) {
                 var options = {
                     params: [
-                        {name: this.id + '_startDate', value: properties.start.toISOString()},
-                        {name: this.id + '_endDate', value: properties.end.toISOString()}
+                        {name: this.id + '_startDate', value: PrimeFaces.toISOString(properties.start)},
+                        {name: this.id + '_endDate', value: PrimeFaces.toISOString(properties.end)}
                     ],
                     properties: properties
                 };
@@ -434,12 +434,12 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
                 var params = [];
                 params.push({
                     name: this.id + '_startDate',
-                    value: snappedStart.toISOString()
+                    value: PrimeFaces.toISOString(snappedStart)
                 });
 
                 params.push({
                     name: this.id + '_endDate',
-                    value: snappedEnd.toISOString()
+                    value: PrimeFaces.toISOString(snappedEnd)
                 });
 
                 var group = inst.itemSet.groupFromTarget(evt); // (group may be undefined)
@@ -540,13 +540,13 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
         };
 
         if (range.startFirst != null && range.endFirst != null) {
-            options.params[0] = {name: this.id + '_startDateFirst', value: new Date(range.startFirst).toISOString()};
-            options.params[1] = {name: this.id + '_endDateFirst', value: new Date(range.endFirst).toISOString()};
+            options.params[0] = {name: this.id + '_startDateFirst', value: PrimeFaces.toISOString(new Date(range.startFirst))};
+            options.params[1] = {name: this.id + '_endDateFirst', value: PrimeFaces.toISOString(new Date(range.endFirst))};
         }
 
         if (range.startSecond != null && range.endSecond != null) {
-            options.params[2] = {name: this.id + '_startDateSecond', value: new Date(range.startSecond).toISOString()};
-            options.params[3] = {name: this.id + '_endDateSecond', value: new Date(range.endSecond).toISOString()};
+            options.params[2] = {name: this.id + '_startDateSecond', value: PrimeFaces.toISOString(new Date(range.startSecond))};
+            options.params[3] = {name: this.id + '_endDateSecond', value: PrimeFaces.toISOString(new Date(range.endSecond))};
         }
 
         this.getBehavior("lazyload").call(this, options);


### PR DESCRIPTION
- JavaScript date.toIsoString() repsect the browser timezone. So it is turning `05-07-2020 00:00` into `05-26-2020 23:00` if your browser timezone is GMT+1.
- Found https://stackoverflow.com/questions/10830357/javascript-toisostring-ignores-timezone-offset
- This fixes the problem by keeping the UTC date and not respecting their browser offset.

@jasonex7 @christophs78 @OBreidenbach keeping you guys in the loop since you have worked on  Timeline and Schedule components affected