### PR TITLE
Fix #4374 menuButton: Add support for submenus

### DIFF
--- a/docs/9_0/components/menubutton.md
+++ b/docs/9_0/components/menubutton.md
@@ -36,6 +36,9 @@ menuStyleClass | null | String | Style class of the overlay menu element.
 ariaLabel | null | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
 collision | flip | String | For the overlay menu that shows up when the menu button is clicked. When the overlay menu overflows the window in some direction, move it to an alternative position. Supported values are flip, fit, flipfit and none. See https://api.jqueryui.com/position/ for more details. Defaults to flip. When you the body of your layout does not scroll, you may also want to set the option maxHeight.
 maxHeight | null | String | The maximum height of the overlay menu that shows up when the menu button is clicked. May be either a number (such as 200), which is interpreted as a height in pixels. Alternatively, may also be a CSS length such as 90vh or 10em. Useful in case the body of your layout does not scroll, especially in combination with the collision property.
+autoDisplay | true | Boolean | Defines whether the first level of submenus will be displayed on mouseover or not. When set to false, click event is required to display.
+delay | 0 | int | Delay in milliseconds before displaying the submenu. Default is 0 meaning immediate.
+toggleEvent | hover | String | Event to toggle the submenus, valid values are "hover" and "click".
 
 ## Getting started with the MenuButton
 MenuButton consists of one ore more menuitems. Following menubutton example has three

