### PR TITLE
Fix #4519: Autocomplete remove all items at once

### DIFF
--- a/docs/9_0/components/autocomplete.md
+++ b/docs/9_0/components/autocomplete.md
@@ -208,8 +208,9 @@ empty query or search with the current value in input.
 ```
 ## Multiple Selection
 AutoComplete supports multiple selection as well, to use this feature set multiple option to true and
-define a list as your backend model. Following example demonstrates multiple selection with
-custom content support.
+define a list as your back-end model. Use BACKSPACE key to remove a selected item and CTRL or SHIFT+BACKSPACE 
+to remove all items at once.
+Following example demonstrates multiple selection with custom content support.
 
 ```xhtml
 <p:autoComplete id="advanced" value="#{autoCompleteBean.selectedPlayers}" completeMethod="#{autoCompleteBean.completePlayer}"
@@ -308,6 +309,7 @@ Widget: _PrimeFaces.widget.AutoComplete_
 | enable() | - | void | Enables the input field |
 | deactivate() | - | void | Deactivates search behavior |
 | activate() | - | void | Activates search behavior |
+| removeAllItems() | - | void | In multiple mode removes all selected items |
 
 ## Skinning
 Following is the list of structural style classes;

--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -469,7 +469,12 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
 
                     case keyCode.BACKSPACE:
                         if ($this.cfg.multiple && !$this.input.val().length) {
-                            $this.removeItem(e, $(this).parent().prev());
+                            
+                            if (e.metaKey||e.ctrlKey||e.shiftKey) {
+                                $this.removeAllItems();
+                            } else {
+                                $this.removeItem(e, $(this).parent().prev());
+                            }
 
                             e.preventDefault();
                         }
@@ -989,6 +994,18 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         // if empty return placeholder
         if (this.placeholder && this.hinput.children('option').length === 0) {
             this.input.attr('placeholder', this.placeholder);
+        }
+    },
+    
+    /**
+     * Removes all items if in multiple mode.
+     */
+    removeAllItems: function() {
+        var $this = this;
+        if (this.cfg.multiple && !this.input.val().length) {
+            this.multiItemContainer.find('.ui-autocomplete-token').each(function( index ) {
+                $this.removeItem(null, $(this));
+            });
         }
     },
 


### PR DESCRIPTION
- Added new client side widget method `removeAllItems` to remove all selected items at once
- BACKSPACE removes a single item and now CTRL or SHIFT + BACKSPACE removes all items at once