### PR TITLE
Fix #4546: Datepicker mask attribute

### DIFF
--- a/docs/9_0/components/calendar.md
+++ b/docs/9_0/components/calendar.md
@@ -24,57 +24,49 @@ ajax selection and more.
 | rendered | true | Boolean | Boolean value to specify the rendering of the component.
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 | value | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.util.Date (deprecated) | Value of the component
-| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
-| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
-| required | false | Boolean | Marks component as required
-| validator | null | Method Expr | A method expression that refers to a method validationg the input
-| valueChangeListener | null | Method Expr | A method expression that refers to a method for handling a valuchangeevent
-| requiredMessage | null | String | Message to be displayed when required field validation fails.
-| converterMessage | null | String | Message to be displayed when conversion fails.
-| validatorMessage | null | String | Message to be displayed when validation fails.
-| widgetVar | null | String | Name of the client side widget.
-| mindate | null | java.time.LocalDate, java.util.Date (deprecated) or String | Sets calendar's minimum visible date; Also used for validation on the server-side.
-| maxdate | null | java.time.LocalDate, java.util.Date (deprecated) or String | Sets calendar's maximum visible date; Also used for validation on the server-side.
-| pages | 1 | Integer | Enables multiple page rendering.
-| disabled | false | Boolean | Disables the calendar when set to true.
-| mode | popup | String | Defines how the calendar will be displayed.
-| pattern | MM/dd/yyyy | String | DateFormat pattern for localization
-| locale | null | Object | Locale to be used for labels and conversion.
-| navigator | false | Boolean | Enables month/year navigator
-| timeZone | null | Time Zone | String or a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault().
-| readonly | false | Boolean | Makes the entire component readonly not allowing calendar popup or text entry.
-| readonlyInput | false | Boolean | Makes input text of a popup calendar readonly.
-| showButtonPanel | false | Boolean | Visibility of button panel containing today and done buttons.
-| effect | null | String | Effect to use when displaying and showing the popup calendar.
-| effectDuration | normal | String | Duration of the effect.
-| showOn | both | String | Client side event that displays the popup calendar.
-| showWeek | false | Boolean | Displays the week number next to each week.
-| disabledWeekends | false | Boolean | Disables weekend columns.
-| showOtherMonths | false | Boolean | Displays days belonging to other months.
-| selectOtherMonths | false | Boolean | Enables selection of days belonging to other months.
-| yearRange | null | String | Year range for the navigator, default "c-10:c+10"
-| timeOnly | false | Boolean | Shows only timepicker without date.
-| stepHour | 1 | Integer | Hour steps.
-| stepMinute | 1 | Integer | Minute steps.
-| stepSecond | 1 | Integer | Second steps.
-| minHour | 0 | Integer | Minimum boundary for hour selection.
-| maxHour | 23 | Integer | Maximum boundary for hour selection.
-| minMinute | 0 | Integer | Minimum boundary for minute selection.
-| maxMinute | 59 | Integer | Maximum boundary for hour selection.
-| minSecond | 0 | Integer | Minimum boundary for second selection.
-| maxSecond | 59 | Integer | Maximum boundary for second selection.
-| pagedate | null | Object | Initial date to display if value is null.
 | accesskey | null | String | Access key that when pressed transfers focus to the input element.
 | alt | null | String | Alternate textual description of the input field.
 | autocomplete | null | String | Controls browser autocomplete behavior.
+| beforeShow | null | String | Callback to execute before displaying calendar, element and calendar instance are passed as parameters
+| beforeShowDay | null | String | Client side callback to execute before displaying a date, used to customize date display.
+| buttonTabindex | null | String | Position of the button in the tabbing order.
+| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
+| converterMessage | null | String | Message to be displayed when conversion fails.
+| defaultHour | 0 | Integer | Default for hour selection, if no date is given. Default is 0.
+| defaultMillisec | 0 | Integer | Default for millisecond selection, if no date is given. Default is 0.
+| defaultMinute | 0 | Integer | Default for minute selection, if no date is given. Default is 0.
+| defaultSecond | 0 | Integer | Default for second selection, if no date is given. Default is 0.
 | dir | null | String | Direction indication for text that does not inherit directionality. Valid values are LTR and RTL.
