### PR TITLE
Fix #1895/#6691: Chips allow pasting of delimited list

### DIFF
--- a/docs/9_0/components/chips.md
+++ b/docs/9_0/components/chips.md
@@ -29,6 +29,7 @@ Chips is used to enter multiple values on an inputfield.
 | inputmode | null | String | Hint at the type of data this control has for touch devices to display appropriate virtual keyboard.
 | max | null | Integer | Maximum number of entries allowed.
 | addOnBlur | false | Boolean | Whether to add an item when the input loses focus.
+| addOnPaste | false | Boolean | Whether to add the items immediately when pasting into the input. Default false.
 | onblur | null | String | Client side callback to execute when input element loses focus.
 | onchange | null | String | Client side callback to execute when input element loses focus and its value has been modified since gaining focus.
 | onclick | null | String | Client side callback to execute when input element is clicked.
@@ -63,6 +64,7 @@ Chips is used to enter multiple values on an inputfield.
 | rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
 | required | false | Boolean | Marks component as required.
 | requiredMessage | null | String | Message to be displayed when required field validation fails.
+| separator | , | String | Separator character to allow multiple values such if a list is pasted into the input. Default is ','.
 | title | null | String | Advisory tooltip information.
 | unique | false | Boolean | Prevent duplicate entries from being added. Default false.
 | validator | null | MethodExpr | A method expression that refers to a method for validation the input.
@@ -105,6 +107,16 @@ The following AJAX behavior events are available for this component. If no event
 | --- | --- | --- |
 | itemSelect | org.primefaces.event.SelectEvent | When an item is added.
 | itemUnselect | org.primefaces.event.UnselectEvent | When an item is removed.
+
+## Client Side API
+Widget: _PrimeFaces.widget.Chips_
+
+| Method | Params | Return Type | Description |
+| --- | --- | --- | --- |
+| toggleEditor() | none | void | Converts the current list into a separator delimited list for mass editing while keeping original order of the items or closes the editor turning the values back into chips.|
+| addItem(value) | value: to add | void | Adds a new item (chip) to the list of currently displayed items. |
+| removeItem(value) | value: to remove | void | Removes an item (chip) from the list of currently displayed items. |
+
 
 ## Skinning
 Following is the list of structural style classes;

--- a/src/main/java/org/primefaces/component/chips/ChipsBase.java
+++ b/src/main/java/org/primefaces/component/chips/ChipsBase.java
@@ -42,7 +42,9 @@ public abstract class ChipsBase extends AbstractPrimeHtmlInputText implements Wi
         inputStyle,
         inputStyleClass,
         addOnBlur,
-        unique
+        addOnPaste,
+        unique,
+        separator
     }
 
     public ChipsBase() {
@@ -102,11 +104,27 @@ public abstract class ChipsBase extends AbstractPrimeHtmlInputText implements Wi
         getStateHelper().put(PropertyKeys.addOnBlur, addOnBlur);
     }
 
+    public boolean isAddOnPaste() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.addOnPaste, false);
+    }
+
+    public void setAddOnPaste(boolean addOnPaste) {
+        getStateHelper().put(PropertyKeys.addOnPaste, addOnPaste);
+    }
+
     public boolean isUnique() {
         return (Boolean) getStateHelper().eval(PropertyKeys.unique, false);
     }
 
     public void setUnique(boolean unique) {
         getStateHelper().put(PropertyKeys.unique, unique);
+    }
+
+    public String getSeparator() {
+        return (String) getStateHelper().eval(PropertyKeys.separator, ",");
+    }
+
+    public void setSeparator(String separator) {
+        getStateHelper().put(PropertyKeys.separator, separator);
     }
 }

--- a/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
+++ b/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
@@ -204,7 +204,9 @@ public class ChipsRenderer extends InputRenderer {
         wb.init("Chips", chips)
                 .attr("max", chips.getMax(), Integer.MAX_VALUE)
                 .attr("addOnBlur", chips.isAddOnBlur(), false)
-                .attr("unique", chips.isUnique(), false);
+                .attr("addOnPaste", chips.isAddOnPaste(), false)
+                .attr("unique", chips.isUnique(), false)
+                .attr("separator", chips.getSeparator(), ",");
 
         encodeClientBehaviors(context, chips);
 

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -4737,11 +4737,27 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Whether to add the items immediately when pasting into the input. Default false.]]>
+            </description>
+            <name>addOnPaste</name>
+            <required>false</required>
+            <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Prevent duplicate entries from being added. Default false.]]>
             </description>
             <name>unique</name>
             <required>false</required>
             <type>boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Separator character to allow multiple values such if a list is pasted into the input. Default is ','.]]>
+            </description>
+            <name>separator</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
     </tag>
     <tag>

--- a/src/main/resources/META-INF/resources/primefaces/chips/chips.js
+++ b/src/main/resources/META-INF/resources/primefaces/chips/chips.js
@@ -17,6 +17,7 @@
  * @prop {boolean} cfg.addOnBlur Whether to add an item when the input loses focus.
  * @prop {boolean} cfg.unique Prevent duplicate entries from being added.
  * @prop {number} cfg.max Maximum number of entries allowed.
+ * @prop {string} cfg.separator Separator character to allow multiple values such if a list is pasted into the input. Default is ','.
  */
 PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
 
