### PR TITLE
Fix #6648: Excel export numbers as numeric cells

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -44,7 +44,8 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.export.ExcelOptions;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
-import org.primefaces.util.*;
+import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.LangUtils;
 
 
 public class DataTableExcelExporter extends DataTableExporter {
@@ -191,7 +192,7 @@ public class DataTableExcelExporter extends DataTableExporter {
         applyColumnAlignments(column, cell);
 
         if (column.getExportFunction() != null) {
-            cell.setCellValue(createRichTextString(exportColumnByFunction(context, column)));
+            updateCell(cell, exportColumnByFunction(context, column));
         }
         else {
             StringBuilder builder = new StringBuilder();
@@ -205,7 +206,16 @@ public class DataTableExcelExporter extends DataTableExporter {
                 }
             }
 
-            cell.setCellValue(createRichTextString(builder.toString()));
+            updateCell(cell, builder.toString());
+        }
+    }
+
+    protected void updateCell(Cell cell, String value) {
+        if (LangUtils.isNumeric(value)) {
+            cell.setCellValue(Double.parseDouble(value));
+        }
+        else {
+            cell.setCellValue(createRichTextString(value));
         }
     }
 

--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -411,4 +411,55 @@ public class LangUtils {
             throw new FacesException(e);
         }
     }
+
+
+    /**
+     * <p>Checks whether the given String is a parsable number.</p>
+     *
+     * <p>Parsable numbers include those Strings understood by {@link Integer#parseInt(String)},
+     * {@link Long#parseLong(String)}, {@link Float#parseFloat(String)} or
+     * {@link Double#parseDouble(String)}. This method can be used instead of catching {@link java.text.ParseException}
+     * when calling one of those methods.</p>
+     *
+     * <p>Hexadecimal and scientific notations are <strong>not</strong> considered parsable.
+     * See {@link #isCreatable(String)} on those cases.</p>
+     *
+     * <p>{@code Null} and empty String will return {@code false}.</p>
+     *
+     * @param str the String to check.
+     * @return {@code true} if the string is a parsable number.
+     * @since 3.4
+     */
+    public static boolean isNumeric(final String str) {
+        if (isValueEmpty(str)) {
+            return false;
+        }
+        if (str.charAt(str.length() - 1) == '.') {
+            return false;
+        }
+        if (str.charAt(0) == '-') {
+            if (str.length() == 1) {
+                return false;
+            }
+            return withDecimalsParsing(str, 1);
+        }
+        return withDecimalsParsing(str, 0);
+    }
+
+    private static boolean withDecimalsParsing(final String str, final int beginIdx) {
+        int decimalPoints = 0;
+        for (int i = beginIdx; i < str.length(); i++) {
+            final boolean isDecimalPoint = str.charAt(i) == '.';
+            if (isDecimalPoint) {
+                decimalPoints++;
+            }
+            if (decimalPoints > 1) {
+                return false;
+            }
+            if (!isDecimalPoint && !Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/test/java/org/primefaces/util/LangUtilsTest.java
+++ b/src/test/java/org/primefaces/util/LangUtilsTest.java
@@ -24,7 +24,9 @@
 package org.primefaces.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -87,6 +89,29 @@ public class LangUtilsTest {
         assertEquals(SENTENCE, LangUtils.substring(SENTENCE, 0, 80));
         assertEquals("", LangUtils.substring(SENTENCE, 2, 2));
         assertEquals("b", LangUtils.substring("abc", -2, -1));
+    }
+
+    @Test
+    public void testIsParsable() {
+        assertFalse(LangUtils.isNumeric(null));
+        assertFalse(LangUtils.isNumeric(""));
+        assertFalse(LangUtils.isNumeric("0xC1AB"));
+        assertFalse(LangUtils.isNumeric("65CBA2"));
+        assertFalse(LangUtils.isNumeric("pendro"));
+        assertFalse(LangUtils.isNumeric("64, 2"));
+        assertFalse(LangUtils.isNumeric("64.2.2"));
+        assertFalse(LangUtils.isNumeric("64."));
+        assertFalse(LangUtils.isNumeric("64L"));
+        assertFalse(LangUtils.isNumeric("-"));
+        assertFalse(LangUtils.isNumeric("--2"));
+        assertTrue(LangUtils.isNumeric("64.2"));
+        assertTrue(LangUtils.isNumeric("64"));
+        assertTrue(LangUtils.isNumeric("018"));
+        assertTrue(LangUtils.isNumeric(".18"));
+        assertTrue(LangUtils.isNumeric("-65"));
+        assertTrue(LangUtils.isNumeric("-018"));
+        assertTrue(LangUtils.isNumeric("-018.2"));
+        assertTrue(LangUtils.isNumeric("-.236"));
     }
 
     class SimpleClass {


### PR DESCRIPTION
Borrowed Commons Lang3 `isParseable` as from performance tests is the fastest way to tell if a String is a number value.

See: https://www.baeldung.com/java-check-string-number for performance metrics.