### PR TITLE
Correct type declarations for PrimeFaces.ajax.Response.handle

### DIFF
--- a/src/main/type-definitions/core.d.ts
+++ b/src/main/type-definitions/core.d.ts
@@ -699,7 +699,7 @@ declare namespace PrimeFaces.ajax {
          * The handle function which is given the HTML string of the update
          * @param content The new HTML content from the update. 
          */
-        handler(this: TWidget, content: string): void;
+        handle(this: TWidget, content: string): void;
     }
 
     /**


### PR DESCRIPTION
The method on the UpdateHandler for `PrimeFaces.ajax.Response.handle(responseXML, status, xhr, updateHandler)` is named `handle`, not `handler` (see https://github.com/primefaces/primefaces/blob/master/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js#L1153)

Just noticed this because I'm working on a project where I had to create a new PrimeFaces widget, and the code completion + type checking is really helpful.