### PR TITLE
Timeline: added nested group functionality

### DIFF
--- a/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
@@ -30,10 +30,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -319,9 +316,10 @@ public class TimelineRenderer extends CoreRenderer {
         if (group.getTreeLevel() != null) {
             fsw.write(", treeLevel: \"" + group.getTreeLevel() + "\"");
 
-            if (group.getNestedGroups() != null) {
+            Set<String> nestedGroups = group.getNestedGroups();
+            if (nestedGroups != null && !nestedGroups.isEmpty()) {
                 fsw.write(", nestedGroups: [");
-                for (String s: group.getNestedGroups()) {
+                for (String s: nestedGroups) {
                     fsw.write("\"" + EscapeUtils.forJavaScriptBlock(s) + "\"" + ", ");
                 }
                 fsw.write("]");

--- a/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
+++ b/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
@@ -316,6 +316,18 @@ public class TimelineRenderer extends CoreRenderer {
             fsw.write(", content:\"" + groupsContent.get(group.getId()) + "\"");
         }
 
+        if (group.getTreeLevel() != null) {
+            fsw.write(", treeLevel: \"" + group.getTreeLevel() + "\"");
+
+            if (group.getNestedGroups() != null) {
+                fsw.write(", nestedGroups: [");
+                for (String s: group.getNestedGroups()) {
+                    fsw.write("\"" + EscapeUtils.forJavaScriptBlock(s) + "\"" + ", ");
+                }
+                fsw.write("]");
+            }
+        }
+
         if (timeline.getGroupStyle() != null) {
             fsw.write(", style: \"" + timeline.getGroupStyle() + "\"");
         }

--- a/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
+++ b/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
@@ -24,7 +24,7 @@
 package org.primefaces.model.timeline;
 
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.Set;
 
 public class TimelineGroup<T> implements Serializable {
 
@@ -54,7 +54,7 @@ public class TimelineGroup<T> implements Serializable {
      *
      * it is a set of ids of nested groups that a group or nested group contains.
      */
-    private HashSet<String> nestedGroups;
+    private Set<String> nestedGroups;
 
     /**
      * any custom style class for this event in UI (optional)
@@ -101,14 +101,14 @@ public class TimelineGroup<T> implements Serializable {
         this.treeLevel = treeLevel;
     }
 
-    public TimelineGroup(String id, T data, int treeLevel, HashSet<String> nestedGroups) {
+    public TimelineGroup(String id, T data, int treeLevel, Set<String> nestedGroups) {
         this.id = id;
         this.data = data;
         this.treeLevel = treeLevel;
         this.nestedGroups = nestedGroups;
     }
 
-    public TimelineGroup(String id, T data, String title, int treeLevel, HashSet<String> nestedGroups) {
+    public TimelineGroup(String id, T data, String title, int treeLevel, Set<String> nestedGroups) {
         this.id = id;
         this.data = data;
         this.title = title;
@@ -140,11 +140,11 @@ public class TimelineGroup<T> implements Serializable {
         this.treeLevel = treeLevel;
     }
 
-    public HashSet<String> getNestedGroups() {
+    public Set<String> getNestedGroups() {
         return nestedGroups;
     }
 
-    public void setNestedGroups(HashSet<String> nestedGroups) {
+    public void setNestedGroups(Set<String> nestedGroups) {
         this.nestedGroups = nestedGroups;
     }
 

--- a/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
+++ b/src/main/java/org/primefaces/model/timeline/TimelineGroup.java
@@ -24,6 +24,7 @@
 package org.primefaces.model.timeline;
 
 import java.io.Serializable;
+import java.util.HashSet;
 
 public class TimelineGroup<T> implements Serializable {
 
@@ -43,6 +44,17 @@ public class TimelineGroup<T> implements Serializable {
      * A title for the group, displayed when holding the mouse on the groups label. The title can only contain plain text.
      */
     private String title;
+
+    /**
+     * root level of the nested groups.
+     */
+    private Integer treeLevel;
+
+    /**
+     *
+     * it is a set of ids of nested groups that a group or nested group contains.
+     */
+    private HashSet<String> nestedGroups;
 
     /**
      * any custom style class for this event in UI (optional)
@@ -83,6 +95,27 @@ public class TimelineGroup<T> implements Serializable {
         this.title = title;
     }
 
+    public TimelineGroup(String id, T data, int treeLevel) {
+        this.id = id;
+        this.data = data;
+        this.treeLevel = treeLevel;
+    }
+
+    public TimelineGroup(String id, T data, int treeLevel, HashSet<String> nestedGroups) {
+        this.id = id;
+        this.data = data;
+        this.treeLevel = treeLevel;
+        this.nestedGroups = nestedGroups;
+    }
+
+    public TimelineGroup(String id, T data, String title, int treeLevel, HashSet<String> nestedGroups) {
+        this.id = id;
+        this.data = data;
+        this.title = title;
+        this.treeLevel = treeLevel;
+        this.nestedGroups = nestedGroups;
+    }
+
     public String getId() {
         return id;
     }
@@ -97,6 +130,22 @@ public class TimelineGroup<T> implements Serializable {
 
     public void setData(T data) {
         this.data = data;
+    }
+
+    public Integer getTreeLevel() {
+        return treeLevel;
+    }
+
+    public void setTreeLevel(Integer treeLevel) {
+        this.treeLevel = treeLevel;
+    }
+
+    public HashSet<String> getNestedGroups() {
+        return nestedGroups;
+    }
+
+    public void setNestedGroups(HashSet<String> nestedGroups) {
+        this.nestedGroups = nestedGroups;
     }
 
     public String getStyleClass() {


### PR DESCRIPTION
https://visjs.github.io/vis-timeline/examples/timeline/groups/nestedThreeLevels.html

Adds new feature to primefaces timeline component for nested groups such as in the visjs link above.

I will also make a pull request for the showcase with an example like in the picture.
![image](https://user-images.githubusercontent.com/45278820/99653481-1c063180-2a6a-11eb-8c5e-030a31aac454.png)