+| disabled | false | Boolean | Disables the calendar when set to true.
+| disabledWeekends | false | Boolean | Disables weekend columns.
+| effect | null | String | Effect to use when displaying and showing the popup calendar.
+| effectDuration | normal | String | Duration of the effect.
+| focusOnSelect | false | Boolean | If enabled, the input is focused again after selecting a date. Default is false.
+| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
+| inputStyle | null | String | Inline style of the input element. Used when mode is popup.
+| inputStyleClass | null | String | Style class of the input element. Used when mode is popup.
 | label | null | String | A localized user presentable name.
 | lang | null | String | Code describing the language used in the generated markup for this component.
+| locale | null | Object | Locale to be used for labels and conversion.
+| mask | null | String | Defines if a mask should be applied to the input field. Default value is "false" and valid values to enable are "true" that uses the pattern as the mask or a custom template. Refer to inputMask component for more information about custom templates..
+| maskAutoClear | true | Boolean | Clears the field on blur when incomplete input is entered
+| maskSlotChar | '_' | String | Placeholder in mask template.  Default to `_`.
+| maxdate | null | java.time.LocalDate, java.util.Date (deprecated) or String | Sets calendar's maximum visible date; Also used for validation on the server-side.
+| maxHour | 23 | Integer | Maximum boundary for hour selection.
 | maxlength | null | Integer | Maximum number of characters that may be entered in this field.
+| maxMinute | 59 | Integer | Maximum boundary for hour selection.
+| maxSecond | 59 | Integer | Maximum boundary for second selection.
+| mindate | null | java.time.LocalDate, java.util.Date (deprecated) or String | Sets calendar's minimum visible date; Also used for validation on the server-side.
+| minHour | 0 | Integer | Minimum boundary for hour selection.
+| minMinute | 0 | Integer | Minimum boundary for minute selection.
+| minSecond | 0 | Integer | Minimum boundary for second selection.
+| mode | popup | String | Defines how the calendar will be displayed.
+| navigator | false | Boolean | Enables month/year navigator
 | onblur | null | String | Client side callback to execute when input element loses focus.
 | onchange | null | String | Client side callback to execute when input element loses focus and its value has been modified since gaining focus.
 | onclick | null | String | Client side callback to execute onclick event.
 | ondblclick | null | String | Client side callback to execute when input element is double clicked.
+| oneLine | false | Boolean | Try to show the time dropdowns all on one line. This should be used with controlType 'select'.
 | onfocus | null | String | Client side callback to execute when input element receives focus.
 | onkeydown | null | String | Client side callback to execute when a key is pressed down over input element.
 | onkeypress | null | String | Client side callback to execute when a key is pressed and released over input element.
@@ -85,38 +77,46 @@ ajax selection and more.
 | onmouseover | null | String | Client side callback to execute when a pointer button is moved onto input element.
 | onmouseup | null | String | Client side callback to execute when a pointer button is released over input element.
 | onselect | null | String | Client side callback to execute when text within input element is selected by user.
+| pagedate | null | Object | Initial date to display if value is null.
+| pages | 1 | Integer | Enables multiple page rendering.
+| pattern | MM/dd/yyyy | String | DateFormat pattern for localization
 | placeholder | null | String | Specifies a short hint.
 | readonly | false | Boolean | Flag indicating that this component will prevent changes by the user.
+| readonly | false | Boolean | Makes the entire component readonly not allowing calendar popup or text entry.
+| readonlyInput | false | Boolean | Makes input text of a popup calendar readonly.
+| required | false | Boolean | Marks component as required
+| requiredMessage | null | String | Message to be displayed when required field validation fails.
+| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
+| selectOtherMonths | false | Boolean | Enables selection of days belonging to other months.
+| showButtonPanel | false | Boolean | Visibility of button panel containing today and done buttons.
+| showHour | null | String | Whether to show the hour control.
+| showMillisec | null | String | Whether to show the millisec control
+| showMinute | null | String | Whether to show the minute control.
+| showOn | both | String | Client side event that displays the popup calendar.
+| showOtherMonths | false | Boolean | Displays days belonging to other months.
+| showSecond | null | String | Whether to show the second control.
+| showTodayButton | true | Boolean | Whether to show the "Current Date" button if showButtonPanel is rendered.
+| showWeek | false | Boolean | Displays the week number next to each week.
+| size | null | Integer | Number of characters used to determine the width of the input element.
+| stepHour | 1 | Integer | Hour steps.
+| stepMinute | 1 | Integer | Minute steps.
+| stepSecond | 1 | Integer | Second steps.
 | style | null | String | Inline style of the component.
 | styleClass | null | String | Style class of the component.
