### PR TITLE
Fix #2238: Column exportValue attribute

### DIFF
--- a/docs/9_0/components/column.md
+++ b/docs/9_0/components/column.md
@@ -51,6 +51,7 @@ treetable and more.
 | ariaHeaderText | null | String | Label to read by screen readers, when not specified headerText is used.
 | exportFunction | null | MethodExpr | Custom pluggable exportFunction for data exporter.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
+| exportValue | null | String | Defines the value of the cell to be exported if you want something other than the cell contents or exportFunction.
 | exportHeaderValue | null | String | Defines if the header value of column to be exported.
 | exportFooterValue | null | String | Defines if the footer value of column to be exported.
 | nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"

--- a/docs/9_0/components/columns.md
+++ b/docs/9_0/components/columns.md
@@ -50,6 +50,7 @@ Columns is used by datatable to create columns dynamically.
 | selectRow | true | Boolean | Whether clicking the column selects the row when parent component has row selection enabled, default is true.
 | ariaHeaderText | null | String | Label to read by screen readers, when not specified headerText is used.
 | exportFunction | null | MethodExpression | Custom pluggable exportFunction.
+| exportValue | null | String | Defines the value of the cell to be exported if something other than the cell contents or exportFunction.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
 | exportHeaderValue | null | String | Defines if the header value of column to be exported.
 | exportFooterValue | null | String | Defines if the footer value of column to be exported.

--- a/src/main/java/org/primefaces/component/api/DynamicColumn.java
+++ b/src/main/java/org/primefaces/component/api/DynamicColumn.java
@@ -328,4 +328,10 @@ public class DynamicColumn implements UIColumn {
     public boolean isDraggable() {
         return columns.isDraggable();
     }
+
+    @Override
+    public String getExportValue() {
+        return columns.getExportValue();
+    }
+
 }

--- a/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -121,6 +121,8 @@ public interface UIColumn {
 
     MethodExpression getExportFunction();
 
+    String getExportValue();
+
     boolean isGroupRow();
 
     String getExportHeaderValue();

--- a/src/main/java/org/primefaces/component/column/ColumnBase.java
+++ b/src/main/java/org/primefaces/component/column/ColumnBase.java
@@ -69,6 +69,7 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
         ariaHeaderText,
         exportFunction,
         groupRow,
+        exportValue,
         exportHeaderValue,
         exportFooterValue,
         sortOrder,
@@ -372,6 +373,15 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
 
     public void setGroupRow(boolean groupRow) {
         getStateHelper().put(PropertyKeys.groupRow, groupRow);
+    }
+
+    @Override
+    public String getExportValue() {
+        return (String) getStateHelper().eval(PropertyKeys.exportValue, null);
+    }
+
+    public void setExportValue(String exportValue) {
+        getStateHelper().put(PropertyKeys.exportValue, exportValue);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/columns/ColumnsBase.java
+++ b/src/main/java/org/primefaces/component/columns/ColumnsBase.java
@@ -65,6 +65,7 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
         ariaHeaderText,
         exportFunction,
         groupRow,
+        exportValue,
         exportHeaderValue,
         exportFooterValue,
         sortOrder,
@@ -359,6 +360,15 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
 
     public void setGroupRow(boolean groupRow) {
         getStateHelper().put(PropertyKeys.groupRow, groupRow);
+    }
+
+    @Override
+    public String getExportValue() {
+        return (String) getStateHelper().eval(PropertyKeys.exportValue, null);
+    }
+
+    public void setExportValue(String exportValue) {
+        getStateHelper().put(PropertyKeys.exportValue, exportValue);
     }
 
     @Override

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
@@ -41,6 +41,7 @@ import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
+import org.primefaces.util.LangUtils;
 
 public class DataTableCSVExporter extends DataTableExporter {
 
@@ -204,7 +205,14 @@ public class DataTableCSVExporter extends DataTableExporter {
 
         writer.append(csvOptions.getQuoteChar());
 
-        if (column.getExportFunction() != null) {
+        if (LangUtils.isNotBlank(column.getExportValue())) {
+            String value = column.getExportValue();
+            //escape double quotes
+            value = value == null ? "" : value.replace(csvOptions.getQuoteString(), csvOptions.getDoubleQuoteString());
+
+            writer.append(value);
+        }
+        else if (column.getExportFunction() != null) {
             String value = exportColumnByFunction(context, column);
             //escape double quotes
             value = value == null ? "" : value.replace(csvOptions.getQuoteString(), csvOptions.getDoubleQuoteString());

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -198,7 +198,10 @@ public class DataTableExcelExporter extends DataTableExporter {
 
         applyColumnAlignments(column, cell);
 
-        if (column.getExportFunction() != null) {
+        if (LangUtils.isNotBlank(column.getExportValue())) {
+            updateCell(cell, column.getExportValue());
+        }
+        else if (column.getExportFunction() != null) {
             updateCell(cell, exportColumnByFunction(context, column));
         }
         else {

--- a/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -278,7 +278,11 @@ public class DataTablePDFExporter extends DataTableExporter {
     protected void addColumnValue(PdfPTable pdfTable, List<UIComponent> components, Font font, UIColumn column) {
         FacesContext context = FacesContext.getCurrentInstance();
 
-        if (column.getExportFunction() != null) {
+        if (LangUtils.isNotBlank(column.getExportValue())) {
+            PdfPCell cell = createCell(column, new Paragraph(column.getExportValue(), font));
+            pdfTable.addCell(cell);
+        }
+        else if (column.getExportFunction() != null) {
             PdfPCell cell = createCell(column, new Paragraph(exportColumnByFunction(context, column), font));
             pdfTable.addCell(cell);
         }

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
@@ -23,18 +23,22 @@
  */
 package org.primefaces.component.datatable.export;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.List;
+
+import javax.faces.FacesException;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.EscapeUtils;
-
-import javax.faces.FacesException;
-import javax.faces.component.UIComponent;
-import javax.faces.context.FacesContext;
-import java.io.*;
-import java.util.List;
+import org.primefaces.util.LangUtils;
 
 public class DataTableXMLExporter extends DataTableExporter {
 
@@ -138,7 +142,10 @@ public class DataTableXMLExporter extends DataTableExporter {
 
         writer.append("\t\t<" + tag + ">");
 
-        if (column.getExportFunction() != null) {
+        if (LangUtils.isNotBlank(column.getExportValue())) {
+            writer.append(EscapeUtils.forXml(column.getExportValue()));
+        }
+        else if (column.getExportFunction() != null) {
             writer.append(EscapeUtils.forXml(exportColumnByFunction(context, column)));
         }
         else {

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -5290,6 +5290,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Defines the value of the cell to be exported if something other than the cell contents or exportFunction.]]>
+            </description>
+            <name>exportValue</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines if the header value of column to be exported.]]>
             </description>
             <name>exportHeaderValue</name>
@@ -5683,6 +5691,14 @@
             <name>groupRow</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Defines the value of the cell to be exported if something other than the cell contents or exportFunction.]]>
+            </description>
+            <name>exportValue</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>


### PR DESCRIPTION
I have needed this myself. 
**For example:**
```xml
<p:column exportValue="***#{car.color}***" headerText="Color">
        <h:outputText value="#{car.color}" />
</p:column>
```

**Exports:**
![image](https://user-images.githubusercontent.com/4399574/102545330-18bf8f00-4084-11eb-822f-a48a33f4c6b1.png)

