### PR TITLE
Fix #6271: Hazelcast 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>4.0.2</version>
+            <version>4.1-BETA-1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This fixes two CVE's in HazelCast CVE-2020-24616 and CVE-2017-18640

hazelcast-4.0.2.jar/META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.xml (pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.7, cpe:2.3:a:fasterxml:jackson:2.9.7:*:*:*:*:*:*:*) : CVE-2020-24616

hazelcast-4.0.2.jar/META-INF/maven/org.snakeyaml/snakeyaml-engine/pom.xml (pkg:maven/org.snakeyaml/snakeyaml-engine@1.0, cpe:2.3:a:snakeyaml_project:snakeyaml:1.0:*:*:*:*:*:*:*) : CVE-2017-18640