### PR TITLE
Fix #1039: DefaultMenuModel allow manually set Ids

### DIFF
--- a/src/main/java/org/primefaces/model/menu/BaseMenuModel.java
+++ b/src/main/java/org/primefaces/model/menu/BaseMenuModel.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.primefaces.util.LangUtils;
+
 /**
  * Base implementation for model of a programmatic menu
  */
@@ -60,8 +62,12 @@ public class BaseMenuModel implements MenuModel, Serializable {
         int counter = 0;
 
         for (MenuElement element : elements) {
-            String id = (seed == null) ? String.valueOf(counter++) : seed + ID_SEPARATOR + counter++;
-            element.setId(id);
+            // #1039 check if ID was already manually set
+            String id = element.getId();
+            if (LangUtils.isValueBlank(id)) {
+                id = (seed == null) ? String.valueOf(counter++) : seed + ID_SEPARATOR + counter++;
+                element.setId(id);
+            }
 
             if (element instanceof MenuGroup) {
                 generateUniqueIds(((MenuGroup) element).getElements(), id);


### PR DESCRIPTION
I think its this simple just use the ID if it was already set else generate a custom one.