### PR TITLE
Fix #4468, #1172: Datatable radio selection same as checkbox

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -784,6 +784,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     bindSelectionEvents: function() {
         if(this.cfg.selectionMode === 'radio') {
             this.bindRadioEvents();
+            this.bindRowEvents();
         }
         else if(this.cfg.selectionMode === 'checkbox') {
             this.bindCheckboxEvents();
@@ -2373,6 +2374,13 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 this.selectCheckbox(row.children('td.ui-selection-column').find('> div.ui-chkbox > div.ui-chkbox-box'));
 
             this.updateHeaderCheckbox();
+        }
+        
+        if(this.isRadioSelectionEnabled()) {
+            if(this.cfg.nativeElements)
+                row.children('td.ui-selection-column').find(':radio').prop('checked', true);
+            else
+                this.selectRadio(row.children('td.ui-selection-column').find('> div.ui-radiobutton > div.ui-radiobutton-box'));
         }
 
         this.addSelection(rowMeta.key);


### PR DESCRIPTION
This PR now makes radio selection the same as checkbox selection when clicking on a datatable row.