### PR TITLE
new ImageCropper 'cache' attribute

### DIFF
--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperBase.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperBase.java
@@ -47,7 +47,8 @@ public abstract class ImageCropperBase extends UIInput implements Widget {
         sizeLimit,
         responsive,
         guides,
-        viewMode
+        viewMode,
+        cache
     }
 
     public ImageCropperBase() {
@@ -161,5 +162,13 @@ public abstract class ImageCropperBase extends UIInput implements Widget {
 
     public int getViewMode() {
         return (Integer) getStateHelper().eval(PropertyKeys.viewMode, 1);
+    }
+
+    public boolean isCache() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.cache, true);
+    }
+
+    public void setCache(boolean cache) {
+        getStateHelper().put(PropertyKeys.cache, cache);
     }
 }

--- a/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -28,6 +28,7 @@ import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import javax.el.ValueExpression;
@@ -152,11 +153,25 @@ public class ImageCropperRenderer extends CoreRenderer {
         writer.startElement("img", null);
         writer.writeAttribute("id", clientId + "_image", null);
         writer.writeAttribute("alt", alt, null);
-        writer.writeAttribute("src", getResourceURL(context, cropper.getImage()), null);
+        String imageSrc = generateImageSrc(context, cropper);
+        writer.writeAttribute("src", imageSrc, null);
         writer.writeAttribute("height", "auto", null);
         writer.writeAttribute("width", "100%", null);
         writer.writeAttribute("style", "max-width: 100%;", null);
         writer.endElement("img");
+    }
+
+    private String generateImageSrc(FacesContext context, ImageCropper cropper) {
+        String result = getResourceURL(context, cropper.getImage());
+        if (!cropper.isCache()) {
+            StringBuilder builder = new StringBuilder();
+            builder.append(result);
+            builder.append(result.contains("?") ? "&" : "?");
+            builder.append("no-cache-uid=");
+            builder.append(UUID.randomUUID().toString());
+            result = builder.toString();
+        }
+        return result;
     }
 
     @Override

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -11186,6 +11186,14 @@
             <required>false</required>
             <type>java.lang.Integer</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Controls browser caching mode of the resource. Default is true]]>
+            </description>
+            <name>cache</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>


### PR DESCRIPTION
Hi! 

This PR aiming to resolve the issue https://github.com/primefaces/primefaces/issues/5926 by including a new `cache` attribute in `ImageCropper` component. This attribute works in the same way as the `cache` attribute of `GraphicImage` component.

Example of usage:
```
<p:imageCropper value="#{cropperView.croppedImage}" 
    image="/resources/demo/images/nature/nature6.jpg" 
    cache="false" 
    initialCoords="225,75,300,125" minSize="100,100" maxSize="250,250"/>
```
preventing the browser to use a cached image in the imageCropper.