### PR TITLE
Fixes #6387 format of InputNumber.getValue() for decimalPlaces='0'

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -213,7 +213,7 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
      */
     getValue: function () {
         var val = this.autonumeric.getNumericString();
-        if (val && this.cfg.decimalPlaces) {
+        if (val && parseInt(this.cfg.decimalPlaces, 10) > 0) {
             var decimalPlacesToPad;
             if (val.indexOf('.') === -1) {
                 decimalPlacesToPad = this.cfg.decimalPlaces;


### PR DESCRIPTION
Fixes #6387 format of the InputNumber.getValue() function for decimalPlaces='0'