-| size | null | Integer | Number of characters used to determine the width of the input element.
 | tabindex | null | Integer | Position of the input element in the tabbing order.
-| title | null | String | Advisory tooltip informaton.
-| beforeShowDay | null | String | Client side callback to execute before displaying a date, used to customize date display.
-| timeControlType | slider | String | Defines the type of element to use for time picker, valid values are "slider" and "select".
-| beforeShow | null | String | Callback to execute before displaying calendar, element and calendar instance are passed as parameters
-| mask | null | String | Applies a mask using the pattern.
-| maskSlotChar | '_' | String | Placeholder in mask template.  Default to `_`.
-| maskAutoClear | true | Boolean | Clears the field on blur when incomplete input is entered
 | timeControlObject | null | String | Client side object to use in custom timeControlType.
+| timeControlType | slider | String | Defines the type of element to use for time picker, valid values are "slider" and "select".
 | timeInput | false | Boolean | Allows direct input in time field.
-| showHour | null | String | Whether to show the hour control.
-| showMinute | null | String | Whether to show the minute control.
-| showSecond | null | String | Whether to show the second control.
-| showMillisec | null | String | Whether to show the millisec control
-| showTodayButton | true | Boolean | Whether to show the "Current Date" button if showButtonPanel is rendered.
-| buttonTabindex | null | String | Position of the button in the tabbing order.
-| inputStyle | null | String | Inline style of the input element. Used when mode is popup.
-| inputStyleClass | null | String | Style class of the input element. Used when mode is popup.
-| type | text | String | Input field type. Default is text.
-| focusOnSelect | false | Boolean | If enabled, the input is focused again after selecting a date. Default is false.
-| oneLine | false | Boolean | Try to show the time dropdowns all on one line. This should be used with controlType 'select'.
-| defaultHour | 0 | Integer | Default for hour selection, if no date is given. Default is 0.
-| defaultMinute | 0 | Integer | Default for minute selection, if no date is given. Default is 0.
-| defaultSecond | 0 | Integer | Default for second selection, if no date is given. Default is 0.
-| defaultMillisec | 0 | Integer | Default for millisecond selection, if no date is given. Default is 0.
-| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
+| timeOnly | false | Boolean | Shows only timepicker without date.
+| timeZone | null | Time Zone | String or a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault().
+| title | null | String | Advisory tooltip informaton.
 | touchable | true | Boolean | Enable touch support if browser detection supports it.
+| type | text | String | Input field type. Default is text.
+| validator | null | Method Expr | A method expression that refers to a method validationg the input
+| validatorMessage | null | String | Message to be displayed when validation fails.
+| valueChangeListener | null | Method Expr | A method expression that refers to a method for handling a valuchangeevent
+| widgetVar | null | String | Name of the client side widget.
+| yearRange | null | String | Year range for the navigator, default "c-10:c+10"
 
 ## Getting Started with Calendar
 Value of the calendar should be a java.time.LocalDate.

