### PR TITLE
Fix #6677: Dialog closeOnEscape improvements

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -376,11 +376,13 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
         if(this.cfg.closeOnEscape) {
             $(document).on('keydown.dialog_' + this.id, function(e) {
-                var keyCode = $.ui.keyCode,
-                active = parseInt($this.jq.css('z-index')) === PrimeFaces.zindex;
-
-                if(e.which === keyCode.ESCAPE && $this.isVisible() && active) {
-                    $this.hide();
+                var keyCode = $.ui.keyCode;
+                if(e.which === keyCode.ESCAPE && $this.isVisible()) {
+                    // GitHub #6677 if multiple dialogs check if this is the topmost active dialog to close
+                    var active = parseInt($this.jq.css('z-index')) === parseInt($('.ui-dialog:visible').last().css('z-index'));
+                    if(active) {
+                         $this.hide();
+                    }
                 };
             });
         }


### PR DESCRIPTION
Improved performance by only checking `active` after we have determined the ESC key was pressed.

Finds the topmost dialog not counting on the PrimFaces.zindex which felt like a lucky hack before.