### PR TITLE
Add note on scope for deeper graph navigation

### DIFF
--- a/docs/9_0/components/mindmap.md
+++ b/docs/9_0/components/mindmap.md
@@ -94,5 +94,5 @@ parent | null | MindmapNode | Parent node instance.
 **Tips**
 
 - IE 7 and IE 8 are not supported due to technical limitations, IE 9 is supported.
-- The `ManagedBean` backing this component must be `@SessionScoped` to support navigating to nodes deeper than level 1 below the root
+- The `ManagedBean` backing this component must be at least `@SessionScoped` to support navigating to nodes deeper than level 1 below the root. Using a `@RequestScoped` bean is not supported.
 

--- a/docs/9_0/components/mindmap.md
+++ b/docs/9_0/components/mindmap.md
@@ -94,4 +94,5 @@ parent | null | MindmapNode | Parent node instance.
 **Tips**
 
 - IE 7 and IE 8 are not supported due to technical limitations, IE 9 is supported.
+- The `ManagedBean` must be `@SessionScoped` to support navigating to nodes deeper than level 1 below the root
 

--- a/docs/9_0/components/mindmap.md
+++ b/docs/9_0/components/mindmap.md
@@ -94,5 +94,5 @@ parent | null | MindmapNode | Parent node instance.
 **Tips**
 
 - IE 7 and IE 8 are not supported due to technical limitations, IE 9 is supported.
-- The `ManagedBean` must be `@SessionScoped` to support navigating to nodes deeper than level 1 below the root
+- The `ManagedBean` backing this component must be `@SessionScoped` to support navigating to nodes deeper than level 1 below the root
 

--- a/docs/9_0/components/mindmap.md
+++ b/docs/9_0/components/mindmap.md
@@ -94,5 +94,5 @@ parent | null | MindmapNode | Parent node instance.
 **Tips**
 
 - IE 7 and IE 8 are not supported due to technical limitations, IE 9 is supported.
-- The `ManagedBean` backing this component must be at least `@SessionScoped` to support navigating to nodes deeper than level 1 below the root. Using a `@RequestScoped` bean is not supported.
+- The `ManagedBean` backing this component must be at least `@ViewScoped` or `@SessionScoped` to support navigating to nodes deeper than level 1 below the root. Using a `@RequestScoped` bean is not supported.
 


### PR DESCRIPTION
To navigate beyond depth 1 in the graph, the ManagedBean needs to be SessionScoped.

See https://stackoverflow.com/a/18880589