### PR TITLE
Fix #5912: DatePicker incorrect behavior with keyboard entry

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1704,6 +1704,9 @@
                 this.options.onBlur.call(this, event);
             }
 
+            //reformat input - is always OK? or only if it was modified?
+            this.inputfield.val(this.getValueToRender());
+
             this.inputfield.removeClass('ui-state-focus');
             this.container.removeClass('ui-inputwrapper-focus');
         },

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1,4 +1,4 @@
-/**
+or only if it was modified?/**
  * Prime DatePicker Widget
  */
 (function (factory) {
@@ -1709,7 +1709,6 @@
                 this.options.onBlur.call(this, event);
             }
 
-            //reformat input - is always OK? or only if it was modified?
             this.inputfield.val(this.getValueToRender());
 
             this.inputfield.removeClass('ui-state-focus');

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -788,6 +788,11 @@
                         minSize = (match === "y" ? size : 1),
                         digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
                         num = value.substring(iValue).match(digits);
+                    if (!num && match === "y" && isDoubled) {
+                        //allow 2 digit-inputs for 4-digit-year-pattern (gets reformated to 4 digits onBlur)
+                        digits = new RegExp("^\\d{" + 2 + "," + size + "}"),
+                            num = value.substring(iValue).match(digits);
+                    }
                     if (!num) {
                         throw "Missing number at position " + iValue;
                     }

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1735,12 +1735,12 @@
 
             try {
                 var value = this.parseValueFromString(rawValue);
-                this.updateModel(event, value);
+                this.updateModel(event, value, false);
                 this.updateViewDate(event, value.length ? value[0] : value);
             }
             catch (err) {
                 if (!this.options.mask) {
-                    this.updateModel(event, rawValue);
+                    this.updateModel(event, rawValue, false);
                 }
             }
 
@@ -2488,9 +2488,11 @@
             this._setInitOptionValues();
         },
 
-        updateModel: function (event, value) {
+        updateModel: function (event, value, updateInput) {
             this.value = (value === '' ? null : value);
-            this.inputfield.val(this.getValueToRender());
+            if (updateInput != false) {
+                this.inputfield.val(this.getValueToRender());
+            }
 
             this.panel.get(0).innerHTML = this.renderPanelElements();
 

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1,4 +1,4 @@
-or only if it was modified?/**
+/**
  * Prime DatePicker Widget
  */
 (function (factory) {


### PR DESCRIPTION
- [x] My first steps to decouple the update of the input-field from the update of the model and DatePicker-widget. I think this already improves input-behaviour.
- [x] I´ll try to add some code which does the reformating on focus-lost as next step and add this to this PR.
- [x] And maybe we can add something to accept 2-digits-year-inpuz also for 4-digit-patterns.

As already said before people choose libraries like PrimeFaces because they expect this things to work. And now we are as a community on a point where we need to fix dozens of issues for DatePicker. PrimeTek released DatePicker in sub-par quality with 7.0. And now we as community need to do this work.