### PR TITLE
Fix #6442: InputNumber 'inputMode' attribute for touch devices

### DIFF
--- a/docs/9_0/components/inputnumber.md
+++ b/docs/9_0/components/inputnumber.md
@@ -85,6 +85,7 @@ decimalSeparator | *1 | String | Decimal separator char.
 decimalSeparatorAlternative | null | String | Allow to declare an alternative decimal separator which is automatically replaced by `decimalCharacter` when typed.
 emptyValue | focus | String | Defines what to display when the input value is empty (possible options are null, focus, press, always, min, max, zero, number, or a string representing a number)
 leadingZero | allow | Sting | Controls leading zero behavior. Valid values are "allow"(default), "deny" and "keep".
+inputMode | null | String | HTML5 inputmode attribute for hinting at the type of data this control has for touch devices. Default is 'numeric' if decimalPlaces==0, 'decimal' if decimalPlaces>0.
 inputStyle | null | String | Inline style of the input element.
 inputStyleClass | null | String | Style class of the input element.
 maxValue | 10000000000000 | String | Maximum values allowed.

--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
@@ -54,7 +54,8 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
         padControl,
         leadingZero,
         decimalSeparatorAlternative,
-        modifyValueOnWheel
+        modifyValueOnWheel,
+        inputMode
     }
 
     public InputNumberBase() {
@@ -210,5 +211,13 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
 
     public void setModifyValueOnWheel(boolean modifyValueOnWheel) {
         getStateHelper().put(PropertyKeys.modifyValueOnWheel, modifyValueOnWheel);
+    }
+
+    public String getInputMode() {
+        return (String) getStateHelper().eval(PropertyKeys.inputMode, null);
+    }
+
+    public void setInputMode(String inputMode) {
+        getStateHelper().put(PropertyKeys.inputMode, inputMode);
     }
 }

--- a/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -138,6 +138,15 @@ public class InputNumberRenderer extends InputRenderer {
             writer.writeAttribute("style", inputNumber.getStyle(), "style");
         }
 
+        String defaultDecimalPlaces = "2";
+        if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof BigInteger) {
+            defaultDecimalPlaces = "0";
+        }
+        String decimalPlaces = isValueBlank(inputNumber.getDecimalPlaces())
+                ? defaultDecimalPlaces
+                : inputNumber.getDecimalPlaces();
+        inputNumber.setDecimalPlaces(decimalPlaces);
+
         encodeInput(context, inputNumber, clientId, valueToRender);
         encodeHiddenInput(context, inputNumber, clientId, valueToRender);
 
@@ -182,12 +191,17 @@ public class InputNumberRenderer extends InputRenderer {
         String inputStyle = inputNumber.getInputStyle();
         String style = inputStyle;
         String styleClass = createStyleClass(inputNumber, InputNumber.PropertyKeys.inputStyleClass.name(), InputText.STYLE_CLASS) ;
+        String inputMode = inputNumber.getInputMode();
+        if (inputMode == null) {
+            inputMode = "0".equals(inputNumber.getDecimalPlaces()) ? "numeric" : "decimal";
+        }
 
         writer.startElement("input", null);
         writer.writeAttribute("id", inputId, null);
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", inputNumber.getType(), null);
         writer.writeAttribute("value", valueToRender, null);
+        writer.writeAttribute("inputmode", inputMode, null);
 
         if (!isValueBlank(style)) {
             writer.writeAttribute("style", style, null);
@@ -212,14 +226,6 @@ public class InputNumberRenderer extends InputRenderer {
                 ? Constants.EMPTY_STRING
                 : inputNumber.getThousandSeparator();
 
-        String defaultDecimalPlaces = "2";
-        if (value instanceof Long || value instanceof Integer || value instanceof Short || value instanceof BigInteger) {
-            defaultDecimalPlaces = "0";
-        }
-        String decimalPlaces = isValueBlank(inputNumber.getDecimalPlaces())
-                ? defaultDecimalPlaces
-                : inputNumber.getDecimalPlaces();
-
         String decimalSeparator = isValueBlank(inputNumber.getDecimalSeparator())
                     ? "."
                     : inputNumber.getDecimalSeparator();
@@ -235,7 +241,7 @@ public class InputNumberRenderer extends InputRenderer {
             .attr("currencySymbolPlacement", inputNumber.getSymbolPosition(), "p")
             .attr("minimumValue", formatForPlugin(inputNumber.getMinValue()))
             .attr("maximumValue", formatForPlugin(inputNumber.getMaxValue()))
-            .attr("decimalPlaces", decimalPlaces)
+            .attr("decimalPlaces", inputNumber.getDecimalPlaces())
             .attr("emptyInputBehavior", emptyValue, "focus")
             .attr("leadingZero", inputNumber.getLeadingZero(), "deny")
             .attr("allowDecimalPadding", inputNumber.isPadControl(), true)

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -13002,6 +13002,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[HTML5 inputmode attribute for hinting at the type of data this control has for touch devices. Default is 'numeric' if decimalPlaces==0, 'decimal' if decimalPlaces>0.]]>
+            </description>
+            <name>inputMode</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Inline style of the input element.]]>
             </description>
             <name>inputStyle</name>


### PR DESCRIPTION
InputMode is supported by most major browses now: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode

This sets inputMode to 'numeric' if DecimalPlaces==0 and 'decimal' if DecimalPlaces>0 or allows the user to override to 'none' if no behavior is desired.