### PR TITLE
Fix #5481: DataTable: removal of processEvent method

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1374,11 +1374,6 @@ public class DataTable extends DataTableBase {
         return iterableChildren;
     }
 
-    @Override
-    public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
-        super.processEvent(event);
-    }
-
     public void updateFilteredValue(FacesContext context, List<?> value) {
         ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.toString());
 

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1377,12 +1377,6 @@ public class DataTable extends DataTableBase {
     @Override
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         super.processEvent(event);
-        if (!isLazy() && event instanceof PostRestoreStateEvent && (this == event.getComponent())) {
-            Object filteredValue = getFilteredValue();
-            if (filteredValue != null) {
-                updateValue(filteredValue);
-            }
-        }
     }
 
     public void updateFilteredValue(FacesContext context, List<?> value) {


### PR DESCRIPTION
Removes code that was introduced with https://github.com/primefaces/primefaces/commit/20baf62631dd3662c978abb6cb57669940ca967d#diff-ae92f04fa2a452febc87c6833e245f56.

Currently can´t find a regression due to removing this code.