### PR TITLE
Fix #2062: Dialog scroll with fixed position

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -780,6 +780,16 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
                 $this.positionInitialized = false;
             }
         });
+        PrimeFaces.utils.registerScrollHandler(this, 'scroll.' + this.id + '_align', function() {
+            if ($this.isVisible()) {
+                // instant reinit position
+                $this.initPosition();
+            }
+            else {
+                // reset, so the dialog will be positioned again when showing the dialog next time
+                $this.positionInitialized = false;
+            }
+        });
     },
 
     /**


### PR DESCRIPTION
@djmj Similar issue to others fixed using register scroll. Had a resize handler but not a scroll handler.

Reproducer proving the issue is fixed:
[pf-2062.zip](https://github.com/primefaces/primefaces/files/5731494/pf-2062.zip)

Also had to put `responsive="true"` on the dialog for it to register the resize/scroll handler:
```xml
<p:dialog header="Basic Dialog" widgetVar="dlg1" minHeight="40" position="50, 50" modal="true" responsive="true">
	<h:outputText value="Resistance to PrimeFaces is futile!" />
</p:dialog>
```
