### PR TITLE
Fix #5312: Steps allow activeIndex execution

### DIFF
--- a/docs/9_0/components/steps.md
+++ b/docs/9_0/components/steps.md
@@ -25,6 +25,7 @@ model | null | MenuModel | MenuModel instance to build menu dynamically.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 activeIndex | 0 | Integer | Index of the active tab.
+activeStepExecutable | false | boolean | Allows the active index menu to remain executable. Default is false.
 widgetVar | null | String | Name of the client side widget.
 readonly | true | Boolean | Defines whether items would be clickable or not.
 

--- a/src/main/java/org/primefaces/component/steps/StepsBase.java
+++ b/src/main/java/org/primefaces/component/steps/StepsBase.java
@@ -39,7 +39,8 @@ public abstract class StepsBase extends AbstractMenu implements Widget {
         style,
         styleClass,
         activeIndex,
-        readonly
+        readonly,
+        activeStepExecutable
     }
 
     public StepsBase() {
@@ -98,5 +99,13 @@ public abstract class StepsBase extends AbstractMenu implements Widget {
 
     public void setReadonly(boolean readonly) {
         getStateHelper().put(PropertyKeys.readonly, readonly);
+    }
+
+    public boolean isActiveStepExecutable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.activeStepExecutable, false);
+    }
+
+    public void setActiveStepExecutable(boolean activeStepExecutable) {
+        getStateHelper().put(PropertyKeys.activeStepExecutable, activeStepExecutable);
     }
 }

--- a/src/main/java/org/primefaces/component/steps/StepsRenderer.java
+++ b/src/main/java/org/primefaces/component/steps/StepsRenderer.java
@@ -23,16 +23,17 @@
  */
 package org.primefaces.component.steps;
 
-import org.primefaces.component.menu.AbstractMenu;
-import org.primefaces.component.menu.BaseMenuRenderer;
-import org.primefaces.model.menu.MenuElement;
-import org.primefaces.model.menu.MenuItem;
+import java.io.IOException;
+import java.util.List;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
-import java.io.IOException;
-import java.util.List;
+
+import org.primefaces.component.menu.AbstractMenu;
+import org.primefaces.component.menu.BaseMenuRenderer;
+import org.primefaces.model.menu.MenuElement;
+import org.primefaces.model.menu.MenuItem;
 
 public class StepsRenderer extends BaseMenuRenderer {
 
@@ -81,7 +82,12 @@ public class StepsRenderer extends BaseMenuRenderer {
         }
         else {
             if (index == activeIndex) {
-                itemClass = Steps.ACTIVE_ITEM_CLASS;
+                if (steps.isActiveStepExecutable()) {
+                    itemClass = Steps.VISITED_ITEM_CLASS;
+                }
+                else {
+                    itemClass = Steps.ACTIVE_ITEM_CLASS;
+                }
             }
             else if (index < activeIndex) {
                 itemClass = Steps.VISITED_ITEM_CLASS;
@@ -118,7 +124,6 @@ public class StepsRenderer extends BaseMenuRenderer {
         String styleClass = getLinkStyleClass(menuitem);
 
         writer.startElement("a", null);
-        writer.writeAttribute("tabindex", "-1", null);
         if (shouldRenderId(menuitem)) {
             writer.writeAttribute("id", menuitem.getClientId(), null);
         }
@@ -132,11 +137,14 @@ public class StepsRenderer extends BaseMenuRenderer {
             writer.writeAttribute("style", style, null);
         }
 
-        if (steps.isReadonly() || menuitem.isDisabled() || (activeIndex <= index)) {
+        boolean isDisabled = steps.isActiveStepExecutable() ?  activeIndex < index : activeIndex <= index;
+        if (steps.isReadonly() || menuitem.isDisabled() || isDisabled) {
+            writer.writeAttribute("tabindex", "-1", null);
             writer.writeAttribute("href", "#", null);
             writer.writeAttribute("onclick", "return false;", null);
         }
         else {
+            writer.writeAttribute("tabindex", steps.getTabindex(), null);
             encodeOnClick(context, steps, menuitem);
         }
 

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -26749,6 +26749,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Allows the active index menu to remain executable. Default is false.]]>
+            </description>
+            <name>activeStepExecutable</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines whether items would be clickable or not. Default is true.]]>
             </description>
             <name>readonly</name>


### PR DESCRIPTION
I am not married to the property name `allowActiveIndexExecution` so any suggestions welcome.
This took advice from @mertsincan on my PR last year and does the following:

- tabindex value -> line 121
- if check -> line 135
- cursor style for the active item.

Previous PR for reference: https://github.com/primefaces/primefaces/pull/5314