### PR TITLE
Fix #3812,#929: Datatable selection fix

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -757,10 +757,6 @@ public class DataTable extends DataTableBase {
         return null;
     }
 
-    public Object getLocalSelection() {
-        return getStateHelper().get(PropertyKeys.selection);
-    }
-
     @Override
     public Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping() {
         return BEHAVIOR_EVENT_MAPPING;

--- a/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -23,14 +23,15 @@
  */
 package org.primefaces.component.datatable;
 
-import org.primefaces.component.api.*;
-import org.primefaces.model.FilterMeta;
-import org.primefaces.model.SortMeta;
+import java.util.Collections;
+import java.util.Map;
 
 import javax.el.MethodExpression;
 import javax.faces.component.behavior.ClientBehaviorHolder;
-import java.util.Collections;
-import java.util.Map;
+
+import org.primefaces.component.api.*;
+import org.primefaces.model.FilterMeta;
+import org.primefaces.model.SortMeta;
 
 public abstract class DataTableBase extends UIData
         implements Widget, RTLAware, ClientBehaviorHolder, PrimeClientBehaviorHolder, Pageable, MultiViewStateAware<DataTableState> {
@@ -167,11 +168,21 @@ public abstract class DataTableBase extends UIData
     }
 
     public Object getSelection() {
-        return getStateHelper().eval(PropertyKeys.selection, null);
+        Object o = getLocalSelection();
+        if (o == null) {
+            return getStateHelper().eval(PropertyKeys.selection, null);
+        }
+        else {
+            return o;
+        }
     }
 
     public void setSelection(Object selection) {
-        getStateHelper().put(PropertyKeys.selection, selection);
+        getStateHelper().put(PropertyKeys.selection + getClientId(), selection);
+    }
+
+    public Object getLocalSelection() {
+        return getStateHelper().get(PropertyKeys.selection + getClientId());
     }
 
     public String getEmptyMessage() {


### PR DESCRIPTION
I have confirmed it is fixed using this test case and also regression tested all the Selection examples in the Showcase and everything is working.

Also of note this doesn't just fix tables in a `p:repeat` it also fixes them for AccordionPanel/TabView etc when using a dynamic `model`.  The Datatable has the same issue.