--- a/docs/9_0/components/datepicker.md
+++ b/docs/9_0/components/datepicker.md
@@ -26,71 +26,41 @@ ajax selection and more.
 | rendered | true | Boolean | Boolean value to specify the rendering of the component.
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 | value | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.time.YearMonth, java.util.Date (deprecated) | Value of the component
-| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
-| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
-| required | false | Boolean | Marks component as required
-| validator | null | Method Expr | A method expression that refers to a method validationg the input
-| valueChangeListener | null | Method Expr | A method expression that refers to a method for handling a valuchangeevent
-| requiredMessage | null | String | Message to be displayed when required field validation fails.
-| converterMessage | null | String | Message to be displayed when conversion fails.
-| validatorMessage | null | String | Message to be displayed when validation fails.
-| widgetVar | null | String | Name of the client side widget.
-| placeholder | null | String | Specifies a short hint.
-| timeOnly | false * | Boolean | Shows only timepicker without date. (* Defaults to true, when value is bound to java.time.LocalTime)
-| inline |  false | Boolean | Whether to show the datepicker inline or as a popup
-| buttonTabindex | null | String | Tabindex of the datepicker button
-| showIcon | false | String | Whether to show an icon to display the picker in an overlay
-| beforeShow | null | String | Callback to execute before displaying DatePicker, element and DatePicker instance are passed as parameters
-| focusOnSelect | false | Boolean | When enabled, input receives focus after a value is picked.
-| yearRange | null | String | The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020). Default value is "displayed_date - 10 : displayed_date + 10".
-| selectionMode | single | String | Defines the selection mode, valid values are "single", "multiple" and "range"
-| showOtherMonths | false | Boolean | Displays days belonging to other months.
-| selectOtherMonths | false | Boolean | Enables selection of days belonging to other months.
-| showOnFocus | true | Boolean | Whether to show the popup when input receives focus.
-| shortYearCutoff | +10 | String | The cutoff year for determining the century for a date. Any dates entered with a year value less than or equal to the cutoff year are considered to be in the current century, while those greater than it are deemed to be in the previous century.
-| monthNavigator | false | Boolean | Whether to show the month navigator
-| yearNavigator | false | Boolean | Whether to show the year navigator
-| showTime | false * | Boolean | Specifies if the timepicker should be displayed.  (* Defaults to true, when value is bound to java.time.LocalDateTime)
-| hourFormat | '24' | String | Defines the hour format, valid values are '12' and '24'
-| showSeconds | false | Boolean | Whether to show the seconds in time picker. Default is false.
-| stepHour | 1 | Integer | Hour steps.
-| stepMinute | 1 | Integer | Minute steps.
-| stepSecond | 1 | Integer | Second steps.
-| showButtonBar | false | Boolean | Whether to display buttons at the footer.
-| showWeek | false | Boolean | Displays the week number next to each week.
-| weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
-| panelStyleClass | null | String | Style class of the container element.
-| panelStyle | null | String | Inline style of the container element.
-| keepInvalid | false | Boolean | Whether to keep the invalid inputs in the field or not.
-| hideOnDateTimeSelect | false | Boolean | Defines if the popup should be hidden when a time is selected.
-| maxDateCount | null | Integer | Defines the maximum number of selectable dates in multiple selection mode.
-| numberOfMonths | 1 | Integer | Number of months to display concurrently.
-| view | date | String | Defines the view mode, valid values are "date" for datepicker and "month" for month picker.
-| touchUI | false | Boolean | Activates touch friendly mode
-| dateTemplate | null | Function | Javascript function that takes a date object and returns the content for the date cell.
-| appendTo | @(body) | String | Appends the dialog to the element defined by the given search expression.
-| triggerButtonIcon | null | String | Icon of the datepicker element that toggles the visibility in popup mode.
-| disabledDates | null | List<java.time.LocalDate>, List<java.util.Date> (deprecated) | List of dates that should be disabled.
-| disabledDays | null | List<Integer> | List of week day indexes that should be disabled.
-| onMonthChange | null | Function | Javascript function to invoke when month changes.
-| onYearChange | null | Function | Javascript function to invoke when year changes.
-| locale | null | Object | Locale to be used for labels and conversion.
-| timeZone | null | Time Zone | String a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault().
-| pattern | MM/dd/yy | String | DateFormat pattern for localization (for the date part only)
-| mindate | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.util.Date (deprecated) or String | Sets DatePicker's minimum selectable value; Also used for validation on the server-side.
-| maxdate | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.util.Date (deprecated) or String | Sets DatePicker's maximum selectable value; Also used for validation on the server-side.
-| readonlyInput | false | Boolean | Makes input text of a popup DatePicker readonly.
-| inputStyle | null | String | Inline style of the input element. Used when mode is popup.
-| inputStyleClass | null | String | Style class of the input element. Used when mode is popup.
-| type | text | String | Type of the input field
 | accesskey | null | String | Access key that when pressed transfers focus to the input element.
 | alt | null | String | Alternate textual description of the input field.
+| appendTo | @(body) | String | Appends the dialog to the element defined by the given search expression.
 | autocomplete | null | String | Controls browser autocomplete behavior.
