### PR TITLE
Fix #1904/#6713: AutoComplete addItem and token addition

### DIFF
--- a/docs/9_0/components/autocomplete.md
+++ b/docs/9_0/components/autocomplete.md
@@ -368,14 +368,16 @@ Widget: _PrimeFaces.widget.AutoComplete_
 
 | Method | Params | Return Type | Description |
 | --- | --- | --- | --- |
-| search(value) | value: keyword for search | void | Initiates a search with given value |
+| activate() | - | void | Activates search behavior |
+| addItem(item) | JQuery or String | void | Adds the given suggestion item. |
+| clear() | - | void | Clears the input field |
 | close() | - | void | Hides suggested items menu |
+| deactivate() | - | void | Deactivates search behavior |
 | disable() | - | void | Disables the input field |
 | enable() | - | void | Enables the input field |
-| deactivate() | - | void | Deactivates search behavior |
-| activate() | - | void | Activates search behavior |
 | removeAllItems() | - | void | In multiple mode removes all selected items |
-| clear() | - | void | Clears the input field |
+| removeItem(item) | JQuery or String | void | Removes the given suggestion item. |
+| search(value) | value: keyword for search | void | Initiates a search with given value |
 
 ## Skinning
 Following is the list of structural style classes;

--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -247,7 +247,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                 $this.input.css('display', 'inline');
                 $this.enableDropdown();
             }
-            $this.removeItem(event, $(this).parent());
+            $this.removeItem($(this).parent());
         });
     },
 
@@ -464,12 +464,19 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                     break;
 
                     case keyCode.ENTER:
+                        var itemValue = $(this).val();
                         if($this.cfg.queryEvent === 'enter' || ($this.timeout > 0) || $this.querying) {
                             e.preventDefault();
                         }
 
                         if($this.cfg.queryEvent !== 'enter') {
-                            $this.isValid($(this).val(), true);
+                            $this.isValid(itemValue, true);
+                        }
+
+                        if($this.cfg.multiple && itemValue) {
+                            $this.addItem(itemValue);
+                            e.preventDefault();
+                            e.stopPropagation();
                         }
                     break;
 
@@ -479,7 +486,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                             if (e.metaKey||e.ctrlKey||e.shiftKey) {
                                 $this.removeAllItems();
                             } else {
-                                $this.removeItem(e, $(this).parent().prev());
+                                $this.removeItem($(this).parent().prev());
                             }
 
                             e.preventDefault();
@@ -508,7 +515,8 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
 
         //visuals and click handler for items
