### PR TITLE
Fix #1816: Datatable correctly calculate column size

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -944,7 +944,7 @@ public class DataTable extends DataTableBase {
             for (UIComponent kid : getChildren()) {
                 if (kid.isRendered()) {
                     if (kid instanceof Columns) {
-                        int dynamicColumnsCount = ((Columns) kid).getRowCount();
+                        int dynamicColumnsCount = ((Columns) kid).getDynamicColumns().size();
                         if (dynamicColumnsCount > 0) {
                             columnsCountWithSpan += dynamicColumnsCount;
                         }

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -912,7 +912,7 @@ public class DataTable extends DataTableBase {
             for (UIComponent kid : getChildren()) {
                 if (kid.isRendered()) {
                     if (kid instanceof Columns) {
-                        int dynamicColumnsCount = ((Columns) kid).getRowCount();
+                        int dynamicColumnsCount = ((Columns) kid).getDynamicColumns().size();
                         if (dynamicColumnsCount > 0) {
                             columnsCount += dynamicColumnsCount;
                         }


### PR DESCRIPTION
This is a pretty obvious error but for some reason when getting `table.getColumnsCount()` for dynamic columns it was using `rowCount` which is obviously wrong it needs to be the count of dynamic columns.