### PR TITLE
Fix #1898: Column draggable attribute

### DIFF
--- a/docs/9_0/components/column.md
+++ b/docs/9_0/components/column.md
@@ -39,7 +39,8 @@ treetable and more.
 | width | null | String | The width of the column ('px' as default if no length unit is defined)
 | exportable | true | Boolean | Defines if the column should be exported by dataexporter.
 | filterValue | null | Object | Value of the filter field.
-| toggleable | true | Boolean | Defines if panel is toggleable by columnToggler component. Default value is true and a false value marks the column as static.
+| toggleable | true | Boolean | Defines if column is toggleable by columnToggler component. Default value is true and a false value marks the column as static.
+| draggable | true | Boolean | Defines if column is draggable if draggableColumns is set. Default true.
 | filterFunction | null | MethodExpr | Custom implementation to filter a value against a constraint.
 | field | null | String | Name of the field associated to bean "var". If not specified, filterBy-sortBy values are used to identify the field name.
 | priority | 0 | Integer | Priority of the column defined as an integer, lower values have more priority.

--- a/docs/9_0/components/columns.md
+++ b/docs/9_0/components/columns.md
@@ -39,7 +39,8 @@ Columns is used by datatable to create columns dynamically.
 | exportable | true | Boolean | Defines if the column should be exported by dataexporter.
 | columnIndexVar | null | String | Name of iterator to refer each index.
 | filterValue | null | Object | Value of the filter field.
-| toggleable | true | Boolean | Defines if panel is toggleable by columnToggler component. Default value is true and a false value marks the column as static.
+| toggleable | true | Boolean | Defines if columns are toggleable by columnToggler component. Default value is true and a false value marks the column as static.
+| draggable | true | Boolean | Defines if columns are draggable if draggableColumns is set. Default true.
 | filterFunction | null | MethodExpr | Custom implementation to filter a value against a constraint.
 | field | null | String | Name of the field associated to bean "var". If not specified, filterBy-sortBy values are used to identify the field name.
 | priority | 0 | Integer | Priority of the column defined as an integer, lower values have more priority.

--- a/src/main/java/org/primefaces/component/api/DynamicColumn.java
+++ b/src/main/java/org/primefaces/component/api/DynamicColumn.java
@@ -323,4 +323,9 @@ public class DynamicColumn implements UIColumn {
     public boolean isCaseSensitiveSort() {
         return columns.isCaseSensitiveSort();
     }
+
+    @Override
+    public boolean isDraggable() {
+        return columns.isDraggable();
+    }
 }

--- a/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -101,6 +101,8 @@ public interface UIColumn {
 
     boolean isToggleable();
 
+    boolean isDraggable();
+
     MethodExpression getFilterFunction();
 
     String getField();

--- a/src/main/java/org/primefaces/component/column/ColumnBase.java
+++ b/src/main/java/org/primefaces/component/column/ColumnBase.java
@@ -58,6 +58,7 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
         filterValue,
         width,
         toggleable,
+        draggable,
         filterFunction,
         field,
         priority,
@@ -272,6 +273,15 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
 
     public void setToggleable(boolean toggleable) {
         getStateHelper().put(PropertyKeys.toggleable, toggleable);
+    }
+
+    @Override
+    public boolean isDraggable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.draggable, true);
+    }
+
+    public void setDraggable(boolean draggable) {
+        getStateHelper().put(PropertyKeys.draggable, draggable);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/columns/ColumnsBase.java
+++ b/src/main/java/org/primefaces/component/columns/ColumnsBase.java
@@ -54,6 +54,7 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
         exportable,
         width,
         toggleable,
+        draggable,
         filterFunction,
         field,
         priority,
@@ -259,6 +260,15 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
 
     public void setToggleable(boolean toggleable) {
         getStateHelper().put(PropertyKeys.toggleable, toggleable);
+    }
+
+    @Override
+    public boolean isDraggable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.draggable, true);
+    }
+
+    public void setDraggable(boolean draggable) {
+        getStateHelper().put(PropertyKeys.draggable, draggable);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -97,6 +97,7 @@ public class DataTable extends DataTableBase {
     public static final String COLUMN_INPUT_FILTER_CLASS = "ui-column-filter ui-inputfield ui-inputtext ui-widget ui-state-default ui-corner-all";
     public static final String COLUMN_CUSTOM_FILTER_CLASS = "ui-column-customfilter";
     public static final String RESIZABLE_COLUMN_CLASS = "ui-resizable-column";
+    public static final String DRAGGABLE_COLUMN_CLASS = "ui-draggable-column";
     public static final String EXPANDED_ROW_CLASS = "ui-expanded-row";
     public static final String EXPANDED_ROW_CONTENT_CLASS = "ui-expanded-row-content";
     public static final String ROW_TOGGLER_CLASS = "ui-row-toggler";

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -607,6 +607,7 @@ public class DataTableRenderer extends DataRenderer {
         String selectionMode = column.getSelectionMode();
         String sortIcon = null;
         boolean resizable = table.isResizableColumns() && column.isResizable();
+        boolean draggable = table.isDraggableColumns() && column.isDraggable();
         int priority = column.getPriority();
 
         boolean isColVisible = column.isVisible();
@@ -619,6 +620,7 @@ public class DataTableRenderer extends DataRenderer {
         columnClass = filterable ? columnClass + " " + DataTable.FILTER_COLUMN_CLASS : columnClass;
         columnClass = selectionMode != null ? columnClass + " " + DataTable.SELECTION_COLUMN_CLASS : columnClass;
         columnClass = resizable ? columnClass + " " + DataTable.RESIZABLE_COLUMN_CLASS : columnClass;
+        columnClass = draggable ? columnClass + " " + DataTable.DRAGGABLE_COLUMN_CLASS : columnClass;
         columnClass = !column.isToggleable() ? columnClass + " " + DataTable.STATIC_COLUMN_CLASS : columnClass;
         columnClass = !isColVisible ? columnClass + " " + DataTable.HIDDEN_COLUMN_CLASS : columnClass;
         columnClass = column.getStyleClass() != null ? columnClass + " " + column.getStyleClass() : columnClass;

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -5050,9 +5050,17 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Defines if panel is toggleable by columnToggler component. Default value is true and a false value marks the column as static.]]>
+                <![CDATA[Defines if column is toggleable by columnToggler component. Default value is true and a false value marks the column as static.]]>
             </description>
             <name>toggleable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines if column is draggable if draggableColumns is set. Default true.]]>
+            </description>
+            <name>draggable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
@@ -5438,9 +5446,17 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Defines if panel is toggleable by columnToggler component. Default value is true and a false value marks the column as static.]]>
+                <![CDATA[Defines if columns are toggleable by columnToggler component. Default value is true and a false value marks the column as static.]]>
             </description>
             <name>toggleable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines if columns are draggable if draggableColumns is set. Default true.]]>
+            </description>
+            <name>draggable</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4115,7 +4115,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
         var $this = this;
 
-        $(this.jqId + ' thead th').draggable({
+        $(this.jqId + ' thead th.ui-draggable-column').draggable({
             appendTo: 'body',
             opacity: 0.75,
             cursor: 'move',


### PR DESCRIPTION
Added `draggable="false"` attribute to `p:column` to allow a column to be marked as not draggable