### PR TITLE
Fix #5811: Diagram fix connection count

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/diagram/diagram.js
+++ b/src/main/resources/META-INF/resources/primefaces/diagram/diagram.js
@@ -175,9 +175,8 @@ PrimeFaces.widget.Diagram = PrimeFaces.widget.DeferredWidget.extend({
 
         if(this.connectionChanged) {
             options.params.push({name: this.id + '_connectionChanged', value: true});
-        } else {
-            this.connectionChanged = false;
         }
+        this.connectionChanged = false;
 
         if(this.hasBehavior('connect')) {
             this.callBehavior('connect', options);


### PR DESCRIPTION
issue was once you moved an element the flag `this.connectionChanged = false;` was not ever being set back to FALSE so every new connection after that it thought it was a Connection Change instead of a move.