### PR TITLE
Fix #6151: IdleMonitor docs and use createStorageKey

### DIFF
--- a/docs/8_0/components/idlemonitor.md
+++ b/docs/8_0/components/idlemonitor.md
@@ -42,8 +42,11 @@ By default, idleMonitor waits for 5 minutes (300000 ms) until triggering the oni
 customize this duration with the timeout attribute.
 
 ## Ajax Behavior Events
-IdleMonitor provides two ajax behavior events which are _idle_ and _active_ that are fired according to
-user status changes. Example below displays messages for each event;
+IdleMonitor provides two AJAX behavior events which are _idle_ and _active_ that are fired according to
+user status changes. If `multiWindowSupport=true` then the _active_ and _idle_ events will be fired for the
+active window and all other windows will only fire the _idle_ event.
+
+Example below displays messages for each event;
 
 ```xhtml
 <p:idleMonitor timeout="5000" update="messages">
@@ -57,7 +60,7 @@ public class Bean {
     public void idleListener() {
         //Add facesmessage
     }
-    public void idle() {
+    public void activeListener() {
         //Add facesmessage
     }
 }
@@ -67,6 +70,6 @@ Widget: _PrimeFaces.widget.IdleMonitor_
 
 | Method | Params | Return Type | Description | 
 | --- | --- | --- | --- | 
-pause() | - | void | Pauses the monitor.
+pause() | - | void | Pauses the idle monitor.
 resume() | - | void | Resumes monitoring
-reset() | - | void | Resets the timer of monitor.
+reset() | - | void | Resets the timer of idle monitor.

--- a/docs/9_0/components/idlemonitor.md
+++ b/docs/9_0/components/idlemonitor.md
@@ -44,8 +44,11 @@ By default, idleMonitor waits for 5 minutes (300000 ms) until triggering the oni
 customize this duration with the timeout attribute.
 
 ## Ajax Behavior Events
-IdleMonitor provides two ajax behavior events which are _idle_ and _active_ that are fired according to
-user status changes. Example below displays messages for each event;
+IdleMonitor provides two AJAX behavior events which are _idle_ and _active_ that are fired according to
+user status changes. If `multiWindowSupport=true` then the _active_ and _idle_ events will be fired for the
+active window and all other windows will only fire the _idle_ event.
+
+Example below displays messages for each event;
 
 ```xhtml
 <p:idleMonitor timeout="5000" update="messages">
@@ -59,7 +62,7 @@ public class Bean {
     public void idleListener() {
         //Add facesmessage
     }
-    public void idle() {
+    public void activeListener() {
         //Add facesmessage
     }
 }
@@ -69,6 +72,6 @@ Widget: _PrimeFaces.widget.IdleMonitor_
 
 | Method | Params | Return Type | Description | 
 | --- | --- | --- | --- | 
-pause() | - | void | Pauses the monitor.
+pause() | - | void | Pauses the idle monitor.
 resume() | - | void | Resumes monitoring
-reset() | - | void | Resets the timer of monitor.
+reset() | - | void | Resets the timer of idle monitor.

--- a/src/main/java/org/primefaces/component/idlemonitor/IdleMonitorRenderer.java
+++ b/src/main/java/org/primefaces/component/idlemonitor/IdleMonitorRenderer.java
@@ -47,7 +47,6 @@ public class IdleMonitorRenderer extends CoreRenderer {
         wb.init("IdleMonitor", idleMonitor.resolveWidgetVar(context), clientId)
                 .attr("timeout", idleMonitor.getTimeout())
                 .attr("multiWindowSupport", idleMonitor.isMultiWindowSupport())
-                .attr("contextPath", context.getExternalContext().getRequestContextPath())
                 .callback("onidle", "function()", idleMonitor.getOnidle())
                 .callback("onactive", "function()", idleMonitor.getOnactive());
 

--- a/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
+++ b/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
@@ -18,7 +18,6 @@
  * configuration is usually meant to be read-only and should not be modified.
  * @extends {PrimeFaces.widget.BaseWidgetCfg} cfg
  * 
- * @prop {string} cfg.contextPath The context path of the web application.
  * @prop {boolean} cfg.multiWindowSupport When set to true, the lastAccessed state will be shared between all browser
  * windows for the same servlet context.
  * @prop {PrimeFaces.widget.IdleMonitor.OnActiveCallback} cfg.onactive Client side callback to execute when the user
@@ -59,7 +58,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
 
 
         if (cfg.multiWindowSupport) {
-            var globalLastActiveKey = $this.cfg.contextPath + '_idleMonitor_lastActive' + this.cfg.id;
+            var globalLastActiveKey = PrimeFaces.createStorageKey(this.cfg.id, 'IdleMonitor_lastActive');
 
             // always reset with current time on init
             localStorage.setItem(globalLastActiveKey, $(document).data('idleTimerObj' + this.cfg.id).lastActive);


### PR DESCRIPTION
- Use our new `createStorageKey` method rather than internal passing context path
- Update docs to indicate when AJAX events are called in `multiWindowSupport=true`