### PR TITLE
Fix #5296: GroupHeader IndexOutOfBoundsException

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4326,7 +4326,13 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             },
             update: function(event, ui) {
                 var fromIndex = ui.item.data('ri'),
-                toIndex = $this.paginator ? $this.paginator.getFirst() + ui.item.index(): ui.item.index();
+                itemIndex = ui.item.index();
+                
+                // #5296 must not count header group rows
+                var groupHeaders = $this.tbody.children('.ui-rowgroup-header').length;
+                itemIndex = itemIndex - groupHeaders;
+                
+                var toIndex = $this.paginator ? $this.paginator.getFirst() + itemIndex: itemIndex;
 
                 $this.syncRowParity();
 


### PR DESCRIPTION
Similar to https://github.com/primefaces/primefaces/issues/6557 the header rows must not be used in the index.