### PR TITLE
Fix #6397: InputNumber+Slider combination syncing

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -160,6 +160,7 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
      */
     setValueToHiddenInput: function(value) {
         this.hiddenInput.val(value);
+        this.hiddenInput.trigger('change');
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/slider/slider.js
+++ b/src/main/resources/META-INF/resources/primefaces/slider/slider.js
@@ -92,7 +92,7 @@ PrimeFaces.widget.Slider = PrimeFaces.widget.BaseWidget.extend({
         });
 
         if (this.input.parent().hasClass('ui-inputnumber')) {
-            this.input.parent().find('input:hidden').on('change', function () {
+            this.input.parent().find('input:hidden').off('change.slider').on('change.slider', function () {
                 $this.setValue($(this).val());
             });
         }


### PR DESCRIPTION
The real issue is the Slider was subscribed to a `change` event on the Hidden Input that was never being fired.

You can see its broken on the Showcase currently: https://www.primefaces.org/showcase/ui/input/slider.xhtml in the "InputNumber Slider" example type 50 into the box the slider doesn't move.