+| beforeShow | null | String | Callback to execute before displaying DatePicker, element and DatePicker instance are passed as parameters
+| buttonTabindex | null | String | Tabindex of the datepicker button
+| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
+| converterMessage | null | String | Message to be displayed when conversion fails.
+| dateTemplate | null | Function | Javascript function that takes a date object and returns the content for the date cell.
 | dir | null | String | Direction indication for text that does not inherit directionality. Valid values are LTR and RTL.
 | disabled | false | Boolean | Disables input field
+| disabledDates | null | List<java.time.LocalDate>, List<java.util.Date> (deprecated) | List of dates that should be disabled.
+| disabledDays | null | List<Integer> | List of week day indexes that should be disabled.
+| focusOnSelect | false | Boolean | When enabled, input receives focus after a value is picked.
+| hideOnDateTimeSelect | false | Boolean | Defines if the popup should be hidden when a time is selected.
+| hourFormat | '24' | String | Defines the hour format, valid values are '12' and '24'
+| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
+| inline |  false | Boolean | Whether to show the datepicker inline or as a popup
+| inputStyle | null | String | Inline style of the input element. Used when mode is popup.
+| inputStyleClass | null | String | Style class of the input element. Used when mode is popup.
+| keepInvalid | false | Boolean | Whether to keep the invalid inputs in the field or not.
 | label | null | String | A localized user presentable name.
 | lang | null | String | Code describing the language used in the generated markup for this component.
+| locale | null | Object | Locale to be used for labels and conversion.
+| mask | null | String | Defines if a mask should be applied to the input field. Default value is "false" and valid values to enable are "true" that uses the pattern as the mask or a custom template. Refer to inputMask component for more information about custom templates..
+| maskAutoClear | true | Boolean | Clears the field on blur when incomplete input is entered
+| maskSlotChar | '_' | String | Placeholder in mask template.  Default to `_`.
+| maxDateCount | null | Integer | Defines the maximum number of selectable dates in multiple selection mode.
+| maxdate | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.util.Date (deprecated) or String | Sets DatePicker's maximum selectable value; Also used for validation on the server-side.
 | maxlength | null | Integer | Maximum number of characters that may be entered in this field.
+| mindate | null | java.time.LocalDate, java.time.LocalDateTime, java.time.LocalTime, java.util.Date (deprecated) or String | Sets DatePicker's minimum selectable value; Also used for validation on the server-side.
+| monthNavigator | false | Boolean | Whether to show the month navigator
+| numberOfMonths | 1 | Integer | Number of months to display concurrently.
+| onMonthChange | null | Function | Javascript function to invoke when month changes.
+| onYearChange | null | Function | Javascript function to invoke when year changes.
 | onblur | null | String | Client side callback to execute when input element loses focus.
 | onchange | null | String | Client side callback to execute when input element loses focus and its value has been modified since gaining focus.
 | onclick | null | String | Client side callback to execute when input element is clicked.
@@ -105,17 +75,50 @@ ajax selection and more.
 | onmouseover | null | String | Client side callback to execute when a pointer button is moved onto input element.
 | onmouseup | null | String | Client side callback to execute when a pointer button is released over input element.
 | onselect | null | String | Client side callback to execute when text within input element is selected by user.
+| panelStyle | null | String | Inline style of the container element.
+| panelStyleClass | null | String | Style class of the container element.
+| pattern | MM/dd/yy | String | DateFormat pattern for localization (for the date part only)
 | placeholder | null | String | Specifies a short hint.
+| placeholder | null | String | Specifies a short hint.
+| rangeSeparator | - | String | Separator for joining start and end dates on range selection mode.
 | readonly | false | Boolean | Flag indicating that this component will prevent changes by the user.
+| readonlyInput | false | Boolean | Makes input text of a popup DatePicker readonly.
+| required | false | Boolean | Marks component as required
+| requiredMessage | null | String | Message to be displayed when required field validation fails.
+| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
+| selectOtherMonths | false | Boolean | Enables selection of days belonging to other months.
+| selectionMode | single | String | Defines the selection mode, valid values are "single", "multiple" and "range"
+| shortYearCutoff | +10 | String | The cutoff year for determining the century for a date. Any dates entered with a year value less than or equal to the cutoff year are considered to be in the current century, while those greater than it are deemed to be in the previous century.
+| showButtonBar | false | Boolean | Whether to display buttons at the footer.
+| showIcon | false | String | Whether to show an icon to display the picker in an overlay
+| showOnFocus | true | Boolean | Whether to show the popup when input receives focus.
+| showOtherMonths | false | Boolean | Displays days belonging to other months.
+| showSeconds | false | Boolean | Whether to show the seconds in time picker. Default is false.
+| showTime | false * | Boolean | Specifies if the timepicker should be displayed.  (* Defaults to true, when value is bound to java.time.LocalDateTime)
+| showWeek | false | Boolean | Displays the week number next to each week.
 | size | null | Integer | Number of characters used to determine the width of the input element.
