### PR TITLE
Fix #5923: Prevent native date converter errors

### DIFF
--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -86,7 +86,8 @@ public class CalendarRenderer extends BaseCalendarRenderer {
         String defaultDate = null;
 
         if (calendar.isConversionFailed()) {
-            defaultDate = CalendarUtils.getValueAsString(context, calendar, CalendarUtils.now(uicalendar));
+            Class<?> dateType = resolveDateType(context, calendar);
+            defaultDate = CalendarUtils.getValueAsString(context, calendar, CalendarUtils.now(uicalendar, dateType));
         }
         else if (!isValueBlank(value)) {
             defaultDate = value;

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -24,7 +24,6 @@
 package org.primefaces.component.calendar;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.Locale;
 
 import javax.faces.context.FacesContext;

--- a/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarRenderer.java
@@ -87,7 +87,7 @@ public class CalendarRenderer extends BaseCalendarRenderer {
         String defaultDate = null;
 
         if (calendar.isConversionFailed()) {
-            defaultDate = CalendarUtils.getValueAsString(context, calendar, LocalDateTime.now());
+            defaultDate = CalendarUtils.getValueAsString(context, calendar, CalendarUtils.now(uicalendar));
         }
         else if (!isValueBlank(value)) {
             defaultDate = value;

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -110,7 +110,8 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
         String defaultDate = null;
 
         if (datepicker.isConversionFailed()) {
-            defaultDate = CalendarUtils.getValueAsString(context, datepicker, CalendarUtils.now(uicalendar));
+            Class<?> dateType = resolveDateType(context, datepicker);
+            defaultDate = CalendarUtils.getValueAsString(context, datepicker, CalendarUtils.now(uicalendar, dateType));
         }
         else if (!isValueBlank(value)) {
             defaultDate = value;

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -110,7 +110,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
         String defaultDate = null;
 
         if (datepicker.isConversionFailed()) {
-            defaultDate = CalendarUtils.getValueAsString(context, datepicker, LocalDateTime.now());
+            defaultDate = CalendarUtils.getValueAsString(context, datepicker, CalendarUtils.now(uicalendar));
         }
         else if (!isValueBlank(value)) {
             defaultDate = value;

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -236,7 +236,7 @@ public class CalendarUtils {
     }
 
     public static final String getValue(FacesContext context, UICalendar calendar, Object value, String pattern) {
-      //first ask the converter, if it fails fall back to built-in conversion
+        //first ask the converter
         if (calendar.getConverter() != null) {
             return calendar.getConverter().getAsString(context, calendar, value);
         }
@@ -530,7 +530,11 @@ public class CalendarUtils {
      */
     public static Temporal now(UICalendar uicalendar) {
         boolean hasTime = uicalendar.hasTime();
+        boolean timeOnly = uicalendar.isTimeOnly();
         ZoneId zone = calculateZoneId(uicalendar.getTimeZone());
+        if (hasTime && timeOnly) {
+            return LocalTime.now(zone);
+        }
         return hasTime ? LocalDateTime.now(zone) : LocalDate.now(zone);
     }
 
@@ -547,6 +551,9 @@ public class CalendarUtils {
             java.util.Date date;
             if (now instanceof LocalDate) {
                 date = java.util.Date.from(((LocalDate) now).atStartOfDay(zone).toInstant());
+            }
+            else if (now instanceof LocalTime) {
+                date = java.util.Date.from(((LocalTime) now).atDate(LocalDate.now(zone)).atZone(zone).toInstant());
             }
             else {
                 date = java.util.Date.from(((LocalDateTime) now).atZone(zone).toInstant());

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -44,9 +44,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class CalendarUtils {
 
+    private static final Logger LOGGER = Logger.getLogger(CalendarUtils.class.getName());
     private static final String[] TIME_CHARS = {"H", "K", "h", "k", "m", "s"};
 
     private static final PatternConverter[] PATTERN_CONVERTERS =
@@ -236,10 +239,18 @@ public class CalendarUtils {
 
     public static final String getValue(FacesContext context, UICalendar calendar, Object value, String pattern) {
         //first ask the converter
-        if (calendar.getConverter() != null) {
-            return calendar.getConverter().getAsString(context, calendar, value);
+        try {
+            if (calendar.getConverter() != null) {
+                return calendar.getConverter().getAsString(context, calendar, value);
+            }
         }
-        else if (value instanceof String) {
+        catch (Exception e) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Could not convert date value...defaulting to built-in converter"));
+            }
+        }
+
+        if (value instanceof String) {
             return (String) value;
         }
         //Use built-in converter

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -529,12 +529,12 @@ public class CalendarUtils {
      * @return a Temporal representing either a Date or DateTime
      */
     public static Temporal now(UICalendar uicalendar) {
-        boolean hasTime = uicalendar.hasTime();
         boolean timeOnly = uicalendar.isTimeOnly();
         ZoneId zone = calculateZoneId(uicalendar.getTimeZone());
-        if (hasTime && timeOnly) {
+        if (timeOnly) {
             return LocalTime.now(zone);
         }
+        boolean hasTime = uicalendar.hasTime();
         return hasTime ? LocalDateTime.now(zone) : LocalDate.now(zone);
     }
 

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -30,10 +30,7 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
 
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
@@ -246,10 +243,10 @@ public class CalendarUtils {
 
                 try {
                     javax.faces.convert.DateTimeConverter nativeConverter = (javax.faces.convert.DateTimeConverter) converter;
-                    if (PrimeApplicationContext.getCurrentInstance(FacesContext.getCurrentInstance()).getEnvironment().isAtLeastJsf23()) {
+                    if (PrimeApplicationContext.getCurrentInstance(context).getEnvironment().isAtLeastJsf23()) {
                         Field field = javax.faces.convert.DateTimeConverter.class.getDeclaredField("type");
                         field.setAccessible(true);
-                        dateType = (String) field.get(nativeConverter);
+                        dateType = Objects.toString(field.get(nativeConverter), "date");
                     }
                 }
                 catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -255,11 +255,11 @@ public class CalendarUtils {
 
                 // only run converter if type for dates match
                 if (dateType.equalsIgnoreCase(value.getClass().getSimpleName())) {
-                    return calendar.getConverter().getAsString(context, calendar, value);
+                    return converter.getAsString(context, calendar, value);
                 }
             }
             else {
-                return calendar.getConverter().getAsString(context, calendar, value);
+                return converter.getAsString(context, calendar, value);
             }
         }
 

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -238,15 +238,15 @@ public class CalendarUtils {
     }
 
     public static final String getValue(FacesContext context, UICalendar calendar, Object value, String pattern) {
-        //first ask the converter
         try {
+            //first ask the converter, if it fails fall back to built-in conversion
             if (calendar.getConverter() != null) {
                 return calendar.getConverter().getAsString(context, calendar, value);
             }
         }
         catch (Exception e) {
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine(String.format("Could not convert date value...defaulting to built-in converter"));
+                LOGGER.fine(String.format("Could not convert date value using converter...defaulting to built-in converter"));
             }
         }
 

--- a/src/test/java/org/primefaces/util/CalendarUtilsTest.java
+++ b/src/test/java/org/primefaces/util/CalendarUtilsTest.java
@@ -180,4 +180,19 @@ public class CalendarUtilsTest {
         assertTrue(LocalDateTime.now().compareTo(now) >= 0);
     }
 
+    @Test
+    public void now_DateTime() {
+        when(datePicker.hasTime()).thenReturn(true);
+        when(datePicker.getTimeZone()).thenReturn(ZoneId.systemDefault());
+        Date now = (Date) CalendarUtils.now(datePicker, java.util.Date.class);
+        assertTrue(new Date().compareTo(now) >= 0);
+    }
+
+    @Test
+    public void now_Date() {
+        when(datePicker.hasTime()).thenReturn(false);
+        when(datePicker.getTimeZone()).thenReturn(ZoneId.systemDefault());
+        Date now = (Date) CalendarUtils.now(datePicker, java.util.Date.class);
+        assertTrue(new Date().compareTo(now) >= 0);
+    }
 }

--- a/src/test/java/org/primefaces/util/CalendarUtilsTest.java
+++ b/src/test/java/org/primefaces/util/CalendarUtilsTest.java
@@ -33,11 +33,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.Temporal;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
 
 import javax.el.ELContext;
 import javax.faces.context.ExternalContext;
@@ -191,6 +187,15 @@ public class CalendarUtilsTest {
     @Test
     public void now_Date() {
         when(datePicker.hasTime()).thenReturn(false);
+        when(datePicker.getTimeZone()).thenReturn(ZoneId.systemDefault());
+        Date now = (Date) CalendarUtils.now(datePicker, java.util.Date.class);
+        assertTrue(new Date().compareTo(now) >= 0);
+    }
+
+    @Test
+    public void now_Time() {
+        when(datePicker.hasTime()).thenReturn(true);
+        when(datePicker.isTimeOnly()).thenReturn(true);
         when(datePicker.getTimeZone()).thenReturn(ZoneId.systemDefault());
         Date now = (Date) CalendarUtils.now(datePicker, java.util.Date.class);
         assertTrue(new Date().compareTo(now) >= 0);


### PR DESCRIPTION
@christophs78 Not sure if this is the best way to fix it but.

1. Used our new `CalendarUtils.now(cal)` method instead of LocalDateTime.now() so it calculates NOW in the calendar's timezone.

2. I basically eat the conversion exception and log it and fall back to built in conversion.