### PR TITLE
Fix #59: DataExporter for ColumnGroup

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -37,14 +37,17 @@ import org.apache.poi.hssf.usermodel.HSSFRichTextString;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.hssf.util.HSSFColor;
 import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.WorkbookUtil;
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
+import org.primefaces.component.columngroup.ColumnGroup;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.export.ExcelOptions;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
 
@@ -80,7 +83,12 @@ public class DataTableExcelExporter extends DataTableExporter {
         }
 
         ExcelOptions options = (ExcelOptions) exportConfiguration.getOptions();
-        stronglyTypedCells = options.isStronglyTypedCells();
+        if (options == null) {
+            stronglyTypedCells = true;
+        }
+        else {
+            stronglyTypedCells = options.isStronglyTypedCells();
+        }
         Sheet sheet = createSheet(wb, sheetName, options);
         applyOptions(wb, table, sheet, options);
         exportTable(context, table, sheet, exportConfiguration);
@@ -130,9 +138,7 @@ public class DataTableExcelExporter extends DataTableExporter {
     }
 
     protected void addColumnFacets(DataTable table, Sheet sheet, DataTableExporter.ColumnType columnType) {
-        int sheetRowIndex = columnType == DataTableExporter.ColumnType.HEADER
-                ? 0
-                : sheet.getLastRowNum() + 1;
+        int sheetRowIndex = sheet.getLastRowNum() + 1;
         Row rowHeader = sheet.createRow(sheetRowIndex);
 
         for (UIColumn col : table.getColumns()) {
@@ -164,9 +170,52 @@ public class DataTableExcelExporter extends DataTableExporter {
                     addColumnValue(rowHeader, facet);
                 }
                 else {
-                    addColumnValue(rowHeader, "");
+                    addColumnValue(rowHeader, Constants.EMPTY_STRING);
                 }
             }
+        }
+    }
+
+    protected void addTableFacets(FacesContext context, DataTable table, Sheet sheet, DataTableExporter.ColumnType columnType) {
+        String facetText = null;
+        UIComponent facet = table.getFacet(columnType.facet());
+        if (ComponentUtils.shouldRenderFacet(facet)) {
+            if (facet instanceof UIPanel) {
+                for (UIComponent child : facet.getChildren()) {
+                    if (child.isRendered()) {
+                        String value = ComponentUtils.getValueToRender(context, child);
+
+                        if (value != null) {
+                            facetText = value;
+                            break;
+                        }
+                    }
+                }
+            }
+            else {
+                facetText = ComponentUtils.getValueToRender(context, facet);
+            }
+        }
+
+        if (facetText != null) {
+            int colspan = 0;
+
+            for (UIColumn col : table.getColumns()) {
+                if (col.isRendered() && col.isExportable()) {
+                    colspan++;
+                }
+            }
+
+            int rowIndex = sheet.getLastRowNum() + 1;
+            Row rowHeader = sheet.createRow(rowIndex);
+
+            sheet.addMergedRegion(new CellRangeAddress(
+                        rowIndex, // first row (0-based)
+                        rowIndex, // last row (0-based)
+                        0, // first column (0-based)
+                        colspan - 1 // last column (0-based)
+            ));
+            addColumnValue(rowHeader, 0, facetText);
         }
     }
 
@@ -176,14 +225,14 @@ public class DataTableExcelExporter extends DataTableExporter {
     }
 
     protected void addColumnValue(Row row, String value) {
-        int cellIndex = row.getLastCellNum() == -1 ? 0 : row.getLastCellNum();
-        Cell cell = row.createCell(cellIndex);
+        int col = row.getLastCellNum() == -1 ? 0 : row.getLastCellNum();
+        addColumnValue(row, col, value);
+    }
 
