### PR TITLE
Fix #5817: JQMIGRATE: jQuery.fn.bind()/unbind() are deprecated

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -259,7 +259,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         this.bindDropdownEvents();
 
         if(PrimeFaces.env.browser.mobile) {
-            this.dropdown.bind('touchstart', function() {
+            this.dropdown.on('touchstart', function() {
                 $this.touchToDropdownButton = true;
             });
         }
@@ -571,7 +571,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         });
 
         if(PrimeFaces.env.browser.mobile) {
-            this.items.bind('touchstart', function() {
+            this.items.on('touchstart', function() {
                 if(!$this.touchToDropdownButton) {
                     $this.itemClick = true;
                 }

--- a/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
@@ -425,7 +425,7 @@ PrimeFaces.widget.Chart = PrimeFaces.widget.DeferredWidget.extend({
     bindItemSelect: function() {
         var $this = this;
 
-        this.jq.bind("jqplotClick", function(ev, gridpos, datapos, neighbor) {
+        this.jq.on("jqplotClick", function(ev, gridpos, datapos, neighbor) {
             if(neighbor && $this.hasBehavior('itemSelect')) {
                 var ext = {
                     params: [

--- a/src/main/resources/META-INF/resources/primefaces/colorpicker/0-jquery.colorpicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/colorpicker/0-jquery.colorpicker.js
@@ -114,8 +114,8 @@
 					val: parseInt(field.val(), 10),
 					preview: $(this).parent().parent().data('colorpicker').livePreview
 				};
-				$(document).bind('mouseup', current, upIncrement);
-				$(document).bind('mousemove', current, moveIncrement);
+				$(document).on('mouseup', current, upIncrement);
+				$(document).on('mousemove', current, moveIncrement);
 			},
 			moveIncrement = function (ev) {
 				ev.data.field.val(Math.max(0, Math.min(ev.data.max, parseInt(ev.data.val + ev.pageY - ev.data.y, 10))));
@@ -127,8 +127,8 @@
 			upIncrement = function (ev) {
 				change.apply(ev.data.field.get(0), [true]);
 				ev.data.el.removeClass('ui-colorpicker_slider').find('input').focus();
-				$(document).unbind('mouseup', upIncrement);
-				$(document).unbind('mousemove', moveIncrement);
+				$(document).off('mouseup', upIncrement);
+				$(document).off('mousemove', moveIncrement);
 				return false;
 			},
 			downHue = function (ev) {
@@ -137,8 +137,8 @@
 					y: $(this).offset().top
 				};
 				current.preview = current.cal.data('colorpicker').livePreview;
-				$(document).bind('mouseup', current, upHue);
-				$(document).bind('mousemove', current, moveHue);
+				$(document).on('mouseup', current, upHue);
+				$(document).on('mousemove', current, moveHue);
 
 				ev.data = current;
 
@@ -158,8 +158,8 @@
 			upHue = function (ev) {
 				fillRGBFields(ev.data.cal.data('colorpicker').color, ev.data.cal.get(0));
 				fillHexFields(ev.data.cal.data('colorpicker').color, ev.data.cal.get(0));
-				$(document).unbind('mouseup', upHue);
-				$(document).unbind('mousemove', moveHue);
+				$(document).off('mouseup', upHue);
+				$(document).off('mousemove', moveHue);
 				return false;
 			},
 			downSelector = function (ev) {
@@ -168,8 +168,8 @@
 					pos: $(this).offset()
 				};
 				current.preview = current.cal.data('colorpicker').livePreview;
-				$(document).bind('mouseup', current, upSelector);
-				$(document).bind('mousemove', current, moveSelector);
+				$(document).on('mouseup', current, upSelector);
+				$(document).on('mousemove', current, moveSelector);
 
 				ev.data = current;
 
@@ -192,8 +192,8 @@
 			upSelector = function (ev) {
 				fillRGBFields(ev.data.cal.data('colorpicker').color, ev.data.cal.get(0));
 				fillHexFields(ev.data.cal.data('colorpicker').color, ev.data.cal.get(0));
-				$(document).unbind('mouseup', upSelector);
-				$(document).unbind('mousemove', moveSelector);
+				$(document).off('mouseup', upSelector);
+				$(document).off('mousemove', moveSelector);
 				return false;
 			},
 			enterSubmit = function (ev) {
@@ -226,7 +226,7 @@
 				if (cal.data('colorpicker').onShow.apply(this, [cal.get(0)]) != false) {
 					cal.show();
 				}
-				$(document).bind('mousedown', {cal: cal}, hide);
+				$(document).on('mousedown', {cal: cal}, hide);
 				return false;
 			},
 			hide = function (ev) {
@@ -234,7 +234,7 @@
 					if (ev.data.cal.data('colorpicker').onHide.apply(this, [ev.data.cal.get(0)]) != false) {
 						ev.data.cal.hide();
 					}
-					$(document).unbind('mousedown', hide);
+					$(document).off('mousedown', hide);
 				}
 			},
 			isChildOf = function(parentEl, el, container) {
@@ -405,25 +405,25 @@
 						}
 						options.fields = cal
 											.find('input')
-												.bind('keyup', keyDown)
-												.bind('change', change)
-												.bind('blur', blur)
-												.bind('focus', focus);
+												.on('keyup', keyDown)
+												.on('change', change)
+												.on('blur', blur)
+												.on('focus', focus);
 						cal
-							.find('span').bind('mousedown', downIncrement).end()
-							.find('>div.ui-colorpicker_current_color').bind('click', restoreOriginal);
-						options.selector = cal.find('div.ui-colorpicker_color').bind('mousedown', downSelector);
+							.find('span').on('mousedown', downIncrement).end()
+							.find('>div.ui-colorpicker_current_color').on('click', restoreOriginal);
+						options.selector = cal.find('div.ui-colorpicker_color').on('mousedown', downSelector);
 						options.selectorIndic = options.selector.find('div div');
 						options.el = this;
 						options.hue = cal.find('div.ui-colorpicker_hue div');
-						cal.find('div.ui-colorpicker_hue').bind('mousedown', downHue);
+						cal.find('div.ui-colorpicker_hue').on('mousedown', downHue);
 						options.newColor = cal.find('div.ui-colorpicker_new_color');
 						options.currentColor = cal.find('div.ui-colorpicker_current_color');
 						cal.data('colorpicker', options);
 						cal.find('div.ui-colorpicker_submit')
-							.bind('mouseenter', enterSubmit)
-							.bind('mouseleave', leaveSubmit)
-							.bind('click', clickSubmit);
+							.on('mouseenter', enterSubmit)
+							.on('mouseleave', leaveSubmit)
+							.on('click', clickSubmit);
 						fillRGBFields(options.color, cal.get(0));
 						fillHSBFields(options.color, cal.get(0));
 						fillHexFields(options.color, cal.get(0));
@@ -437,7 +437,7 @@
 								display: 'block'
 							});
 						} else {
-							$(this).bind(options.eventName, show);
+							$(this).on(options.eventName, show);
 						}
 					}
 				});

--- a/src/main/resources/META-INF/resources/primefaces/editor/editor.js
+++ b/src/main/resources/META-INF/resources/primefaces/editor/editor.js
@@ -262,7 +262,7 @@
                     .data(BUTTON_NAME, button.name)
                     .addClass(BUTTON_CLASS)
                     .attr("title", button.title)
-                    .bind(CLICK, $.proxy(buttonClick, editor))
+                    .on(CLICK, $.proxy(buttonClick, editor))
                     .appendTo($group)
                     .hover(hoverEnter, hoverLeave);
 
@@ -307,7 +307,7 @@
 
         // Bind the window resize event when the width or height is auto or %
         if (/auto|%/.test("" + options.width + options.height))
-            $(window).bind("resize.cleditor", function () { refresh(editor); });
+            $(window).on("resize.cleditor", function () { refresh(editor); });
 
         // Create the iframe and resize the controls
         refresh(editor);
@@ -350,22 +350,22 @@
         };
     });
 
-    // blurred - shortcut for .bind("blurred", handler) or .trigger("blurred")
+    // blurred - shortcut for .on("blurred", handler) or .trigger("blurred")
     fn.blurred = function (handler) {
         var $this = $(this);
-        return handler ? $this.bind(BLURRED, handler) : $this.trigger(BLURRED);
+        return handler ? $this.on(BLURRED, handler) : $this.trigger(BLURRED);
     };
 
-    // change - shortcut for .bind("change", handler) or .trigger("change")
+    // change - shortcut for .on("change", handler) or .trigger("change")
     fn.change = function change(handler) {
         var $this = $(this);
-        return handler ? $this.bind(CHANGE, handler) : $this.trigger(CHANGE);
+        return handler ? $this.on(CHANGE, handler) : $this.trigger(CHANGE);
     };
 
-    // focused - shortcut for .bind("focused", handler) or .trigger("focused")
+    // focused - shortcut for .on("focused", handler) or .trigger("focused")
     fn.focused = function (handler) {
         var $this = $(this);
-        return handler ? $this.bind(FOCUSED, handler) : $this.trigger(FOCUSED);
+        return handler ? $this.on(FOCUSED, handler) : $this.trigger(FOCUSED);
     };
 
     //===============
@@ -438,8 +438,8 @@
 
                     // Wire up the submit button click event handler
                     $popup.children(":button")
-                        .unbind(CLICK)
-                        .bind(CLICK, function () {
+                        .off(CLICK)
+                        .on(CLICK, function () {
 
                             // Insert the image or link if a url was entered
                             var $text = $popup.find(":text"),
@@ -461,8 +461,8 @@
 
                     // Wire up the submit button click event handler
                     $popup.children(":button")
-                        .unbind(CLICK)
-                        .bind(CLICK, function () {
+                        .off(CLICK)
+                        .on(CLICK, function () {
 
                             // Insert the unformatted text replacing new lines with break tags
                             var $textarea = $popup.find("textarea"),
@@ -828,7 +828,7 @@
         $.each(popups, function (idx, popup) {
             $(popup)
                 .hide()
-                .unbind(CLICK)
+                .off(CLICK)
                 .removeData(BUTTON);
         });
     }
@@ -887,7 +887,7 @@
             // Save the current user selection. This code is needed since IE will
             // reset the selection just after the beforedeactivate event and just
             // before the beforeactivate event.
-            $doc.bind("beforedeactivate beforeactivate selectionchange keypress keyup", function (e) {
+            $doc.on("beforedeactivate beforeactivate selectionchange keypress keyup", function (e) {
 
                 // Flag the editor as inactive
                 if (e.type === "beforedeactivate")
@@ -943,11 +943,11 @@
                     e.preventDefault();
                 }
             })
-            .bind("keyup mouseup", function () {
+            .on("keyup mouseup", function () {
                 refreshButtons(editor);
                 updateTextArea(editor, true);
             })
-            .bind("paste", function() {
+            .on("paste", function() {
                 setTimeout(function() {
                     refreshButtons(editor);
                     updateTextArea(editor, true);
@@ -1126,7 +1126,7 @@
         // Assign the popup button and click event handler
         if (button) {
             $.data(popup, BUTTON, button);
-            $popup.bind(CLICK, { popup: popup }, $.proxy(popupClick, editor));
+            $popup.on(CLICK, { popup: popup }, $.proxy(popupClick, editor));
         }
 
         // Focus the first input element if any
@@ -1276,7 +1276,7 @@ PrimeFaces.widget.Editor = PrimeFaces.widget.DeferredWidget.extend({
         var $this = this,
         frameDoc = this.editor.$frame[0].contentWindow.document;
 
-        $(frameDoc).bind('keydown.editor', function(event){
+        $(frameDoc).on('keydown.editor', function(event){
             $this.editor.updateTextArea();
 
             var text = $this.editor.$area.val();

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/0-jquery.iframe-transport.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/0-jquery.iframe-transport.js
@@ -81,12 +81,12 @@
               '" name="iframe-transport-' +
               counter +
               '"></iframe>'
-          ).bind('load', function() {
+          ).on('load', function() {
             var fileInputClones,
               paramNames = $.isArray(options.paramName)
                 ? options.paramName
                 : [options.paramName];
-            iframe.unbind('load').bind('load', function() {
+            iframe.off('load').on('load', function() {
               var response;
               // Wrap in a try/catch block to catch exceptions thrown
               // when trying to access cross-domain iframe contents:
@@ -173,7 +173,7 @@
           if (iframe) {
             // javascript:false as iframe src aborts the request
             // and prevents warning popups on HTTPS in IE6.
-            iframe.unbind('load').prop('src', initialIframeSrc);
+            iframe.off('load').prop('src', initialIframeSrc);
           }
           if (form) {
             form.remove();

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/1-jquery.fileupload.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/1-jquery.fileupload.js
@@ -217,7 +217,7 @@
       // and allows you to override plugin options as well as define ajax settings.
       //
       // Listeners for this callback can also be bound the following way:
-      // .bind('fileuploadadd', func);
+      // .on('fileuploadadd', func);
       //
       // data.submit() returns a Promise object and allows to attach additional
       // handlers using jQuery's Deferred callbacks:
@@ -240,58 +240,58 @@
       // Other callbacks:
 
       // Callback for the submit event of each file upload:
-      // submit: function (e, data) {}, // .bind('fileuploadsubmit', func);
+      // submit: function (e, data) {}, // .on('fileuploadsubmit', func);
 
       // Callback for the start of each file upload request:
-      // send: function (e, data) {}, // .bind('fileuploadsend', func);
+      // send: function (e, data) {}, // .on('fileuploadsend', func);
 
       // Callback for successful uploads:
-      // done: function (e, data) {}, // .bind('fileuploaddone', func);
+      // done: function (e, data) {}, // .on('fileuploaddone', func);
 
       // Callback for failed (abort or error) uploads:
-      // fail: function (e, data) {}, // .bind('fileuploadfail', func);
+      // fail: function (e, data) {}, // .on('fileuploadfail', func);
 
       // Callback for completed (success, abort or error) requests:
-      // always: function (e, data) {}, // .bind('fileuploadalways', func);
+      // always: function (e, data) {}, // .on('fileuploadalways', func);
 
       // Callback for upload progress events:
-      // progress: function (e, data) {}, // .bind('fileuploadprogress', func);
+      // progress: function (e, data) {}, // .on('fileuploadprogress', func);
 
       // Callback for global upload progress events:
-      // progressall: function (e, data) {}, // .bind('fileuploadprogressall', func);
+      // progressall: function (e, data) {}, // .on('fileuploadprogressall', func);
 
       // Callback for uploads start, equivalent to the global ajaxStart event:
-      // start: function (e) {}, // .bind('fileuploadstart', func);
+      // start: function (e) {}, // .on('fileuploadstart', func);
 
       // Callback for uploads stop, equivalent to the global ajaxStop event:
-      // stop: function (e) {}, // .bind('fileuploadstop', func);
+      // stop: function (e) {}, // .on('fileuploadstop', func);
 
       // Callback for change events of the fileInput(s):
-      // change: function (e, data) {}, // .bind('fileuploadchange', func);
+      // change: function (e, data) {}, // .on('fileuploadchange', func);
 
       // Callback for paste events to the pasteZone(s):
-      // paste: function (e, data) {}, // .bind('fileuploadpaste', func);
+      // paste: function (e, data) {}, // .on('fileuploadpaste', func);
 
       // Callback for drop events of the dropZone(s):
-      // drop: function (e, data) {}, // .bind('fileuploaddrop', func);
+      // drop: function (e, data) {}, // .on('fileuploaddrop', func);
 
       // Callback for dragover events of the dropZone(s):
-      // dragover: function (e) {}, // .bind('fileuploaddragover', func);
+      // dragover: function (e) {}, // .on('fileuploaddragover', func);
 
       // Callback before the start of each chunk upload request (before form data initialization):
-      // chunkbeforesend: function (e, data) {}, // .bind('fileuploadchunkbeforesend', func);
+      // chunkbeforesend: function (e, data) {}, // .on('fileuploadchunkbeforesend', func);
 
       // Callback for the start of each chunk upload request:
-      // chunksend: function (e, data) {}, // .bind('fileuploadchunksend', func);
+      // chunksend: function (e, data) {}, // .on('fileuploadchunksend', func);
 
       // Callback for successful chunk uploads:
-      // chunkdone: function (e, data) {}, // .bind('fileuploadchunkdone', func);
+      // chunkdone: function (e, data) {}, // .on('fileuploadchunkdone', func);
 
       // Callback for failed (abort or error) chunk uploads:
-      // chunkfail: function (e, data) {}, // .bind('fileuploadchunkfail', func);
+      // chunkfail: function (e, data) {}, // .on('fileuploadchunkfail', func);
 
       // Callback for completed (success, abort or error) chunk upload requests:
-      // chunkalways: function (e, data) {}, // .bind('fileuploadchunkalways', func);
+      // chunkalways: function (e, data) {}, // .on('fileuploadchunkalways', func);
 
       // The plugin options are used as settings object for the ajax calls.
       // The following are jQuery ajax settings required for the file uploads:
@@ -448,7 +448,7 @@
       // Accesss to the native XHR object is required to add event listeners
       // for the upload progress event:
       if (xhr.upload) {
-        $(xhr.upload).bind('progress', function(e) {
+        $(xhr.upload).on('progress', function(e) {
           var oe = e.originalEvent;
           // Make sure the progress event properties get copied over:
           e.lengthComputable = oe.lengthComputable;
@@ -465,7 +465,7 @@
     _deinitProgressListener: function(options) {
       var xhr = options.xhr ? options.xhr() : $.ajaxSettings.xhr();
       if (xhr.upload) {
-        $(xhr.upload).unbind('progress');
+        $(xhr.upload).off('progress');
       }
     },
 
@@ -1179,7 +1179,7 @@
         inputClone.focus();
       }
       // Avoid memory leaks with the detached file input:
-      $.cleanData(input.unbind('remove'));
+      $.cleanData(input.off('remove'));
       // Replace the original file input element in the fileInput
       // elements set with the clone, which has been copied including
       // event handlers:

--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/0-jquery.idletimer.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/0-jquery.idletimer.js
@@ -273,7 +273,7 @@
         });
 
         if (opts.timerSyncId) {
-            $(window).bind("storage", handleEvent);
+            $(window).on("storage", handleEvent);
         }
 
         // Internal Object Properties, This isn't all necessary, but we

--- a/src/main/resources/META-INF/resources/primefaces/imageswitch/imageswitch.js
+++ b/src/main/resources/META-INF/resources/primefaces/imageswitch/imageswitch.js
@@ -188,13 +188,13 @@ function removeFilter(el, opts) {
 // unbind event handlers
 function destroy(opts) {
 	if (opts.next)
-		$(opts.next).unbind(opts.prevNextEvent);
+		$(opts.next).off(opts.prevNextEvent);
 	if (opts.prev)
-		$(opts.prev).unbind(opts.prevNextEvent);
+		$(opts.prev).off(opts.prevNextEvent);
 
 	if (opts.pager || opts.pagerAnchorBuilder)
 		$.each(opts.pagerAnchors || [], function() {
-			this.unbind().remove();
+			this.off().remove();
 		});
 	opts.pagerAnchors = null;
 	if (opts.destroy) // callback
@@ -392,9 +392,9 @@ function buildOptions($cont, $slides, els, options, o) {
 		opts.after[1].apply(e0, [e0, e0, opts, true]);
 
 	if (opts.next)
-		$(opts.next).bind(opts.prevNextEvent,function(){return advance(opts,opts.rev?-1:1)});
+		$(opts.next).on(opts.prevNextEvent,function(){return advance(opts,opts.rev?-1:1)});
 	if (opts.prev)
-		$(opts.prev).bind(opts.prevNextEvent,function(){return advance(opts,opts.rev?1:-1)});
+		$(opts.prev).on(opts.prevNextEvent,function(){return advance(opts,opts.rev?1:-1)});
 	if (opts.pager || opts.pagerAnchorBuilder)
 		buildPager(els,opts);
 
@@ -751,7 +751,7 @@ $.fn.cycle.createPagerAnchor = function(i, el, $p, els, opts) {
 
 	opts.pagerAnchors =  opts.pagerAnchors || [];
 	opts.pagerAnchors.push($a);
-	$a.bind(opts.pagerEvent, function(e) {
+	$a.on(opts.pagerEvent, function(e) {
 		e.preventDefault();
 		opts.nextSlide = i;
 		var p = opts.$cont[0], timeout = p.cycleTimeout;
@@ -767,7 +767,7 @@ $.fn.cycle.createPagerAnchor = function(i, el, $p, els, opts) {
 	});
 
 	if ( ! /^click/.test(opts.pagerEvent) && !opts.allowPagerClickBubble)
-		$a.bind('click.cycle', function(){return false;}); // suppress click
+		$a.on('click.cycle', function(){return false;}); // suppress click
 
 	if (opts.pauseOnPagerHover)
 		$a.hover(function() {opts.$cont[0].cyclePause++;}, function() {opts.$cont[0].cyclePause--;} );

--- a/src/main/resources/META-INF/resources/primefaces/inplace/inplace.js
+++ b/src/main/resources/META-INF/resources/primefaces/inplace/inplace.js
@@ -49,7 +49,7 @@ PrimeFaces.widget.Inplace = PrimeFaces.widget.BaseWidget.extend({
         if(!this.cfg.disabled) {
 
             if(this.cfg.toggleable) {
-                this.display.bind(this.cfg.event, function(){
+                this.display.on(this.cfg.event, function(){
                     $this.show();
                 });
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.mousewheel.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.mousewheel.js
@@ -81,11 +81,11 @@
 
     $.fn.extend({
         mousewheel: function(fn) {
-            return fn ? this.bind('mousewheel', fn) : this.trigger('mousewheel');
+            return fn ? this.on('mousewheel', fn) : this.trigger('mousewheel');
         },
 
         unmousewheel: function(fn) {
-            return this.unbind('mousewheel', fn);
+            return this.off('mousewheel', fn);
         }
     });
 

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.js
@@ -46,7 +46,7 @@
                     return false;
                 }
             };
-            $(this).bind(this.getAttribute("data-event"), handler[this.getAttribute("data-handler")]);
+            $(this).on(this.getAttribute("data-event"), handler[this.getAttribute("data-handler")]);
         });
     };
 
@@ -202,14 +202,14 @@
                     "mousedown";
 
             return function () {
-                return this.bind(eventType + ".ui-disableSelection", function (event) {
+                return this.on(eventType + ".ui-disableSelection", function (event) {
                     event.preventDefault();
                 });
             };
         })(),
 
         enableSelection: function () {
-            return this.unbind(".ui-disableSelection");
+            return this.off(".ui-disableSelection");
         },
 
         zIndex: function (zIndex) {

--- a/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.timepicker.js
@@ -304,7 +304,7 @@
 			if (tp_inst._defaults.maxDateTime !== undefined && tp_inst._defaults.maxDateTime instanceof Date) {
 				tp_inst._defaults.maxDate = new Date(tp_inst._defaults.maxDateTime.getTime());
 			}
-			tp_inst.$input.bind('focus', function () {
+			tp_inst.$input.on('focus', function () {
 				tp_inst._onFocus();
 			});
 

--- a/src/main/resources/META-INF/resources/primefaces/knob/1-jquery.knob.js
+++ b/src/main/resources/META-INF/resources/primefaces/knob/1-jquery.knob.js
@@ -154,7 +154,7 @@
                     s.i[k] = $this;
                     s.v[k] = s.o.parse($this.val());
 
-                    $this.bind(
+                    $this.on(
                         'change blur',
                         function () {
                             var val = {};
@@ -170,7 +170,7 @@
                 this.i = this.$;
                 this.v = this.o.parse(this.$.val());
                 this.v === '' && (this.v = this.o.min);
-                this.$.bind(
+                this.$.on(
                     'change blur',
                     function () {
                         s.val(s._validate(s.o.parse(s.$.val())));
@@ -240,9 +240,9 @@
 
             // binds configure event
             this.$
-                .bind("configure", cf)
+                .on("configure", cf)
                 .parent()
-                .bind("configure", cf);
+                .on("configure", cf);
 
             // finalize init
             this._listen()
@@ -336,11 +336,11 @@
 
             // Touch events listeners
             k.c.d
-                .bind("touchmove.k", touchMove)
-                .bind(
+                .on("touchmove.k", touchMove)
+                .on(
                     "touchend.k",
                     function () {
-                        k.c.d.unbind('touchmove.k touchend.k');
+                        k.c.d.off('touchmove.k touchend.k');
                         s.val(s.cv);
                     }
                 );
@@ -365,13 +365,13 @@
 
             // Mouse events listeners
             k.c.d
-                .bind("mousemove.k", mouseMove)
-                .bind(
+                .on("mousemove.k", mouseMove)
+                .on(
                     // Escape key cancel current change
                     "keyup.k",
                     function (e) {
                         if (e.keyCode === 27) {
-                            k.c.d.unbind("mouseup.k mousemove.k keyup.k");
+                            k.c.d.off("mouseup.k mousemove.k keyup.k");
 
                             if (s.eH && s.eH() === false)
                                 return;
@@ -380,10 +380,10 @@
                         }
                     }
                 )
-                .bind(
+                .on(
                     "mouseup.k",
                     function (e) {
-                        k.c.d.unbind('mousemove.k mouseup.k keyup.k');
+                        k.c.d.off('mousemove.k mouseup.k keyup.k');
                         s.val(s.cv);
                     }
                 );
@@ -402,14 +402,14 @@
         this._listen = function () {
             if (!this.o.readOnly) {
                 this.$c
-                    .bind(
+                    .on(
                         "mousedown",
                         function (e) {
                             e.preventDefault();
                             s._xy()._mouse(e);
                         }
                     )
-                    .bind(
+                    .on(
                         "touchstart",
                         function (e) {
                             e.preventDefault();
@@ -615,7 +615,7 @@
                 };
 
             this.$
-                .bind(
+                .on(
                     "keydown",
                     function (e) {
                         var kc = e.keyCode;
@@ -654,7 +654,7 @@
                         }
                     }
                 )
-                .bind(
+                .on(
                     "keyup",
                     function (e) {
                         if (isNaN(kval)) {
@@ -672,8 +672,8 @@
                     }
                 );
 
-            this.$c.bind("mousewheel DOMMouseScroll", mw);
-            this.$.bind("mousewheel DOMMouseScroll", mw);
+            this.$c.on("mousewheel DOMMouseScroll", mw);
+            this.$.on("mousewheel DOMMouseScroll", mw);
         };
 
         this.init = function () {

--- a/src/main/resources/META-INF/resources/primefaces/rating/rating.js
+++ b/src/main/resources/META-INF/resources/primefaces/rating/rating.js
@@ -71,9 +71,9 @@ PrimeFaces.widget.Rating = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     unbindEvents: function() {
-        this.stars.unbind('click');
+        this.stars.off('click');
 
-        this.cancel.unbind('hover click');
+        this.cancel.off('hover click');
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/ring/ring.js
+++ b/src/main/resources/META-INF/resources/primefaces/ring/ring.js
@@ -162,13 +162,13 @@
 					// unbind any events that we set if we're relaying out
 					if (relayout) {
 						self
-							.unbind(".roundabout")
+							.off(".roundabout")
 							.children(settings.childSelector)
-								.unbind(".roundabout");
+								.off(".roundabout");
 					} else {
 						// bind responsive action
 						if (settings.responsive) {
-							$(window).bind("resize", function() {
+							$(window).on("resize", function() {
 								methods.stopAutoplay.apply(self);
 								methods.relayoutChildren.apply(self);
 							});
@@ -181,7 +181,7 @@
 							.children(settings.childSelector)
 							.each(function(i) {
 								$(this)
-									.bind("click.roundabout", function() {
+									.on("click.roundabout", function() {
 										var degrees = methods.getPlacement.apply(self, [i]);
 
 										if (!methods.isInFocus.apply(self, [degrees])) {
@@ -198,7 +198,7 @@
 					// bind next buttons
 					if (settings.btnNext) {
 						$(settings.btnNext)
-							.bind("click.roundabout", function() {
+							.on("click.roundabout", function() {
 								if (!self.data("roundabout").animating) {
 									methods.animateToNextChild.apply(self, [self.data("roundabout").btnNextCallback]);
 								}
@@ -209,7 +209,7 @@
 					// bind previous buttons
 					if (settings.btnPrev) {
 						$(settings.btnPrev)
-							.bind("click.roundabout", function() {
+							.on("click.roundabout", function() {
 								methods.animateToPreviousChild.apply(self, [self.data("roundabout").btnPrevCallback]);
 								return false;
 							});
@@ -218,7 +218,7 @@
 					// bind toggle autoplay buttons
 					if (settings.btnToggleAutoplay) {
 						$(settings.btnToggleAutoplay)
-							.bind("click.roundabout", function() {
+							.on("click.roundabout", function() {
 								methods.toggleAutoplay.apply(self);
 								return false;
 							});
@@ -227,7 +227,7 @@
 					// bind start autoplay buttons
 					if (settings.btnStartAutoplay) {
 						$(settings.btnStartAutoplay)
-							.bind("click.roundabout", function() {
+							.on("click.roundabout", function() {
 								methods.startAutoplay.apply(self);
 								return false;
 							});
@@ -236,7 +236,7 @@
 					// bind stop autoplay buttons
 					if (settings.btnStopAutoplay) {
 						$(settings.btnStopAutoplay)
-							.bind("click.roundabout", function() {
+							.on("click.roundabout", function() {
 								methods.stopAutoplay.apply(self);
 								return false;
 							});
@@ -245,10 +245,10 @@
 					// autoplay pause on hover
 					if (settings.autoplayPauseOnHover) {
 						self
-							.bind("mouseenter.roundabout.autoplay", function() {
+							.on("mouseenter.roundabout.autoplay", function() {
 								methods.stopAutoplay.apply(self, [true]);
 							})
-							.bind("mouseleave.roundabout.autoplay", function() {
+							.on("mouseleave.roundabout.autoplay", function() {
 								methods.startAutoplay.apply(self);
 							});
 					}
@@ -965,7 +965,7 @@
 					
 					// this will prevent autoplayPauseOnHover from restarting autoplay
 					if (!keepAutoplayBindings) {
-						$(this).unbind(".autoplay");
+						$(this).off(".autoplay");
 					}
 					
 					$(this).trigger("autoplayStop");

--- a/src/main/resources/META-INF/resources/primefaces/scrollpanel/scrollpanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/scrollpanel/scrollpanel.js
@@ -215,15 +215,15 @@
 					verticalDrag = verticalTrack.find('>.ui-scrollpanel-drag');
 
 					if (settings.showArrows) {
-						arrowUp = $('<a class="jspArrow jspArrowUp"></a>').bind(
+						arrowUp = $('<a class="jspArrow jspArrowUp"></a>').on(
 							'mousedown.jsp', getArrowScroll(0, -1)
-						).bind('click.jsp', nil);
-						arrowDown = $('<a class="jspArrow jspArrowDown"></a>').bind(
+						).on('click.jsp', nil);
+						arrowDown = $('<a class="jspArrow jspArrowDown"></a>').on(
 							'mousedown.jsp', getArrowScroll(0, 1)
-						).bind('click.jsp', nil);
+						).on('click.jsp', nil);
 						if (settings.arrowScrollOnHover) {
-							arrowUp.bind('mouseover.jsp', getArrowScroll(0, -1, arrowUp));
-							arrowDown.bind('mouseover.jsp', getArrowScroll(0, 1, arrowDown));
+							arrowUp.on('mouseover.jsp', getArrowScroll(0, -1, arrowUp));
+							arrowDown.on('mouseover.jsp', getArrowScroll(0, 1, arrowDown));
 						}
 
 						appendArrows(verticalTrack, settings.verticalArrowPositions, arrowUp, arrowDown);
@@ -247,24 +247,24 @@
 						{
 							verticalDrag.removeClass('jspHover');
 						}
-					).bind(
+					).on(
 						'mousedown.jsp',
 						function(e)
 						{
 							// Stop IE from allowing text selection
-							$('html').bind('dragstart.jsp selectstart.jsp', nil);
+							$('html').on('dragstart.jsp selectstart.jsp', nil);
 
 							verticalDrag.addClass('jspActive');
 
 							var startY = e.pageY - verticalDrag.position().top;
 
-							$('html').bind(
+							$('html').on(
 								'mousemove.jsp',
 								function(e)
 								{
 									positionDragY(e.pageY - startY, false);
 								}
-							).bind('mouseup.jsp mouseleave.jsp', cancelDrag);
+							).on('mouseup.jsp mouseleave.jsp', cancelDrag);
 							return false;
 						}
 					);
@@ -313,15 +313,15 @@
 					horizontalDrag = horizontalTrack.find('>.ui-scrollpanel-drag');
 
 					if (settings.showArrows) {
-						arrowLeft = $('<a class="jspArrow jspArrowLeft"></a>').bind(
+						arrowLeft = $('<a class="jspArrow jspArrowLeft"></a>').on(
 							'mousedown.jsp', getArrowScroll(-1, 0)
-						).bind('click.jsp', nil);
-						arrowRight = $('<a class="jspArrow jspArrowRight"></a>').bind(
+						).on('click.jsp', nil);
+						arrowRight = $('<a class="jspArrow jspArrowRight"></a>').on(
 							'mousedown.jsp', getArrowScroll(1, 0)
-						).bind('click.jsp', nil);
+						).on('click.jsp', nil);
 						if (settings.arrowScrollOnHover) {
-							arrowLeft.bind('mouseover.jsp', getArrowScroll(-1, 0, arrowLeft));
-							arrowRight.bind('mouseover.jsp', getArrowScroll(1, 0, arrowRight));
+							arrowLeft.on('mouseover.jsp', getArrowScroll(-1, 0, arrowLeft));
+							arrowRight.on('mouseover.jsp', getArrowScroll(1, 0, arrowRight));
 						}
 						appendArrows(horizontalTrack, settings.horizontalArrowPositions, arrowLeft, arrowRight);
 					}
@@ -335,24 +335,24 @@
 						{
 							horizontalDrag.removeClass('jspHover');
 						}
-					).bind(
+					).on(
 						'mousedown.jsp',
 						function(e)
 						{
 							// Stop IE from allowing text selection
-							$('html').bind('dragstart.jsp selectstart.jsp', nil);
+							$('html').on('dragstart.jsp selectstart.jsp', nil);
 
 							horizontalDrag.addClass('jspActive');
 
 							var startX = e.pageX - horizontalDrag.position().left;
 
-							$('html').bind(
+							$('html').on(
 								'mousemove.jsp',
 								function(e)
 								{
 									positionDragX(e.pageX - startX, false);
 								}
-							).bind('mouseup.jsp mouseleave.jsp', cancelDrag);
+							).on('mouseup.jsp mouseleave.jsp', cancelDrag);
 							return false;
 						}
 					);
@@ -480,14 +480,14 @@
 
 				eve = ele ? 'mouseout.jsp' : 'mouseup.jsp';
 				ele = ele || $('html');
-				ele.bind(
+				ele.on(
 					eve,
 					function()
 					{
 						arrow.removeClass('jspActive');
 						scrollTimeout && clearTimeout(scrollTimeout);
 						scrollTimeout = null;
-						ele.unbind(eve);
+						ele.off(eve);
 					}
 				);
 			}
@@ -496,7 +496,7 @@
 			{
 				removeClickOnTrack();
 				if (isScrollableV) {
-					verticalTrack.bind(
+					verticalTrack.on(
 						'mousedown.jsp',
 						function(e)
 						{
@@ -535,10 +535,10 @@
 									{
 										scrollTimeout && clearTimeout(scrollTimeout);
 										scrollTimeout = null;
-										$(document).unbind('mouseup.jsp', cancelClick);
+										$(document).off('mouseup.jsp', cancelClick);
 									};
 								doScroll();
-								$(document).bind('mouseup.jsp', cancelClick);
+								$(document).on('mouseup.jsp', cancelClick);
 								return false;
 							}
 						}
@@ -546,7 +546,7 @@
 				}
 				
 				if (isScrollableH) {
-					horizontalTrack.bind(
+					horizontalTrack.on(
 						'mousedown.jsp',
 						function(e)
 						{
@@ -585,10 +585,10 @@
 									{
 										scrollTimeout && clearTimeout(scrollTimeout);
 										scrollTimeout = null;
-										$(document).unbind('mouseup.jsp', cancelClick);
+										$(document).off('mouseup.jsp', cancelClick);
 									};
 								doScroll();
-								$(document).bind('mouseup.jsp', cancelClick);
+								$(document).on('mouseup.jsp', cancelClick);
 								return false;
 							}
 						}
@@ -599,16 +599,16 @@
 			function removeClickOnTrack()
 			{
 				if (horizontalTrack) {
-					horizontalTrack.unbind('mousedown.jsp');
+					horizontalTrack.off('mousedown.jsp');
 				}
 				if (verticalTrack) {
-					verticalTrack.unbind('mousedown.jsp');
+					verticalTrack.off('mousedown.jsp');
 				}
 			}
 
 			function cancelDrag()
 			{
-				$('html').unbind('dragstart.jsp selectstart.jsp mousemove.jsp mouseup.jsp mouseleave.jsp');
+				$('html').off('dragstart.jsp selectstart.jsp mousemove.jsp mouseup.jsp mouseleave.jsp');
 
 				if (verticalDrag) {
 					verticalDrag.removeClass('jspActive');
@@ -820,7 +820,7 @@
 
 			function initMousewheel()
 			{
-				container.unbind(mwEvent).bind(
+				container.off(mwEvent).on(
 					mwEvent,
 					function (event, delta, deltaX, deltaY) {
 						var dX = horizontalDragPosition, dY = verticalDragPosition, factor = event.deltaFactor || settings.mouseWheelSpeed;
@@ -833,7 +833,7 @@
 
 			function removeMousewheel()
 			{
-				container.unbind(mwEvent);
+				container.off(mwEvent);
 			}
 
 			function nil()
@@ -843,7 +843,7 @@
 
 			function initFocusHandler()
 			{
-				pane.find(':input,a').unbind('focus.jsp').bind(
+				pane.find(':input,a').off('focus.jsp').on(
 					'focus.jsp',
 					function(e)
 					{
@@ -854,7 +854,7 @@
 
 			function removeFocusHandler()
 			{
-				pane.find(':input,a').unbind('focus.jsp');
+				pane.find(':input,a').off('focus.jsp');
 			}
 			
 			function initKeyboardNav()
@@ -872,8 +872,8 @@
 				);
 				
 				elem.attr('tabindex', 0)
-					.unbind('keydown.jsp keypress.jsp')
-					.bind(
+					.off('keydown.jsp keypress.jsp')
+					.on(
 						'keydown.jsp',
 						function(e)
 						{
@@ -905,7 +905,7 @@
 							elementHasScrolled = e.which == keyDown && dX != horizontalDragPosition || dY != verticalDragPosition;
 							return !elementHasScrolled;
 						}
-					).bind(
+					).on(
 						'keypress.jsp', // For FF/ OSX so that we can cancel the repeat key presses if the JSP scrolls...
 						function(e)
 						{
@@ -962,7 +962,7 @@
 			{
 				elem.attr('tabindex', '-1')
 					.removeAttr('tabindex')
-					.unbind('keydown.jsp keypress.jsp');
+					.off('keydown.jsp keypress.jsp');
 			}
 
 			function observeHash()
@@ -1080,7 +1080,7 @@
 					moved,
 					moving = false;
   
-				container.unbind('touchstart.jsp touchmove.jsp touchend.jsp click.jsp-touchclick').bind(
+				container.off('touchstart.jsp touchmove.jsp touchend.jsp click.jsp-touchclick').on(
 					'touchstart.jsp',
 					function(e)
 					{
@@ -1092,7 +1092,7 @@
 						moved = false;
 						moving = true;
 					}
-				).bind(
+				).on(
 					'touchmove.jsp',
 					function(ev)
 					{
@@ -1110,7 +1110,7 @@
 						// return true if there was no movement so rest of screen can scroll
 						return dX == horizontalDragPosition && dY == verticalDragPosition;
 					}
-				).bind(
+				).on(
 					'touchend.jsp',
 					function(e)
 					{
@@ -1119,7 +1119,7 @@
 							return false;
 						}*/
 					}
-				).bind(
+				).on(
 					'click.jsp-touchclick',
 					function(e)
 					{
@@ -1134,7 +1134,7 @@
 			function destroy(){
 				var currentY = contentPositionY(),
 					currentX = contentPositionX();
-				elem.removeClass('jspScrollable').unbind('.jsp');
+				elem.removeClass('jspScrollable').off('.jsp');
 				elem.replaceWith(originalElement.append(pane.children()));
 				originalElement.scrollTop(currentY);
 				originalElement.scrollLeft(currentX);

--- a/src/main/resources/META-INF/resources/primefaces/touch/touchswipe.js
+++ b/src/main/resources/META-INF/resources/primefaces/touch/touchswipe.js
@@ -506,8 +506,8 @@
 
     // Add gestures to all swipable areas if supported
     try {
-      $element.bind(START_EV, touchStart);
-      $element.bind(CANCEL_EV, touchCancel);
+      $element.on(START_EV, touchStart);
+      $element.on(CANCEL_EV, touchCancel);
     } catch (e) {
       $.error('events not supported ' + START_EV + ',' + CANCEL_EV + ' on jQuery.swipe');
     }
@@ -526,8 +526,8 @@
     this.enable = function() {
       //Incase we are already enabled, clean up...
       this.disable();
-      $element.bind(START_EV, touchStart);
-      $element.bind(CANCEL_EV, touchCancel);
+      $element.on(START_EV, touchStart);
+      $element.on(CANCEL_EV, touchCancel);
       return $element;
     };
 
@@ -930,14 +930,14 @@
      * @inner
      */
     function removeListeners() {
-      $element.unbind(START_EV, touchStart);
-      $element.unbind(CANCEL_EV, touchCancel);
-      $element.unbind(MOVE_EV, touchMove);
-      $element.unbind(END_EV, touchEnd);
+      $element.off(START_EV, touchStart);
+      $element.off(CANCEL_EV, touchCancel);
+      $element.off(MOVE_EV, touchMove);
+      $element.off(END_EV, touchEnd);
 
       //we only have leave events on desktop, we manually calculate leave on touch as its not supported in webkit
       if (LEAVE_EV) {
-        $element.unbind(LEAVE_EV, touchLeave);
+        $element.off(LEAVE_EV, touchLeave);
       }
 
       setTouchInProgress(false);
@@ -1597,21 +1597,21 @@
 
       //Add or remove event listeners depending on touch status
       if (val === true) {
-        $element.bind(MOVE_EV, touchMove);
-        $element.bind(END_EV, touchEnd);
+        $element.on(MOVE_EV, touchMove);
+        $element.on(END_EV, touchEnd);
 
         //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
         if (LEAVE_EV) {
-          $element.bind(LEAVE_EV, touchLeave);
+          $element.on(LEAVE_EV, touchLeave);
         }
       } else {
 
-        $element.unbind(MOVE_EV, touchMove, false);
-        $element.unbind(END_EV, touchEnd, false);
+        $element.off(MOVE_EV, touchMove, false);
+        $element.off(END_EV, touchEnd, false);
 
         //we only have leave events on desktop, we manually calcuate leave on touch as its not supported in webkit
         if (LEAVE_EV) {
-          $element.unbind(LEAVE_EV, touchLeave, false);
+          $element.off(LEAVE_EV, touchLeave, false);
         }
       }
 


### PR DESCRIPTION
JQMIGRATE: jQuery.fn.bind() is deprecated
JQMIGRATE: jQuery.fn.unbind() is deprecated