### PR TITLE
Fix #5528: DatePicker time separator from Locale

### DIFF
--- a/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -23,7 +23,11 @@
  */
 package org.primefaces.component.datepicker;
 
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.FormatStyle;
 import java.util.List;
+import java.util.Locale;
 
 import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.MixedClientBehaviorHolder;
@@ -444,11 +448,16 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
     @Override
     public String calculateTimeOnlyPattern() {
         if (timeOnlyPattern == null) {
+            // #5528 Determine separator for locale
+            Locale locale = calculateLocale(getFacesContext());
+            String localePattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(null, FormatStyle.SHORT, IsoChronology.INSTANCE, locale);
+            String separator = localePattern.contains(":") ? ":" : ".";
+
             boolean ampm = "12".equals(getHourFormat());
             timeOnlyPattern = ampm ? "hh" : "HH";
-            timeOnlyPattern += ":mm";
+            timeOnlyPattern += (separator + "mm");
             if (isShowSeconds()) {
-                timeOnlyPattern += ":ss";
+                timeOnlyPattern += (separator + "ss");
             }
             if (ampm) {
                 timeOnlyPattern += " a";

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -41,6 +41,8 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
 
     public static final String DEFAULT_RENDERER = "org.primefaces.component.DatePickerRenderer";
 
+    protected String timeSeparator = null;
+
     public enum PropertyKeys {
 
         placeholder,
@@ -448,11 +450,7 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
     @Override
     public String calculateTimeOnlyPattern() {
         if (timeOnlyPattern == null) {
-            // #5528 Determine separator for locale
-            Locale locale = calculateLocale(getFacesContext());
-            String localePattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(null, FormatStyle.SHORT, IsoChronology.INSTANCE, locale);
-            String separator = localePattern.contains(":") ? ":" : ".";
-
+            String separator = getTimeSeparator();
             boolean ampm = "12".equals(getHourFormat());
             timeOnlyPattern = ampm ? "hh" : "HH";
             timeOnlyPattern += (separator + "mm");
@@ -465,5 +463,17 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         }
         return timeOnlyPattern;
     }
+
+    public String getTimeSeparator() {
+        if (timeSeparator == null) {
+            // #5528 Determine separator for locale
+            Locale locale = calculateLocale(getFacesContext());
+            String localePattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(null, FormatStyle.SHORT, IsoChronology.INSTANCE, locale);
+            timeSeparator = localePattern.contains(":") ? ":" : ".";
+        }
+        return timeSeparator;
+    }
+
+
 
 }

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -145,7 +145,8 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("appendTo", SearchExpressionFacade.resolveClientId(context, datepicker, datepicker.getAppendTo(),
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
             .attr("icon", datepicker.getTriggerButtonIcon(), null)
-            .attr("rangeSeparator", datepicker.getRangeSeparator(), null)
+            .attr("rangeSeparator", datepicker.getRangeSeparator(), "-")
+            .attr("timeSeparator", datepicker.getTimeSeparator(), ":")
             .attr("timeInput", datepicker.isTimeInput())
             .attr("touchable", ComponentUtils.isTouchable(context, datepicker),  true);
 

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -28,6 +28,7 @@
             inline: false,
             selectionMode: 'single',
             rangeSeparator: '-',
+            timeSeparator: ':',
             inputId: null,
             inputStyle: null,
             inputStyleClass: null,
@@ -716,11 +717,11 @@
             } else {
                 output += (hours < 10) ? '0' + hours : hours;
             }
-            output += ':';
+            output += this.options.timeSeparator;
             output += (minutes < 10) ? '0' + minutes : minutes;
 
             if (this.options.showSeconds) {
-                output += ':';
+                output += this.options.timeSeparator;
                 output += (seconds < 10) ? '0' + seconds : seconds;
             }
 
@@ -732,7 +733,7 @@
         },
 
         parseTime: function (value, ampm) {
-            var tokens = value.split(':'),
+            var tokens = value.split(this.options.timeSeparator),
                 validTokenLength = this.options.showSeconds ? 3 : 2;
 
             if (tokens.length !== validTokenLength) {

--- a/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
+++ b/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
@@ -112,6 +112,7 @@ public class DatePickerTest {
         when(datePicker.calculatePattern()).thenCallRealMethod();
         when(datePicker.calculateTimeOnlyPattern()).thenCallRealMethod();
         when(datePicker.calculateWidgetPattern()).thenCallRealMethod();
+        when(datePicker.getTimeSeparator()).thenCallRealMethod();
         when(datePicker.isValid()).thenCallRealMethod();
         doCallRealMethod().when(datePicker).setValid(anyBoolean());
         when(datePicker.getSelectionMode()).thenReturn("single");


### PR DESCRIPTION
Uses the Locale default time format to determine whether to use `:` or `.` as the time separator.