### PR TITLE
Fix #6666: Chips stop ENTER propagation

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/chips/chips.js
+++ b/src/main/resources/META-INF/resources/primefaces/chips/chips.js
@@ -69,8 +69,7 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
             var value = $(this).val();
 
             switch(e.which) {
-                //backspace
-                case 8:
+                case keyCode.BACKSPACE:
                     if(value.length === 0 && $this.hinput.children('option') && $this.hinput.children('option').length > 0) {
                         var lastOption = $this.hinput.children('option:last'),
                             index = lastOption.index();
@@ -78,10 +77,10 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
                     }
                 break;
 
-                //enter
-                case 13:
+                case keyCode.ENTER:
                     $this.addItem(value, true);
                     e.preventDefault();
+                    e.stopPropagation();
                 break;
 
                 default:


### PR DESCRIPTION
Marking this as Draft as there may be other fixes but looking at AutoComplete ENTER key it was stopping propagation and so should Chips to prevent it triggering anything outside of it.