### PR TITLE
Fix #6325: HeaderRow add expanded attribute

### DIFF
--- a/docs/9_0/components/headerrow.md
+++ b/docs/9_0/components/headerrow.md
@@ -19,7 +19,8 @@ HeaderRow is a helper component of datatable used for dynamic grouping.
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
-binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
+binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean.
+expanded | true | Boolean | Boolean value to specify whether the row group will be rendered expanded or closed.
 
 ## Getting started with HeaderRow
 See DataTable section for more information.

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -124,7 +124,8 @@ public class DataTable extends DataTableBase {
     public static final String SUMMARY_ROW_CLASS = "ui-datatable-summaryrow ui-widget-header";
     public static final String HEADER_ROW_CLASS = "ui-rowgroup-header ui-datatable-headerrow ui-widget-header";
     public static final String ROW_GROUP_TOGGLER_CLASS = "ui-rowgroup-toggler";
-    public static final String ROW_GROUP_TOGGLER_ICON_CLASS = "ui-rowgroup-toggler-icon ui-icon ui-icon-circle-triangle-s";
+    public static final String ROW_GROUP_TOGGLER_OPEN_ICON_CLASS = "ui-rowgroup-toggler-icon ui-icon ui-icon-circle-triangle-s";
+    public static final String ROW_GROUP_TOGGLER_CLOSED_ICON_CLASS = "ui-rowgroup-toggler-icon ui-icon ui-icon-circle-triangle-e";
     public static final String EDITING_ROW_CLASS = "ui-row-editing";
     public static final String STICKY_HEADER_CLASS = "ui-datatable-sticky";
     public static final String ARIA_FILTER_BY = "primefaces.datatable.aria.FILTER_BY";

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1336,6 +1336,7 @@ public class DataTableRenderer extends DataRenderer {
         boolean selectionEnabled = table.isSelectionEnabled();
         Object rowKey = null;
         List<UIColumn> columns = table.getColumns();
+        HeaderRow headerRow = table.getHeaderRow();
 
         if (selectionEnabled) {
             //try rowKey attribute
@@ -1381,6 +1382,9 @@ public class DataTableRenderer extends DataRenderer {
         writer.writeAttribute("role", "row", null);
         if (selectionEnabled) {
             writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(selected), null);
+        }
+        if (headerRow != null && !headerRow.isExpanded()) {
+            writer.writeAttribute("style", "display: none;", null);
         }
 
         for (int i = columnStart; i < columnEnd; i++) {

--- a/src/main/java/org/primefaces/component/headerrow/HeaderRowBase.java
+++ b/src/main/java/org/primefaces/component/headerrow/HeaderRowBase.java
@@ -33,6 +33,7 @@ public abstract class HeaderRowBase extends UIComponentBase {
     public static final String DEFAULT_RENDERER = "org.primefaces.component.HeaderRowRenderer";
 
     public enum PropertyKeys {
+        expanded
     }
 
     public HeaderRowBase() {
@@ -42,6 +43,14 @@ public abstract class HeaderRowBase extends UIComponentBase {
     @Override
     public String getFamily() {
         return COMPONENT_FAMILY;
+    }
+
+    public boolean isExpanded() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.expanded, true);
+    }
+
+    public void setExpanded(boolean expanded) {
+        getStateHelper().put(PropertyKeys.expanded, expanded);
     }
 
 }

--- a/src/main/java/org/primefaces/component/headerrow/HeaderRowRenderer.java
+++ b/src/main/java/org/primefaces/component/headerrow/HeaderRowRenderer.java
@@ -43,6 +43,7 @@ public class HeaderRowRenderer extends CoreRenderer {
         DataTable table = (DataTable) row.getParent();
         ResponseWriter writer = context.getResponseWriter();
         boolean isExpandableRowGroups = table.isExpandableRowGroups();
+        boolean isExpanded = row.isExpanded();
 
         writer.startElement("tr", null);
         writer.writeAttribute("class", DataTable.HEADER_ROW_CLASS, null);
@@ -74,11 +75,11 @@ public class HeaderRowRenderer extends CoreRenderer {
 
                     writer.startElement("a", null);
                     writer.writeAttribute("class", DataTable.ROW_GROUP_TOGGLER_CLASS, null);
-                    writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(true), null);
+                    writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(isExpanded), null);
                     writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
                     writer.writeAttribute("href", "#", null);
                     writer.startElement("span", null);
-                    writer.writeAttribute("class", DataTable.ROW_GROUP_TOGGLER_ICON_CLASS, null);
+                    writer.writeAttribute("class", isExpanded ? DataTable.ROW_GROUP_TOGGLER_OPEN_ICON_CLASS : DataTable.ROW_GROUP_TOGGLER_CLOSED_ICON_CLASS, null);
                     writer.endElement("span");
                     writer.endElement("a");
 

--- a/src/main/java/org/primefaces/component/summaryrow/SummaryRowRenderer.java
+++ b/src/main/java/org/primefaces/component/summaryrow/SummaryRowRenderer.java
@@ -31,6 +31,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.component.column.Column;
 import org.primefaces.component.datatable.DataTable;
+import org.primefaces.component.headerrow.HeaderRow;
 import org.primefaces.renderkit.CoreRenderer;
 
 public class SummaryRowRenderer extends CoreRenderer {
@@ -38,10 +39,16 @@ public class SummaryRowRenderer extends CoreRenderer {
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
         SummaryRow row = (SummaryRow) component;
+        DataTable table = (DataTable) row.getParent();
         ResponseWriter writer = context.getResponseWriter();
+        HeaderRow headerRow = table.getHeaderRow();
 
         writer.startElement("tr", null);
         writer.writeAttribute("class", DataTable.SUMMARY_ROW_CLASS, null);
+
+        if (headerRow != null && !headerRow.isExpanded()) {
+            writer.writeAttribute("style", "display: none;", null);
+        }
 
         for (UIComponent kid : row.getChildren()) {
             if (kid.isRendered() && kid instanceof Column) {

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -11010,6 +11010,14 @@
             <required>false</required>
             <type>javax.faces.component.UIComponent</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Boolean value to specify whether the row group will be rendered expanded or closed. Default true.]]>
+            </description>
+            <name>expanded</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>


### PR DESCRIPTION
Also updating Showcase with PR.

For example:
```xml        
<p:headerRow expanded="#{car.brand != 'BMW'}">
    <p:column colspan="3">
        <h:outputText value="#{car.brand}" />
    </p:column>
</p:headerRow>
```

Now renders the starting screen like this:
![image](https://user-images.githubusercontent.com/4399574/93595002-e74ffe00-f984-11ea-9980-a66037c9a5a7.png)
