### PR TITLE
Datatable moved migration notes to top, removed commented out line.

### DIFF
--- a/docs/migrationguide/9_0.md
+++ b/docs/migrationguide/9_0.md
@@ -3,6 +3,33 @@
 ## Core
   * Facelet function `p:resolveWidgetVar` now returns the widget var name only, instead of `PF('widgetVarName')`.
 
+## DataTable
+**Removed**:
+  - `DataTable#sortMeta` _(replaced by DataTable#sortBy)_
+  - `DataTable#sortField` _(replaced by UIColumn#field)_
+  - `DataTable#sortOrder` _(replaced by UIColumn#sortOrder)_
+  - `DataTable#sortFunction` _(replaced by UIColumn#sortFunction)_
+  - `DataTable#expandableRowGroups` _(replaced by HeaderRow#expandable)_
+  - `DataTable#nullSortOrder` _(replaced by UIColumn#nullSortOrder)_
+  - `DataTable#caseSensitiveSort` _(replaced by UIColumn#caseSensitiveSort)_
+  
+**Updated**
+  - `DataTable#sortMode`: default value "multiple"
+  - `DataTable#allowUnsorting`: default value "false"
+  - `DataTable#sortBy`: expects a single or a collection of SortMeta _(default sorting can either be configured through markup or programmatically)_
+  
+**Added**
+  - `Column#sortPriority`: defines in which order columns sorter should apply initially
+  - `Column#sortOrder`: defines default sort order
+  - `Column#nullSortOrder`
+  - `Column#caseSensitiveSort`
+  
+**Breaking changes**
+  - `DataTable#sortBy`: no longer expect a Map, but a single or a collection of SortMeta _(use SortMeta#builder)_ `UIColumn#field` or `UIColumn#sortBy` must be set to enable default sorting.
+  - As it is possible from now on to configure default sorted columns on a single sort mode datatable. Users will be expected to implement only one method `LazyDataModel#load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy)`
+  * detects lazy-attribute automatically based on value-binding to LazyDataModel. So no need to set this explicit anymore.
+
+
 ## Dock
   * Re-implemented using CSS. Deprecated props `itemWidth, maxWidth, proximity` for CSS instead. (https://primefaces.github.io/primefaces/9_0/#/components/dock)
 
@@ -45,32 +72,6 @@
 
 ## AutoComplete
   * Event `moreText` is renamed to `moreTextSelect`.
-
-## DataTable
-**Removed**:
-  - `DataTable#sortMeta` _(replaced by DataTable#sortBy)_
-  - `DataTable#sortField` _(replaced by UIColumn#field)_
-  - `DataTable#sortOrder` _(replaced by UIColumn#sortOrder)_
-  - `DataTable#sortFunction` _(replaced by UIColumn#sortFunction)_
-  - `DataTable#expandableRowGroups` _(replaced by HeaderRow#expandable)_
-  - `DataTable#nullSortOrder` _(replaced by UIColumn#nullSortOrder)_
-  - `DataTable#caseSensitiveSort` _(replaced by UIColumn#caseSensitiveSort)_
-  
-**Updated**
-  - `DataTable#sortMode`: default value "multiple"
-  - `DataTable#allowUnsorting`: default value "false"
-  - `DataTable#sortBy`: expects a single or a collection of SortMeta _(default sorting can either be configured through markup or programmatically)_
-  
-**Added**
-  - `Column#sortPriority`: defines in which order columns sorter should apply initially
-  - `Column#sortOrder`: defines default sort order
-  - `Column#nullSortOrder`
-  - `Column#caseSensitiveSort`
-  
-**Breaking changes**
-  - `DataTable#sortBy`: no longer expect a Map, but a single or a collection of SortMeta _(use SortMeta#builder)_ `UIColumn#field` or `UIColumn#sortBy` must be set to enable default sorting.
-  - As it is possible from now on to configure default sorted columns on a single sort mode datatable. Users will be expected to implement only one method `LazyDataModel#load(int first, int pageSize, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy)`
-  * detects lazy-attribute automatically based on value-binding to LazyDataModel. So no need to set this explicit anymore.
 
 ## DataView
   * detects lazy-attribute automatically based on value-binding to LazyDataModel. So no need to set this explicit anymore.

--- a/src/main/java/org/primefaces/model/LazyDataModel.java
+++ b/src/main/java/org/primefaces/model/LazyDataModel.java
@@ -24,11 +24,7 @@
 package org.primefaces.model;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -174,7 +170,6 @@ public abstract class LazyDataModel<T> extends DataModel<T> implements Selectabl
         }
         else {
             sortBy = new HashMap<>(1);
-            //sortBy.put(sortField, new SortMeta(null, sortField, sortOrder == null ? SortOrder.UNSORTED : sortOrder, null));
         }
 
         return iterator(sortBy, filterBy);


### PR DESCRIPTION
@Rapster I removed a commented out line of code from a Sonar warning and I moved your migration notes to the top of the page since I think this will be the most important thing people look at when migrating to 9.0!