### PR TITLE
Fix #5182: Add editInitEvent attribute to editable TreeTable

### DIFF
--- a/docs/9_0/components/treetable.md
+++ b/docs/9_0/components/treetable.md
@@ -65,6 +65,7 @@ rows | 0 | Integer | Number of rows to display per page. Default value is 0 mean
 first | 0 | Integer | Index of the first data to display.
 disabledTextSelection | true | Boolean | Disables text selection on row click.
 touchable | true | Boolean | Enable touch support if browser detection supports it.
+editInitEvent             | null               | String           | Defines a client side event to open cell on editable treetable.
 
 ## Getting started with the TreeTable
 Similar to the Tree, TreeTable is populated with an _org.primefaces.model.TreeNode_ instance that

--- a/docs/9_0/components/treetable.md
+++ b/docs/9_0/components/treetable.md
@@ -65,7 +65,7 @@ rows | 0 | Integer | Number of rows to display per page. Default value is 0 mean
 first | 0 | Integer | Index of the first data to display.
 disabledTextSelection | true | Boolean | Disables text selection on row click.
 touchable | true | Boolean | Enable touch support if browser detection supports it.
-editInitEvent             | null               | String           | Defines a client side event to open cell on editable treetable.
+editInitEvent | null | String | Defines a client side event to open cell on editable treetable.
 
 ## Getting started with the TreeTable
 Similar to the Tree, TreeTable is populated with an _org.primefaces.model.TreeNode_ instance that

--- a/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -76,7 +76,8 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
         filteredNode,
         filterEvent,
         filterDelay,
-        cellEditMode
+        cellEditMode,
+        editInitEvent
     }
 
     public TreeTableBase() {
@@ -409,4 +410,13 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
     public void setCellEditMode(String cellEditMode) {
         getStateHelper().put(PropertyKeys.cellEditMode, cellEditMode);
     }
+
+    public String getEditInitEvent() {
+        return (String) getStateHelper().eval(PropertyKeys.editInitEvent, "click");
+    }
+
+    public void setEditInitEvent(String editInitEvent) {
+        getStateHelper().put(PropertyKeys.editInitEvent, editInitEvent);
+    }
+
 }

--- a/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -249,7 +249,8 @@ public class TreeTableRenderer extends DataRenderer {
             wb.attr("editable", true)
                     .attr("editMode", tt.getEditMode())
                     .attr("cellEditMode", tt.getCellEditMode(), "eager")
-                    .attr("cellSeparator", tt.getCellSeparator(), null);
+                    .attr("cellSeparator", tt.getCellSeparator(), null)
+                    .attr("editInitEvent", tt.getEditInitEvent());
         }
 
         //Filtering

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -28497,6 +28497,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines a client side event to open cell on editable table.]]>
+            </description>
+            <name>editInitEvent</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -94,6 +94,7 @@
  * @prop {boolean} cfg.scrollable Whether or not the data should be scrollable.
  * @prop {PrimeFaces.widget.TreeTable.SelectionMode} cfg.selectionMode How rows may be selected.
  * @prop {boolean} cfg.stickyHeader Sticky header stays in window viewport during scrolling.
+ * @prop {string} cfg.editInitEvent Event that triggers row/cell editing.
  */
 PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
 
@@ -616,18 +617,25 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
         }
         else if(this.cfg.editMode === 'cell') {
             var cellSelector = '> tr > td.ui-editable-column';
+            var editEvent = (this.cfg.editInitEvent !== 'click') ? this.cfg.editInitEvent + '.treetable-cell click.treetable-cell' : 'click.treetable-cell';
 
-            this.tbody.off('click.treetable-cell', cellSelector)
-                        .on('click.treetable-cell', cellSelector, null, function(e) {
-                            if(!$(e.target).is('span.ui-treetable-toggler.ui-c')) {
-                                $this.incellClick = true;
-
-                                var cell = $(this);
-                                if(!cell.hasClass('ui-cell-editing')) {
-                                    $this.showCellEditor($(this));
-                                }
-                            }
-                        });
+            this.tbody.off(editEvent, cellSelector)
+				.on(editEvent, cellSelector, null, function(e) {
+				    if(!$(e.target).is('span.ui-treetable-toggler.ui-c')) {
+				        $this.incellClick = true;
+				
+				        var item = $(this);
+				        var cell = item.hasClass('ui-editable-column') ? item : item.closest('.ui-editable-column');
+				        
+				        if(!cell.hasClass('ui-cell-editing') && e.type === $this.cfg.editInitEvent) {
+				            $this.showCellEditor($(this));
+				            
+				            if($this.cfg.editInitEvent === "dblclick") {
+				                $this.incellClick = false;
+				            }
+				        }
+				    }
+				});
 
             $(document).off('click.treetable-cell-blur' + this.id)
                         .on('click.treetable-cell-blur' + this.id, function(e) {

--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -620,22 +620,22 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
             var editEvent = (this.cfg.editInitEvent !== 'click') ? this.cfg.editInitEvent + '.treetable-cell click.treetable-cell' : 'click.treetable-cell';
 
             this.tbody.off(editEvent, cellSelector)
-				.on(editEvent, cellSelector, null, function(e) {
-				    if(!$(e.target).is('span.ui-treetable-toggler.ui-c')) {
-				        $this.incellClick = true;
+                .on(editEvent, cellSelector, null, function(e) {
+                    if(!$(e.target).is('span.ui-treetable-toggler.ui-c')) {
+                        $this.incellClick = true;
 				
-				        var item = $(this);
-				        var cell = item.hasClass('ui-editable-column') ? item : item.closest('.ui-editable-column');
+                        var item = $(this);
+                        var cell = item.hasClass('ui-editable-column') ? item : item.closest('.ui-editable-column');
 				        
-				        if(!cell.hasClass('ui-cell-editing') && e.type === $this.cfg.editInitEvent) {
-				            $this.showCellEditor($(this));
+                        if(!cell.hasClass('ui-cell-editing') && e.type === $this.cfg.editInitEvent) {
+                            $this.showCellEditor($(this));
 				            
-				            if($this.cfg.editInitEvent === "dblclick") {
-				                $this.incellClick = false;
-				            }
-				        }
-				    }
-				});
+                            if($this.cfg.editInitEvent === "dblclick") {
+                                $this.incellClick = false;
+                            }
+                        }
+                     }
+                });
 
             $(document).off('click.treetable-cell-blur' + this.id)
                         .on('click.treetable-cell-blur' + this.id, function(e) {


### PR DESCRIPTION
Hi, this PR is intended to fix issue https://github.com/primefaces/primefaces/issues/5182.

The change allows the cell edition mode to be triggered by different kinds of client-side events than only `click` event in `p:treetable`’s. For instance, the edition can be triggered by `mouseover` events as shown below:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/9665358/83949119-70895d80-a7f8-11ea-8bf5-07bbbab5d8c6.gif)

Note that this feature is also present in `p:datatable` already.

The code was tested on MS IE 11, MS Edge 44.18362.449.0, Mozilla Firefox 76.0.1, and Google Chrome 83.0.4103.61 on Alienware area-51M machine running MS Windows 10.