### PR TITLE
Fix #6187: Row editor prevent multiple focus calls

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3092,7 +3092,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
         var inputs=row.find(':input:enabled');
         if (inputs.length > 0) {
-            inputs.first().trigger('focus');
+            inputs.first().triggerHandler('focus');
         }
     },
 


### PR DESCRIPTION
Use triggerHandler instead of `trigger('focus')` because that propogates the focus to all registered events and bubbles up.  TriggerHandler See: https://stackoverflow.com/questions/3772537/triggerhandler-vs-trigger-in-jquery