### PR TITLE
Fix #6359: Dynamic downloads should not be cached

### DIFF
--- a/src/main/java/org/primefaces/application/resource/BaseDynamicContentHandler.java
+++ b/src/main/java/org/primefaces/application/resource/BaseDynamicContentHandler.java
@@ -28,7 +28,10 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
+
 import javax.faces.context.ExternalContext;
+
+import org.primefaces.util.ResourceUtils;
 
 public abstract class BaseDynamicContentHandler implements DynamicContentHandler {
 
@@ -42,9 +45,7 @@ public abstract class BaseDynamicContentHandler implements DynamicContentHandler
             externalContext.setResponseHeader("Expires", httpDateFormat.format(calendar.getTime()));
         }
         else {
-            externalContext.setResponseHeader("Cache-Control", "no-cache, no-store, must-revalidate");
-            externalContext.setResponseHeader("Pragma", "no-cache");
-            externalContext.setResponseHeader("Expires", "Mon, 8 Aug 1980 10:00:00 GMT");
+            ResourceUtils.addNoCacheControl(externalContext);
         }
     }
 }

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -384,9 +384,7 @@ public abstract class DataTableExporter implements Exporter<DataTable> {
     }
 
     protected void setResponseHeader(ExternalContext externalContext , String contentDisposition) {
-        externalContext.setResponseHeader("Expires", "0");
-        externalContext.setResponseHeader("Cache-Control", "must-revalidate, post-check=0, pre-check=0");
-        externalContext.setResponseHeader("Pragma", "public");
+        ResourceUtils.addNoCacheControl(externalContext);
         externalContext.setResponseHeader("Content-disposition", contentDisposition);
     }
 

--- a/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
@@ -36,16 +37,12 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.ActionListener;
+
 import org.apache.commons.io.IOUtils;
 import org.primefaces.PrimeFaces;
 import org.primefaces.application.resource.DynamicContentType;
-import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.model.StreamedContent;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
-import org.primefaces.util.DynamicContentSrcBuilder;
-import org.primefaces.util.LangUtils;
-import org.primefaces.util.ResourceUtils;
+import org.primefaces.util.*;
 
 public class FileDownloadActionListener implements ActionListener, StateHolder {
 
@@ -104,14 +101,10 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
                 ? "/"
                 : externalContext.getRequestContextPath()); // Always add cookies to context root; see #3108
         ResourceUtils.addResponseCookie(context, monitorKeyCookieName, "true", cookieOptions);
+        ResourceUtils.addNoCacheControl(externalContext);
 
         if (content.getContentLength() != null) {
             externalContext.setResponseContentLength(content.getContentLength());
-        }
-
-        if (PrimeRequestContext.getCurrentInstance(context).isSecure()) {
-            externalContext.setResponseHeader("Cache-Control", "public");
-            externalContext.setResponseHeader("Pragma", "public");
         }
 
         try (InputStream is = content.getStream()) {

--- a/src/main/java/org/primefaces/util/ResourceUtils.java
+++ b/src/main/java/org/primefaces/util/ResourceUtils.java
@@ -32,6 +32,7 @@ import javax.faces.application.Resource;
 import javax.faces.application.ResourceHandler;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIOutput;
+import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 
 import org.primefaces.context.PrimeRequestContext;
@@ -56,6 +57,19 @@ public class ResourceUtils {
 
             return context.getExternalContext().encodeResourceURL(url);
         }
+    }
+
+    /**
+     * Adds no cache pragma to the response to ensure it is not cached.  Dynamic downloads should always add this
+     * to prevent caching and for GDPR.
+     *
+     * @param context the ExternalContext we add the pragma to
+     * @see https://github.com/primefaces/primefaces/issues/6359
+     */
+    public static void addNoCacheControl(ExternalContext externalContext) {
+        externalContext.setResponseHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        externalContext.setResponseHeader("Pragma", "no-cache");
+        externalContext.setResponseHeader("Expires", "0");
     }
 
     /**


### PR DESCRIPTION
Consolidated cache control into ResourceUtils.

3 spots are caching and were all doing it slightly differently.