### PR TITLE
Fix #6271: HazelCast 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>4.1-BETA-1</version>
+            <version>4.0.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
They finally fixed SnakeYaml and Jackson CVE dependencies.  This will fix out build