### PR TITLE
Fix #6382: Schedule cancel default URL click

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -193,6 +193,7 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
                     targetWindow.opener = null;    
                 }
                 targetWindow.location = eventClickInfo.event.url;
+                eventClickInfo.jsEvent.preventDefault(); // don't let the browser navigate
                 return false;
             }
 


### PR DESCRIPTION
From the FullCalendar Docs for "Cancelling Default Behavior":
https://fullcalendar.io/docs/eventClick

We were not killing the original URL click only generating a new one