### PR TITLE
Fix #6458: DatePicker defaults before super.encodeEnd

### DIFF
--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -54,12 +54,38 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
-        DatePicker datePicker = (DatePicker) component;
+        DatePicker datepicker = (DatePicker) component;
 
-        if (datePicker.getModel() instanceof LazyDateMetadataModel && ComponentUtils.isRequestSource(datePicker, context, "viewChange")) {
-            encodeDateMetadata(context, datePicker);
+        if (datepicker.getModel() instanceof LazyDateMetadataModel && ComponentUtils.isRequestSource(datepicker, context, "viewChange")) {
+            encodeDateMetadata(context, datepicker);
             return;
         }
+
+        String pattern = datepicker.getPattern() == null ? datepicker.calculatePattern() : datepicker.getPattern();
+
+        if (datepicker.isShowTimeWithoutDefault() == null) {
+            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
+
+            if (type != null) {
+                datepicker.setShowTime(LocalDateTime.class.isAssignableFrom(type));
+            }
+            else {
+                datepicker.setShowTime(CalendarUtils.hasTime(pattern));
+            }
+        }
+
+        if (datepicker.isTimeOnlyWithoutDefault() == null) {
+            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
+
+            if (type != null) {
+                datepicker.setTimeOnly(LocalTime.class.isAssignableFrom(type));
+            }
+        }
+
+        if (datepicker.isShowSecondsWithoutDefault() == null) {
+            datepicker.setShowSeconds(pattern.contains("s"));
+        }
+
         super.encodeEnd(context, component);
     }
 
