### PR TITLE
Fix #5997: javax to jakarta APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 
 jdk:
 - oraclejdk8
-- openjdk8
-# - openjdk7  (not possible since JSF 2.3 dependency - we need to compile it)
+- openjdk11
+
 
 script:
 # add --update-snapshots if snapshots are used

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
     <dependencies>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.faces</artifactId>
-            <version>2.3.9</version>
+            <artifactId>jakarta.faces</artifactId>
+            <version>2.3.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -98,9 +98,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>el-api</artifactId>
-            <version>2.2</version>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <version>3.0.3</version>
             <scope>provided</scope>
         </dependency>
 
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.3</version>
+            <version>1.4</version>
             <scope>provided</scope>
         </dependency>
 
@@ -140,18 +140,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JAXB for JDK11+-->
         <dependency>
-            <groupId>com.rometools</groupId>
-            <artifactId>rome-utils</artifactId>
-            <version>1.13.0</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- PhotoCam for Java5 -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.0</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
             <scope>provided</scope>
         </dependency>
 
@@ -194,11 +187,17 @@
             <version>2.2.7</version>
             <scope>test</scope>
         </dependency>
-        <!-- Content type validation in FileUploadUtilsTest -->
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b11</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Content type validation in FileUploadUtilsTest -->
+        <dependency> 
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-java7</artifactId>
-            <version>1.22</version>
+            <version>1.24.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- switch to latest Jakarta API's
- marked implementations as "test" scope needed to make all unit tests pass
- OpenJDK11 to Travis build