-        cell.setCellValue(createRichTextString(value));
-
-        if (facetStyle != null) {
-            cell.setCellStyle(facetStyle);
-        }
+    protected void addColumnValue(Row row, int col, String text) {
+        Cell cell = row.createCell(col);
+        cell.setCellValue(createRichTextString(text));
+        cell.setCellStyle(facetStyle);
     }
 
     protected void addColumnValue(Row row, List<UIComponent> components, UIColumn column) {
@@ -210,6 +259,99 @@ public class DataTableExcelExporter extends DataTableExporter {
 
             updateCell(cell, builder.toString());
         }
+    }
+
+    protected boolean addColumnGroup(DataTable table, Sheet sheet, DataTableExporter.ColumnType columnType) {
+        ColumnGroup cg = table.getColumnGroup(columnType.facet());
+        if (cg == null || cg.getChildCount() == 0) {
+            return false;
+        }
+        for (UIComponent component : cg.getChildren()) {
+            if (!(component instanceof org.primefaces.component.row.Row)) {
+                continue;
+            }
+            org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
+            int rowIndex = sheet.getLastRowNum() + 1;
+            Row xlRow = sheet.createRow(rowIndex);
+            int colIndex = 0;
+            for (UIComponent rowComponent : row.getChildren()) {
+                if (!(rowComponent instanceof UIColumn)) {
+                    // most likely a ui:repeat which won't work here
+                    continue;
+                }
+                UIColumn column = (UIColumn) rowComponent;
+                if (!column.isRendered() || !column.isExportable()) {
+                    continue;
+                }
+
+                String text = null;
+                switch (columnType) {
+                    case HEADER:
+                        text = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+                        break;
+
+                    case FOOTER:
+                        text = (column.getExportFooterValue() != null) ? column.getExportFooterValue() : column.getFooterText();
+                        break;
+
+                    default:
+                        text = null;
+                        break;
+                }
+
+                // by default column has 1 rowspan && colspan
+                int rowSpan = column.getRowspan() - 1;
+                int colSpan = column.getColspan() - 1;
+
+                if (rowSpan > 0 && colSpan > 0) {
+                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
+                    sheet.addMergedRegion(new CellRangeAddress(
+                                rowIndex, // first row (0-based)
+                                rowIndex + rowSpan, // last row (0-based)
+                                colIndex, // first column (0-based)
+                                colIndex + colSpan // last column (0-based)
+                    ));
+                    addColumnValue(xlRow, (short) colIndex, text);
+                    colIndex = colIndex + colSpan;
+                }
+                else if (rowSpan > 0) {
+                    sheet.addMergedRegion(new CellRangeAddress(
+                                rowIndex, // first row (0-based)
+                                rowIndex + rowSpan, // last row (0-based)
+                                colIndex, // first column (0-based)
+                                colIndex // last column (0-based)
+                    ));
+                    addColumnValue(xlRow, (short) colIndex, text);
+                }
+                else if (colSpan > 0) {
+                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
+                    sheet.addMergedRegion(new CellRangeAddress(
+                                rowIndex, // first row (0-based)
+                                rowIndex, // last row (0-based)
+                                colIndex, // first column (0-based)
+                                colIndex + colSpan // last column (0-based)
+                    ));
+                    addColumnValue(xlRow, (short) colIndex, text);
+                    colIndex = colIndex + colSpan;
+                }
+                else {
+                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
+                    addColumnValue(xlRow, (short) colIndex, text);
+                }
+                colIndex++;
+            }
+        }
+        return true;
+    }
+
+    protected int calculateColumnOffset(Sheet sheet, int row, int col) {
+        for (int j = 0; j < sheet.getNumMergedRegions(); j++) {
+            CellRangeAddress merged = sheet.getMergedRegion(j);
+            if (merged.isInRange(row, col)) {
+                col = merged.getLastColumn() + 1;
+            }
+        }
+        return col;
     }
 
     /**
@@ -256,7 +398,11 @@ public class DataTableExcelExporter extends DataTableExporter {
 
     public void exportTable(FacesContext context, UIComponent component, Sheet sheet, ExportConfiguration exportConfiguration) {
         DataTable table = (DataTable) component;
-        addColumnFacets(table, sheet, DataTableExporter.ColumnType.HEADER);
+        addTableFacets(context, table, sheet, DataTableExporter.ColumnType.HEADER);
+        boolean headerGroup = addColumnGroup(table, sheet, DataTableExporter.ColumnType.HEADER);
+        if (!headerGroup) {
+            addColumnFacets(table, sheet, DataTableExporter.ColumnType.HEADER);
+        }
 
         if (exportConfiguration.isPageOnly()) {
             exportPageOnly(context, table, sheet);
@@ -268,9 +414,11 @@ public class DataTableExcelExporter extends DataTableExporter {
             exportAll(context, table, sheet);
         }
 
+        addColumnGroup(table, sheet, DataTableExporter.ColumnType.FOOTER);
         if (table.hasFooterColumn()) {
             addColumnFacets(table, sheet, DataTableExporter.ColumnType.FOOTER);
         }
+        addTableFacets(context, table, sheet, DataTableExporter.ColumnType.FOOTER);
 
         table.setRowIndex(-1);
     }
@@ -378,7 +526,7 @@ public class DataTableExcelExporter extends DataTableExporter {
         cellStyle.setFont(cellFont);
     }
 
-    protected Cell applyColumnAlignments(final UIColumn column, final Cell cell) {
+    protected Cell applyColumnAlignments(UIColumn column, Cell cell) {
         String[] styles = new String[] {column.getStyle(), column.getStyleClass()};
         if (LangUtils.containsIgnoreCase(styles, "right")) {
             cell.setCellStyle(cellStyleRightAlign);

--- a/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -33,12 +33,14 @@ import javax.faces.context.FacesContext;
 
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
+import org.primefaces.component.columngroup.ColumnGroup;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.component.export.PDFOptions;
 import org.primefaces.component.export.PDFOrientationType;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
 import com.lowagie.text.*;
@@ -145,9 +147,11 @@ public class DataTablePDFExporter extends DataTableExporter {
             config.getOnTableRender().invoke(context.getELContext(), new Object[]{pdfTable, table});
         }
 
-        addTableFacets(context, table, pdfTable, "header");
-
-        addColumnFacets(table, pdfTable, ColumnType.HEADER);
+        addTableFacets(context, table, pdfTable, ColumnType.HEADER);
+        boolean headerGroup = addColumnGroup(table, pdfTable, ColumnType.HEADER);
+        if (!headerGroup) {
+            addColumnFacets(table, pdfTable, ColumnType.HEADER);
+        }
 
         if (config.isPageOnly()) {
             exportPageOnly(context, table, pdfTable);
@@ -159,20 +163,20 @@ public class DataTablePDFExporter extends DataTableExporter {
             exportAll(context, table, pdfTable);
         }
 
+        addColumnGroup(table, pdfTable, ColumnType.FOOTER);
         if (table.hasFooterColumn()) {
             addColumnFacets(table, pdfTable, ColumnType.FOOTER);
         }
-
-        addTableFacets(context, table, pdfTable, "footer");
+        addTableFacets(context, table, pdfTable, ColumnType.FOOTER);
 
         table.setRowIndex(-1);
 
         return pdfTable;
     }
 
-    protected void addTableFacets(FacesContext context, DataTable table, PdfPTable pdfTable, String facetType) {
+    protected void addTableFacets(FacesContext context, DataTable table, PdfPTable pdfTable, ColumnType columnType) {
         String facetText = null;
-        UIComponent facet = table.getFacet(facetType);
+        UIComponent facet = table.getFacet(columnType.facet());
         if (ComponentUtils.shouldRenderFacet(facet)) {
             if (facet instanceof UIPanel) {
                 for (UIComponent child : facet.getChildren()) {
@@ -249,30 +253,82 @@ public class DataTablePDFExporter extends DataTableExporter {
                 }
 
                 if (textValue != null) {
-                    addColumnValue(pdfTable, textValue);
+                    addColumnValue(pdfTable, textValue, 1, 1);
                 }
                 else if (ComponentUtils.shouldRenderFacet(facet)) {
                     addColumnValue(pdfTable, facet);
                 }
                 else {
-                    addColumnValue(pdfTable, "");
+                    addColumnValue(pdfTable, Constants.EMPTY_STRING, 1, 1);
                 }
             }
         }
     }
 
-    protected void addColumnValue(PdfPTable pdfTable, UIComponent component) {
-        String value = component == null ? "" : exportValue(FacesContext.getCurrentInstance(), component);
-        addColumnValue(pdfTable, value);
+    protected boolean addColumnGroup(DataTable table, PdfPTable pdfTable,  ColumnType columnType) {
+        ColumnGroup cg = table.getColumnGroup(columnType.facet());
+        if (cg == null || cg.getChildCount() == 0) {
+            return false;
+        }
+        for (UIComponent component : cg.getChildren()) {
+            if (!(component instanceof org.primefaces.component.row.Row)) {
+                continue;
+            }
+            org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
+            for (UIComponent rowComponent : row.getChildren()) {
+                if (!(rowComponent instanceof UIColumn)) {
+                    // most likely a ui:repeat which won't work here
+                    continue;
+                }
+                UIColumn column = (UIColumn) rowComponent;
+                if (column.isRendered() && column.isExportable()) {
+                    String textValue;
+                    switch (columnType) {
+                        case HEADER:
+                            textValue = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+                            break;
+
+                        case FOOTER:
+                            textValue = (column.getExportFooterValue() != null) ? column.getExportFooterValue() : column.getFooterText();
+                            break;
+
+                        default:
+                            textValue = Constants.EMPTY_STRING;
+                            break;
+                    }
+
+                    int rowSpan = column.getRowspan();
+                    int colSpan = column.getColspan();
+                    addColumnValue(pdfTable, textValue, rowSpan, colSpan);
+                }
+            }
+            pdfTable.completeRow();
+        }
+        return true;
     }
 
-    protected void addColumnValue(PdfPTable pdfTable, String value) {
+    protected void addColumnValue(PdfPTable pdfTable, UIComponent component) {
+        String value = component == null ? "" : exportValue(FacesContext.getCurrentInstance(), component);
+        addColumnValue(pdfTable, value, 1, 1);
+    }
+
+    protected PdfPCell addColumnValue(PdfPTable pdfTable, String value, int rowSpan, int colSpan) {
         PdfPCell cell = new PdfPCell(new Paragraph(value, facetFont));
         if (facetBgColor != null) {
             cell.setBackgroundColor(facetBgColor);
         }
+        if (rowSpan > 1) {
+            cell.setVerticalAlignment(Element.ALIGN_CENTER);
+            cell.setRowspan(rowSpan);
+
+        }
+        if (colSpan > 1) {
+            cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+            cell.setColspan(colSpan);
+        }
 
         pdfTable.addCell(cell);
+        return cell;
     }
 
     protected void addColumnValue(PdfPTable pdfTable, List<UIComponent> components, Font font, UIColumn column) {
@@ -383,12 +439,12 @@ public class DataTablePDFExporter extends DataTableExporter {
         facetFont = FontFactory.getFont(newFont, encoding, Font.DEFAULTSIZE, Font.BOLD);
     }
 
-    protected PdfPCell createCell(final UIColumn column, Phrase phrase) {
+    protected PdfPCell createCell(UIColumn column, Phrase phrase) {
         PdfPCell cell = new PdfPCell(phrase);
         return applyColumnAlignments(column, cell);
     }
 
-    protected PdfPCell applyColumnAlignments(final UIColumn column, final PdfPCell cell) {
+    protected PdfPCell applyColumnAlignments(UIColumn column, PdfPCell cell) {
         String[] styles = new String[] {column.getStyle(), column.getStyleClass()};
         if (LangUtils.containsIgnoreCase(styles, "right")) {
             cell.setHorizontalAlignment(Element.ALIGN_RIGHT);


### PR DESCRIPTION
Ported code from PF Extensions and cleaned it up greatly.

**Before:**
![image](https://user-images.githubusercontent.com/4399574/102540254-c29b1d80-407c-11eb-9b6c-64f0bb9fbba8.png)

**After:**
![image](https://user-images.githubusercontent.com/4399574/102540426-02fa9b80-407d-11eb-93be-2341a7aa0255.png)

**PDF:**
![image](https://user-images.githubusercontent.com/4399574/102540501-202f6a00-407d-11eb-9346-58fc69569c17.png)