@@ -99,31 +125,6 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
     @Override
     protected void encodeMarkup(FacesContext context, UICalendar uicalendar, String value) throws IOException {
         DatePicker datepicker = (DatePicker) uicalendar;
-        String pattern = datepicker.getPattern() == null ? datepicker.calculatePattern() : datepicker.getPattern();
-
-        if (datepicker.isShowTimeWithoutDefault() == null) {
-            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
-
-            if (type != null) {
-                datepicker.setShowTime(LocalDateTime.class.isAssignableFrom(type));
-            }
-            else {
-                datepicker.setShowTime(CalendarUtils.hasTime(pattern));
-            }
-        }
-
-        if (datepicker.isTimeOnlyWithoutDefault() == null) {
-            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
-
-            if (type != null) {
-                datepicker.setTimeOnly(LocalTime.class.isAssignableFrom(type));
-            }
-        }
-
-        if (datepicker.isShowSecondsWithoutDefault() == null) {
-            datepicker.setShowSeconds(pattern.contains("s"));
-        }
-
         ResponseWriter writer = context.getResponseWriter();
         String clientId = datepicker.getClientId(context);
         String styleClass = datepicker.getStyleClass();

--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -54,36 +54,36 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
-        DatePicker datepicker = (DatePicker) component;
+        DatePicker datePicker = (DatePicker) component;
 
-        if (datepicker.getModel() instanceof LazyDateMetadataModel && ComponentUtils.isRequestSource(datepicker, context, "viewChange")) {
-            encodeDateMetadata(context, datepicker);
+        if (datePicker.getModel() instanceof LazyDateMetadataModel && ComponentUtils.isRequestSource(datePicker, context, "viewChange")) {
+            encodeDateMetadata(context, datePicker);
             return;
         }
 
-        String pattern = datepicker.getPattern() == null ? datepicker.calculatePattern() : datepicker.getPattern();
+        String pattern = datePicker.getPattern() == null ? datePicker.calculatePattern() : datePicker.getPattern();
 
-        if (datepicker.isShowTimeWithoutDefault() == null) {
-            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
+        if (datePicker.isShowTimeWithoutDefault() == null) {
+            Class<?> type = datePicker.getTypeFromValueByValueExpression(context);
 
             if (type != null) {
-                datepicker.setShowTime(LocalDateTime.class.isAssignableFrom(type));
+                datePicker.setShowTime(LocalDateTime.class.isAssignableFrom(type));
             }
             else {
-                datepicker.setShowTime(CalendarUtils.hasTime(pattern));
+                datePicker.setShowTime(CalendarUtils.hasTime(pattern));
             }
         }
 
-        if (datepicker.isTimeOnlyWithoutDefault() == null) {
-            Class<?> type = datepicker.getTypeFromValueByValueExpression(context);
+        if (datePicker.isTimeOnlyWithoutDefault() == null) {
+            Class<?> type = datePicker.getTypeFromValueByValueExpression(context);
 
             if (type != null) {
-                datepicker.setTimeOnly(LocalTime.class.isAssignableFrom(type));
+                datePicker.setTimeOnly(LocalTime.class.isAssignableFrom(type));
             }
         }
 
-        if (datepicker.isShowSecondsWithoutDefault() == null) {
-            datepicker.setShowSeconds(pattern.contains("s"));
+        if (datePicker.isShowSecondsWithoutDefault() == null) {
+            datePicker.setShowSeconds(pattern.contains("s"));
         }
 
         super.encodeEnd(context, component);
@@ -124,25 +124,25 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
     @Override
     protected void encodeMarkup(FacesContext context, UICalendar uicalendar, String value) throws IOException {
-        DatePicker datepicker = (DatePicker) uicalendar;
+        DatePicker datePicker = (DatePicker) uicalendar;
         ResponseWriter writer = context.getResponseWriter();
-        String clientId = datepicker.getClientId(context);
-        String styleClass = datepicker.getStyleClass();
+        String clientId = datePicker.getClientId(context);
+        String styleClass = datePicker.getStyleClass();
         styleClass = (styleClass == null) ? UICalendar.CONTAINER_CLASS : UICalendar.CONTAINER_CLASS + " " + styleClass;
         styleClass = DatePicker.CONTAINER_EXTENSION_CLASS + " " + styleClass;
         String inputId = clientId + "_input";
-        boolean inline = datepicker.isInline();
+        boolean inline = datePicker.isInline();
 
-        writer.startElement("span", datepicker);
+        writer.startElement("span", datePicker);
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("class", styleClass, null);
 
-        if (datepicker.getStyle() != null) {
-            writer.writeAttribute("style", datepicker.getStyle(), null);
+        if (datePicker.getStyle() != null) {
+            writer.writeAttribute("style", datePicker.getStyle(), null);
         }
 
         //input
-        encodeInput(context, datepicker, inputId, value, !inline);
+        encodeInput(context, datePicker, inputId, value, !inline);
 
         writer.endElement("span");
 
@@ -150,132 +150,132 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
     @Override
     protected void encodeScript(FacesContext context, UICalendar uicalendar, String value) throws IOException {
-        DatePicker datepicker = (DatePicker) uicalendar;
-        String clientId = datepicker.getClientId(context);
-        Locale locale = datepicker.calculateLocale(context);
-        String pattern = datepicker.calculateWidgetPattern();
+        DatePicker datePicker = (DatePicker) uicalendar;
+        String clientId = datePicker.getClientId(context);
+        Locale locale = datePicker.calculateLocale(context);
+        String pattern = datePicker.calculateWidgetPattern();
         WidgetBuilder wb = getWidgetBuilder(context);
-        wb.init("DatePicker", datepicker.resolveWidgetVar(context), clientId);
+        wb.init("DatePicker", datePicker.resolveWidgetVar(context), clientId);
 
         String defaultDate = null;
 
-        if (datepicker.isConversionFailed()) {
-            Class<?> dateType = resolveDateType(context, datepicker);
-            defaultDate = CalendarUtils.getValueAsString(context, datepicker, CalendarUtils.now(uicalendar, dateType));
+        if (datePicker.isConversionFailed()) {
+            Class<?> dateType = resolveDateType(context, datePicker);
+            defaultDate = CalendarUtils.getValueAsString(context, datePicker, CalendarUtils.now(uicalendar, dateType));
         }
         else if (!isValueBlank(value)) {
             defaultDate = value;
         }
 
         wb.attr("defaultDate", defaultDate, null)
-            .attr("inline", datepicker.isInline())
+            .attr("inline", datePicker.isInline())
             .attr("userLocale", locale.toString())
             .attr("dateFormat", CalendarUtils.convertPattern(pattern))
-            .attr("showIcon", datepicker.isShowIcon(), false)
-            .attr("buttonTabindex", datepicker.getButtonTabindex())
-            .attr("focusOnSelect", datepicker.isFocusOnSelect(), false)
-            .attr("disabled", datepicker.isDisabled(), false)
-            .attr("valid", datepicker.isValid(), true)
-            .attr("yearRange", datepicker.getYearRange(), null)
-            .attr("minDate", getMinMaxDate(context, datepicker, datepicker.getMindate(), false), null)
-            .attr("maxDate", getMinMaxDate(context, datepicker, datepicker.getMaxdate(), true), null)
-            .attr("selectionMode", datepicker.getSelectionMode(), null)
-            .attr("showOnFocus", datepicker.isShowOnFocus())
-            .attr("shortYearCutoff", datepicker.getShortYearCutoff(), null)
-            .attr("monthNavigator", datepicker.isMonthNavigator(), false)
-            .attr("yearNavigator", datepicker.isYearNavigator(), false)
-            .attr("showButtonBar", datepicker.isShowButtonBar(), false)
-            .attr("panelStyleClass", datepicker.getPanelStyleClass(), null)
-            .attr("panelStyle", datepicker.getPanelStyle(), null)
-            .attr("keepInvalid", datepicker.isKeepInvalid(), false)
-            .attr("maxDateCount", datepicker.getMaxDateCount(), Integer.MAX_VALUE)
-            .attr("numberOfMonths", datepicker.getNumberOfMonths(), 1)
-            .attr("view", datepicker.getView(), null)
-            .attr("touchUI", datepicker.isTouchUI(), false)
-            .attr("showWeek", datepicker.isShowWeek(), false)
-            .attr("appendTo", SearchExpressionFacade.resolveClientId(context, datepicker, datepicker.getAppendTo(),
+            .attr("showIcon", datePicker.isShowIcon(), false)
+            .attr("buttonTabindex", datePicker.getButtonTabindex())
+            .attr("focusOnSelect", datePicker.isFocusOnSelect(), false)
+            .attr("disabled", datePicker.isDisabled(), false)
+            .attr("valid", datePicker.isValid(), true)
+            .attr("yearRange", datePicker.getYearRange(), null)
+            .attr("minDate", getMinMaxDate(context, datePicker, datePicker.getMindate(), false), null)
+            .attr("maxDate", getMinMaxDate(context, datePicker, datePicker.getMaxdate(), true), null)
+            .attr("selectionMode", datePicker.getSelectionMode(), null)
+            .attr("showOnFocus", datePicker.isShowOnFocus())
+            .attr("shortYearCutoff", datePicker.getShortYearCutoff(), null)
+            .attr("monthNavigator", datePicker.isMonthNavigator(), false)
+            .attr("yearNavigator", datePicker.isYearNavigator(), false)
+            .attr("showButtonBar", datePicker.isShowButtonBar(), false)
+            .attr("panelStyleClass", datePicker.getPanelStyleClass(), null)
+            .attr("panelStyle", datePicker.getPanelStyle(), null)
+            .attr("keepInvalid", datePicker.isKeepInvalid(), false)
+            .attr("maxDateCount", datePicker.getMaxDateCount(), Integer.MAX_VALUE)
+            .attr("numberOfMonths", datePicker.getNumberOfMonths(), 1)
+            .attr("view", datePicker.getView(), null)
+            .attr("touchUI", datePicker.isTouchUI(), false)
+            .attr("showWeek", datePicker.isShowWeek(), false)
+            .attr("appendTo", SearchExpressionFacade.resolveClientId(context, datePicker, datePicker.getAppendTo(),
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
-            .attr("icon", datepicker.getTriggerButtonIcon(), null)
-            .attr("rangeSeparator", datepicker.getRangeSeparator(), "-")
-            .attr("timeSeparator", datepicker.getTimeSeparator(), ":")
-            .attr("timeInput", datepicker.isTimeInput())
-            .attr("touchable", ComponentUtils.isTouchable(context, datepicker), true)
-            .attr("lazyModel", datepicker.getModel() instanceof LazyDateMetadataModel, false);
+            .attr("icon", datePicker.getTriggerButtonIcon(), null)
+            .attr("rangeSeparator", datePicker.getRangeSeparator(), "-")
+            .attr("timeSeparator", datePicker.getTimeSeparator(), ":")
+            .attr("timeInput", datePicker.isTimeInput())
+            .attr("touchable", ComponentUtils.isTouchable(context, datePicker), true)
+            .attr("lazyModel", datePicker.getModel() instanceof LazyDateMetadataModel, false);
 
-        List<Integer> disabledDays = datepicker.getDisabledDays();
+        List<Integer> disabledDays = datePicker.getDisabledDays();
         if (disabledDays != null) {
-            CalendarUtils.encodeListValue(context, datepicker, "disabledDays", disabledDays, pattern);
+            CalendarUtils.encodeListValue(context, datePicker, "disabledDays", disabledDays, pattern);
         }
 
-        List<Object> disabledDates = datepicker.getInitialDisabledDates(context);
+        List<Object> disabledDates = datePicker.getInitialDisabledDates(context);
         if (disabledDates != null) {
-            CalendarUtils.encodeListValue(context, datepicker, "disabledDates", disabledDates, pattern);
+            CalendarUtils.encodeListValue(context, datePicker, "disabledDates", disabledDates, pattern);
         }
 
-        String dateTemplate = datepicker.getDateTemplate();
+        String dateTemplate = datePicker.getDateTemplate();
         if (dateTemplate != null) {
             wb.nativeAttr("dateTemplate", dateTemplate);
         }
 
-        String beforeShow = datepicker.getBeforeShow();
+        String beforeShow = datePicker.getBeforeShow();
         if (beforeShow != null) {
             wb.nativeAttr("preShow", beforeShow);
         }
 
-        String onMonthChange = datepicker.getOnMonthChange();
+        String onMonthChange = datePicker.getOnMonthChange();
         if (onMonthChange != null) {
             wb.nativeAttr("onMonthChange", onMonthChange);
         }
 
-        String onYearChange = datepicker.getOnYearChange();
+        String onYearChange = datePicker.getOnYearChange();
         if (onYearChange != null) {
             wb.nativeAttr("onYearChange", onYearChange);
         }
 
-        String weekCalculator = datepicker.getWeekCalculator();
+        String weekCalculator = datePicker.getWeekCalculator();
         if (weekCalculator != null) {
             wb.nativeAttr("weekCalculator", weekCalculator);
         }
 
-        if (datepicker.isShowOtherMonths()) {
-            wb.attr("showOtherMonths", true).attr("selectOtherMonths", datepicker.isSelectOtherMonths());
+        if (datePicker.isShowOtherMonths()) {
+            wb.attr("showOtherMonths", true).attr("selectOtherMonths", datePicker.isSelectOtherMonths());
         }
 
-        if (datepicker.hasTime()) {
-            wb.attr("showTime", datepicker.isShowTime(), false)
-                .attr("hourFormat", datepicker.getHourFormat(), null)
-                .attr("timeOnly", datepicker.isTimeOnly(), false)
-                .attr("showSeconds", datepicker.isShowSeconds(), false)
-                .attr("stepHour", datepicker.getStepHour(), 1)
-                .attr("stepMinute", datepicker.getStepMinute(), 1)
-                .attr("stepSecond", datepicker.getStepSecond(), 1)
-                .attr("hideOnDateTimeSelect", datepicker.isHideOnDateTimeSelect(), false);
+        if (datePicker.hasTime()) {
+            wb.attr("showTime", datePicker.isShowTime(), false)
+                .attr("hourFormat", datePicker.getHourFormat(), null)
+                .attr("timeOnly", datePicker.isTimeOnly(), false)
+                .attr("showSeconds", datePicker.isShowSeconds(), false)
+                .attr("stepHour", datePicker.getStepHour(), 1)
+                .attr("stepMinute", datePicker.getStepMinute(), 1)
+                .attr("stepSecond", datePicker.getStepSecond(), 1)
+                .attr("hideOnDateTimeSelect", datePicker.isHideOnDateTimeSelect(), false);
         }
 
-        String mask = datepicker.getMask();
+        String mask = datePicker.getMask();
         if (mask != null && !mask.equals("false")) {
-            String patternTemplate = datepicker.calculatePattern();
-            String maskTemplate = (mask.equals("true")) ? datepicker.convertPattern(patternTemplate) : mask;
+            String patternTemplate = datePicker.calculatePattern();
+            String maskTemplate = (mask.equals("true")) ? datePicker.convertPattern(patternTemplate) : mask;
             wb.attr("mask", maskTemplate)
-                .attr("maskSlotChar", datepicker.getMaskSlotChar(), "_")
-                .attr("maskAutoClear", datepicker.isMaskAutoClear(), true);
+                .attr("maskSlotChar", datePicker.getMaskSlotChar(), "_")
+                .attr("maskAutoClear", datePicker.isMaskAutoClear(), true);
         }
 
-        encodeClientBehaviors(context, datepicker);
+        encodeClientBehaviors(context, datePicker);
 
         wb.finish();
     }
 
     @Override
     public Object getConvertedValue(FacesContext context, UIComponent component, Object value) throws ConverterException {
-        DatePicker datepicker = (DatePicker) component;
+        DatePicker datePicker = (DatePicker) component;
         String submittedValue = (String) value;
 
         if (isValueBlank(submittedValue)) {
             return null;
         }
 
-        String selectionMode = datepicker.getSelectionMode();
+        String selectionMode = datePicker.getSelectionMode();
         switch (selectionMode) {
             case "multiple": {
                 String[] parts = submittedValue.split(",");
@@ -287,7 +287,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                 return multi;
             }
             case "range": {
-                String[] parts = submittedValue.split(datepicker.getRangeSeparator());
+                String[] parts = submittedValue.split(datePicker.getRangeSeparator());
                 List<Object> range = new ArrayList<>();
                 if (parts.length == 2) {
                     for (String part : parts) {
@@ -302,12 +302,12 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
         }
     }
 
-    private String getMinMaxDate(FacesContext context, DatePicker datepicker, Object value, boolean max) {
-        if (value instanceof LocalDate && datepicker.isShowTime()) {
+    private String getMinMaxDate(FacesContext context, DatePicker datePicker, Object value, boolean max) {
+        if (value instanceof LocalDate && datePicker.isShowTime()) {
             LocalDate date = (LocalDate) value;
             value = date.atTime(max ? LocalTime.MAX : LocalTime.MIN);
         }
-        return CalendarUtils.getValueAsString(context, datepicker, value);
+        return CalendarUtils.getValueAsString(context, datePicker, value);
     }
 }
 


### PR DESCRIPTION
Basically what was happening was in `BaseCalendarRenderer.encodeEnd` decisions were being made with configs before calling `DatePicker.encodeMarkup`.

So we had to move this default setting to the `encodeEnd` before calling `super.encodeEnd` so the proper values for `showTime`, `showSeconds` etc are calculated before it tries to build the default markup date.

@christophs78 @jepsar 

I have tested both the Showcase and the provided test case from user.  We also have our Primefaces Integration Tests that will run.

I will add an Integration Test case there.