### PR TITLE
Fix #5638: DatePicker detect showTime/showSeconds from pattern

### DIFF
--- a/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -236,6 +236,10 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         return (Boolean) getStateHelper().eval(PropertyKeys.showSeconds, false);
     }
 
+    public Boolean isShowSecondsWithoutDefault() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.showSeconds);
+    }
+
     public void setShowSeconds(boolean showSeconds) {
         getStateHelper().put(PropertyKeys.showSeconds, showSeconds);
     }

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -55,20 +55,10 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
 
             if (type != null) {
-                if (LocalDateTime.class.isAssignableFrom(type)) {
-                    datepicker.setShowTime(true);
-                }
-                else {
-                    datepicker.setShowTime(false);
-                }
+                datepicker.setShowTime(LocalDateTime.class.isAssignableFrom(type));
             }
             else {
-                if (CalendarUtils.hasTime(pattern)) {
-                    datepicker.setShowTime(true);
-                }
-                else {
-                    datepicker.setShowTime(false);
-                }
+                datepicker.setShowTime(CalendarUtils.hasTime(pattern));
             }
         }
 
@@ -76,22 +66,12 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
 
             if (type != null) {
-                if (LocalTime.class.isAssignableFrom(type)) {
-                    datepicker.setTimeOnly(true);
-                }
-                else {
-                    datepicker.setTimeOnly(false);
-                }
+                datepicker.setTimeOnly(LocalTime.class.isAssignableFrom(type));
             }
         }
 
         if (datepicker.isShowSecondsWithoutDefault() == null) {
-            if (pattern.contains("s")) {
-                datepicker.setShowSeconds(true);
-            }
-            else {
-                datepicker.setShowSeconds(false);
-            }
+            datepicker.setShowSeconds(pattern.contains("s"));
         }
 
         ResponseWriter writer = context.getResponseWriter();

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -65,12 +65,6 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             else {
                 if (CalendarUtils.hasTime(pattern)) {
                     datepicker.setShowTime(true);
-                    if (pattern.contains("s")) {
-                        datepicker.setShowSeconds(true);
-                    }
-                    else {
-                        datepicker.setShowSeconds(false);
-                    }
                 }
                 else {
                     datepicker.setShowTime(false);
@@ -88,6 +82,15 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                 else {
                     datepicker.setTimeOnly(false);
                 }
+            }
+        }
+
+        if (datepicker.isShowSecondsWithoutDefault() == null) {
+            if (pattern.contains("s")) {
+                datepicker.setShowSeconds(true);
+            }
+            else {
+                datepicker.setShowSeconds(false);
             }
         }
 

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -49,6 +49,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
     @Override
     protected void encodeMarkup(FacesContext context, UICalendar uicalendar, String value) throws IOException {
         DatePicker datepicker = (DatePicker) uicalendar;
+        String pattern = datepicker.calculatePattern();
 
         if (datepicker.isShowTimeWithoutDefault() == null) {
             Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
@@ -56,6 +57,20 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             if (type != null) {
                 if (LocalDateTime.class.isAssignableFrom(type)) {
                     datepicker.setShowTime(true);
+                }
+                else {
+                    datepicker.setShowTime(false);
+                }
+            }
+            else {
+                if (CalendarUtils.hasTime(pattern)) {
+                    datepicker.setShowTime(true);
+                    if (pattern.contains("s")) {
+                        datepicker.setShowSeconds(true);
+                    }
+                    else {
+                        datepicker.setShowSeconds(false);
+                    }
                 }
                 else {
                     datepicker.setShowTime(false);
@@ -202,7 +217,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
         String mask = datepicker.getMask();
         if (mask != null && !mask.equals("false")) {
-            String patternTemplate = datepicker.getPattern() == null ? pattern : datepicker.getPattern();
+            String patternTemplate = datepicker.calculatePattern();
             String maskTemplate = (mask.equals("true")) ? datepicker.convertPattern(patternTemplate) : mask;
             wb.attr("mask", maskTemplate)
                 .attr("maskSlotChar", datepicker.getMaskSlotChar(), "_")

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -516,6 +516,15 @@ public class CalendarUtils {
         return pattern.trim();
     }
 
+    public static final boolean hasTime(String pattern) {
+        for (String timeChar : TIME_CHARS) {
+            if (pattern.contains(timeChar)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Convert ISO-String (@see <a href="https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString">https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString</a>)
      * to LocalDateTime.


### PR DESCRIPTION
@christophs78 @tuerker this builds off the other smart PR for detecting LocalDateTime or LocalTime this add the checking of pattern for `showTime` and `showSeconds`.  

I ran into this issue myself recently switching from Calendar to DatePicker.