### PR TITLE
Fix #5914: Proper ISO conversion from client

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/Schedule.java
+++ b/src/main/java/org/primefaces/component/schedule/Schedule.java
@@ -83,7 +83,6 @@ public class Schedule extends ScheduleBase {
         Map<String, String> params = context.getExternalContext().getRequestParameterMap();
         String eventName = params.get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
         String clientId = getClientId(context);
-        ZoneId zoneId = CalendarUtils.calculateZoneId(this.getTimeZone());
 
         if (ComponentUtils.isRequestSource(this, context)) {
 
@@ -92,6 +91,7 @@ public class Schedule extends ScheduleBase {
 
             if (eventName.equals("dateSelect")) {
                 String selectedDateStr = params.get(clientId + "_selectedDate");
+                ZoneId zoneId = CalendarUtils.calculateZoneId(this.getTimeZone());
                 LocalDateTime selectedDate =  CalendarUtils.toLocalDateTime(zoneId, selectedDateStr);
                 SelectEvent<?> selectEvent = new SelectEvent(this, behaviorEvent.getBehavior(), selectedDate);
                 selectEvent.setPhaseId(behaviorEvent.getPhaseId());

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -529,8 +529,8 @@ public class CalendarUtils {
         }
 
         Instant instant = Instant.parse(isoDateString);
-        LocalDateTime result = LocalDateTime.ofInstant(instant, zoneId);
-        return result;
+        ZonedDateTime utc = ZonedDateTime.ofInstant(instant, ZoneId.of("Etc/UTC"));
+        return utc.withZoneSameLocal(zoneId).toLocalDateTime();
     }
 
     /**

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -529,7 +529,7 @@ public class CalendarUtils {
         }
 
         Instant instant = Instant.parse(isoDateString);
-        ZonedDateTime utc = ZonedDateTime.ofInstant(instant, ZoneId.of("Etc/UTC"));
+        ZonedDateTime utc = ZonedDateTime.ofInstant(instant, ZoneId.of("UTC"));
         return utc.withZoneSameLocal(zoneId).toLocalDateTime();
     }
 


### PR DESCRIPTION
@blutorange @christophs78 
OK this finishes the fix for 5914 for Schedule and Timeline.

On the client side it doesn't care about your browser timezone so if you click on 7AM it sends 7AM in UTC ISO string like "2020-06-17T07:00:00.000Z"

Now on the server we have to convert that to UTC first, then basically swap out the timezone like "America/New_York" WITHOUT changing the time so it stays 7AM.  In JODA this was called `withZoneRetainFields` in Java8 time its `withZoneSameLocal`.

So now everything it working properly.