### PR TITLE
Fix #6527: CSP for dialogReturn from link

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.dialog.js
@@ -313,7 +313,13 @@ if (!PrimeFaces.dialog) {
             else if(sourceComponentId) {
                 var dialogReturnBehaviorStr = $(windowContext.document.getElementById(sourceComponentId)).data('dialogreturn');
                 if(dialogReturnBehaviorStr) {
-                    dialogReturnBehavior = windowContext.eval('(function(ext){this.' + dialogReturnBehaviorStr + '})');
+                    var dialogFunction = '(function(ext){this.' + dialogReturnBehaviorStr + '})';
+                    if (PrimeFaces.csp.NONCE_VALUE) {
+                        dialogReturnBehavior = PrimeFaces.csp.evalResult(dialogFunction);
+                    }
+                    else {
+                        dialogReturnBehavior = windowContext.eval(dialogFunction);
+                    }
                 }
             }
 


### PR DESCRIPTION
Leaves the current behavior the same but if using CSP need to call CSP evalResult.  I didn't want to disturb the original functionality of it using a specific WindowContext for its eval.