### PR TITLE
Fix #6258: Improve modal support

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/blockui/blockui.css
+++ b/src/main/resources/META-INF/resources/primefaces/blockui/blockui.css
@@ -1,14 +1,10 @@
 .ui-blockui {
     position: absolute;
-    top: 0;
-    left: 0;
     text-align: center;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
     user-select: none;
 }
 

--- a/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -80,15 +80,24 @@ if (!PrimeFaces.utils) {
 
         /**
          * Creates a new (empty) container for a modal overlay. A modal overlay is an overlay that blocks the content
-         * belown it. To remove the modal overlay, use `PrimeFaces.utils.removeModal`.
+         * below it. To remove the modal overlay, use `PrimeFaces.utils.removeModal`.
          * @param {PrimeFaces.widget.BaseWidget} widget An overlay widget instance.
-         * @param {number} zIndex The z-index to set on the modal overlay.
+         * @param {JQuery} overlay The modal overlay element should be a DIV.
          * @param {() => JQuery} tabbablesCallback A supplier function that return a list of tabbable elements. A
          * tabbable element is an element to which the user can navigate to via the tab key.
          * @return {JQuery} The DOM element for the newly added modal overlay container.
          */
-        addModal: function(widget, zIndex, tabbablesCallback) {
-            var id = widget.id;
+        addModal: function(widget, overlay, tabbablesCallback) {
+            var id = widget.id,
+                zIndex = overlay.css('z-index') - 1;
+            
+            overlay.attr({
+                'role': 'dialog'
+                ,'aria-hidden': false
+                ,'aria-modal': true
+                ,'aria-live': 'polite'
+            });
+            
             PrimeFaces.utils.preventTabbing(id, zIndex, tabbablesCallback);
 
             if (widget.cfg.blockScroll) {
@@ -96,7 +105,6 @@ if (!PrimeFaces.utils) {
             }
 
             var modalId = id + '_modal';
-
             var modalOverlay = $('<div id="' + modalId + '" class="ui-widget-overlay ui-dialog-mask"></div>');
             modalOverlay.appendTo($(document.body));
             modalOverlay.css('z-index' , String(zIndex));
@@ -167,10 +175,18 @@ if (!PrimeFaces.utils) {
          * Given a modal overlay widget, removes the modal overlay element from the DOM. This reverts the changes as
          * made by `PrimeFaces.utils.addModal`.
          * @param {PrimeFaces.widget.BaseWidget} widget A modal overlay widget instance.
+         * @param {JQuery} overlay The modal overlay element should be a DIV.
          */
-        removeModal: function(widget) {
+        removeModal: function(widget, overlay) {
             var id = widget.id;
             var modalId = id + '_modal';
+            
+            overlay.attr({
+                'role': ''
+                ,'aria-hidden': true
+                ,'aria-modal': false
+                ,'aria-live': 'off' 
+            });
 
             // if the id contains a ':'
             $(PrimeFaces.escapeClientId(modalId)).remove();

--- a/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -564,10 +564,12 @@ if (!PrimeFaces.widget) {
         /**
          * Enables modality for this widget and creates the modal overlay element, but does not change whether the
          * overlay is currently displayed.
+         * @param {JQuery} overlay The target overlay, if null default to this.jq.
          */
-        enableModality: function() {
+        enableModality: function(overlay) {
+            var target = overlay||this.jq;
             this.modalOverlay = PrimeFaces.utils.addModal(this,
-                this.jq.css('z-index') - 1,
+                target,
                 $.proxy(function() {
                     return this.getModalTabbables();
                 }, this));
@@ -576,9 +578,11 @@ if (!PrimeFaces.widget) {
         /**
          * Disabled modality for this widget and removes the modal overlay element, but does not change whether the
          * overlay is currently displayed.
+         * @param {JQuery} overlay The target overlay, if null default to this.jq.
          */
-        disableModality: function(){
-            PrimeFaces.utils.removeModal(this);
+        disableModality: function(overlay){
+            var target = overlay||this.jq;
+            PrimeFaces.utils.removeModal(this, target);
             this.modalOverlay = null;
         },
 

--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.css
@@ -20,12 +20,9 @@
 .ui-dialog-mask {
     position: fixed;
     top: 0;
+    right: 0;
+    bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }
 

--- a/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
+++ b/src/main/resources/META-INF/resources/primefaces/lightbox/lightbox.js
@@ -401,14 +401,14 @@ PrimeFaces.widget.LightBox = PrimeFaces.widget.BaseWidget.extend({
      * Makes this  lightbox a modal dialog so that the user cannot interact with other content on the page.
      */
     enableModality: function() {
-        PrimeFaces.utils.addModal(this, this.panel.css('z-index') - 1);
+        PrimeFaces.utils.addModal(this, this.panel);
     },
 
     /**
      * Makes this  lightbox a non-modal dialog so that the user can interact with other content on the page.
      */
     disableModality: function() {
-        PrimeFaces.utils.removeModal(this);
+        PrimeFaces.utils.removeModal(this, this.panel);
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.css
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.css
@@ -20,12 +20,8 @@
 .ui-overlaypanel-mask {
     position: fixed;
     top: 0;
+    right: 0;
+    bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 }

--- a/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
+++ b/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
@@ -120,11 +120,6 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
         if(this.cfg.onShow) {
             this.cfg.onShow.call(this);
         }
-
-        this.jq.attr({
-            'aria-hidden': false
-            ,'aria-live': 'polite'
-        });
     },
 
     /**
@@ -155,11 +150,6 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
      * @param {unknown} ui Currently unused.
      */
     onHide: function(event, ui) {
-        this.jq.attr({
-            'aria-hidden': true
-            ,'aria-live': 'off'
-        });
-
         if(this.cfg.onHide) {
             this.cfg.onHide.call(this, event, ui);
         }
@@ -183,7 +173,7 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this._super();
 
         var $this = this;
-        this.modalOverlay.on('click', function() {
+        this.modalOverlay.one('click.sidebar', function() {
             $this.hide();
         });
     },
@@ -205,6 +195,7 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.jq.attr({
             'role': 'dialog'
             ,'aria-hidden': !this.cfg.visible
+            ,'aria-modal': this.cfg.visible
         });
 
         this.closeIcon.attr('role', 'button');

--- a/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
+++ b/src/main/resources/META-INF/resources/primefaces/spotlight/spotlight.js
@@ -50,6 +50,10 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
     show: function() {
         this.calculatePositions();
 
+        this.target.attr({
+            'role': 'dialog'
+            ,'aria-modal': true
+        });
         $(document.body).children('div.ui-spotlight').show();
 
         this.bindEvents();
@@ -70,8 +74,6 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
             'top': '0px',
             'width': documentBody.width() + 'px',
             'height': offset.top + 'px',
-            'pointer-events' : 'none',
-            'user-select': 'none',
             'z-index': zindex
         });
 
@@ -81,8 +83,6 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
             'top': bottomTop + 'px',
             'width': documentBody.width() + 'px',
             'height': (doc.height() - bottomTop) + 'px',
-            'pointer-events' : 'none',
-            'user-select': 'none',
             'z-index': zindex
         });
 
@@ -91,8 +91,6 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
             'top': offset.top + 'px',
             'width': offset.left + 'px',
             'height': this.target.outerHeight() + 'px',
-            'pointer-events' : 'none',
-            'user-select': 'none',
             'z-index': zindex
         });
 
@@ -102,8 +100,6 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
             'top': offset.top + 'px',
             'width': (documentBody.width() - rightLeft) + 'px',
             'height': this.target.outerHeight() + 'px',
-            'pointer-events' : 'none',
-            'user-select': 'none',
             'z-index': zindex
         });
     },
@@ -148,6 +144,10 @@ PrimeFaces.widget.Spotlight = PrimeFaces.widget.BaseWidget.extend({
         $(document.body).children('.ui-spotlight').hide();
         this.unbindEvents();
         this.target.css('z-index', String(this.target.zIndex()));
+        this.target.attr({
+            'role': ''
+            ,'aria-modal': false
+        });
     }
 
 });


### PR DESCRIPTION
OK so i found out a lot today and I tested this changes and they are working. But not perfect.

So based on ARIA specs modal's should get `aria-modal:true` and `role=dialog` that tells both the browser and screenreaders that this is the only thing that should have focus and be tabbable which is great.
https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html

So I have refactored our `addModal` and `removeModal` method to add these aria attributes and it works great.  HOWEVER there is a cavaeat. For the browser to truly do it right like the modal example above you need a Main area and the dialogs to live outside of it which we can't do..

```xml
<main aria-hidden="true"><!-- main content here--></main>
<dialog role="dialog" aria-modal="true">Your dialog here</dialog>
```

because our dialogs can be anywhere in the DOM is why this doesn't work all the way.