### PR TITLE
Fix #6633: Improve drag and drop cancel

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -385,7 +385,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         // #5582: destroy any current draggable items
         if (this.cfg.draggableColumns || this.cfg.draggableRows) {
             var dragdrop = $.ui.ddmanager.current;
-            if (dragdrop) {
+            if (dragdrop && ($.ui.ddmanager.current.currentItem.closest('.ui-datatable')[0] == this.jq[0])) {
                 document.body.style.cursor = 'default';
                 dragdrop.cancel();
             }

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -385,9 +385,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         // #5582: destroy any current draggable items
         if (this.cfg.draggableColumns || this.cfg.draggableRows) {
             var dragdrop = $.ui.ddmanager.current;
-            if (dragdrop && ($.ui.ddmanager.current.currentItem.closest('.ui-datatable')[0] == this.jq[0])) {
-                document.body.style.cursor = 'default';
-                dragdrop.cancel();
+            if (dragdrop) {
+                var item = $.ui.ddmanager.current.currentItem || $.ui.ddmanager.current.element;
+                if(item.closest('.ui-datatable')[0] == this.jq[0]) {
+                    document.body.style.cursor = 'default';
+                    dragdrop.cancel();
+                }
             }
         }
     },

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -386,8 +386,8 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         if (this.cfg.draggableColumns || this.cfg.draggableRows) {
             var dragdrop = $.ui.ddmanager.current;
             if (dragdrop) {
-                var item = $.ui.ddmanager.current.currentItem || $.ui.ddmanager.current.element;
-                if(item.closest('.ui-datatable')[0] == this.jq[0]) {
+                var item = dragdrop.currentItem || dragdrop.element;
+                if(item.closest('.ui-datatable')[0] === this.jq[0]) {
                     document.body.style.cursor = 'default';
                     dragdrop.cancel();
                 }


### PR DESCRIPTION
It compares the parent of the currently dragged item with the `jq` of the datatable to determine if this drag and drop affects the datatable.