-        this.items.on('mouseover', function() {
+        this.items.off('click.autocomplete mousedown.autocomplete mouseover.autocomplete')
+        .on('mouseover.autocomplete', function() {
             var item = $(this);
 
             if(!item.hasClass('ui-state-highlight')) {
@@ -520,7 +528,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                 }
             }
         })
-        .on('click', function(event) {
+        .on('click.autocomplete', function(event) {
             var item = $(this),
             isMoreText = item.hasClass('ui-autocomplete-moretext');
 
@@ -529,66 +537,12 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                 $this.invokeMoreTextBehavior();
             }
             else {
-                var itemValue = item.attr('data-item-value');
-
-                if($this.cfg.multiple) {
-                    var found = false;
-                    if($this.cfg.unique) {
-                        found = $this.multiItemContainer.children("li[data-token-value='" + $.escapeSelector(itemValue) + "']").length != 0;
-                    }
-
-                    if(!found) {
-                        var itemStyleClass = item.attr('data-item-class');
-                        var itemDisplayMarkup = '<li data-token-value="' + PrimeFaces.escapeHTML(itemValue);
-                        itemDisplayMarkup += '"class="ui-autocomplete-token ui-state-active ui-corner-all ui-helper-hidden';
-                        itemDisplayMarkup += (itemStyleClass === '' ? '' : ' '+itemStyleClass) + '">';
-                        itemDisplayMarkup += '<span class="ui-autocomplete-token-icon ui-icon ui-icon-close"></span>';
-                        itemDisplayMarkup += '<span class="ui-autocomplete-token-label">' + PrimeFaces.escapeHTML(item.attr('data-item-label')) + '</span></li>';
-
-                        $this.inputContainer.before(itemDisplayMarkup);
-                        $this.multiItemContainer.children('.ui-helper-hidden').fadeIn();
-                        $this.input.val('');
-                        $this.input.removeAttr('placeholder');
-
-                        $this.hinput.append('<option value="' + PrimeFaces.escapeHTML(itemValue) + '" selected="selected"></option>');
-                        if($this.multiItemContainer.children('li.ui-autocomplete-token').length >= $this.cfg.selectLimit) {
-                            $this.input.css('display', 'none').trigger("blur");
-                            $this.disableDropdown();
-                        }
-
-                        $this.invokeItemSelectBehavior(event, itemValue);
-                    }
-                }
-                else {
-                    $this.input.val(item.attr('data-item-label'));
-
-                    this.currentText = $this.input.val();
-                    this.previousText = $this.input.val();
-
-                    if($this.cfg.pojo) {
-                        $this.hinput.val(itemValue);
-                    }
-
-                    if(PrimeFaces.env.isLtIE(10)) {
-                        var length = $this.input.val().length;
-                        $this.input.setSelection(length,length);
-                    }
-
-                    $this.invokeItemSelectBehavior(event, itemValue);
-                }
-
-                if ($this.cfg.onChange) {
-                    $this.cfg.onChange.call(this);
-                }
-
-                if (!$this.isTabPressed) {
-                    $this.input.trigger('focus');
-                }
+                $this.addItem(item);
             }
 
             $this.hide();
         })
-        .on('mousedown', function() {
+        .on('mousedown.autocomplete', function() {
             $this.preventInputChangeEvent = true;
             $this.checkMatchedItem = false;
         });
@@ -606,7 +560,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         });
 
         if(PrimeFaces.env.browser.mobile) {
-            this.items.on('touchstart', function() {
+            this.items.on('touchstart.autocomplete', function() {
                 if(!$this.touchToDropdownButton) {
                     $this.itemClick = true;
                 }
@@ -975,10 +929,9 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
     /**
      * Invokes the appropriate behavior for when a suggestion item was selected.
      * @private
-     * @param {JQuery.Event} event The event that occurred.
      * @param {string} itemValue Value of the selected item.
      */
-    invokeItemSelectBehavior: function(event, itemValue) {
+    invokeItemSelectBehavior: function(itemValue) {
         if(this.hasBehavior('itemSelect')) {
             var ext = {
                 params : [
@@ -993,10 +946,9 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
     /**
      * Invokes the appropriate behavior when a suggestion item was unselected.
      * @private
-     * @param {JQuery.Event} event The event that occurred.
      * @param {string} itemValue Value of the unselected item.
      */
-    invokeItemUnselectBehavior: function(event, itemValue) {
+    invokeItemUnselectBehavior: function(itemValue) {
         if(this.hasBehavior('itemUnselect')) {
             var ext = {
                 params : [
@@ -1041,26 +993,124 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
-     * Removes the given suggestion item.
-     * @private
-     * @param {JQuery.Event} event The event that occurred.
-     * @param {JQuery} item Suggestion item to remove.
+     * Add the given suggestion item.
+     * @param {JQuery | string} item Suggestion item to add.
      */
-    removeItem: function(event, item) {
-        var itemValue = item.attr('data-token-value'),
-        itemIndex = this.multiItemContainer.children('li.ui-autocomplete-token').index(item),
-        $this = this;
+    addItem: function(item) {
+        var $this = this,
+            itemValue = '',
+            itemStyleClass = '',
+            itemLabel = '';
+ 
+        if($this.input.hasClass('ui-state-disabled')) {
+            return;
+        }
+
+        if(typeof item === 'string' || item instanceof String) {
+            itemValue = item;
+            itemLabel = item;
+        }
+        else {
+            itemValue = item.attr('data-item-value');
+            itemLabel = item.attr('data-item-label');
+            itemStyleClass = item.attr('data-item-class');
+        }
+
+        if (!itemValue) {
+            return;
+        }
+
+        if ($this.cfg.multiple) {
+            var found = false;
+            if ($this.cfg.unique) {
+                found = $this.multiItemContainer.children("li[data-token-value='" + $.escapeSelector(itemValue) + "']").length != 0;
+            }
+
+            if (!found) {
+                if ($this.multiItemContainer.children('li.ui-autocomplete-token').length >= $this.cfg.selectLimit) {
+                   return;
+                }
+                var itemDisplayMarkup = '<li data-token-value="' + PrimeFaces.escapeHTML(itemValue);
+                itemDisplayMarkup += '"class="ui-autocomplete-token ui-state-active ui-corner-all ui-helper-hidden';
+                itemDisplayMarkup += (itemStyleClass === '' ? '' : ' ' + itemStyleClass) + '">';
+                itemDisplayMarkup += '<span class="ui-autocomplete-token-icon ui-icon ui-icon-close"></span>';
+                itemDisplayMarkup += '<span class="ui-autocomplete-token-label">' + PrimeFaces.escapeHTML(itemLabel) + '</span></li>';
+
+                $this.inputContainer.before(itemDisplayMarkup);
+                $this.multiItemContainer.children('.ui-helper-hidden').fadeIn();
+                $this.input.val('');
+                $this.input.removeAttr('placeholder');
+
+                $this.hinput.append('<option value="' + PrimeFaces.escapeHTML(itemValue) + '" selected="selected"></option>');
+                if ($this.multiItemContainer.children('li.ui-autocomplete-token').length >= $this.cfg.selectLimit) {
+                    $this.input.css('display', 'none').trigger("blur");
+                    $this.disableDropdown();
+                }
+
+                $this.invokeItemSelectBehavior(itemValue);
+            }
+        } else {
+            $this.input.val(item.attr('data-item-label'));
+
+            this.currentText = $this.input.val();
+            this.previousText = $this.input.val();
+
+            if ($this.cfg.pojo) {
+                $this.hinput.val(itemValue);
+            }
+
+            if (PrimeFaces.env.isLtIE(10)) {
+                var length = $this.input.val().length;
+                $this.input.setSelection(length, length);
+            }
+
+            $this.invokeItemSelectBehavior(itemValue);
+        }
+
+        if ($this.cfg.onChange) {
+            $this.cfg.onChange.call(this);
+        }
+
+        if (!$this.isTabPressed) {
+            $this.input.trigger('focus');
+        }
+    },
+
+    /**
+     * Removes the given suggestion item.
+     * @param {JQuery | string} item Suggestion item to remove.
+     */
+    removeItem: function(item) {
+        var $this = this,
+            itemValue = '';
+        if($this.input.hasClass('ui-state-disabled')) {
+            return;
+        }
+
+        if(typeof item === 'string' || item instanceof String) {
+            itemValue = item;
+        }
+        else {
+            itemValue = item.attr('data-token-value');
+        }
+
+        var foundItem = this.multiItemContainer.children("li.ui-autocomplete-token[data-token-value='"+itemValue+"']");
+        if(!foundItem.length) {
+            return;
+        }
+        var itemIndex = foundItem.index();
+        if(!itemValue || itemIndex === -1) {
+            return;
+        }
 
         //remove from options
         this.hinput.children('option').eq(itemIndex).remove();
 
         //remove from items
-        item.fadeOut('fast', function() {
+        foundItem.fadeOut('fast', function() {
             var token = $(this);
-
             token.remove();
-
-            $this.invokeItemUnselectBehavior(event, itemValue);
+            $this.invokeItemUnselectBehavior(itemValue);
         });
         
         // if empty return placeholder
@@ -1076,7 +1126,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
         if (this.cfg.multiple && !this.input.val().length) {
             this.multiItemContainer.find('.ui-autocomplete-token').each(function( index ) {
-                $this.removeItem(null, $(this));
+                $this.removeItem($(this));
             });
         }
     },


### PR DESCRIPTION
- Adds new `addItem(item)` client side widget method which addresses #1904
- Reuses that `addItem` method to allow fixing of #6713 to add a multiple token that does not have to be in the dropdown list
- Cleans up code and makes the `addItem` and `removeItem` widget methods public and available for use.