### PR TITLE
Fix #6469: InputMask optional character fix

### DIFF
--- a/docs/9_0/components/inputmask.md
+++ b/docs/9_0/components/inputmask.md
@@ -76,8 +76,8 @@ style | null | String | Inline style of the input element.
 styleClass | null | String | Style class of the input element.
 tabindex | null | Integer | Position of the input element in the tabbing order.
 title | null | String | Advisory tooltip information.
-validateMask | false | Boolean | Defines whether mask pattern would be validated or not on the server side.
-validator | null | MethodExpr | A method binding expression that refers to a method validationg the input
+validateMask | true | Boolean | Defines whether mask pattern would be validated or not on the server side.
+validator | null | MethodExpr | A method binding expression that refers to a method validating the input
 validatorMessage | null | String | Message to be displayed when validation fields.
 value | null | Object | Value of the component than can be either an EL expression of a literal text
 valueChangeListener | null | MethodExpr | A method binding expression that refers to a method for handling a valuchangeevent

--- a/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -52,9 +52,11 @@ public class InputMaskRenderer extends InputRenderer {
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(clientId);
 
         if (submittedValue != null) {
+            // strip mask characters in case of optional values
+            submittedValue = submittedValue.replace(inputMask.getSlotChar(), Constants.EMPTY_STRING);
             String mask = inputMask.getMask();
 
-            if (inputMask.isValidateMask() && !submittedValue.isEmpty() && !LangUtils.isValueBlank(mask)) {
+            if (inputMask.isValidateMask() && !LangUtils.isValueEmpty(submittedValue) && !LangUtils.isValueBlank(mask)) {
                 Pattern pattern = translateMaskIntoRegex(context, mask);
                 if (!pattern.matcher(submittedValue).matches()) {
                     submittedValue = Constants.EMPTY_STRING;
@@ -80,6 +82,10 @@ public class InputMaskRenderer extends InputRenderer {
      */
     protected Pattern translateMaskIntoRegex(FacesContext context, String mask) {
         StringBuilder regex = SharedStringBuilder.get(context, SB_PATTERN);
+        return translateMaskIntoRegex(regex, mask);
+    }
+
+    protected Pattern translateMaskIntoRegex(StringBuilder regex, String mask) {
         boolean optionalFound = false;
 
         for (char c : mask.toCharArray()) {

--- a/src/test/java/org/primefaces/component/inputmask/InputMaskRendererTest.java
+++ b/src/test/java/org/primefaces/component/inputmask/InputMaskRendererTest.java
@@ -1,0 +1,25 @@
+package org.primefaces.component.inputmask;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+class InputMaskRendererTest {
+
+    @Test
+    void translateMaskIntoRegex_Optional() {
+        // Arrange
+        InputMaskRenderer comp = new InputMaskRenderer();
+        StringBuilder sb = new StringBuilder();
+        String mask = "9[999]";
+
+        // Act
+        Pattern result = comp.translateMaskIntoRegex(sb, mask);
+
+        // Assert
+        assertEquals("[0-9][0-9]?[0-9]?[0-9]?", result.pattern());
+    }
+
+}


### PR DESCRIPTION
When using optional characters the value submitted to the server side contains the remaining mask which must be removed.

So when submitting "12__" it must be "12"

Integration Test: https://github.com/primefaces-extensions/primefaces-integration-tests/commit/147341e414c61e0db84b70ad9c3af578735d0688