### PR TITLE
Fix #6461: File validation remove Nashhorn JS Engine

### DIFF
--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,9 +42,6 @@ import javax.faces.FacesException;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.ValidatorException;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.FilenameUtils;
@@ -154,7 +152,7 @@ public class FileUploadUtils {
             }
             return validType;
         }
-        catch (IOException | ScriptException ex) {
+        catch (IOException ex) {
             if (LOGGER.isLoggable(Level.WARNING)) {
                 LOGGER.log(Level.WARNING, String.format("The type of the uploaded file %s could not be validated", fileName), ex);
             }
@@ -162,31 +160,18 @@ public class FileUploadUtils {
         }
     }
 
-    private static boolean isValidFileName(FileUpload fileUpload, UploadedFile uploadedFile) throws ScriptException {
+    private static boolean isValidFileName(FileUpload fileUpload, UploadedFile uploadedFile) {
         String allowTypesRegex = fileUpload.getAllowTypes();
         if (!LangUtils.isValueBlank(allowTypesRegex)) {
-            //We use rhino or nashorn javascript engine bundled with java to re-evaluate javascript regex that cannot be easily translated to java regex
-            //TODO If at some day nashorn will not be bundled with java (http://openjdk.java.net/jeps/335), we have to put some notes in the user guide
-            ScriptEngine engine = new ScriptEngineManager().getEngineByName("javascript");
-
-            if (engine == null) {
-
-                // Attempt to use the default extension loader to obtain the engine for environments where the
-                // JavaScript ScriptEngine isn't available via the Thread.currentThread().getContextClassLoader()
-                // (such as Liferay).
-                engine = new ScriptEngineManager(null).getEngineByName("javascript");
-            }
-
-            if (engine == null) {
-                throw new ScriptException(new NullPointerException(
-                    "JavaScript ScriptEngine not available via the context ClassLoader or the extension ClassLoader."));
-            }
-
+            allowTypesRegex = convertJavaScriptRegex(allowTypesRegex);
             String fileName = EscapeUtils.forJavaScriptAttribute(uploadedFile.getFileName());
             String contentType = EscapeUtils.forJavaScriptAttribute(uploadedFile.getContentType());
 
-            String evalJs = String.format("%s.test(\"%s\") || %s.test(\"%s\")", allowTypesRegex, contentType, allowTypesRegex, fileName);
-            if (!Boolean.TRUE.equals(engine.eval(evalJs))) {
+            final Pattern allowTypesPattern = Pattern.compile(allowTypesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+            final Matcher fileNameMatcher = allowTypesPattern.matcher(fileName);
+            final Matcher contentTypeMatcher = allowTypesPattern.matcher(contentType);
+            boolean isValid = fileNameMatcher.find() || contentTypeMatcher.find();
+            if (!isValid) {
                 if (LOGGER.isLoggable(Level.WARNING)) {
                     LOGGER.warning(String.format("The uploaded filename %s does not match the specified regex %s", fileName, allowTypesRegex));
                 }
@@ -194,6 +179,25 @@ public class FileUploadUtils {
             }
         }
         return true;
+    }
+
+    /**
+     * Converts a JavaScript regular expression like '/(\.|\/)(gif|jpe?g|png)$/i'
+     * to the Java usable format '(\\.|\\/)(gif|jpe?g|png)$'
+     * @param jsRegex the client side JavaScript regex
+     * @return the Java converted version of the regex
+     */
+    protected static String convertJavaScriptRegex(String jsRegex) {
+        int start = 0;
+        int end = jsRegex.length() - 1;
+        if (jsRegex.charAt(0) == '/') {
+            start = 1;
+        }
+        char endChar = jsRegex.charAt(end);
+        if (endChar != '/' && endChar == 'i' || endChar == 'g') {
+            end = end - 1;
+        }
+        return LangUtils.substring(jsRegex, start, end);
     }
 
     private static boolean isValidFileContent(PrimeApplicationContext context, FileUpload fileUpload, String fileName, InputStream stream) throws IOException {

--- a/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -161,23 +161,30 @@ public class FileUploadUtils {
     }
 
     private static boolean isValidFileName(FileUpload fileUpload, UploadedFile uploadedFile) {
-        String allowTypesRegex = fileUpload.getAllowTypes();
-        if (!LangUtils.isValueBlank(allowTypesRegex)) {
-            allowTypesRegex = convertJavaScriptRegex(allowTypesRegex);
-            String fileName = EscapeUtils.forJavaScriptAttribute(uploadedFile.getFileName());
-            String contentType = EscapeUtils.forJavaScriptAttribute(uploadedFile.getContentType());
-
-            final Pattern allowTypesPattern = Pattern.compile(allowTypesRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
-            final Matcher fileNameMatcher = allowTypesPattern.matcher(fileName);
-            final Matcher contentTypeMatcher = allowTypesPattern.matcher(contentType);
-            boolean isValid = fileNameMatcher.find() || contentTypeMatcher.find();
-            if (!isValid) {
-                if (LOGGER.isLoggable(Level.WARNING)) {
-                    LOGGER.warning(String.format("The uploaded filename %s does not match the specified regex %s", fileName, allowTypesRegex));
-                }
-                return false;
-            }
+        String javascriptRegex = fileUpload.getAllowTypes();
+        if (LangUtils.isValueBlank(javascriptRegex)) {
+            return true;
         }
+
+        String javaRegex = convertJavaScriptRegex(javascriptRegex);
+        if (LangUtils.isValueBlank(javaRegex)) {
+            return true;
+        }
+
+        String fileName = EscapeUtils.forJavaScriptAttribute(uploadedFile.getFileName());
+        String contentType = EscapeUtils.forJavaScriptAttribute(uploadedFile.getContentType());
+
+        final Pattern allowTypesPattern = Pattern.compile(javaRegex, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+        final Matcher fileNameMatcher = allowTypesPattern.matcher(fileName);
+        final Matcher contentTypeMatcher = allowTypesPattern.matcher(contentType);
+        boolean isValid = fileNameMatcher.find() || contentTypeMatcher.find();
+        if (!isValid) {
+            if (LOGGER.isLoggable(Level.WARNING)) {
+                LOGGER.warning(String.format("The uploaded filename %s does not match the specified regex %s", fileName, javaRegex));
+            }
+            return false;
+        }
+
         return true;
     }
 

--- a/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -188,4 +188,30 @@ public class FileUploadUtilsTest {
         assertEquals(relativePath, result);
     }
 
+    @Test
+    public void convertJavaScriptRegex_Normal() {
+        // Arrange
+        String jsRegex = "/(\\.|\\/)(gif|jpe?g|png)$/";
+
+        // Act
+        String result = FileUploadUtils.convertJavaScriptRegex(jsRegex);
+
+        // Assert
+        assertEquals("(\\.|\\/)(gif|jpe?g|png)$", result);
+    }
+
+    @Test
+    public void convertJavaScriptRegex_CaseInsensitive() {
+        // Arrange
+        String jsRegex = "/\\.(gif|png|jpe?g)$/i";
+
+        // Act
+        String result = FileUploadUtils.convertJavaScriptRegex(jsRegex);
+
+        // Assert
+        assertEquals("\\.(gif|png|jpe?g)$", result);
+    }
+
+
+
 }

--- a/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -84,14 +84,23 @@ public class FileUploadUtilsTest {
     }
 
     @Test
-    public void isValidTypeFilenameCheck() {
+    public void isValidType_NameCheck() {
         when(fileUpload.getAllowTypes()).thenReturn(null);
         Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.png", "image/png", inputStream)));
 
         when(fileUpload.getAllowTypes()).thenReturn("/\\.(gif|png|jpe?g)$/i");
         Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.PNG", "image/png", inputStream)));
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.jpeg", "image/jpeg", inputStream)));
+        Assertions.assertFalse(FileUploadUtils.isValidType(appContext, fileUpload,createFile("test.bmp", "image/bitmap", inputStream)));
+    }
+
+    @Test
+    public void isValidType_MimeTypeCheck() {
+        when(fileUpload.getAllowTypes()).thenReturn("/image/g");
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.PNG", "image/png", inputStream)));
         Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.jpeg", "image/png", inputStream)));
-        Assertions.assertFalse(FileUploadUtils.isValidType(appContext, fileUpload,createFile( "test.bmp", "text/plain", inputStream)));
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload,createFile("test.bmp", "image/bitmap", inputStream)));
+        Assertions.assertFalse(FileUploadUtils.isValidType(appContext, fileUpload,createFile("adobe.pdf", "application/pdf", inputStream)));
     }
 
     //TODO Once including Apache Tika as test scope dependency, we never check the default implementation which should work well also for the non-tampered cases

--- a/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -103,6 +103,16 @@ public class FileUploadUtilsTest {
         Assertions.assertFalse(FileUploadUtils.isValidType(appContext, fileUpload,createFile("adobe.pdf", "application/pdf", inputStream)));
     }
 
+    @Test
+    public void isValidType_InvalidRegex() {
+        when(fileUpload.getAllowTypes()).thenReturn("x");
+        // all of these should be true when the regex is not valid
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.PNG", "image/png", inputStream)));
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload, createFile("test.jpeg", "image/png", inputStream)));
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload,createFile("test.bmp", "image/bitmap", inputStream)));
+        Assertions.assertTrue(FileUploadUtils.isValidType(appContext, fileUpload,createFile("adobe.pdf", "application/pdf", inputStream)));
+    }
+
     //TODO Once including Apache Tika as test scope dependency, we never check the default implementation which should work well also for the non-tampered cases
     //TODO Can we somehow run specific tests with AND without Apache Tika in place, e.g. by differently configured executions of maven-surefire-plugin?
     @Test
@@ -221,6 +231,29 @@ public class FileUploadUtilsTest {
         assertEquals("\\.(gif|png|jpe?g)$", result);
     }
 
+    @Test
+    public void convertJavaScriptRegex_Short() {
+        // Arrange
+        String jsRegex = "/x/";
+
+        // Act
+        String result = FileUploadUtils.convertJavaScriptRegex(jsRegex);
+
+        // Assert
+        assertEquals("x", result);
+    }
+
+    @Test
+    public void convertJavaScriptRegex_NotRegex() {
+        // Arrange
+        String jsRegex = "x";
+
+        // Act
+        String result = FileUploadUtils.convertJavaScriptRegex(jsRegex);
+
+        // Assert
+        assertEquals("", result);
+    }
 
 
 }


### PR DESCRIPTION
OK I understand why we originally were using Nashhorn so the exact same REGEX on the client side was tested but converting a JS regex to Java Regex was not that hard.

- Original unit tests that were there are still passing
- new Unit tests to test functonality
- Completes the same functionality that was there before without adding a new property.

Converts JS regex like `/\.(gif|png|jpe?g)$/i` to Java regex `"\\.(gif|png|jpe?g)$"`