### PR TITLE
Fix: #6674 HeadRenderer: When Session tracking is 'URL', HeadRenderer don't add the jsesionid param to the resources #6674

### DIFF
--- a/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -34,6 +34,7 @@ import javax.faces.application.Resource;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
+import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.lifecycle.ClientWindow;
@@ -140,6 +141,7 @@ public class HeadRenderer extends Renderer {
 
     protected void encodeCSS(FacesContext context, String library, String resource) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
+        ExternalContext externalContext = context.getExternalContext();
 
         Resource cssResource = context.getApplication().getResourceHandler().createResource(resource, library);
         if (cssResource == null) {
@@ -149,19 +151,20 @@ public class HeadRenderer extends Renderer {
             writer.startElement("link", null);
             writer.writeAttribute("type", "text/css", null);
             writer.writeAttribute("rel", "stylesheet", null);
-            writer.writeAttribute("href", cssResource.getRequestPath(), null);
+            writer.writeAttribute("href", externalContext.encodeResourceURL(cssResource.getRequestPath()), null);
             writer.endElement("link");
         }
     }
 
     protected void encodeValidationResources(FacesContext context, boolean beanValidationEnabled) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
+        ExternalContext externalContext = context.getExternalContext();
         Resource resource = context.getApplication().getResourceHandler().createResource("validation/validation.js", "primefaces");
 
         if (resource != null) {
             writer.startElement("script", null);
             writer.writeAttribute("type", "text/javascript", null);
-            writer.writeAttribute("src", resource.getRequestPath(), null);
+            writer.writeAttribute("src", externalContext.encodeResourceURL(resource.getRequestPath()), null);
             writer.endElement("script");
         }
 
@@ -171,7 +174,7 @@ public class HeadRenderer extends Renderer {
             if (resource != null) {
                 writer.startElement("script", null);
                 writer.writeAttribute("type", "text/javascript", null);
-                writer.writeAttribute("src", resource.getRequestPath(), null);
+                writer.writeAttribute("src", externalContext.encodeResourceURL(resource.getRequestPath()), null);
                 writer.endElement("script");
             }
         }


### PR DESCRIPTION
Fixes: #6674 
The solution is simple 
Tested on mojarra 2.2, 2.3 and  myfaces 2.2, 2.3
