### PR TITLE
Fix #5831: add chooseButtonTitle,uploadButtonTitle,cancelButtonTitle in FileUpload

### DIFF
--- a/docs/9_0/components/fileupload.md
+++ b/docs/9_0/components/fileupload.md
@@ -64,6 +64,9 @@ powered rich solution with graceful degradation for legacy browsers.
 | chooseIcon | ui-icon-plusthick | String | The icon of choose button
 | uploadIcon | ui-icon-arrowreturnthick-1-n | String | The icon of upload button
 | cancelIcon | ui-icon-cancel | String | The icon of cancel button
+| chooseButtonTitle | null | String | Native title tooltip for choose button
+| uploadButtonTitle | null | String | Native title tooltip for upload button
+| cancelButtonTitle | null | String | Native title tooltip for cancel button
 | onAdd | null | String | Callback to execute before adding a file.
 | validateContentType | false | Boolean | Whether content type validation should be performed, based on the types defined in the accept attribute. Default is false.
 | virusScan | false | Boolean | Whether virus scan should be performed. Default is false.

--- a/docs/9_0/components/fileupload.md
+++ b/docs/9_0/components/fileupload.md
@@ -64,6 +64,7 @@ powered rich solution with graceful degradation for legacy browsers.
 | chooseIcon | ui-icon-plusthick | String | The icon of choose button
 | uploadIcon | ui-icon-arrowreturnthick-1-n | String | The icon of upload button
 | cancelIcon | ui-icon-cancel | String | The icon of cancel button
