### PR TITLE
Fix #5943: AJAX abortAll was still processing requests.

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -361,7 +361,7 @@ if (!PrimeFaces.ajax) {
             abortAll: function() {
                 // clear out any pending requests
                 this.requests = new Array();
-                
+
                 // abort any in-flight that are not DONE(4)
                 for(var i = 0; i < this.xhrs.length; i++) {
                     var xhr = this.xhrs[i];

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -362,6 +362,7 @@ if (!PrimeFaces.ajax) {
                 // clear out any pending requests
                 this.requests = new Array();
                 
+                // abort any in-flight that are not DONE(4)
                 for(var i = 0; i < this.xhrs.length; i++) {
                     var xhr = this.xhrs[i];
                     if (xhr.readyState != 4) {

--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -359,12 +359,17 @@ if (!PrimeFaces.ajax) {
              * removes all requests that are waiting in the queue and have not been sent yet.
              */
             abortAll: function() {
+                // clear out any pending requests
+                this.requests = new Array();
+                
                 for(var i = 0; i < this.xhrs.length; i++) {
-                    this.xhrs[i].abort();
+                    var xhr = this.xhrs[i];
+                    if (xhr.readyState != 4) {
+                        xhr.abort();
+                    }
                 }
 
                 this.xhrs = new Array();
-                this.requests = new Array();
             }
         },
 


### PR DESCRIPTION
What was happening was as soon as `abort` was called it was popping the next one out of the request queue and running it.

So we need to clear the request queue first which are all pending requests before calling abort on any XHR's.  I also only call abort if !=4 which is DONE.