+| stepHour | 1 | Integer | Hour steps.
+| stepMinute | 1 | Integer | Minute steps.
+| stepSecond | 1 | Integer | Second steps.
 | style | null | String | Inline style of the input element.
 | styleClass | null | String | Style class of the input element.
 | tabindex | null | Integer | Position of the input element in the tabbing order.
-| title | null | String | Advisory tooltip informaton.
-| rangeSeparator | - | String | Separator for joining start and end dates on range selection mode.
-| resolverStyle | smart | String | Relevant when parsing to a Java 8 Date/Time object. lenient, smart or strict. See [ResolverStyle](https://docs.oracle.com/javase/8/docs/api/java/time/format/ResolverStyle.html).
 | timeInput | false | Boolean | Allows direct input in time field.
+| timeOnly | false * | Boolean | Shows only timepicker without date. (* Defaults to true, when value is bound to java.time.LocalTime)
+| timeZone | null | Time Zone | String a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault().
+| title | null | String | Advisory tooltip informaton.
+| touchUI | false | Boolean | Activates touch friendly mode
 | touchable | true | Boolean | Enable touch support if browser detection supports it.
+| triggerButtonIcon | null | String | Icon of the datepicker element that toggles the visibility in popup mode.
+| type | text | String | Type of the input field
+| validator | null | Method Expr | A method expression that refers to a method validationg the input
+| validatorMessage | null | String | Message to be displayed when validation fails.
+| valueChangeListener | null | Method Expr | A method expression that refers to a method for handling a valuchangeevent
+| view | date | String | Defines the view mode, valid values are "date" for datepicker and "month" for month picker.
+| weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
+| widgetVar | null | String | Name of the client side widget.
+| yearNavigator | false | Boolean | Whether to show the year navigator
+| yearRange | null | String | The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020). Default value is "displayed_date - 10 : displayed_date + 10".
 
 ## Getting Started with DatePicker
 Value of the DatePicker should be a java.time.LocalDate in single selection mode which is the default.

--- a/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -66,7 +66,10 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder, T
         type,
         rangeSeparator,
         resolverStyle,
-        touchable
+        touchable,
+        mask,
+        maskSlotChar,
+        maskAutoClear
     }
 
     public Object getLocale() {
@@ -279,6 +282,30 @@ public abstract class UICalendar extends HtmlInputText implements InputHolder, T
     @Override
     public void setTouchable(boolean touchable) {
         getStateHelper().put(PropertyKeys.touchable, touchable);
+    }
+
+    public String getMask() {
+        return (String) getStateHelper().eval(PropertyKeys.mask, "false");
+    }
+
+    public void setMask(String mask) {
+        getStateHelper().put(PropertyKeys.mask, mask);
+    }
+
+    public String getMaskSlotChar() {
+        return (String) getStateHelper().eval(PropertyKeys.maskSlotChar, "_");
+    }
+
+    public void setMaskSlotChar(String maskSlotChar) {
+        getStateHelper().put(PropertyKeys.maskSlotChar, maskSlotChar);
+    }
+
+    public boolean isMaskAutoClear() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.maskAutoClear, true);
+    }
+
+    public void setMaskAutoClear(boolean maskAutoClear) {
+        getStateHelper().put(PropertyKeys.maskAutoClear, maskAutoClear);
     }
 
     public enum ValidationResult {

--- a/src/main/java/org/primefaces/component/calendar/CalendarBase.java
+++ b/src/main/java/org/primefaces/component/calendar/CalendarBase.java
@@ -61,11 +61,8 @@ public abstract class CalendarBase extends UICalendar implements Widget, InputHo
         maxSecond,
         pagedate,
         beforeShowDay,
-        mask,
         timeControlType,
         beforeShow,
-        maskSlotChar,
-        maskAutoClear,
         timeControlObject,
         timeInput,
         showHour,
@@ -291,14 +288,6 @@ public abstract class CalendarBase extends UICalendar implements Widget, InputHo
         getStateHelper().put(PropertyKeys.beforeShowDay, beforeShowDay);
     }
 
