### PR TITLE
Fix #6050 - TreeTable: ajax events not fired from column facets

### DIFF
--- a/src/main/java/org/primefaces/component/api/UITree.java
+++ b/src/main/java/org/primefaces/component/api/UITree.java
@@ -39,6 +39,8 @@ import javax.faces.component.visit.VisitResult;
 import javax.faces.context.FacesContext;
 import javax.faces.event.*;
 
+import org.primefaces.component.column.Column;
+import org.primefaces.component.columngroup.ColumnGroup;
 import org.primefaces.component.columns.Columns;
 import org.primefaces.component.tree.UITreeNode;
 import org.primefaces.model.CheckboxTreeNode;
@@ -1007,6 +1009,9 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
                         }
                     }
                 }
+                else if (child instanceof ColumnGroup) {
+                    visitColumnGroup(context, callback, (ColumnGroup) child);
+                }
             }
         }
 
@@ -1017,6 +1022,25 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
         for (UIComponent columnFacet : component.getFacets().values()) {
             if (columnFacet.visitTree(context, callback)) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean visitColumnGroup(VisitContext context, VisitCallback callback, ColumnGroup group) {
+        if (group.getChildCount() > 0) {
+            for (UIComponent row : group.getChildren()) {
+                if (row.getChildCount() > 0) {
+                    for (UIComponent col : row.getChildren()) {
+                        if (col instanceof Column && col.getFacetCount() > 0) {
+                            boolean value = visitColumnFacets(context, callback, col);
+                            if (value) {
+                                return true;
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -713,4 +713,9 @@ public class TreeTable extends TreeTableBase {
             }
         }
     }
+
+    @Override
+    protected boolean requiresColumns() {
+        return true;
+    }
 }


### PR DESCRIPTION
Let me know what you think. I could have reused `visitFacets` but the impl is slightly different from what I read in DataTable (e.g setRowKey call). By the way, do we need to call setRowKey while it's been previously called in UITree#visitTree l.812? This method is very consuming at it saves/restore state of the component (recursive call) so if we could get rid of that call that would be a good improvement