### PR TITLE
Ajax uploads are not supported in simple upload.

### DIFF
--- a/docs/8_0/components/fileupload.md
+++ b/docs/8_0/components/fileupload.md
@@ -152,7 +152,7 @@ uses a new request for each file.
 However, in simple mode, it is possible to get all updated files at once via the `UploadedFiles` model:
 ```xhtml
 <p:fileUpload value="#{fileUploadView.files}" multiple="true" mode="simple" />
-<p:commandButton value="Submit" action="#{fileUploadView.upload}" />
+<p:commandButton value="Submit" action="#{fileUploadView.upload}" ajax="false"/>
 ```
 
 ```java

--- a/docs/9_0/components/fileupload.md
+++ b/docs/9_0/components/fileupload.md
@@ -162,7 +162,7 @@ uses a new request for each file.
 However, in simple mode, it is possible to get all updated files at once via the `UploadedFiles` model:
 ```xhtml
 <p:fileUpload value="#{fileUploadView.files}" multiple="true" mode="simple" />
-<p:commandButton value="Submit" action="#{fileUploadView.upload}" />
+<p:commandButton value="Submit" action="#{fileUploadView.upload}" ajax="false"/>
 ```
 
 ```java


### PR DESCRIPTION
The doco states "Ajax uploads are not supported in simple upload" and all examples of simple file upload require the Ajax attribute on the command button to be disabled.

This commit makes that consistent with a new example added to the doco in PF 8.