### PR TITLE
Fix #5817: JQMIGRATE: jQuery.isFunction is deprecated

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/charts/0-jqPlot.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/0-jqPlot.js
@@ -687,7 +687,7 @@
     Axis.prototype.constructor = Axis;
     
     Axis.prototype.init = function() {
-        if ($.isFunction(this.renderer)) {
+        if (typeof this.renderer === "function") {
             this.renderer = new this.renderer();  
         }
         // set the axis name
@@ -1076,7 +1076,7 @@
     };
     
     Legend.prototype.init = function() {
-        if ($.isFunction(this.renderer)) {
+        if (typeof this.renderer === "function") {
             this.renderer = new this.renderer();  
         }
         this.renderer.init.call(this, this.rendererOptions);
@@ -1141,7 +1141,7 @@
     Title.prototype.constructor = Title;
     
     Title.prototype.init = function() {
-        if ($.isFunction(this.renderer)) {
+        if (typeof this.renderer === "function") {
             this.renderer = new this.renderer();  
         }
         this.renderer.init.call(this, this.rendererOptions);
@@ -1377,7 +1377,7 @@
             var comp = $.jqplot.getColorComponents(comp);
             this.fillColor = 'rgba('+comp[0]+','+comp[1]+','+comp[2]+','+this.fillAlpha+')';
         }
-        if ($.isFunction(this.renderer)) {
+        if (typeof this.renderer === "function") {
             this.renderer = new this.renderer();  
         }
         this.renderer.init.call(this, this.rendererOptions, plot);
@@ -1615,7 +1615,7 @@
     Grid.prototype.constructor = Grid;
     
     Grid.prototype.init = function() {
-        if ($.isFunction(this.renderer)) {
+        if (typeof this.renderer === "function") {
             this.renderer = new this.renderer();  
         }
         this.renderer.init.call(this, this.rendererOptions);
@@ -2048,7 +2048,7 @@
                 throw new Error("Canvas dimension not set");
             }
             
-            if (options.dataRenderer && $.isFunction(options.dataRenderer)) {
+            if (options.dataRenderer && typeof options.dataRenderer === "function") {
                 if (options.dataRendererOptions) {
                     this.dataRendererOptions = options.dataRendererOptions;
                 }
@@ -2272,7 +2272,7 @@
             }
             
             if (data) {
-                if (options.dataRenderer && $.isFunction(options.dataRenderer)) {
+                if (options.dataRenderer && typeof options.dataRenderer === "function") {
                     if (options.dataRendererOptions) {
                         this.dataRendererOptions = options.dataRendererOptions;
                     }
@@ -11316,7 +11316,7 @@
         }
 
         // catch (effect, callback)
-        if ( $.isFunction( options ) ) {
+        if ( typeof options === "function" ) {
             callback = options;
             speed = null;
             options = {};
@@ -11330,7 +11330,7 @@
         }
 
         // catch (effect, options, callback)
-        if ( $.isFunction( speed ) ) {
+        if ( typeof speed === "function" ) {
             callback = speed;
             speed = null;
         }
@@ -11396,10 +11396,10 @@
                     mode = args.mode;
 
                 function done() {
-                    if ( $.isFunction( complete ) ) {
+                    if ( typeof complete === "function" ) {
                         complete.call( elem[0] );
                     }
-                    if ( $.isFunction( next ) ) {
+                    if ( typeof next === "function" ) {
                         next();
                     }
                 }
@@ -19824,7 +19824,7 @@
                 } 
             }
         }
-        if ($.isFunction(opts.tooltipContentEditor)) {
+        if (typeof opts.tooltipContentEditor === "function") {
             // args str, seriesIndex, pointIndex are essential so the hook can look up
             // extra data for the point.
             str = opts.tooltipContentEditor(str, neighbor.seriesIndex, neighbor.pointIndex, plot);

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -990,7 +990,7 @@ if (!PrimeFaces.ajax) {
                             var activeElement = $(document.activeElement);
                             var activeElementId = activeElement.attr('id');
                             var activeElementSelection;
-                            if (activeElement.length > 0 && activeElement.is('input') && $.isFunction($.fn.getSelection)) {
+                            if (activeElement.length > 0 && activeElement.is('input') && typeof $.fn.getSelection === "function") {
                                 activeElementSelection = activeElement.getSelection();
                             }
 

--- a/src/main/resources/META-INF/resources/primefaces/imagecropper/1-jquery-cropper.js
+++ b/src/main/resources/META-INF/resources/primefaces/imagecropper/1-jquery-cropper.js
@@ -47,7 +47,7 @@
         if (typeof option === 'string') {
           var fn = cropper[option];
 
-          if ($.isFunction(fn)) {
+          if (typeof fn === "function") {
             result = fn.apply(cropper, args);
 
             if (result === cropper) {

--- a/src/main/resources/META-INF/resources/primefaces/imageswitch/imageswitch.js
+++ b/src/main/resources/META-INF/resources/primefaces/imageswitch/imageswitch.js
@@ -376,7 +376,7 @@ function buildOptions($cont, $slides, els, options, o) {
 	// run transition init fn
 	if (!opts.multiFx) {
 		var init = $.fn.cycle.transitions[opts.fx];
-		if ($.isFunction(init))
+		if (typeof init === "function")
 			init($cont, $slides, opts);
 		else if (opts.fx != 'custom' && !opts.multiFx) {
 			log('unknown transition: ' + opts.fx,'; slideshow terminating');
@@ -424,7 +424,7 @@ function supportMultiTransitions(opts) {
 		for (i=0; i < opts.fxs.length; i++) {
 			var fx = opts.fxs[i];
 			tx = txs[fx];
-			if (!tx || !txs.hasOwnProperty(fx) || !$.isFunction(tx)) {
+			if (!tx || !txs.hasOwnProperty(fx) || typeof tx !== "function") {
 				log('discarding unknown transition: ',fx);
 				opts.fxs.splice(i,1);
 				i--;
@@ -441,7 +441,7 @@ function supportMultiTransitions(opts) {
 		opts.fxs = [];
 		for (p in txs) {
 			tx = txs[p];
-			if (txs.hasOwnProperty(p) && $.isFunction(tx))
+			if (txs.hasOwnProperty(p) && typeof tx === "function")
 				opts.fxs.push(p);
 		}
 	}
@@ -491,7 +491,7 @@ function exposeAddSlide(opts, els) {
 		if (opts.pager || opts.pagerAnchorBuilder)
 			$.fn.cycle.createPagerAnchor(els.length-1, s, $(opts.pager), els, opts);
 
-		if ($.isFunction(opts.onAddSlide))
+		if (typeof opts.onAddSlide === "function")
 			opts.onAddSlide($s);
 		else
 			$s.hide(); // default behavior
@@ -512,7 +512,7 @@ $.fn.cycle.resetState = function(opts, fx) {
 
 	// re-init
 	var init = $.fn.cycle.transitions[fx];
-	if ($.isFunction(init))
+	if (typeof init === "function")
 		init(opts.$cont, $(opts.elements), opts);
 };
 
@@ -594,7 +594,7 @@ function go(els, opts, manual, fwd) {
 		opts.busy = 1;
 		if (opts.fxFn) // fx function provided?
 			opts.fxFn(curr, next, opts, after, fwd, manual && opts.fastOnEvent);
-		else if ($.isFunction($.fn.cycle[opts.fx])) // fx plugin ?
+		else if (typeof $.fn.cycle[opts.fx] === "function") // fx plugin ?
 			$.fn.cycle[opts.fx](curr, next, opts, after, fwd, manual && opts.fastOnEvent);
 		else
 			$.fn.cycle.custom(curr, next, opts, after, fwd, manual && opts.fastOnEvent);
@@ -707,7 +707,7 @@ function advance(opts, val) {
 	}
 
 	var cb = opts.onPrevNextEvent || opts.prevNextClick; // prevNextClick is deprecated
-	if ($.isFunction(cb))
+	if (typeof cb === "function")
 		cb(val > 0, opts.nextSlide, els[opts.nextSlide]);
 	go(els, opts, 1, val>=0);
 	return false;
@@ -723,7 +723,7 @@ function buildPager(els, opts) {
 
 $.fn.cycle.createPagerAnchor = function(i, el, $p, els, opts) {
 	var a;
-	if ($.isFunction(opts.pagerAnchorBuilder)) {
+	if (typeof opts.pagerAnchorBuilder === "function") {
 		a = opts.pagerAnchorBuilder(i,el);
 		debug('pagerAnchorBuilder('+i+', el) returned: ' + a);
 	}
@@ -760,7 +760,7 @@ $.fn.cycle.createPagerAnchor = function(i, el, $p, els, opts) {
 			p.cycleTimeout = 0;
 		}
 		var cb = opts.onPagerEvent || opts.pagerClick; // pagerClick is deprecated
-		if ($.isFunction(cb))
+		if (typeof cb === "function")
 			cb(opts.nextSlide, els[opts.nextSlide]);
 		go(els,opts,1,opts.currSlide < i); // trigger the trans
 //		return false; // <== allow bubble

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.cookie.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.cookie.js
@@ -49,14 +49,14 @@
 
 	function read(s, converter) {
 		var value = config.raw ? s : parseCookieValue(s);
-		return $.isFunction(converter) ? converter(value) : value;
+		return typeof converter === "function" ? converter(value) : value;
 	}
 
 	var config = $.cookie = function (key, value, options) {
 
 		// Write
 
-		if (arguments.length > 1 && !$.isFunction(value)) {
+		if (arguments.length > 1 && typeof value !== "function") {
 			options = $.extend({}, config.defaults, options);
 
 			if (typeof options.expires === 'number') {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.js
@@ -120,7 +120,7 @@ $.widget = function( name, base, prototype ) {
 	// inheriting from
 	basePrototype.options = $.widget.extend( {}, basePrototype.options );
 	$.each( prototype, function( prop, value ) {
-		if ( !$.isFunction( value ) ) {
+		if ( typeof value !== "function" ) {
 			proxiedPrototype[ prop ] = value;
 			return;
 		}
@@ -248,7 +248,7 @@ $.widget.bridge = function( name, object ) {
 							"attempted to call method '" + options + "'" );
 					}
 
-					if ( !$.isFunction( instance[ options ] ) || options.charAt( 0 ) === "_" ) {
+					if ( typeof instance[ options ] !== "function" || options.charAt( 0 ) === "_" ) {
 						return $.error( "no such method '" + options + "' for " + name +
 							" widget instance" );
 					}
@@ -693,7 +693,7 @@ $.Widget.prototype = {
 		}
 
 		this.element.trigger( event, data );
-		return !( $.isFunction( callback ) &&
+		return !( typeof callback === "function" &&
 			callback.apply( this.element[ 0 ], [ event ].concat( data ) ) === false ||
 			event.isDefaultPrevented() );
 	}
@@ -2209,7 +2209,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 
 		if ( ( this.options.revert === "invalid" && !dropped ) ||
 				( this.options.revert === "valid" && dropped ) ||
-				this.options.revert === true || ( $.isFunction( this.options.revert ) &&
+				this.options.revert === true || ( typeof this.options.revert === "function" &&
 				this.options.revert.call( this.element, dropped ) )
 		) {
 			$( this.helper ).animate(
@@ -2281,7 +2281,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 	_createHelper: function( event ) {
 
 		var o = this.options,
-			helperIsFunction = $.isFunction( o.helper ),
+			helperIsFunction = typeof o.helper === "function",
 			helper = helperIsFunction ?
 				$( o.helper.apply( this.element[ 0 ], [ event ] ) ) :
 				( o.helper === "clone" ?
@@ -3204,7 +3204,7 @@ $.widget( "ui.droppable", {
 		this.isover = false;
 		this.isout = true;
 
-		this.accept = $.isFunction( accept ) ? accept : function( d ) {
+		this.accept = typeof accept === "function" ? accept : function( d ) {
 			return d.is( accept );
 		};
 
@@ -3256,7 +3256,7 @@ $.widget( "ui.droppable", {
 	_setOption: function( key, value ) {
 
 		if ( key === "accept" ) {
-			this.accept = $.isFunction( value ) ? value : function( d ) {
+			this.accept = typeof value === "function" ? value : function( d ) {
 				return d.is( value );
 			};
 		} else if ( key === "scope" ) {
@@ -5826,7 +5826,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 				for ( j = cur.length - 1; j >= 0; j-- ) {
 					inst = $.data( cur[ j ], this.widgetFullName );
 					if ( inst && inst !== this && !inst.options.disabled ) {
-						queries.push( [ $.isFunction( inst.options.items ) ?
+						queries.push( [ typeof inst.options.items === "function" ?
 							inst.options.items.call( inst.element ) :
 							$( inst.options.items, inst.element )
 								.not( ".ui-sortable-helper" )
@@ -5836,7 +5836,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 			}
 		}
 
-		queries.push( [ $.isFunction( this.options.items ) ?
+		queries.push( [ typeof this.options.items === "function" ?
 			this.options.items
 				.call( this.element, null, { options: this.options, item: this.currentItem } ) :
 			$( this.options.items, this.element )
@@ -5876,7 +5876,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 
 		var i, j, cur, inst, targetData, _queries, item, queriesLength,
 			items = this.items,
-			queries = [ [ $.isFunction( this.options.items ) ?
+			queries = [ [ typeof this.options.items === "function" ?
 				this.options.items.call( this.element[ 0 ], event, { item: this.currentItem } ) :
 				$( this.options.items, this.element ), this ] ],
 			connectWith = this._connectWith();
@@ -5888,7 +5888,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 				for ( j = cur.length - 1; j >= 0; j-- ) {
 					inst = $.data( cur[ j ], this.widgetFullName );
 					if ( inst && inst !== this && !inst.options.disabled ) {
-						queries.push( [ $.isFunction( inst.options.items ) ?
+						queries.push( [ typeof inst.options.items === "function" ?
 							inst.options.items
 								.call( inst.element[ 0 ], event, { item: this.currentItem } ) :
 							$( inst.options.items, inst.element ), inst ] );
@@ -6172,7 +6172,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 	_createHelper: function( event ) {
 
 		var o = this.options,
-			helper = $.isFunction( o.helper ) ?
+			helper = typeof o.helper === "function" ?
 				$( o.helper.apply( this.element[ 0 ], [ event, this.currentItem ] ) ) :
 				( o.helper === "clone" ? this.currentItem.clone() : this.currentItem );
 
@@ -10775,7 +10775,7 @@ function _normalizeArguments( effect, options, speed, callback ) {
 	}
 
 	// Catch (effect, callback)
-	if ( $.isFunction( options ) ) {
+	if ( typeof options === "function" ) {
 		callback = options;
 		speed = null;
 		options = {};
@@ -10789,7 +10789,7 @@ function _normalizeArguments( effect, options, speed, callback ) {
 	}
 
 	// Catch (effect, options, callback)
-	if ( $.isFunction( speed ) ) {
+	if ( typeof speed === "function" ) {
 		callback = speed;
 		speed = null;
 	}
@@ -10823,7 +10823,7 @@ function standardAnimationOption( option ) {
 	}
 
 	// Complete callback
-	if ( $.isFunction( option ) ) {
+	if ( typeof option === "function" ) {
 		return true;
 	}
 
@@ -10868,7 +10868,7 @@ $.fn.extend( {
 					$.effects.saveStyle( el );
 				}
 
-				if ( $.isFunction( next ) ) {
+				if ( typeof next === "function" ) {
 					next();
 				}
 			};
@@ -10903,11 +10903,11 @@ $.fn.extend( {
 			}
 
 			function done() {
-				if ( $.isFunction( complete ) ) {
+				if ( typeof complete === "function" ) {
 					complete.call( elem[ 0 ] );
 				}
 
-				if ( $.isFunction( next ) ) {
+				if ( typeof next === "function" ) {
 					next();
 				}
 			}
@@ -11028,7 +11028,7 @@ $.fn.extend( {
 				} )
 				.animate( animation, options.duration, options.easing, function() {
 					transfer.remove();
-					if ( $.isFunction( done ) ) {
+					if ( typeof done === "function" ) {
 						done();
 					}
 				} );

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -187,14 +187,14 @@
 
 			overrides = {
 				beforeShow: function (input, dp_inst) {
-					if ($.isFunction(tp_inst._defaults.evnts.beforeShow)) {
+					if (typeof tp_inst._defaults.evnts.beforeShow === "function") {
 						return tp_inst._defaults.evnts.beforeShow.call($input[0], input, dp_inst, tp_inst);
 					}
 				},
 				onChangeMonthYear: function (year, month, dp_inst) {
 					// Update the time as well : this prevents the time from disappearing from the $input field.
 					// tp_inst._updateDateTime(dp_inst);
-					if ($.isFunction(tp_inst._defaults.evnts.onChangeMonthYear)) {
+					if (typeof tp_inst._defaults.evnts.onChangeMonthYear === "function") {
 						tp_inst._defaults.evnts.onChangeMonthYear.call($input[0], year, month, dp_inst, tp_inst);
 					}
 				},
@@ -202,7 +202,7 @@
 					if (tp_inst.timeDefined === true && $input.val() !== '') {
 						tp_inst._updateDateTime(dp_inst);
 					}
-					if ($.isFunction(tp_inst._defaults.evnts.onClose)) {
+					if (typeof tp_inst._defaults.evnts.onClose === "function") {
 						tp_inst._defaults.evnts.onClose.call($input[0], dateText, dp_inst, tp_inst);
 					}
 				}
@@ -362,7 +362,7 @@
 		*/
 		_afterInject: function() {
 			var o = this.inst.settings;
-			if ($.isFunction(o.afterInject)) {
+			if (typeof o.afterInject === "function") {
 				o.afterInject.call(this);
 			}
 		},

--- a/src/main/resources/META-INF/resources/primefaces/keyboard/0-jquery.keypad.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyboard/0-jquery.keypad.js
@@ -862,7 +862,7 @@ $('selector').tabs(); // And instantiate it */
 					(inst.options.useThemeRoller ? ' ui-widget ui-widget-content ui-corner-all ui-shadow' : '') +
 					(inst.options.isRTL ? ' ' + this._rtlClass : '') + ' ' +
 					(inst._inline ? this._inlineClass : this._mainDivClass));
-			if ($.isFunction(inst.options.beforeShow)) {
+			if (typeof inst.options.beforeShow === "function") {
 				inst.options.beforeShow.apply((inst._input ? inst._input[0] : null),
 					[inst._mainDiv, inst]);
 			}
@@ -941,7 +941,7 @@ $('selector').tabs(); // And instantiate it */
 						(showAnim === 'fadeIn' ? 'fadeOut' : 'hide'))](showAnim ? duration : 0);
 				}
 			}
-			if ($.isFunction(inst.options.onClose)) {
+			if (typeof inst.options.onClose === "function") {
 				inst.options.onClose.apply((inst._input ? inst._input[0] : null),  // trigger custom callback
 					[inst._input.val(), inst]);
 			}
@@ -1112,7 +1112,7 @@ $('selector').tabs(); // And instantiate it */
 				value = value.substr(0, maxlen);
 			}
 			inst._input.val(value);
-			if (!$.isFunction(inst.options.onKeypress)) {
+			if (typeof value !== "function") {
 				inst._input.trigger('change'); // fire the change event
 			}
 		},
@@ -1122,7 +1122,7 @@ $('selector').tabs(); // And instantiate it */
 			@param {object} inst The instance settings.
 			@param {string} key The character pressed. */
 		_notifyKeypress: function(inst, key) {
-			if ($.isFunction(inst.options.onKeypress)) { // trigger custom callback
+			if (typeof inst.options.onKeypress === "function") { // trigger custom callback
 				inst.options.onKeypress.apply((inst._input ? inst._input[0] : null),
 					[key, inst._input.val(), inst]);
 			}

--- a/src/main/resources/META-INF/resources/primefaces/keyfilter/0-jquery.keyfilter.js
+++ b/src/main/resources/META-INF/resources/primefaces/keyfilter/0-jquery.keyfilter.js
@@ -139,7 +139,7 @@
 			{
 				return;
 			}
-			if ($.isFunction(re))
+			if (typeof re === "function")
 			{
 				ok = re.call(this, cc);
 			}

--- a/src/main/resources/META-INF/resources/primefaces/layout/0-jquery.layout.js
+++ b/src/main/resources/META-INF/resources/primefaces/layout/0-jquery.layout.js
@@ -48,7 +48,7 @@
                 try {
                     if (isStr(fn)) // 'name' of a function
                         fn = eval(fn);
-                    if ($.isFunction(fn))
+                    if (typeof fn === "function")
                         g(fn)(Instance);
                 } catch (ex) {
                 }
@@ -1185,7 +1185,7 @@
                             fn = eval(fn);
                     }
                     // execute the callback, if exists
-                    if ($.isFunction(fn)) {
+                    if (typeof fn === "function") {
                         if (args.length)
                             retVal = g(fn)(args[1]); // pass the argument parsed from 'list'
                         else if (hasPane)
@@ -5978,7 +5978,7 @@ jQuery.cookie = function (name, value, options) {
             } else if (sm.enabled) {
                 // update the options from cookie or callback
                 // if options is a function, call it to get stateData
-                if ($.isFunction(sm.autoLoad)) {
+                if (typeof sm.autoLoad === "function") {
                     var d = {};
                     try {
                         d = sm.autoLoad(inst, inst.state, inst.options, inst.options.name || ''); // try to get data from fn
@@ -5995,7 +5995,7 @@ jQuery.cookie = function (name, value, options) {
             var sm = inst.options.stateManagement;
             if (sm.enabled && sm.autoSave) {
                 // if options is a function, call it to save the stateData
-                if ($.isFunction(sm.autoSave)) {
+                if (typeof sm.autoSave === "function") {
                     try {
                         sm.autoSave(inst, inst.state, inst.options, inst.options.name || ''); // try to get data from fn
                     } catch (e) {

--- a/src/main/resources/META-INF/resources/primefaces/ring/ring.js
+++ b/src/main/resources/META-INF/resources/primefaces/ring/ring.js
@@ -125,8 +125,8 @@
 			    now = (new Date()).getTime();
 
 			options   = (typeof options === "object") ? options : {};
-			callback  = ($.isFunction(callback)) ? callback : function() {};
-			callback  = ($.isFunction(options)) ? options : callback;
+			callback  = (typeof callback === "function") ? callback : function() {};
+			callback  = (typeof options === "function") ? options : callback;
 			settings  = $.extend({}, defaults, options, internalData);
 
 			return this
@@ -256,11 +256,11 @@
 					// drag and drop
 					if (settings.enableDrag) {
 						// on screen
-						if (!$.isFunction(self.drag)) {
+						if (typeof self.drag !== "function") {
 							if (settings.debug) {
 								alert("You do not have the drag plugin loaded.");
 							}
-						} else if (!$.isFunction(self.drop)) {
+						} else if (typeof self.drop !== "function") {
 							if (settings.debug) {
 								alert("You do not have the drop plugin loaded.");
 							}
@@ -635,13 +635,13 @@
 			callback = callback || function() {};
 
 			// find callback function in arguments
-			if ($.isFunction(passedData)) {
+			if (typeof passedData === "function") {
 				callback = passedData;
 				passedData = null;
-			} else if ($.isFunction(easing)) {
+			} else if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -730,10 +730,10 @@
 			    callback = passedArgs[2] || function() {};
 
 			// find callback
-			if ($.isFunction(easing)) {
+			if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -802,10 +802,10 @@
 			callback = callback || function() {};
 
 			// find callback
-			if ($.isFunction(easing)) {
+			if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -824,10 +824,10 @@
 			callback = callback || function() {};
 
 			// find callback
-			if ($.isFunction(easing)) {
+			if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -866,10 +866,10 @@
 			callback = callback || function() {};
 
 			// find callback
-			if ($.isFunction(easing)) {
+			if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -888,10 +888,10 @@
 			callback = callback || function() {};
 
 			// find callback
-			if ($.isFunction(easing)) {
+			if (typeof easing === "function") {
 				callback = easing;
 				easing = null;
-			} else if ($.isFunction(duration)) {
+			} else if (typeof duration === "function") {
 				callback = duration;
 				duration = null;
 			}
@@ -1186,7 +1186,7 @@
 	$.fn.roundabout = function(method) {
 		if (methods[method]) {
 			return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
-		} else if (typeof method === "object" || $.isFunction(method) || !method) {
+		} else if (typeof method === "object" || typeof method === "function" || !method) {
 			return methods.init.apply(this, arguments);
 		} else {
 			$.error("Method " + method + " does not exist for jQuery.roundabout.");


### PR DESCRIPTION
As of jQuery 3.3, `jQuery.isFunction()` has been deprecated. In most cases, its use can be replaced by `typeof x === "function"`.

https://api.jquery.com/jQuery.isFunction/