### PR TITLE
Fix #6219: FilterMeta/SortMeta equals() and hashcode()

### DIFF
--- a/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/src/main/java/org/primefaces/model/FilterMeta.java
@@ -24,7 +24,10 @@
 package org.primefaces.model;
 
 import java.io.Serializable;
+import java.util.Objects;
+
 import javax.el.ValueExpression;
+
 import org.primefaces.component.api.UIColumn;
 
 public class FilterMeta implements Serializable {
@@ -96,5 +99,25 @@ public class FilterMeta implements Serializable {
     public String toString() {
         return "FilterMeta [filterField=" + filterField + ", columnKey=" + columnKey + ", filterByVE=" + filterByVE + ", filterMatchMode=" + filterMatchMode
                     + ", filterValue=" + filterValue + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnKey, filterField, filterValue);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof FilterMeta)) {
+            return false;
+        }
+        FilterMeta other = (FilterMeta) obj;
+        return Objects.equals(columnKey, other.columnKey) && Objects.equals(filterField, other.filterField) && Objects.equals(filterValue, other.filterValue);
     }
 }

--- a/src/main/java/org/primefaces/model/SortMeta.java
+++ b/src/main/java/org/primefaces/model/SortMeta.java
@@ -24,6 +24,8 @@
 package org.primefaces.model;
 
 import java.io.Serializable;
+import java.util.Objects;
+
 import javax.el.MethodExpression;
 
 public class SortMeta implements Serializable {
@@ -72,5 +74,26 @@ public class SortMeta implements Serializable {
     public String toString() {
         return "SortMeta [columnKey=" + columnKey + ", sortField=" + sortField + ", sortOrder=" + sortOrder + ", sortFunction="
                 + sortFunction + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnKey, sortField, sortFunction, sortOrder);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof SortMeta)) {
+            return false;
+        }
+        SortMeta other = (SortMeta) obj;
+        return Objects.equals(columnKey, other.columnKey) && Objects.equals(sortField, other.sortField) && Objects.equals(sortFunction, other.sortFunction)
+                    && sortOrder == other.sortOrder;
     }
 }


### PR DESCRIPTION
Because these are added to maps they should implement proper equals and hashcode methods