### PR TITLE
Fix #6648: Excel option to disable strong type of cells

### DIFF
--- a/docs/9_0/components/dataexporter.md
+++ b/docs/9_0/components/dataexporter.md
@@ -336,6 +336,7 @@ public class CustomizedDocumentsView implements Serializable {
         excelOpt.setFacetFontStyle("BOLD");
         excelOpt.setCellFontColor("#00ff00");
         excelOpt.setCellFontSize("8");
+        excelOpt.setStronglyTypedCells(true);
     }
     public ExcelOptions getExcelOpt() {
         return excelOpt;

--- a/src/main/java/org/primefaces/component/export/ExcelOptions.java
+++ b/src/main/java/org/primefaces/component/export/ExcelOptions.java
@@ -43,6 +43,8 @@ public class ExcelOptions implements ExporterOptions {
 
     private boolean autoSizeColumn = true;
 
+    private boolean stronglyTypedCells = true;
+
     public ExcelOptions() {
     }
 
@@ -146,5 +148,13 @@ public class ExcelOptions implements ExporterOptions {
 
     public void setAutoSizeColumn(boolean autoSizeColumn) {
         this.autoSizeColumn = autoSizeColumn;
+    }
+
+    public boolean isStronglyTypedCells() {
+        return stronglyTypedCells;
+    }
+
+    public void setStronglyTypedCells(boolean stronglyTypedCells) {
+        this.stronglyTypedCells = stronglyTypedCells;
     }
 }


### PR DESCRIPTION
@jxmai I added an `ExcelOption` that is `true` by default to enable or disable strong typing of cells.  My thought was call it `StronglyTypedCells` because I can see us also adding `Date` type cells in the future as well.