### PR TITLE
Fix #6513 - Datatable: sorting not available after adding column

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1525,6 +1525,23 @@ public class DataTable extends DataTableBase {
         return getSortByAsMap().values().stream().anyMatch(SortMeta::isActive);
     }
 
+    public boolean isColumnSortable(UIColumn column) {
+        Map<String, SortMeta> sortBy = getSortByAsMap();
+        if (sortBy.containsKey(column.getColumnKey())) {
+            return true;
+        }
+
+        SortMeta s = SortMeta.of(getFacesContext(), getVar(), column);
+        if (s == null) {
+            return false;
+        }
+
+        // unlikely to happen, in case columns change between two ajax requests
+        sortBy.put(s.getColumnKey(), s);
+        setSortByAsMap(sortBy);
+        return true;
+    }
+
     public Map<String, SortMeta> getSortByAsMap() {
         return ComponentUtils.computeIfAbsent(getStateHelper(), "_sortBy", () -> initSortBy(getSortBy()));
     }

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -602,7 +602,8 @@ public class DataTableRenderer extends DataRenderer {
         String clientId = column.getContainerClientId(context);
 
         ValueExpression columnFilterByVE = column.getValueExpression(Column.PropertyKeys.filterBy.toString());
-        boolean sortable = table.getSortByAsMap().containsKey(column.getColumnKey());
+
+        boolean sortable = table.isColumnSortable(column);
         boolean filterable = (columnFilterByVE != null && column.isFilterable());
         String selectionMode = column.getSelectionMode();
         String sortIcon = null;


### PR DESCRIPTION
I can't say I'm thrilled about that fix. The difficulty in this PR is to sync viewscoped sortBy with potential request column changes. This sync is done at renderer level so far, not ideal as its not his responsibility to do so. 

I'll see if I can do that in `DataTable#getColumns` method 