### PR TITLE
Fixes #6518

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -213,7 +213,7 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
      */
     getValue: function () {
         var val = this.autonumeric.getNumericString();
-        if (val && parseInt(this.cfg.decimalPlaces, 10) > 0) {
+        if (val && parseInt(this.cfg.decimalPlaces, 10) > 0 && this.cfg.allowDecimalPadding !== false) {
             var decimalPlacesToPad;
             if (val.indexOf('.') === -1) {
                 decimalPlacesToPad = this.cfg.decimalPlaces;


### PR DESCRIPTION
Fix for missing padControl check in InputNumber getValue().

All Integration tests in @org.primefaces.extensions.integrationtests.inputnumber@ are green on my machine with this change.