### PR TITLE
Fix #6641: DatePicker JS error on destroy

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1005,8 +1005,7 @@
         },
 
         _destroy: function () {
-            this.restoreOverlayAppend();
-            this.onOverlayHide();
+            this.hideOverlay();
         },
 
         /**


### PR DESCRIPTION
This looks like leftover code from the original Prime implementation that was calling a function that did not exist.