+| title | null | String | Native title tooltip for simple mode
 | chooseButtonTitle | null | String | Native title tooltip for choose button
 | uploadButtonTitle | null | String | Native title tooltip for upload button
 | cancelButtonTitle | null | String | Native title tooltip for cancel button

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
@@ -73,7 +73,10 @@ public abstract class FileUploadBase extends UIInput implements Widget {
         virusScan,
         maxChunkSize,
         maxRetries,
-        retryTimeout
+        retryTimeout,
+        chooseButtonTitle,
+        uploadButtonTitle,
+        cancelButtonTitle
     }
 
     public FileUploadBase() {
@@ -397,4 +400,29 @@ public abstract class FileUploadBase extends UIInput implements Widget {
     public void setRetryTimeout(int retryTimeout) {
         getStateHelper().put(PropertyKeys.retryTimeout, retryTimeout);
     }
+
+    public String getChooseButtonTitle() {
+        return (String) getStateHelper().eval(PropertyKeys.chooseButtonTitle, null);
+    }
+
+    public void setChooseButtonTitle(String chooseButtonTitle) {
+        getStateHelper().put(PropertyKeys.chooseButtonTitle, chooseButtonTitle);
+    }
+
+    public String getUploadButtonTitle() {
+        return (String) getStateHelper().eval(PropertyKeys.uploadButtonTitle, null);
+    }
+
+    public void setUploadButtonTitle(String uploadButtonTitle) {
+        getStateHelper().put(PropertyKeys.uploadButtonTitle, uploadButtonTitle);
+    }
+
+    public String getCancelButtonTitle() {
+        return (String) getStateHelper().eval(PropertyKeys.cancelButtonTitle, null);
+    }
+
+    public void setCancelButtonTitle(String cancelButtonTitle) {
+        getStateHelper().put(PropertyKeys.cancelButtonTitle, cancelButtonTitle);
+    }
+
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
@@ -74,6 +74,7 @@ public abstract class FileUploadBase extends UIInput implements Widget {
         maxChunkSize,
         maxRetries,
         retryTimeout,
+        title,
         chooseButtonTitle,
         uploadButtonTitle,
         cancelButtonTitle
@@ -399,6 +400,14 @@ public abstract class FileUploadBase extends UIInput implements Widget {
 
     public void setRetryTimeout(int retryTimeout) {
         getStateHelper().put(PropertyKeys.retryTimeout, retryTimeout);
+    }
+
+    public String getTitle() {
+        return (String) getStateHelper().eval(PropertyKeys.title, null);
+    }
+
+    public void setTitle(String title) {
+        getStateHelper().put(PropertyKeys.title, title);
     }
 
     public String getChooseButtonTitle() {

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -293,6 +293,9 @@ public class FileUploadRenderer extends CoreRenderer {
         if (fileUpload.getAccept() != null) {
             writer.writeAttribute("accept", fileUpload.getAccept(), null);
         }
+        if (fileUpload.getTitle() != null) {
+            writer.writeAttribute("title", fileUpload.getTitle(), null);
+        }
 
         renderDynamicPassThruAttributes(context, fileUpload);
 
@@ -316,6 +319,9 @@ public class FileUploadRenderer extends CoreRenderer {
         }
         if (fileUpload.getAccept() != null) {
             writer.writeAttribute("accept", fileUpload.getAccept(), null);
+        }
+        if (fileUpload.getTitle() != null) {
+            writer.writeAttribute("title", fileUpload.getTitle(), null);
         }
         if (style != null) {
             writer.writeAttribute("style", style, "style");

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -145,8 +145,8 @@ public class FileUploadRenderer extends CoreRenderer {
         encodeChooseButton(context, fileUpload, disabled);
 
         if (!fileUpload.isAuto()) {
-            encodeButton(context, fileUpload.getUploadLabel(), FileUpload.UPLOAD_BUTTON_CLASS, " " + fileUpload.getUploadIcon());
-            encodeButton(context, fileUpload.getCancelLabel(), FileUpload.CANCEL_BUTTON_CLASS, " " + fileUpload.getCancelIcon());
+            encodeButton(context, fileUpload.getUploadLabel(), FileUpload.UPLOAD_BUTTON_CLASS, " " + fileUpload.getUploadIcon(), fileUpload.getUploadButtonTitle());
+            encodeButton(context, fileUpload.getCancelLabel(), FileUpload.CANCEL_BUTTON_CLASS, " " + fileUpload.getCancelIcon(), fileUpload.getCancelButtonTitle());
         }
 
         writer.endElement("div");
@@ -243,6 +243,11 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.writeAttribute("role", "button", null);
         writer.writeAttribute(HTML.ARIA_LABELLEDBY, clientId + "_label", null);
 
+        String chooseButtonTitle = fileUpload.getChooseButtonTitle();
+        if (chooseButtonTitle != null) {
+            writer.writeAttribute("title", chooseButtonTitle, null);
+        }
+
         //button icon
         writer.startElement("span", null);
         writer.writeAttribute("class", HTML.BUTTON_LEFT_ICON_CLASS + " " + fileUpload.getChooseIcon(), null);
@@ -324,7 +329,7 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.endElement("input");
     }
 
-    protected void encodeButton(FacesContext context, String label, String styleClass, String icon) throws IOException {
+    protected void encodeButton(FacesContext context, String label, String styleClass, String icon, String title) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String cssClass = HTML.BUTTON_TEXT_ICON_LEFT_BUTTON_CLASS + " ui-state-disabled " + styleClass;
         cssClass = isValueBlank(label) ? FileUpload.BUTTON_ICON_ONLY + " " + cssClass : cssClass;
@@ -333,6 +338,10 @@ public class FileUploadRenderer extends CoreRenderer {
         writer.writeAttribute("type", "button", null);
         writer.writeAttribute("class", cssClass, null);
         writer.writeAttribute("disabled", "disabled", null);
+
+        if (title != null) {
+            writer.writeAttribute("title", title, null);
+        }
 
         //button icon
         String iconClass = HTML.BUTTON_LEFT_ICON_CLASS;

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -9783,6 +9783,30 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Native title tooltip for choose button.]]>
+            </description>
+            <name>chooseButtonTitle</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Native title tooltip for upload button.]]>
+            </description>
+            <name>uploadButtonTitle</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Native title tooltip for cancel button.]]>
+            </description>
+            <name>cancelButtonTitle</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -9785,6 +9785,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Native title tooltip for simple mode.]]>
+            </description>
+            <name>title</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Native title tooltip for choose button.]]>
             </description>
             <name>chooseButtonTitle</name>


### PR DESCRIPTION
This PR is intended to fix the issue https://github.com/primefaces/primefaces/issues/5831 by including new attributes to `FileUpload` component: _chooseButtonTitle_, _uploadButtonTitle_ and _cancelButtonTitle_. Note that these new attributes refer to the `title` html attribute for the respective buttons inside the component.
Tested on Chrome:
![image](https://user-images.githubusercontent.com/9665358/82833743-50bb7680-9e95-11ea-8f20-2912a597aee7.png)
Firefox:
![image](https://user-images.githubusercontent.com/9665358/82833756-616bec80-9e95-11ea-916e-d559f67a3040.png)
Edge:
![image](https://user-images.githubusercontent.com/9665358/82833791-7c3e6100-9e95-11ea-99e3-bfc93e8987d2.png)
Internet Explorer:
![image](https://user-images.githubusercontent.com/9665358/82833822-9415e500-9e95-11ea-9c7b-272dbf8e99e8.png)
