### PR TITLE
Fix #6250: HTML5 event doc updates and fixes

### DIFF
--- a/docs/9_0/components/autocomplete.md
+++ b/docs/9_0/components/autocomplete.md
@@ -241,8 +241,14 @@ _cacheTimeout_ option to configure how long it takes to clear a cache automatica
 ```
 
 ## Ajax Behavior Events
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, clear, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, itemSelect, itemUnselect, keydown, keypress, keyup, moreText, mousedown, mousemove, mouseout, mouseover, mouseup, paste, query, reset, scroll, search, select, valueChange, wheel`  
+
+
 Instead of waiting for user to submit the form manually to process the selected item, you can enable
-instant ajax selection by using the _itemSelect_ ajax behavior. Example below demonstrates how to
+instant AJAX selection by using the _itemSelect_ AJAX behavior. Example below demonstrates how to
 display a message about the selected item instantly.
 
 ```xhtml

--- a/docs/9_0/components/calendar.md
+++ b/docs/9_0/components/calendar.md
@@ -216,6 +216,11 @@ Various effects can be used when showing and hiding the popup calendar, options 
 slideDown, fadeIn, blind, bounce, clip, drop, fold and slide.
 
 ## Ajax Behavior Events
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, close, contextmenu, copy, cut, dateSelect, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, viewChange, wheel`  
+
 Calendar provides a _dateSelect_ ajax behavior event to execute an instant ajax selection whenever a
 date is selected. If you define a method as a listener, it will be invoked by passing an
 _org.primefaces.event.SelectEvent_ instance.

