### PR TITLE
Fix #6291: FileDownload: classic (non-ajax) FileDownload failes due to class-not-found-exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1038,6 +1038,8 @@
                                 <include>org.apache.commons.io.FilenameUtils</include>
                                 <include>org.apache.commons.io.IOUtils</include>
                                 <include>org.apache.commons.io.input.BoundedInputStream</include>
+                                <include>org.apache.commons.io.output.StringBuilderWriter</include>
+                                <include>org.apache.commons.io.output.ByteArrayOutputStream</include>
                             </includes>
                         </relocation>
                     </relocations>
@@ -1048,6 +1050,8 @@
                                 <include>org/apache/commons/io/FilenameUtils.class</include>
                                 <include>org/apache/commons/io/IOUtils.class</include>
                                 <include>org/apache/commons/io/input/BoundedInputStream.class</include>
+                                <include>org/apache/commons/io/output/StringBuilderWriter.class</include>
+                                <include>org/apache/commons/io/output/ByteArrayOutputStream.class</include>
                             </includes>
                         </filter>
                         <filter>


### PR DESCRIPTION
Issue exists at least with Tomcat 9.0 which does not provide commons-io OOTB.