### PR TITLE
Dialog doesn't set focus on forms with only radio and checkboxes inside them. #3045

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -332,7 +332,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         if(this.cfg.focus)
         	PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.focus).trigger('focus');
         else
-            this.jq.find(':not(:submit):not(:button):not(:radio):not(:checkbox):input:visible:enabled:first').trigger('focus');
+            PrimeFaces.focus(null, this.id);
     },
 
     /**


### PR DESCRIPTION
Use PrimeFaces.focus to support focusing radios and checkboxes, and focus the selected one if there is.