### PR TITLE
Fix #5817: JQMIGRATE: jQuery.isArray is deprecated

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/charts/0-jqPlot.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/0-jqPlot.js
@@ -121,7 +121,7 @@
         var options = [];
         // see how many data arrays we have
         for (var i=0, l=arguments.length; i<l; i++) {
-            if ($.isArray(arguments[i])) {
+            if (Array.isArray(arguments[i])) {
                 datas.push(arguments[i]);
             }
             else if ($.isPlainObject(arguments[i])) {
@@ -200,7 +200,7 @@
         }
 
         else if (arguments.length === 2) {
-            if ($.isArray(data)) {
+            if (Array.isArray(data)) {
                 _data = data;
             }
 
@@ -2060,7 +2060,7 @@
                 $.extend(true, this.noDataIndicator, options.noDataIndicator);
             }
             
-            if (data == null || $.isArray(data) == false || data.length == 0 || $.isArray(data[0]) == false || data[0].length == 0) {
+            if (data == null || Array.isArray(data) == false || data.length == 0 || Array.isArray(data[0]) == false || data[0].length == 0) {
                 
                 if (this.noDataIndicator.show == false) {
                     throw new Error("No data specified");
@@ -2191,7 +2191,7 @@
             if (ax === true) {
                 ax = this.axes;
             }
-            if ($.isArray(ax)) {
+            if (Array.isArray(ax)) {
                 for (var i = 0; i < ax.length; i++) {
                     this.axes[ax[i]].resetScale(opts[ax[i]]);
                 }
@@ -2718,7 +2718,7 @@
                 var temp = [];
                 var i, l;
                 dir = dir || 'vertical';
-                if (!$.isArray(data[0])) {
+                if (!Array.isArray(data[0])) {
                     // we have a series of scalars.  One line with just y values.
                     // turn the scalar list of data into a data array of form:
                     // [[1, data[0]], [2, data[1]], ...]
@@ -3829,7 +3829,7 @@
     // conpute a highlight color or array of highlight colors from given colors.
     $.jqplot.computeHighlightColors  = function(colors) {
         var ret;
-        if ($.isArray(colors)) {
+        if (Array.isArray(colors)) {
             ret = [];
             for (var i=0; i<colors.length; i++){
                 var rgba = $.jqplot.getColorComponents(colors[i]);
@@ -5132,7 +5132,7 @@
         if (bd.length == 2) {
             // Do we have an array of x,y values?
             // like [[[1,1], [2,4], [3,3]], [[1,3], [2,6], [3,5]]]
-            if ($.isArray(bd[0][0])) {
+            if (Array.isArray(bd[0][0])) {
                 // since an arbitrary array of points, spin through all of them to determine max and min lines.
 
                 var p;
@@ -5186,7 +5186,7 @@
         // if more than 2 arrays, have arrays of [ylow, yhi] values.
         // note, can't distinguish case of [[ylow, yhi], [ylow, yhi]] from [[ylow, ylow], [yhi, yhi]]
         // this is assumed to be of the latter form.
-        else if (bd.length > 2 && !$.isArray(bd[0][0])) {
+        else if (bd.length > 2 && !Array.isArray(bd[0][0])) {
             var hi = (bd[0][0] > bd[0][1]) ? 0 : 1;
             var low = (hi) ? 0 : 1;
             for (var i=0, l=bd.length; i<l; i++) {
@@ -5203,7 +5203,7 @@
             var afunc = null;
             var bfunc = null;
 
-            if ($.isArray(intrv)) {
+            if (Array.isArray(intrv)) {
                 a = intrv[0];
                 b = intrv[1];
             }
@@ -6183,7 +6183,7 @@
         this._scalefact = 1.0;
         $.extend(true, this, options);
         if (this.breakPoints) {
-            if (!$.isArray(this.breakPoints)) {
+            if (!Array.isArray(this.breakPoints)) {
                 this.breakPoints = null;
             }
             else if (this.breakPoints.length < 2 || this.breakPoints[1] <= this.breakPoints[0]) {
@@ -6351,7 +6351,7 @@
             for (i=0; i<userTicks.length; i++){
                 var ut = userTicks[i];
                 var t = new this.tickRenderer(this.tickOptions);
-                if ($.isArray(ut)) {
+                if (Array.isArray(ut)) {
                     t.value = ut[0];
                     if (this.breakPoints) {
                         if (ut[0] == this.breakPoints[0]) {
@@ -6846,7 +6846,7 @@
     // > plot.axes.yaxis.renderer.resetTickValues.call(plot.axes.yaxis, yarr);
     //
     $.jqplot.LinearAxisRenderer.prototype.resetTickValues = function(opts) {
-        if ($.isArray(opts) && opts.length == this._ticks.length) {
+        if (Array.isArray(opts) && opts.length == this._ticks.length) {
             var t;
             for (var i=0; i<opts.length; i++) {
                 t = this._ticks[i];

--- a/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -262,7 +262,7 @@ if (!PrimeFaces.widget) {
         init: function(cfg) {
             this.cfg = cfg;
             this.id = cfg.id;
-            if ($.isArray(this.id)) {
+            if (Array.isArray(this.id)) {
                 this.jqId = $.map(this.id, function(id) {
                     return PrimeFaces.escapeClientId(id);
                 }).join(",");
@@ -374,7 +374,7 @@ if (!PrimeFaces.widget) {
          * @param {string | string[]} clientId The client-side ID of the widget.
          */
         removeScriptElement: function(clientId) {
-            if ($.isArray(clientId)) {
+            if (Array.isArray(clientId)) {
                 $.each(clientId, function(_, id) {
                     $(PrimeFaces.escapeClientId(id) + '_s').remove();
                 });

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/0-jquery.iframe-transport.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/0-jquery.iframe-transport.js
@@ -83,7 +83,7 @@
               '"></iframe>'
           ).bind('load', function() {
             var fileInputClones,
-              paramNames = $.isArray(options.paramName)
+              paramNames = Array.isArray(options.paramName)
                 ? options.paramName
                 : [options.paramName];
             iframe.unbind('load').bind('load', function() {

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/1-jquery.fileupload.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/1-jquery.fileupload.js
@@ -346,7 +346,7 @@
       if ($.type(options.formData) === 'function') {
         return options.formData(options.form);
       }
-      if ($.isArray(options.formData)) {
+      if (Array.isArray(options.formData)) {
         return options.formData;
       }
       if ($.type(options.formData) === 'object') {
@@ -639,7 +639,7 @@
         if (!paramName.length) {
           paramName = [fileInput.prop('name') || 'files[]'];
         }
-      } else if (!$.isArray(paramName)) {
+      } else if (!Array.isArray(paramName)) {
         paramName = [paramName];
       }
       return paramName;

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.js
@@ -75,7 +75,7 @@ $.widget = function( name, base, prototype ) {
 		base = $.Widget;
 	}
 
-	if ( $.isArray( prototype ) ) {
+	if ( Array.isArray(prototype) ) {
 		prototype = $.extend.apply( null, [ {} ].concat( prototype ) );
 	}
 
@@ -2320,7 +2320,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 		if ( typeof obj === "string" ) {
 			obj = obj.split( " " );
 		}
-		if ( $.isArray( obj ) ) {
+		if ( Array.isArray(obj) ) {
 			obj = { left: +obj[ 0 ], top: +obj[ 1 ] || 0 };
 		}
 		if ( "left" in obj ) {
@@ -6208,7 +6208,7 @@ var widgetsSortable = $.widget( "ui.sortable", $.ui.mouse, {
 		if ( typeof obj === "string" ) {
 			obj = obj.split( " " );
 		}
-		if ( $.isArray( obj ) ) {
+		if ( Array.isArray(obj) ) {
 			obj = { left: +obj[ 0 ], top: +obj[ 1 ] || 0 };
 		}
 		if ( "left" in obj ) {
@@ -8881,7 +8881,7 @@ var widgetsSlider = $.widget( "ui.slider", $.ui.mouse, {
 					options.values = [ this._valueMin(), this._valueMin() ];
 				} else if ( options.values.length && options.values.length !== 2 ) {
 					options.values = [ options.values[ 0 ], options.values[ 0 ] ];
-				} else if ( $.isArray( options.values ) ) {
+				} else if ( Array.isArray(options.values) ) {
 					options.values = options.values.slice( 0 );
 				}
 			}
@@ -9144,7 +9144,7 @@ var widgetsSlider = $.widget( "ui.slider", $.ui.mouse, {
 		}
 
 		if ( arguments.length ) {
-			if ( $.isArray( arguments[ 0 ] ) ) {
+			if ( Array.isArray(arguments[ 0 ]) ) {
 				vals = this.options.values;
 				newValues = arguments[ 0 ];
 				for ( i = 0; i < vals.length; i += 1 ) {
@@ -9178,7 +9178,7 @@ var widgetsSlider = $.widget( "ui.slider", $.ui.mouse, {
 			}
 		}
 
-		if ( $.isArray( this.options.values ) ) {
+		if ( Array.isArray(this.options.values) ) {
 			valsLength = this.options.values.length;
 		}
 

--- a/src/main/resources/META-INF/resources/primefaces/layout/0-jquery.layout.js
+++ b/src/main/resources/META-INF/resources/primefaces/layout/0-jquery.layout.js
@@ -42,7 +42,7 @@
      * @param {Array.<string>} a_fn
      */
     , runPluginCallbacks = function (Instance, a_fn) {
-        if ($.isArray(a_fn))
+        if (Array.isArray(a_fn))
             for (var i = 0, c = a_fn.length; i < c; i++) {
                 var fn = a_fn[i];
                 try {
@@ -1729,7 +1729,7 @@
                     ;
             if ($.isPlainObject(cos))
                 cos = [cos]; // convert a hash to a 1-elem array
-            else if (!cos || !$.isArray(cos))
+            else if (!cos || !Array.isArray(cos))
                 return;
 
             $.each(cos, function (idx, co) {
@@ -5843,7 +5843,7 @@ jQuery.cookie = function (name, value, options) {
             , pair, pane, key, val
                     , ps, pC, child, array, count, branch
                     ;
-            if ($.isArray(keys))
+            if (Array.isArray(keys))
                 keys = keys.join(",");
             // convert keys to an array and change delimiters from '__' to '.'
             keys = keys.replace(/__/g, ".").split(',');
@@ -5897,7 +5897,7 @@ jQuery.cookie = function (name, value, options) {
 
             function stringify(h) {
                 var D = [], i = 0, k, v, t // k = key, v = value
-                        , a = $.isArray(h)
+                        , a = Array.isArray(h)
                         ;
                 for (k in h) {
                     v = h[k];


### PR DESCRIPTION
Note: This API has been deprecated in jQuery 3.2; please use the native Array.isArray method instead.

https://api.jquery.com/jQuery.isArray/