### PR TITLE
Fix #4919: SelectOneMenu alwaysDisplayLabel attribute

### DIFF
--- a/docs/9_0/components/selectonemenu.md
+++ b/docs/9_0/components/selectonemenu.md
@@ -35,7 +35,9 @@ widgetVar | null | String | Name of the client side widget.
 effect | blind | String | Name of the toggle animation.
 effectSpeed | normal | String | Duration of toggle animation, valid values are "slow", "normal" and "fast".
 disabled | false | Boolean | Disables the component.
-label | null | String | User presentable name.
+alwaysDisplayLabel | false | Boolean | Always display the `label` value instead of the selected item label.
+label | null | String | User presentable name used in conjuction with `alwaysDisplayLabel` to display instead of selected item.
+labelTemplate | null | String | Displays label of the element in a custom template. Valid placeholder is {0}.
 onchange | null | String | Client side callback to execute on value change.
 onkeyup | null | String | Client side callback to execute on keyup.
 onkeydown | null | String | Client side callback to execute on keydown.
@@ -53,7 +55,6 @@ maxlength | null | Integer | Number of maximum characters allowed in editable se
 appendTo | null | String | Appends the overlay to the element defined by search expression. Defaults to document body.
 title | null | String | Advisory tooltip information.
 syncTooltip | false | Boolean | Updates the title of the component with the description of the selected item.
-labelTemplate | null | String | Displays label of the element in a custom template. Valid placeholder is {0}.
 onfocus | null | String | Client side callback to execute when element receives focus.
 onblur | null | String | Client side callback to execute when element loses focus.
 autoWidth | true | Boolean | Calculates a fixed width based on the width of the maximum option label. Set to false for custom width.

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
@@ -55,6 +55,8 @@ public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Wid
         appendTo,
         title,
         syncTooltip,
+        alwaysDisplayLabel,
+        label,
         labelTemplate,
         placeholder,
         autoWidth,
@@ -210,12 +212,28 @@ public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Wid
         getStateHelper().put(PropertyKeys.syncTooltip, syncTooltip);
     }
 
+    public boolean isAlwaysDisplayLabel() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.alwaysDisplayLabel, false);
+    }
+
+    public void setAlwaysDisplayLabel(boolean alwaysDisplayLabel) {
+        getStateHelper().put(PropertyKeys.alwaysDisplayLabel, alwaysDisplayLabel);
+    }
+
     public String getLabelTemplate() {
         return (String) getStateHelper().eval(PropertyKeys.labelTemplate, null);
     }
 
     public void setLabelTemplate(String labelTemplate) {
         getStateHelper().put(PropertyKeys.labelTemplate, labelTemplate);
+    }
+
+    public String getLabel() {
+        return (String) getStateHelper().eval(PropertyKeys.label, null);
+    }
+
+    public void setLabel(String label) {
+        getStateHelper().put(PropertyKeys.label, label);
     }
 
     public String getPlaceholder() {

--- a/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -296,6 +296,10 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             if (menu.getPlaceholder() != null) {
                 writer.writeAttribute("data-placeholder", menu.getPlaceholder(), null);
             }
+            String label = menu.getLabel();
+            if (label != null) {
+                writer.writeText(label, null);
+            }
             writer.write("&nbsp;");
             writer.endElement("label");
         }
@@ -511,6 +515,8 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                 .attr("appendTo", SearchExpressionFacade.resolveClientId(context, menu, menu.getAppendTo(),
                         SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
                 .attr("syncTooltip", menu.isSyncTooltip(), false)
+                .attr("alwaysDisplayLabel", menu.isAlwaysDisplayLabel(), false)
+                .attr("label", menu.getLabel(), null)
                 .attr("labelTemplate", menu.getLabelTemplate(), null)
                 .attr("autoWidth", menu.isAutoWidth(), true)
                 .attr("dynamic", menu.isDynamic(), false)

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -23949,7 +23949,15 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[]]>
+                <![CDATA[Always display the 'label' value instead of the selected item label. Default is false.]]>
+            </description>
+            <name>alwaysDisplayLabel</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[User presentable name used in conjuction with 'alwaysDisplayLabel' to display instead of selected item.]]>
             </description>
             <name>label</name>
             <required>false</required>

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1017,6 +1017,9 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             var hasPlaceholder = this.label[0].hasAttribute('placeholder');
             this.updatePlaceholderClass((hasPlaceholder && value === '&nbsp;'));
         }
+        else if (this.cfg.alwaysDisplayLabel && this.cfg.label) {
+            this.label.text(this.cfg.label);
+        }
         else {
             var labelText = this.label.data('placeholder');
             if (labelText == null || labelText == "") {


### PR DESCRIPTION
Reimplements this change with the added `alwaysDisplayLabel` attribute and tested both uses cases from the ticket.