### PR TITLE
Fix #6170: Locale default pattern should be 4 digit year

### DIFF
--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -27,12 +27,16 @@ import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
-import javax.faces.FacesException;
-import javax.xml.bind.DatatypeConverter;
-import java.lang.reflect.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+
+import javax.faces.FacesException;
+import javax.xml.bind.DatatypeConverter;
 
 public class LangUtils {
 
@@ -59,6 +63,39 @@ public class LangUtils {
             }
         }
         return true;
+    }
+
+    /**
+     * <p>Counts how many times the char appears in the given string.</p>
+     *
+     * <p>A {@code null} or empty ("") String input returns {@code 0}.</p>
+     *
+     * <pre>
+     * StringUtils.countMatches(null, *)       = 0
+     * StringUtils.countMatches("", *)         = 0
+     * StringUtils.countMatches("abba", 0)  = 0
+     * StringUtils.countMatches("abba", 'a')   = 2
+     * StringUtils.countMatches("abba", 'b')  = 2
+     * StringUtils.countMatches("abba", 'x') = 0
+     * </pre>
+     *
+     * @param str  the CharSequence to check, may be null
+     * @param ch  the char to count
+     * @return the number of occurrences, 0 if the CharSequence is {@code null}
+     * @since 3.4
+     */
+    public static int countMatches(final String str, final char ch) {
+        if (isValueEmpty(str)) {
+            return 0;
+        }
+        int count = 0;
+        // We could also call str.toCharArray() for faster look ups but that would generate more garbage.
+        for (int i = 0; i < str.length(); i++) {
+            if (ch == str.charAt(i)) {
+                count++;
+            }
+        }
+        return count;
     }
 
     /**

--- a/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
+++ b/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
@@ -149,6 +149,7 @@ public class DatePickerTest {
     private void setupValues(Class type, Locale locale) {
         when(datePicker.calculateLocale(any())).thenReturn(locale);
         when(valueExpression.getType(elContext)).thenReturn(type);
+        when(datePicker.calculateLocalizedPattern()).thenCallRealMethod();
     }
 
     @Test
@@ -232,7 +233,7 @@ public class DatePickerTest {
     public void convertToJava8DateTimeAPI_LocalDate() {
         Class<?> type = LocalDate.class;
         setupValues(type, Locale.ENGLISH);
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 07, 23), temporal);
     }
@@ -241,7 +242,7 @@ public class DatePickerTest {
     public void convertToJava8DateTimeAPI_LocalDate_German() {
         Class<?> type = LocalDate.class;
         setupValues(type, Locale.GERMAN);
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "23.07.19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "23.07.2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 07, 23), temporal);
     }
@@ -306,7 +307,7 @@ public class DatePickerTest {
          Class<?> type = LocalDateTime.class;
         setupValues(type, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/19 21:31");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/2019 21:31");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDateTime.of(2019, 7, 23,  21, 31), temporal);
     }
@@ -318,7 +319,7 @@ public class DatePickerTest {
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
         when(datePicker.getHourFormat()).thenReturn("12");
         when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/19 09:31:48 PM");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/2019 09:31:48 PM");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDateTime.of(2019, 7, 23,  21, 31, 48), temporal);
     }
@@ -358,32 +359,32 @@ public class DatePickerTest {
     }
 
     /**
-     * {@link ResolverStyle} == SMART (default value). The date 02/30/19 is silently parsed to 02/28/19.
+     * {@link ResolverStyle} == SMART (default value). The date 02/30/2019 is silently parsed to 02/28/2019.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Smart_implicit() {
         Class<?> type = LocalDate.class;
         setupValues(type, Locale.ENGLISH);
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 02, 28), temporal);
     }
 
     /**
-     * {@link ResolverStyle} == SMART (explicitly set). The date 02/30/19 is silently parsed to 02/28/19.
+     * {@link ResolverStyle} == SMART (explicitly set). The date 02/30/2019 is silently parsed to 02/28/2019.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Smart_explicit() {
         Class<?> type = LocalDate.class;
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("SMART");
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 02, 28), temporal);
     }
 
     /**
-     * {@link ResolverStyle} == STRICT. The date 02/30/19 should lead to a thrown ConverterException.
+     * {@link ResolverStyle} == STRICT. The date 02/30/2019 should lead to a thrown ConverterException.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Strict() {
@@ -391,11 +392,11 @@ public class DatePickerTest {
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("STRICT");
 
-        Assertions.assertThrows(ConverterException.class, () -> renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19"));
+        Assertions.assertThrows(ConverterException.class, () -> renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019"));
     }
 
     /**
-     * {@link ResolverStyle} == STRICT. The date 02/30/19 should lead to a thrown ConverterException.
+     * {@link ResolverStyle} == STRICT. The date 02/30/2019 should lead to a thrown ConverterException.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Strict_differentCase() {
@@ -403,11 +404,11 @@ public class DatePickerTest {
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("strict");
 
-        Assertions.assertThrows(ConverterException.class, () -> renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19"));
+        Assertions.assertThrows(ConverterException.class, () -> renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019"));
     }
 
     /**
-     * {@link ResolverStyle} == STRICT. The valid date 02/20/19 should be correctly parsed.
+     * {@link ResolverStyle} == STRICT. The valid date 02/20/2019 should be correctly parsed.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Strict_ValidDate() {
@@ -415,7 +416,7 @@ public class DatePickerTest {
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("STRICT");
 
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/20/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/20/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 02, 20), temporal);
     }
@@ -449,7 +450,7 @@ public class DatePickerTest {
     }
 
     /**
-     * {@link ResolverStyle} == LENIENT. The date 02/30/19 is silently parsed to 03/02/19.
+     * {@link ResolverStyle} == LENIENT. The date 02/30/2019 is silently parsed to 03/02/2019.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Lenient() {
@@ -457,13 +458,13 @@ public class DatePickerTest {
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("LENIENT");
 
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 03, 02), temporal);
     }
 
     /**
-     * Invalid {@link ResolverStyle}. The date 02/30/19 is silently parsed to 02/28/19 as default value 'SMART' is used.
+     * Invalid {@link ResolverStyle}. The date 02/30/2019 is silently parsed to 02/28/2019 as default value 'SMART' is used.
      */
     @Test
     public void convertToJava8DateTimeAPI_ResolveStyle_Invalid() {
@@ -471,7 +472,7 @@ public class DatePickerTest {
         setupValues(type, Locale.ENGLISH);
         when(datePicker.getResolverStyle()).thenReturn("what?");
 
-        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/19");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "2/30/2019");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDate.of(2019, 02, 28), temporal);
     }
@@ -483,7 +484,7 @@ public class DatePickerTest {
 
         when(renderer.getConvertedValue(eq(context), eq(datePicker), any())).thenCallRealMethod();
 
-        Object object = renderer.getConvertedValue(context, datePicker, "7/23/19");
+        Object object = renderer.getConvertedValue(context, datePicker, "7/23/2019");
         assertEquals(type, object.getClass());
         Date date = (Date)object;
         java.util.Calendar calendar = new GregorianCalendar();
@@ -500,7 +501,7 @@ public class DatePickerTest {
 
         when(renderer.getConvertedValue(eq(context), eq(datePicker), any())).thenCallRealMethod();
 
-        Object object = renderer.getConvertedValue(context, datePicker, "7/23/19");
+        Object object = renderer.getConvertedValue(context, datePicker, "7/23/2019");
         assertEquals(type, object.getClass());
         LocalDate localDate = (LocalDate)object;
         assertEquals(LocalDate.of(2019, 07, 23), localDate);
@@ -532,7 +533,7 @@ public class DatePickerTest {
     @Test
     public void validateValueInternal_minDate_String() {
         setupValues(null, Locale.ENGLISH);
-        when(datePicker.getMindate()).thenReturn("1/1/19");
+        when(datePicker.getMindate()).thenReturn("1/1/2019");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDate.of(2019, 7, 23));
         assertTrue(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.OK, validationResult);
@@ -541,7 +542,7 @@ public class DatePickerTest {
     @Test
     public void validateValueInternal_minDate_String_wrong() {
         setupValues(null, Locale.ENGLISH);
-        when(datePicker.getMindate()).thenReturn("1/1/19");
+        when(datePicker.getMindate()).thenReturn("1/1/2019");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDate.of(2018, 7, 23));
         assertFalse(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.INVALID_MIN_DATE, validationResult);
@@ -578,7 +579,7 @@ public class DatePickerTest {
     @Test
     public void validateValueInternal_maxDate_String() {
         setupValues(null, Locale.ENGLISH);
-        when(datePicker.getMaxdate()).thenReturn("12/31/19");
+        when(datePicker.getMaxdate()).thenReturn("12/31/2019");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDate.of(2019, 7, 23));
         assertTrue(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.OK, validationResult);
@@ -587,7 +588,7 @@ public class DatePickerTest {
     @Test
     public void validateValueInternal_maxDate_String_wrong() {
         setupValues(null, Locale.ENGLISH);
-        when(datePicker.getMaxdate()).thenReturn("12/31/19");
+        when(datePicker.getMaxdate()).thenReturn("12/31/2019");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDate.of(2020, 7, 23));
         assertFalse(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.INVALID_MAX_DATE, validationResult);
@@ -854,7 +855,7 @@ public class DatePickerTest {
     public void validateValueInternal_minDateTime_String() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        when(datePicker.getMindate()).thenReturn("1/1/19 00:00");
+        when(datePicker.getMindate()).thenReturn("1/1/2019 00:00");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDateTime.of(2019, 1, 1, 02, 00));
         assertTrue(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.OK, validationResult);
@@ -864,7 +865,7 @@ public class DatePickerTest {
     public void validateValueInternal_minDateTime_String_wrong() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        when(datePicker.getMindate()).thenReturn("1/1/19 12:00");
+        when(datePicker.getMindate()).thenReturn("1/1/2019 12:00");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDateTime.of(2019, 1, 1, 11, 59));
         assertFalse(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.INVALID_MIN_DATE, validationResult);
@@ -929,7 +930,7 @@ public class DatePickerTest {
     public void validateValueInternal_maxDateTime_String() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        when(datePicker.getMaxdate()).thenReturn("12/1/19 20:00");
+        when(datePicker.getMaxdate()).thenReturn("12/1/2019 20:00");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDateTime.of(2019, 11, 30, 16, 00));
         assertTrue(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.OK, validationResult);
@@ -939,7 +940,7 @@ public class DatePickerTest {
     public void validateValueInternal_maxDateTime_String_wrong() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        when(datePicker.getMaxdate()).thenReturn("12/1/19 15:00");
+        when(datePicker.getMaxdate()).thenReturn("12/1/2019 15:00");
         DatePicker.ValidationResult validationResult = datePicker.validateValueInternal(context, LocalDateTime.of(2019, 12, 31, 18, 00));
         assertFalse(datePicker.isValid());
         assertEquals(DatePicker.ValidationResult.INVALID_MAX_DATE, validationResult);
@@ -975,14 +976,14 @@ public class DatePickerTest {
     @Test
     public void calculatePatternDefault() {
         setupValues(null, Locale.ENGLISH);
-        assertEquals("M/d/yy", datePicker.calculatePattern());
+        assertEquals("M/d/yyyy", datePicker.calculatePattern());
     }
 
     @Test
     public void calculatePatternWithTime() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
-        assertEquals("M/d/yy HH:mm", datePicker.calculatePattern());
+        assertEquals("M/d/yyyy HH:mm", datePicker.calculatePattern());
     }
 
     @Test
@@ -990,7 +991,7 @@ public class DatePickerTest {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
         when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
-        assertEquals("M/d/yy HH:mm:ss", datePicker.calculatePattern());
+        assertEquals("M/d/yyyy HH:mm:ss", datePicker.calculatePattern());
     }
 
     @Test
@@ -999,7 +1000,7 @@ public class DatePickerTest {
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
         when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
         when(datePicker.getHourFormat()).thenReturn("12");
-        assertEquals("M/d/yy hh:mm:ss a", datePicker.calculatePattern());
+        assertEquals("M/d/yyyy hh:mm:ss a", datePicker.calculatePattern());
     }
 
     @Test
@@ -1007,7 +1008,7 @@ public class DatePickerTest {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
         when(datePicker.getHourFormat()).thenReturn("12");
-        assertEquals("M/d/yy hh:mm a", datePicker.calculatePattern());
+        assertEquals("M/d/yyyy hh:mm a", datePicker.calculatePattern());
     }
 
 

--- a/src/test/java/org/primefaces/util/CalendarUtilsTest.java
+++ b/src/test/java/org/primefaces/util/CalendarUtilsTest.java
@@ -77,6 +77,7 @@ public class CalendarUtilsTest {
         when(datePicker.calculatePattern()).thenCallRealMethod();
         when(datePicker.calculateTimeOnlyPattern()).thenCallRealMethod();
         when(datePicker.calculateWidgetPattern()).thenCallRealMethod();
+        when(datePicker.calculateLocalizedPattern()).thenCallRealMethod();
         when(datePicker.calculateLocale(any())).thenReturn(locale);
     }
 
@@ -86,7 +87,7 @@ public class CalendarUtilsTest {
         setupValues(localDate, Locale.ENGLISH);
 
         String value = CalendarUtils.getValueAsString (context, datePicker);
-        assertEquals("7/23/19", value);
+        assertEquals("7/23/2019", value);
     }
 
     @Test
@@ -95,7 +96,7 @@ public class CalendarUtilsTest {
         setupValues(localDate, Locale.GERMAN);
 
         String value = CalendarUtils.getValueAsString (context, datePicker);
-        assertEquals("23.07.19", value);
+        assertEquals("23.07.2019", value);
     }
 
     @Test
@@ -106,7 +107,7 @@ public class CalendarUtilsTest {
         setupValues(date, Locale.ENGLISH);
 
         String value = CalendarUtils.getValueAsString (context, datePicker);
-        assertEquals("7/23/19", value);
+        assertEquals("7/23/2019", value);
     }
 
     @Test
@@ -117,7 +118,7 @@ public class CalendarUtilsTest {
         setupValues(date, Locale.GERMAN);
 
         String value = CalendarUtils.getValueAsString (context, datePicker);
-        assertEquals("23.07.19", value);
+        assertEquals("23.07.2019", value);
     }
 
     @Test

--- a/src/test/java/org/primefaces/util/LangUtilsTest.java
+++ b/src/test/java/org/primefaces/util/LangUtilsTest.java
@@ -23,16 +23,16 @@
  */
 package org.primefaces.util;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
 
 public class LangUtilsTest {
-    
+
     private static final String FOO = "foo";
     private static final String SENTENCE = "foo bar baz";
 
@@ -63,8 +63,13 @@ public class LangUtilsTest {
 
         assertEquals(String.class, type);
     }
-    
 
+    @Test
+    public void testCountMatches_char() {
+        assertEquals(0, LangUtils.countMatches(null, 'D'));
+        assertEquals(5, LangUtils.countMatches("one long someone sentence of one", ' '));
+        assertEquals(6, LangUtils.countMatches("one long someone sentence of one", 'o'));
+    }
 
     @Test
     public void substring() {
@@ -83,8 +88,6 @@ public class LangUtilsTest {
         assertEquals("", LangUtils.substring(SENTENCE, 2, 2));
         assertEquals("b", LangUtils.substring("abc", -2, -1));
     }
-
-   
 
     class SimpleClass {
         private List<String> strings;


### PR DESCRIPTION
Converts `dd/MM/yy` into `dd/MM/yyyy` or wherever a 2 digit year is found in the locale default should be a 4 digit year.  This will prevent many problems including the one described in this ticket as a "smart default" if `pattern` is not specified.