### PR TITLE
Fix #1597: jqPlot date I8LN

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
@@ -408,7 +408,7 @@ PrimeFaces.widget.Chart = PrimeFaces.widget.DeferredWidget.extend({
         }
 
         // #1597 must set locale on HTML element
-        document.documentElement.setAttribute('lang', PrimeFaces.settings.locale);
+        document.documentElement.setAttribute('lang', PrimeFaces.settings.locale.split('_')[0]);
         $.jsDate.regional.getLocale();
 
         PrimeFaces.widget.ChartUtils.CONFIGURATORS[this.cfg.type].configure(this);

--- a/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
+++ b/src/main/resources/META-INF/resources/primefaces/charts/1-charts.js
@@ -407,6 +407,10 @@ PrimeFaces.widget.Chart = PrimeFaces.widget.DeferredWidget.extend({
             };
         }
 
+        // #1597 must set locale on HTML element
+        document.documentElement.setAttribute('lang', PrimeFaces.settings.locale);
+        $.jsDate.regional.getLocale();
+
         PrimeFaces.widget.ChartUtils.CONFIGURATORS[this.cfg.type].configure(this);
     },
 


### PR DESCRIPTION
Based on this Stack overflow post: https://stackoverflow.com/questions/11611324/jqplot-date-axis-renderer-internationalization

Now when I set locale="it" I see the correct dates in Italian:
![image](https://user-images.githubusercontent.com/4399574/86622521-fd593f80-bf8d-11ea-8104-7400eb7f811d.png)