--- a/src/main/java/org/primefaces/component/menubutton/MenuButtonBase.java
+++ b/src/main/java/org/primefaces/component/menubutton/MenuButtonBase.java
@@ -47,7 +47,10 @@ public abstract class MenuButtonBase extends AbstractMenu implements Widget {
         title,
         ariaLabel,
         collision,
-        maxHeight
+        maxHeight,
+        autoDisplay,
+        toggleEvent,
+        delay
     }
 
     public MenuButtonBase() {
@@ -170,5 +173,29 @@ public abstract class MenuButtonBase extends AbstractMenu implements Widget {
 
     public void setMaxHeight(String maxHeight) {
         getStateHelper().put(PropertyKeys.maxHeight, maxHeight);
+    }
+
+    public boolean isAutoDisplay() {
+        return (boolean) getStateHelper().eval(PropertyKeys.autoDisplay, true);
+    }
+
+    public void setAutoDisplay(boolean autoDisplay) {
+        getStateHelper().put(PropertyKeys.autoDisplay, autoDisplay);
+    }
+
+    public String getToggleEvent() {
+        return (String) getStateHelper().eval(PropertyKeys.toggleEvent, null);
+    }
+
+    public void setToggleEvent(String toggleEvent) {
+        getStateHelper().put(PropertyKeys.toggleEvent, toggleEvent);
+    }
+
+    public int getDelay() {
+        return (int) getStateHelper().eval(PropertyKeys.delay, 0);
+    }
+
+    public void setDelay(int delay) {
+        getStateHelper().put(PropertyKeys.delay, delay);
     }
 }

--- a/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
@@ -32,19 +32,17 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.menu.AbstractMenu;
-import org.primefaces.component.menu.BaseMenuRenderer;
 import org.primefaces.component.menu.Menu;
+import org.primefaces.component.tieredmenu.TieredMenuRenderer;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.expression.SearchExpressionUtils;
 import org.primefaces.model.menu.MenuElement;
-import org.primefaces.model.menu.MenuItem;
-import org.primefaces.model.menu.Separator;
 import org.primefaces.util.ComponentTraversalUtils;
 import org.primefaces.util.HTML;
 import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
-public class MenuButtonRenderer extends BaseMenuRenderer {
+public class MenuButtonRenderer extends TieredMenuRenderer {
 
     @Override
     protected void encodeMarkup(FacesContext context, AbstractMenu abstractMenu) throws IOException {
@@ -142,21 +140,7 @@ public class MenuButtonRenderer extends BaseMenuRenderer {
 
         if (button.getElementsCount() > 0) {
             List<MenuElement> elements = button.getElements();
-
-            for (MenuElement element : elements) {
-                if (element.isRendered()) {
-                    if (element instanceof MenuItem) {
-                        writer.startElement("li", null);
-                        writer.writeAttribute("class", Menu.MENUITEM_CLASS, null);
-                        writer.writeAttribute(HTML.ARIA_ROLE, HTML.ARIA_ROLE_MENUITEM, null);
-                        encodeMenuItem(context, button, (MenuItem) element, "-1");
-                        writer.endElement("li");
-                    }
-                    else if (element instanceof Separator) {
-                        encodeSeparator(context, (Separator) element);
-                    }
-                }
-            }
+            encodeElements(context, button, elements);
         }
 
         writer.endElement("ul");
@@ -179,6 +163,9 @@ public class MenuButtonRenderer extends BaseMenuRenderer {
         wb.attr("appendTo", SearchExpressionFacade.resolveClientId(context, button, button.getAppendTo(),
                 SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null);
         wb.attr("collision", button.getCollision());
+        wb.attr("autoDisplay", button.isAutoDisplay());
+        wb.attr("toggleEvent", button.getToggleEvent(), null);
+        wb.attr("delay", button.getDelay());
         wb.finish();
     }
 }

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -40,9 +40,7 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
      * @param {JQuery} submenu 
      */
     showSubmenu: function(menuitem, submenu) {
-        var pos = null;
-
-        pos = {
+        var pos = {
             my: 'left top',
             at: 'right top',
             of: menuitem,

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -18,7 +18,7 @@
  * e.g., `flip`, `fit`, `fit flip`, `fit none`.
  * @prop {boolean} cfg.disabled Whether this menu button is initially disabled.
  */
-PrimeFaces.widget.MenuButton = PrimeFaces.widget.BaseWidget.extend({
+PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
 
     /**
      * @override
@@ -28,16 +28,37 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.BaseWidget.extend({
     init: function(cfg) {
         this._super(cfg);
 
-        this.menuId = this.jqId + '_menu';
-        this.button = this.jq.children('button');
-        this.menu = this.jq.children('.ui-menu');
-        this.menuitems = this.jq.find('.ui-menuitem');
-        this.cfg.disabled = this.button.is(':disabled');
-
         if(!this.cfg.disabled) {
-            this.bindEvents();
             PrimeFaces.utils.registerDynamicOverlay(this, this.menu, this.id + '_menu');
         }
+    },
+
+    /**
+     * @override
+     * @inheritdoc
+     * @param {JQuery} menuitem 
+     * @param {JQuery} submenu 
+     */
+    showSubmenu: function(menuitem, submenu) {
+        var pos = null;
+
+        pos = {
+            my: 'left top',
+            at: 'right top',
+            of: menuitem,
+            collision: 'flipfit'
+        };
+
+        //avoid queuing multiple runs
+        if(this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+
+        this.timeoutId = setTimeout(function () {
+           submenu.css('z-index', PrimeFaces.nextZindex())
+                  .show()
+                  .position(pos)
+        }, this.cfg.delay);
     },
 
     /**
@@ -54,6 +75,14 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     bindEvents: function() {
+        this.menuId = this.jqId + '_menu';
+        this.button = this.jq.children('button');
+        this.menu = this.jq.children('.ui-menu');
+        this.menuitems = this.jq.find('.ui-menuitem');
+        this.cfg.disabled = this.button.is(':disabled');
+
+        this._super();
+
         var $this = this;
 
         //button visuals

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -28,7 +28,14 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
     init: function(cfg) {
         this._super(cfg);
 
+        this.menuId = this.jqId + '_menu';
+        this.button = this.jq.children('button');
+        this.menu = this.jq.children('.ui-menu');
+        this.menuitems = this.jq.find('.ui-menuitem');
+        this.cfg.disabled = this.button.is(':disabled');
+
         if(!this.cfg.disabled) {
+            this.bindButtonEvents();
             PrimeFaces.utils.registerDynamicOverlay(this, this.menu, this.id + '_menu');
         }
     },
@@ -72,15 +79,7 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
      * Sets up all event listeners that are required by this widget.
      * @private
      */
-    bindEvents: function() {
-        this.menuId = this.jqId + '_menu';
-        this.button = this.jq.children('button');
-        this.menu = this.jq.children('.ui-menu');
-        this.menuitems = this.jq.find('.ui-menuitem');
-        this.cfg.disabled = this.button.is(':disabled');
-
-        this._super();
-
+    bindButtonEvents: function() {
         var $this = this;
 
         //button visuals


### PR DESCRIPTION
This PR add submenus support to menuButton component. Fixes #4374

Example (source: https://github.com/maruTA-bis5/primefaces-test/tree/menubutton-submenu)
![image](https://user-images.githubusercontent.com/1310661/91291097-84c57100-e7cf-11ea-8d3f-1b2fc41886d4.png)
