### PR TITLE
Fix #6619: DatePicker yearNavigator improved fix

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -190,9 +190,8 @@
                 }
             }
 
-            if (this.options.yearRange === null) {
-                this.updateYearNavigator();
-            }
+            this.hasCustomYearRange = this.options.yearRange !== null;
+            this.updateYearNavigator();
 
             if (this.options.disabledDates) {
                 for (var i = 0; i < this.options.disabledDates.length; i++) {
@@ -2544,6 +2543,9 @@
         },
 
         updateYearNavigator: function() {
+            if (this.hasCustomYearRange) {
+                return;
+            }
             if (this.options.yearNavigator) {
                 var viewYear = this.viewDate.getFullYear();
                 this.options.yearRange = (viewYear - 10) + ':' + (viewYear + 10);


### PR DESCRIPTION
This is an improved fix in case the user choose a custom `yearRange` that won't automatically readjust.