--- a/docs/9_0/components/chips.md
+++ b/docs/9_0/components/chips.md
@@ -87,6 +87,16 @@ public class ChipsView {
 <p:chips value="#{chipsView.cities}" />
 ```
 ## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, itemSelect, itemUnselect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+
+```xhtml
+<p:ajax event="itemSelect" listener="#{bean.handlevalueChange}" update="msgs" />
+```
+
 | Event | Listener Parameter | Fired |
 | --- | --- | --- |
 | itemSelect | org.primefaces.event.SelectEvent | When an item is added.

--- a/docs/9_0/components/datepicker.md
+++ b/docs/9_0/components/datepicker.md
@@ -207,6 +207,11 @@ Multiple dates or a range of dates can be selected by setting the _selectionMode
 ```
 
 ## Ajax Behavior Events
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, close, contextmenu, copy, cut, dateSelect, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, viewChange, wheel`  
+
 DatePicker provides a _dateSelect_ ajax behavior event to execute an instant ajax selection whenever a
 date is selected. If you define a method as a listener, it will be invoked by passing an
 _org.primefaces.event.SelectEvent_ instance.

--- a/docs/9_0/components/inputmask.md
+++ b/docs/9_0/components/inputmask.md
@@ -104,6 +104,17 @@ Here are more samples based on different masks;
 <p:inputMask value="#{bean.productKey}" mask="a*-999-a999"/>
 ```
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```
+
 ## Client Side API
 Widget: _PrimeFaces.widget.AccordionPanel_
 

--- a/docs/9_0/components/inputnumber.md
+++ b/docs/9_0/components/inputnumber.md
@@ -145,10 +145,10 @@ Here are some examples demonstrating various cases;
 
 ## Ajax Behavior Events
 
-The following AJAX behavior events are available for this component. If no event is specific the default event is called.  
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
   
-**Default Event:** valueChange  
-**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
 
 ```xhtml
 <p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />

--- a/docs/9_0/components/inputtext.md
+++ b/docs/9_0/components/inputtext.md
@@ -105,10 +105,10 @@ disable() | - | void | Disables the input field.
 
 ## Ajax Behavior Events
 
-The following AJAX behavior events are available for this component. If no event is specific the default event is called.
-
-**Default Event:** valueChange
-**Available Events:** blur, change, click, dblclick, focus, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
 
 ```xhtml
 <p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />

--- a/docs/9_0/components/inputtextarea.md
+++ b/docs/9_0/components/inputtextarea.md
@@ -155,10 +155,10 @@ As skinning style classes are global, see the main theming section for more info
 
 ## Ajax Behavior Events
 
-The following AJAX behavior events are available for this component. If no event is specific the default event is called.
-
-**Default Event:** valueChange
-**Available Events:** blur, change, click, dblclick, focus, itemSelect, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, select, valueChange, query
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
 
 ```xhtml
 <p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />

--- a/docs/9_0/components/keyboard.md
+++ b/docs/9_0/components/keyboard.md
@@ -151,3 +151,13 @@ clicked the keyboard is shown.
 ```
 Button can also be customized using the _buttonImage_ and _buttonImageOnly_ attributes.
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```

--- a/docs/9_0/components/password.md
+++ b/docs/9_0/components/password.md
@@ -133,6 +133,18 @@ other password component’s id should be used to define the _match_ option.
 <p:password id="pwd1" value="#{passwordBean.password6}" feedback="false" match="pwd2" label="Password 1" required="true"/>
 <p:password id="pwd2" value="#{passwordBean.password6}" feedback="false" label="Password 2" required="true"/>
 ```
+
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```
+
 ## Skinning
 Structural selectors for password are;
 

--- a/docs/9_0/components/spinner.md
+++ b/docs/9_0/components/spinner.md
@@ -143,6 +143,17 @@ request is done to update the outputtext with new value whenever a spinner butto
 <h:outputText id="display" value="#{spinnerBean.number}" />
 ```
 
+## Ajax Behavior Events
+
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
+  
+**Default Event:** `valueChange`  
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+
+```xhtml
+<p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
+```
+
 ## Skinning
 Spinner resides in a container element that using _style_ and _styleClass_ applies. Following is the list of
 structural style classes;

--- a/src/main/java/org/primefaces/component/api/AbstractPrimeHtmlInputText.java
+++ b/src/main/java/org/primefaces/component/api/AbstractPrimeHtmlInputText.java
@@ -23,11 +23,12 @@
  */
 package org.primefaces.component.api;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import javax.faces.component.html.HtmlInputText;
+
+import org.primefaces.util.LangUtils;
 
 /**
  * Extended {@link HtmlInputText} to allow for new events such as "input" and "paste".
@@ -56,8 +57,7 @@ public abstract class AbstractPrimeHtmlInputText extends HtmlInputText {
         onscroll
     }
 
-    private static final Collection<String> EVENT_NAMES = Collections.unmodifiableCollection(
-                Arrays.asList(
+    protected static final List<String> EVENT_NAMES = LangUtils.unmodifiableList(
                             "blur",
                             "change",
                             "valueChange",
@@ -89,7 +89,7 @@ public abstract class AbstractPrimeHtmlInputText extends HtmlInputText {
                             "dragover",
                             "dragstart",
                             "drop",
-                            "scroll"));
+                            "scroll");
 
     @Override
     public Collection<String> getEventNames() {

--- a/src/main/java/org/primefaces/component/api/AbstractPrimeHtmlInputTextArea.java
+++ b/src/main/java/org/primefaces/component/api/AbstractPrimeHtmlInputTextArea.java
@@ -23,11 +23,12 @@
  */
 package org.primefaces.component.api;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 
 import javax.faces.component.html.HtmlInputTextarea;
+
+import org.primefaces.util.LangUtils;
 
 /**
  * Extended {@link HtmlInputTextarea} to allow for new events such as "input" and "paste".
@@ -56,8 +57,7 @@ public abstract class AbstractPrimeHtmlInputTextArea extends HtmlInputTextarea {
         onscroll
     }
 
-    private static final Collection<String> EVENT_NAMES = Collections.unmodifiableCollection(
-                Arrays.asList(
+    protected static final List<String> EVENT_NAMES = LangUtils.unmodifiableList(
                             "blur",
                             "change",
                             "valueChange",
@@ -89,7 +89,7 @@ public abstract class AbstractPrimeHtmlInputTextArea extends HtmlInputTextarea {
                             "dragover",
                             "dragstart",
                             "drop",
-                            "scroll"));
+                            "scroll");
 
     @Override
     public Collection<String> getEventNames() {

--- a/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -27,6 +27,8 @@ import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.time.format.ResolverStyle;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 
 import javax.el.ValueExpression;
@@ -40,6 +42,9 @@ import org.primefaces.util.LocaleUtils;
 import org.primefaces.util.MessageFactory;
 
 public abstract class UICalendar extends AbstractPrimeHtmlInputText implements InputHolder, TouchAware {
+
+    public static final List<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("dateSelect", "viewChange", "close");
+    public static final Collection<String> CALENDAR_EVENT_NAMES =  LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES, UNOBSTRUSIVE_EVENT_NAMES);
 
     public static final String CONTAINER_CLASS = "ui-calendar";
     public static final String INPUT_STYLE_CLASS = "ui-inputfield ui-widget ui-state-default ui-corner-all";

--- a/src/main/java/org/primefaces/component/autocomplete/AutoComplete.java
+++ b/src/main/java/org/primefaces/component/autocomplete/AutoComplete.java
@@ -23,11 +23,7 @@
  */
 package org.primefaces.component.autocomplete;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.el.MethodExpression;
 import javax.faces.application.ResourceDependency;
@@ -36,6 +32,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.FacesEvent;
 
+import org.primefaces.component.api.AbstractPrimeHtmlInputText;
 import org.primefaces.component.column.Column;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
@@ -72,11 +69,10 @@ public class AutoComplete extends AutoCompleteBase {
     public static final String MORE_TEXT_LIST_CLASS = "ui-autocomplete-item ui-autocomplete-moretext ui-corner-all";
     public static final String MORE_TEXT_TABLE_CLASS = "ui-autocomplete-item ui-autocomplete-moretext ui-widget-content ui-corner-all";
 
-    private static final Collection<String> EVENT_NAMES = LangUtils.unmodifiableList("blur", "change", "valueChange", "click", "dblclick",
-            "focus", "keydown", "keypress", "keyup", "mousedown", "mousemove", "mouseout", "mouseover", "mouseup", "select", "itemSelect", "itemUnselect",
-            "query", "moreText", "clear");
-    private static final Collection<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("itemSelect", "itemUnselect", "query",
+
+    private static final List<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("itemSelect", "itemUnselect", "query",
             "moreText", "clear");
+    public static final Collection<String> EVENT_NAMES =  LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES, UNOBSTRUSIVE_EVENT_NAMES);
 
     private Object suggestions = null;
 

--- a/src/main/java/org/primefaces/component/calendar/Calendar.java
+++ b/src/main/java/org/primefaces/component/calendar/Calendar.java
@@ -42,7 +42,6 @@ import org.primefaces.event.SelectEvent;
 import org.primefaces.util.CalendarUtils;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
-import org.primefaces.util.LangUtils;
 
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
@@ -54,11 +53,6 @@ public class Calendar extends CalendarBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.component.Calendar";
 
-    private static final Collection<String> EVENT_NAMES = LangUtils.unmodifiableList("blur", "change", "valueChange", "click", "dblclick",
-            "focus", "keydown", "keypress", "keyup", "mousedown", "mousemove", "mouseout", "mouseover", "mouseup", "select", "dateSelect", "viewChange",
-            "close");
-    private static final Collection<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("dateSelect", "viewChange", "close");
-
     private Map<String, AjaxBehaviorEvent> customEvents = new HashMap<>(1);
 
     public boolean isPopup() {
@@ -67,7 +61,7 @@ public class Calendar extends CalendarBase {
 
     @Override
     public Collection<String> getEventNames() {
-        return EVENT_NAMES;
+        return CALENDAR_EVENT_NAMES;
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/chips/Chips.java
+++ b/src/main/java/org/primefaces/component/chips/Chips.java
@@ -24,6 +24,7 @@
 package org.primefaces.component.chips;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import javax.faces.application.ResourceDependency;
@@ -31,6 +32,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.FacesEvent;
 
+import org.primefaces.component.api.AbstractPrimeHtmlInputText;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
 import org.primefaces.util.ComponentUtils;
@@ -51,9 +53,9 @@ public class Chips extends ChipsBase {
     public static final String TOKEN_CLOSE_ICON_CLASS = "ui-chips-token-icon ui-icon ui-icon-close";
     public static final String TOKEN_INPUT_CLASS = "ui-chips-input-token";
 
-    private static final Collection<String> EVENT_NAMES = LangUtils.unmodifiableList("blur", "change", "valueChange", "click", "dblclick",
-            "focus", "keydown", "keypress", "keyup", "mousedown", "mousemove", "mouseout", "mouseover", "mouseup", "select", "itemSelect", "itemUnselect");
-    private static final Collection<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("itemSelect", "itemUnselect");
+    private static final List<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("itemSelect", "itemUnselect");
+    private static final Collection<String> EVENT_NAMES = LangUtils.concat(AbstractPrimeHtmlInputText.EVENT_NAMES, UNOBSTRUSIVE_EVENT_NAMES);
+
 
     @Override
     public String getInputClientId() {

--- a/src/main/java/org/primefaces/component/datepicker/DatePicker.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePicker.java
@@ -38,7 +38,6 @@ import org.primefaces.event.SelectEvent;
 import org.primefaces.util.CalendarUtils;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
-import org.primefaces.util.LangUtils;
 
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
@@ -52,16 +51,11 @@ public class DatePicker extends DatePickerBase {
     public static final String COMPONENT_TYPE = "org.primefaces.component.DatePicker";
     public static final String CONTAINER_EXTENSION_CLASS = "p-datepicker";
 
-    private static final Collection<String> EVENT_NAMES = LangUtils.unmodifiableList("blur", "change", "valueChange", "click", "dblclick",
-            "focus", "keydown", "keypress", "keyup", "mousedown", "mousemove", "mouseout", "mouseover", "mouseup", "select", "dateSelect", "viewChange",
-            "close");
-    private static final Collection<String> UNOBSTRUSIVE_EVENT_NAMES = LangUtils.unmodifiableList("dateSelect", "viewChange", "close");
-
     private Map<String, AjaxBehaviorEvent> customEvents = new HashMap<>(1);
 
     @Override
     public Collection<String> getEventNames() {
-        return EVENT_NAMES;
+        return CALENDAR_EVENT_NAMES;
     }
 
     @Override

--- a/src/test/java/org/primefaces/documentation/GenerateAjaxBehaviorDoc.java
+++ b/src/test/java/org/primefaces/documentation/GenerateAjaxBehaviorDoc.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License
  *
  * Copyright (c) 2009-2019 PrimeTek
@@ -30,7 +30,7 @@ import java.util.List;
 import javax.faces.component.UIComponentBase;
 
 /**
- * Utility class to scan a component and generated the Markdown information 
+ * Utility class to scan a component and generated the Markdown information
  * for the AJAX behavior events the component supports.
  * <p>
  * Execute by passing component class to the command line argument.
@@ -38,7 +38,7 @@ import javax.faces.component.UIComponentBase;
  */
 public class GenerateAjaxBehaviorDoc {
 
-    
+
     public static void main(String[] args) {
         try {
             for (String className : args) {
@@ -59,10 +59,10 @@ public class GenerateAjaxBehaviorDoc {
         eventString =  eventString.substring(eventString.indexOf("[")+1, eventString.indexOf("]"));
         System.out.println("## Ajax Behavior Events");
         System.out.println();
-        System.out.println("The following AJAX behavior events are available for this component. If no event is specific the default event is called.  ");
+        System.out.println("The following AJAX behavior events are available for this component. If no event is specified the default event is called.  ");
         System.out.println("  ");
-        System.out.println("**Default Event:** " + defaultEvent + "  ");
-        System.out.println("**Available Events:** " + eventString + "  ");
+        System.out.println("**Default Event:** `" + defaultEvent + "`  ");
+        System.out.println("**Available Events:** `" + eventString + "`  ");
         System.out.println();
         System.out.println("```xhtml");
         System.out.println(String.format("<p:ajax event=\"%s\" listener=\"#{bean.handle%s}\" update=\"msgs\" />", defaultEvent,defaultEvent));


### PR DESCRIPTION
- Updated `Ajax Behavior Events` on all MD docs
- Some components like AutoComplete, Calendar, DatePicker were hiding their new events