@@ -27,6 +28,7 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
      */
     init: function(cfg) {
         this._super(cfg);
+        this.cfg.separator = this.cfg.separator||',';
 
         this.input = $(this.jqId + '_input');
         this.hinput = $(this.jqId + '_hinput');
@@ -64,6 +66,13 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
 
             if ($this.cfg.addOnBlur) {
                 $this.addItem($(this).val(), false);
+            }
+        }).on('paste.chips', function(e) {
+            if ($this.cfg.addOnPaste) {
+                var pasteData = e.originalEvent.clipboardData.getData('text');
+                $this.addItem(pasteData, false);
+                e.preventDefault();
+                e.stopPropagation();
             }
         }).on('keydown.chips', function(e) {
             var keyCode = $.ui.keyCode;
@@ -106,32 +115,41 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
      */
     addItem: function(value, refocus) {
         var $this = this;
-        if(value && value.trim().length && (!this.cfg.max||this.cfg.max > this.hinput.children('option').length)) {
-            var escapedValue = PrimeFaces.escapeHTML(value);
 
-            if (this.cfg.unique) {
-                var duplicateFound = false;
-                this.hinput.children('option').each(function() {
-                    if (this.value === escapedValue) {
-                        $this.refocus(refocus);
-                        duplicateFound = true;
-                        return false; // breaks
-                    }
-                });
-                if (duplicateFound) {
-                    return;
-                }
+        if (!value || !value.trim().length) {
+            return;
+        }
+
+        var tokens = value.split(this.cfg.separator);
+        for (var i = 0; i < tokens.length; i++) {
+           var token = tokens[i];
+           if(token && token.trim().length && (!this.cfg.max||this.cfg.max > this.hinput.children('option').length)) {
+               var escapedValue = PrimeFaces.escapeHTML(token);
+
+               if (this.cfg.unique) {
+                   var duplicateFound = false;
+                   this.hinput.children('option').each(function() {
+                       if (this.value === escapedValue) {
+                           $this.refocus(refocus);
+                           duplicateFound = true;
+                           return false; // breaks
+                       }
+                   });
+                   if (duplicateFound) {
+                       return;
+                   }
+               }
+
+               var itemDisplayMarkup = '<li class="ui-chips-token ui-state-active ui-corner-all">';
+               itemDisplayMarkup += '<span class="ui-chips-token-icon ui-icon ui-icon-close"></span>';
+               itemDisplayMarkup += '<span class="ui-chips-token-label">' + escapedValue + '</span></li>';
+
+               this.inputContainer.before(itemDisplayMarkup);
+               this.refocus(refocus);
+
+               this.hinput.append('<option value="' + escapedValue + '" selected="selected"></option>');
+               this.invokeItemSelectBehavior(escapedValue);
             }
-
-            var itemDisplayMarkup = '<li class="ui-chips-token ui-state-active ui-corner-all">';
-            itemDisplayMarkup += '<span class="ui-chips-token-icon ui-icon ui-icon-close"></span>';
-            itemDisplayMarkup += '<span class="ui-chips-token-label">' + escapedValue + '</span></li>';
-
-            this.inputContainer.before(itemDisplayMarkup);
-            this.refocus(refocus);
-
-            this.hinput.append('<option value="' + escapedValue + '" selected="selected"></option>');
-            this.invokeItemSelectBehavior(escapedValue);
         }
     },
 
@@ -153,8 +171,9 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
     /**
      * Removes an item (chip) from the list of currently displayed items.
      * @param {JQuery} item An item  (LI element) that should be removed.
+     * @param {boolean} silent flag indicating whether to animate and fire AJAX event
      */
-    removeItem: function(item) {
+    removeItem: function(item, silent) {
         var itemIndex = this.itemContainer.children('li.ui-chips-token').index(item);
         var itemValue = item.find('span.ui-chips-token-label').html()
         $this = this;
@@ -162,17 +181,47 @@ PrimeFaces.widget.Chips = PrimeFaces.widget.BaseWidget.extend({
         //remove from options
         this.hinput.children('option').eq(itemIndex).remove();
 
-        item.fadeOut('fast', function() {
-            var token = $(this);
-
-            token.remove();
-
-            $this.invokeItemUnselectBehavior(itemValue);
-        });
+        if(silent) {
+            item.remove();
+        }
+        else {
+            item.fadeOut('fast', function() {
+                var token = $(this);
+                token.remove();
+                $this.invokeItemUnselectBehavior(itemValue);
+            });
+        }
 
         // if empty return placeholder
         if (this.placeholder && this.hinput.children('option').length === 0) {
             this.input.attr('placeholder', this.placeholder);
+        }
+    },
+
+    /**
+     * Converts the current list into a separator delimited list for mass editing while keeping original
+     * order of the items or closes the editor turning the values back into chips.
+     */
+    toggleEditor: function() {
+        var $this = this,
+            tokens = this.itemContainer.children('li.ui-chips-token');
+  
+        if(tokens.length) {
+            var editor = '';
+            tokens.each(function() {
+                var token = $(this),
+                    tokenValue = token.find('span.ui-chips-token-label').html();
+                editor = editor + tokenValue +  $this.cfg.separator;
+                $this.removeItem(token, true);
+            });
+
+            if(editor) {
+                editor = editor.slice(0, -1); 
+                this.input.val(editor);
+            }
+        }
+        else {
+            $this.addItem(this.input.val(), true);
         }
     },
 


### PR DESCRIPTION
- New attribute `separator` similar to PrimeNG but different in this is the separator like ',' for pasting a list of items into the Chips.
- New attribute `addOnPaste`  if you want to immediately process the items while pasting. Default is false so you can paste and then edit the list.
- New widget method `edit` allowing you to convert the Chips into a separator list for mass editing so you can keep the order of items.

So you could have a chips like this.
![image](https://user-images.githubusercontent.com/4399574/102797187-56bafc80-437d-11eb-803a-015c006b66c0.png)


Call Edit with...
```xml
<p:commandButton value="Edit" onclick="PF('chips').edit(); return false;" />
```

And turn into this..
![image](https://user-images.githubusercontent.com/4399574/102797148-47d44a00-437d-11eb-889d-e39ec6fcc460.png)


@djmj