-    public String getMask() {
-        return (String) getStateHelper().eval(PropertyKeys.mask, "false");
-    }
-
-    public void setMask(String mask) {
-        getStateHelper().put(PropertyKeys.mask, mask);
-    }
-
     public String getTimeControlType() {
         return (String) getStateHelper().eval(PropertyKeys.timeControlType, "slider");
     }
@@ -315,21 +304,6 @@ public abstract class CalendarBase extends UICalendar implements Widget, InputHo
         getStateHelper().put(PropertyKeys.beforeShow, beforeShow);
     }
 
-    public String getMaskSlotChar() {
-        return (String) getStateHelper().eval(PropertyKeys.maskSlotChar, "_");
-    }
-
-    public void setMaskSlotChar(String maskSlotChar) {
-        getStateHelper().put(PropertyKeys.maskSlotChar, maskSlotChar);
-    }
-
-    public boolean isMaskAutoClear() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.maskAutoClear, true);
-    }
-
-    public void setMaskAutoClear(boolean maskAutoClear) {
-        getStateHelper().put(PropertyKeys.maskAutoClear, maskAutoClear);
-    }
 
     public String getTimeControlObject() {
         return (String) getStateHelper().eval(PropertyKeys.timeControlObject, null);

--- a/src/main/java/org/primefaces/component/datepicker/DatePicker.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePicker.java
@@ -23,9 +23,8 @@
  */
 package org.primefaces.component.datepicker;
 
-import org.primefaces.event.DateViewChangeEvent;
-import org.primefaces.event.SelectEvent;
-import org.primefaces.util.*;
+import java.time.*;
+import java.util.*;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.application.ResourceDependency;
@@ -33,12 +32,18 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.FacesEvent;
 import javax.faces.event.PhaseId;
-import java.time.*;
-import java.util.*;
+
+import org.primefaces.event.DateViewChangeEvent;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.util.CalendarUtils;
+import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
+import org.primefaces.util.LangUtils;
 
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery-plugins.js")
+@ResourceDependency(library = "primefaces", name = "inputmask/inputmask.js")
 @ResourceDependency(library = "primefaces", name = "core.js")
 @ResourceDependency(library = "primefaces", name = "components.js")
 @ResourceDependency(library = "primefaces", name = "datepicker/datepicker.js")

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -200,6 +200,15 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                 .attr("hideOnDateTimeSelect", datepicker.isHideOnDateTimeSelect(), false);
         }
 
+        String mask = datepicker.getMask();
+        if (mask != null && !mask.equals("false")) {
+            String patternTemplate = datepicker.getPattern() == null ? pattern : datepicker.getPattern();
+            String maskTemplate = (mask.equals("true")) ? datepicker.convertPattern(patternTemplate) : mask;
+            wb.attr("mask", maskTemplate)
+                .attr("maskSlotChar", datepicker.getMaskSlotChar(), "_")
+                .attr("maskAutoClear", datepicker.isMaskAutoClear(), true);
+        }
+
         encodeClientBehaviors(context, datepicker);
 
         wb.finish();

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -30003,7 +30003,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Whether the year should be rendered as a dropdown instead of text. Default is false.]]>
+                <![CDATA[Whether the month should be rendered as a dropdown instead of text. Default is false.]]>
             </description>
             <name>monthNavigator</name>
             <required>false</required>

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -2974,15 +2974,6 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Defines if a mask should be applied to the input field. Default value is "false" and valid values to enable are "true" that uses the pattern as the mask or a custom template. Refer to
-                inputMask component for more information about custom templates.]]>
-            </description>
-            <name>mask</name>
-            <required>false</required>
-            <type>java.lang.String</type>
-        </attribute>
-        <attribute>
-            <description>
                 <![CDATA[Defines the type of element to use for time picker, valid values are "slider" , "select" and "custom"(with "timeControlObject" attribute).]]>
             </description>
             <name>timeControlType</name>
