### PR TITLE
Doc: Surrounding the listener in curly braces

### DIFF
--- a/docs/8_0/components/autocomplete.md
+++ b/docs/8_0/components/autocomplete.md
@@ -244,7 +244,7 @@ display a message about the selected item instantly.
 
 ```xhtml
 <p:autoComplete value="#{bean.text}" completeMethod="#{bean.complete}">
-    <p:ajax event="itemSelect" listener="bean.handleSelect" update="msg" />
+    <p:ajax event="itemSelect" listener="#{bean.handleSelect}" update="msg" />
 </p:autoComplete>
 <p:messages id=”msg” />
 ```


### PR DESCRIPTION
In the section Ajax Behavior number sign and braces were missed. 
Original version: listener="#{bean.handleSelect}" 
Proposed version: listener="#{bean.handleSelect}"