### PR TITLE
Fix #6716: DataTable/TreeTable DatePicker/Calendar cell editor issues

### DIFF
--- a/docs/10_0/components/datatable.md
+++ b/docs/10_0/components/datatable.md
@@ -82,7 +82,7 @@ DataTable displays data in tabular format.
 | rows                      | null               | Integer          | Number of rows to display per page.
 | rowsPerPageLabel          | null               | String           | Label for the rowsPerPage dropdown.
 | rowsPerPageTemplate       | null               | String           | Template of the rowsPerPage dropdown.
-| saveOnCellBlur            | true               | Boolean          | Saves the changes in cell editing on blur, when set to false changes are discarded..
+| saveOnCellBlur            | true               | Boolean          | Saves the changes in cell editing on blur, when set to false changes are discarded.
 | scrollHeight              | null               | Integer          | Scroll viewport height.
 | scrollRows                | 0                  | Integer          | Number of rows to load on live scroll.
 | scrollWidth               | null               | Integer          | Scroll viewport width.

--- a/docs/10_0/components/treetable.md
+++ b/docs/10_0/components/treetable.md
@@ -68,6 +68,7 @@ allowUnsorting | false | Boolean | Defines whether columns are allowed to be uns
 sortMode | multiple | String | Defines sorting mode, valid values are _single_ and _multiple_.
 filteredValue  | null | TreeNode | TreeNode to keep filtered data.
 cloneOnFilter | false | Boolean | Defines if nodes should be cloned on filter via Cloneable interface or Copy-Constructor (CustomNode(CustomNode original) or CustomNode(String type, Object data, TreeNode parent)). Normally the filtered nodes are new instanceof of DefaultTreeNode.
+saveOnCellBlur | true | Boolean | Saves the changes in cell editing on blur, when set to false changes are discarded.
 
 ## Getting started with the TreeTable
 Similar to the Tree, TreeTable is populated with an _org.primefaces.model.TreeNode_ instance that

--- a/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -81,7 +81,8 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
         multiViewState,
         allowUnsorting,
         sortMode,
-        cloneOnFilter
+        cloneOnFilter,
+        saveOnCellBlur
     }
 
     protected enum InternalPropertyKeys {
@@ -471,5 +472,13 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
 
     public void setCloneOnFilter(boolean cloneOnFilter) {
         getStateHelper().put(PropertyKeys.cloneOnFilter, cloneOnFilter);
+    }
+
+    public boolean isSaveOnCellBlur() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.saveOnCellBlur, true);
+    }
+
+    public void setSaveOnCellBlur(boolean saveOnCellBlur) {
+        getStateHelper().put(PropertyKeys.saveOnCellBlur, saveOnCellBlur);
     }
 }

--- a/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -262,6 +262,7 @@ public class TreeTableRenderer extends DataRenderer {
         if (tt.isEditable()) {
             wb.attr("editable", true)
                     .attr("editMode", tt.getEditMode())
+                    .attr("saveOnCellBlur", tt.isSaveOnCellBlur(), true)
                     .attr("cellEditMode", tt.getCellEditMode(), "eager")
                     .attr("cellSeparator", tt.getCellSeparator(), null)
                     .attr("editInitEvent", tt.getEditInitEvent());

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -30065,6 +30065,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Saves the changes in cell editing on blur, when set to false changes are discarded.]]>
+            </description>
+            <name>saveOnCellBlur</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3076,7 +3076,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                                 $this.incellClick = true;
                             }
 
-                            if(!$this.incellClick && $this.currentCell && !$this.contextMenuClick && !$.datepicker._datepickerShowing) {
+                            if(!$this.incellClick && $this.currentCell && !$this.contextMenuClick && !$.datepicker._datepickerShowing && $('.p-datepicker-panel:visible').length === 0) {
                                 if($this.cfg.saveOnCellBlur)
                                     $this.saveCell($this.currentCell);
                                 else

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1829,6 +1829,7 @@
         navBackward: function (event) {
             if (this.options.disabled) {
                 event.preventDefault();
+                event.stopPropagation();
                 return;
             }
 
@@ -1851,6 +1852,7 @@
                 if (minDate && minDate > testDate) {
                     this.setNavigationState(newViewDate);
                     event.preventDefault();
+                    event.stopPropagation();
                     return;
                 }
 
@@ -1880,11 +1882,13 @@
             this.updateViewDate(event, newViewDate);
 
             event.preventDefault();
+            event.stopPropagation();
         },
 
         navForward: function (event) {
             if (this.options.disabled) {
                 event.preventDefault();
+                event.stopPropagation();
                 return;
             }
 
@@ -1904,6 +1908,7 @@
                 if (maxDate && maxDate < newViewDate) {
                     this.setNavigationState(newViewDate);
                     event.preventDefault();
+                    event.stopPropagation();
                     return;
                 }
 
@@ -1933,6 +1938,7 @@
             this.updateViewDate(event, newViewDate);
 
             event.preventDefault();
+            event.stopPropagation();
         },
 
         setNavigationState: function(newViewDate) {
@@ -2048,7 +2054,7 @@
         },
 
         hideOverlay: function () {
-            if (this.panel && this.panel.is(':visible')) {
+            if (this.isPanelVisible()) {
                 if (this.options.onBeforeHide) {
                     this.options.onBeforeHide.call(this);
                 }
@@ -2106,8 +2112,12 @@
             $(window).off('resize.'+ this.options.id);
         },
 
+        isPanelVisible: function () {
+           return this.panel && this.panel.is(":visible");
+        },
+
         alignPanel: function () {
-            if (!this.panel || !this.panel.is(":visible")) {
+            if (!this.isPanelVisible()) {
                return;
             }
 


### PR DESCRIPTION
@tandraschko This PR does the following:

1. Aligns Cell Editing behavior by matching what DataTable was doing.  This fixes actually multiple bugs both reported and unreported.

2. Adds `saveOnCellBlur` attribute to TreeTable which Datatable had and was using.

3. Fixes DatePicker navigator bugs by calling `stopPropagation` when clicking on the previous and next months 

4. DataTable cell editor already had a check to see if the legacy Calendar popup was showing with `!$.datepicker._datepickerShowing` but no such check was being done for the new DatePicker so I added `$('.p-datepicker-panel:visible').length === 0` which checks to see if the DatePicker popup is being displayed while cell editing.

All in all this makes the TreeTable and DataTable cell editing more functional, fixes bugs, and brings them in line with each other.