@@ -2994,6 +2985,15 @@
                 <![CDATA[Callback to execute before displaying calendar, element and calendar instance are passed as parameters.]]>
             </description>
             <name>beforeShow</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines if a mask should be applied to the input field. Default value is "false" and valid values to enable are "true" that uses the pattern as the mask or a custom template. Refer to
+                inputMask component for more information about custom templates.]]>
+            </description>
+            <name>mask</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
@@ -30272,6 +30272,31 @@
             <name>weekCalculator</name>
             <required>false</required>
             <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines if a mask should be applied to the input field. Default value is "false" and valid values to enable are "true" that uses the pattern as the mask or a custom template. Refer to
+                inputMask component for more information about custom templates.]]>
+            </description>
+            <name>mask</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[PlaceHolder in mask template.]]>
+            </description>
+            <name>maskSlotChar</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Clears the field on blur when incomplete input is entered.]]>
+            </description>
+            <name>maskAutoClear</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
         </attribute>
     </tag>
 </facelet-taglib>

--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -116,6 +116,7 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
         this.bindDateSelectListener();
         this.bindViewChangeListener();
         this.bindCloseListener();
+        this.applyMask();
 
         //disabled dates
         this.cfg.beforeShowDay = function(date) {
@@ -245,8 +246,14 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
 
         //pfs metadata
         this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
-
-        if (this.cfg.mask) {
+    },
+    
+    /**
+     * Initializes the mask on the input if using a mask and not an inline picker.
+     * @private
+     */
+    applyMask: function() {
+        if (this.cfg.mask && !this.cfg.inline) {
             var maskCfg = {
                 alias:'datetime',
                 inputFormat:this.cfg.mask,

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1732,7 +1732,9 @@
                 this.updateViewDate(event, value.length ? value[0] : value);
             }
             catch (err) {
-                this.updateModel(event, rawValue);
+                if (!this.options.mask) {
+                    this.updateModel(event, rawValue);
+                }
             }
 
             if (this.options.onInput) {

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -36,6 +36,9 @@
  * @extends {PrimeFaces.widget.BaseWidgetCfg} cfg
  * @extends {JQueryPrimeDatePicker.PickerOptions} cfg 
  * 
+ * @prop {string} cfg.mask Applies a mask using the pattern.
+ * @prop {boolean} cfg.maskAutoClear Clears the field on blur when incomplete input is entered
+ * @prop {string} cfg.maskSlotChar Placeholder in mask template.
  * @prop {string} cfg.buttonTabindex Tabindex of the datepicker button
  * @prop {boolean} cfg.focusOnSelect When enabled, input receives focus after a value is picked.
  * @prop {PrimeFaces.widget.DatePicker.PreShowCallback} cfg.preShow User-defined callback that may be overridden by the
@@ -64,6 +67,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         this.bindClearButtonListener();
         this.bindViewChangeListener();
         this.bindCloseListener();
+        this.applyMask();
 
         // is touch support enabled
         var touchEnabled = PrimeFaces.env.isTouchable(this.cfg) && !this.input.attr("readonly") && this.cfg.showIcon;
@@ -135,7 +139,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         if(!this.cfg.inline) {
             this.jq.data('primefaces-overlay-target', this.id).find('*').data('primefaces-overlay-target', this.id);
         }
-
+        
         //pfs metadata
         this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
     },
@@ -179,6 +183,24 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
             }
 
             this.cfg.userLocale = locale;
+        }
+    },
+    
+    /**
+     * Initializes the mask on the input if using a mask and not an inline picker.
+     * @private
+     */
+    applyMask: function() {
+        if (this.cfg.mask && !this.cfg.inline) {
+            var maskCfg = {
+                alias:'datetime',
+                inputFormat:this.cfg.mask,
+                placeholder:this.cfg.maskSlotChar||'_',
+                clearMaskOnLostFocus:this.cfg.maskAutoClear||true,
+                clearIncomplete:this.cfg.maskAutoClear||true,
+                autoUnmask:false
+            };
+            this.input.inputmask('remove').inputmask(maskCfg);
         }
     },
 


### PR DESCRIPTION
- Formatted docs in alpha order because there are so many properties to keep track of
- Refactored Calendar and DatePicker to share`mask`, `maskSlotChar`, `maskAutoClear` props
- Refactored Calendar and DatePicker to use inputmask.js