### PR TITLE
Fix #6187: Cell editor prevent multiple focus calls

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3225,7 +3225,9 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             cell.addClass('ui-state-highlight ui-cell-editing');
             displayContainer.hide();
             inputContainer.show();
-            inputs.eq(0).trigger('focus').trigger('select');
+            var input = inputs.eq(0);
+            input.triggerHandler('focus');
+            input.triggerHandler('select');
 
             //metadata
             if(multi) {


### PR DESCRIPTION
Was previously fixed for row editing but cell editing has same issue.