### PR TITLE
Fix #5956 - SelectCheckboxMenu does not show values for which no option exists

### DIFF
--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -233,7 +233,6 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         Object valuesArray = (submittedValues != null) ? submittedValues : values;
         String listClass = createStyleClass(menu, null, SelectCheckboxMenu.MULTIPLE_CONTAINER_CLASS);
 
-
         writer.startElement("ul", null);
         writer.writeAttribute("label", menu.getLabel(), null);
         writer.writeAttribute("class", listClass, null);

--- a/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -233,6 +233,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         Object valuesArray = (submittedValues != null) ? submittedValues : values;
         String listClass = createStyleClass(menu, null, SelectCheckboxMenu.MULTIPLE_CONTAINER_CLASS);
 
+
         writer.startElement("ul", null);
         writer.writeAttribute("label", menu.getLabel(), null);
         writer.writeAttribute("class", listClass, null);
@@ -241,12 +242,6 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
             for (int i = 0; i < length; i++) {
                 Object value = Array.get(valuesArray, i);
                 String itemValueAsString = getOptionAsString(context, menu, converter, value);
-                writer.startElement("li", null);
-                writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_DISPLAY_CLASS, null);
-                writer.writeAttribute("data-item-value", itemValueAsString, null);
-
-                writer.startElement("span", null);
-                writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_LABEL_CLASS, null);
 
                 SelectItem selectedItem = null;
                 for (SelectItem item : selectItems) {
@@ -265,25 +260,35 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
                     }
                 }
 
-                if (selectedItem != null && selectedItem.getLabel() != null) {
-                    if (selectedItem.isEscape()) {
-                        writer.writeText(selectedItem.getLabel(), null);
+                // #5956 Do not render a chip for the value if no matching option exists
+                if (selectedItem != null) {
+                    writer.startElement("li", null);
+                    writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_DISPLAY_CLASS, null);
+                    writer.writeAttribute("data-item-value", itemValueAsString, null);
+
+                    writer.startElement("span", null);
+                    writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_LABEL_CLASS, null);
+
+                    if (selectedItem.getLabel() != null) {
+                        if (selectedItem.isEscape()) {
+                            writer.writeText(selectedItem.getLabel(), null);
+                        }
+                        else {
+                            writer.write(selectedItem.getLabel());
+                        }
                     }
                     else {
-                        writer.write(selectedItem.getLabel());
+                        writer.writeText(value, null);
                     }
+
+                    writer.endElement("span");
+
+                    writer.startElement("span", null);
+                    writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_ICON_CLASS, null);
+                    writer.endElement("span");
+
+                    writer.endElement("li");
                 }
-                else {
-                    writer.writeText(value, null);
-                }
-
-                writer.endElement("span");
-
-                writer.startElement("span", null);
-                writer.writeAttribute("class", SelectCheckboxMenu.TOKEN_ICON_CLASS, null);
-                writer.endElement("span");
-
-                writer.endElement("li");
             }
         }
 


### PR DESCRIPTION
See #5956 

* When multiple is set to true, the component would render all values currently set,
  irrespective of whether a select item existed for that value. This has been changed
  so that values without a matching select item are not rendered.
* This is consistent with both h:selectManyCheckbox and with multiple set to false.
* Once the user submits the form, values without a matching option were removed anyway.

To test this, you can, for example, modify the CheckboxView.java of the showcase and add some defaults selectedCities etc:

![image](https://user-images.githubusercontent.com/2456413/83405392-515b8c00-a404-11ea-8aaf-11feda18ad89.png)

Before this commit, the options "Tokio" and "313" would have been rendered as chips. Now, they are omitted:

![image](https://user-images.githubusercontent.com/2456413/83405417-59b3c700-a404-11ea-9082-56938113567f.png)
