### PR TITLE
Fix #6730: Datatable selectionPageOnly attribute

### DIFF
--- a/docs/10_0/components/datatable.md
+++ b/docs/10_0/components/datatable.md
@@ -89,6 +89,7 @@ DataTable displays data in tabular format.
 | scrollable                | false              | Boolean          | Makes data scrollable with fixed header.
 | selection                 | null               | Object           | Reference to the selection data.
 | selectionMode             | null               | String           | Enables row selection, valid values are “single" and “multiple".
+| selectionPageOnly         | true               | Boolean          | When using paginator and checkbox selection mode the select all checkbox in header will select the current page if true or all rows if false. Default true.
 | sortMode                  | multiple           | String           | Defines sorting mode, valid values are _single_ and _multiple_.
 | sortBy                    | null               | SortMeta / Collection<SortMeta> | Property to be used for default sorting. Expects a single or a collection of SortMeta.
 | skipChildren              | false              | Boolean          | Ignores processing of children during lifecycle, improves performance if table only has output components.

--- a/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -23,10 +23,10 @@
  */
 package org.primefaces.component.datatable;
 
-import org.primefaces.component.api.*;
-
 import javax.el.MethodExpression;
 import javax.faces.component.behavior.ClientBehaviorHolder;
+
+import org.primefaces.component.api.*;
 
 public abstract class DataTableBase extends UIPageableData implements Widget, RTLAware, ClientBehaviorHolder,
         PrimeClientBehaviorHolder, UITable<DataTableState> {
@@ -37,73 +37,74 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
 
     public enum PropertyKeys {
 
-        widgetVar,
-        scrollable,
+        allowUnsorting,
+        ariaRowLabel,
+        caseSensitiveSort,
+        cellEditMode,
+        cellSeparator,
+        clientCache,
+        dataLocale,
+        dir,
+        disableContextMenuIfEmpty,
+        disabledSelection,
+        disabledTextSelection,
+        draggableColumns,
+        draggableRows,
+        draggableRowsFunction,
+        editInitEvent,
+        editMode,
+        editable,
+        editingRow,
+        escapeText,
+        expandedRow,
+        filterBy,
+        filterDelay,
+        filterEvent,
+        filteredValue,
+        frozenColumns,
+        frozenRows,
+        globalFilter,
+        globalFilterFunction,
+        liveResize,
+        liveScroll,
+        liveScrollBuffer,
+        multiViewState,
+        nativeElements,
+        onExpandStart,
+        onRowClick,
+        reflow,
+        renderEmptyFacets,
+        resizableColumns,
+        resizeMode,
+        rowDragSelector,
+        rowEditMode,
+        rowExpandMode,
+        rowHover,
+        rowKey,
+        rowSelectMode,
+        rowSelector,
+        rowStyleClass,
+        saveOnCellBlur,
         scrollHeight,
+        scrollRows,
         scrollWidth,
-        selectionMode,
+        scrollable,
         selection,
+        selectionMode,
+        selectionPageOnly,
+        skipChildren,
+        sortBy,
+        sortMode,
+        stickyHeader,
+        stickyTopAt,
         style,
         styleClass,
-        liveScroll,
-        rowStyleClass,
-        onExpandStart,
-        resizableColumns,
-        sortMode,
-        sortBy,
-        allowUnsorting,
-        scrollRows,
-        rowKey,
-        filterEvent,
-        filterDelay,
+        summary,
+        tabindex,
         tableStyle,
         tableStyleClass,
-        draggableColumns,
-        editable,
-        filteredValue,
-        editMode,
-        editingRow,
-        cellSeparator,
-        summary,
-        frozenRows,
-        dir,
-        liveResize,
-        stickyHeader,
-        expandedRow,
-        disabledSelection,
-        rowSelectMode,
-        rowExpandMode,
-        dataLocale,
-        nativeElements,
-        frozenColumns,
-        draggableRows,
-        caseSensitiveSort,
-        skipChildren,
-        disabledTextSelection,
-        tabindex,
-        reflow,
-        liveScrollBuffer,
-        rowHover,
-        resizeMode,
-        ariaRowLabel,
-        saveOnCellBlur,
-        clientCache,
-        multiViewState,
-        filterBy,
-        globalFilter,
-        cellEditMode,
         virtualScroll,
-        rowDragSelector,
-        draggableRowsFunction,
-        onRowClick,
-        editInitEvent,
-        rowSelector,
-        disableContextMenuIfEmpty,
-        escapeText,
-        rowEditMode,
-        stickyTopAt,
-        globalFilterFunction,
-        renderEmptyFacets
+        widgetVar
     }
 
     protected enum InternalPropertyKeys {
@@ -660,5 +661,13 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
 
     public void setRenderEmptyFacets(boolean renderEmptyFacets) {
         getStateHelper().put(PropertyKeys.renderEmptyFacets, renderEmptyFacets);
+    }
+
+    public boolean isSelectionPageOnly() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.selectionPageOnly, true);
+    }
+
+    public void setSelectionPageOnly(boolean selectionPageOnly) {
+        getStateHelper().put(PropertyKeys.selectionPageOnly, selectionPageOnly);
     }
 }

--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -161,6 +161,7 @@ public class DataTableRenderer extends DataRenderer {
 
         //Selection
         wb.attr("selectionMode", selectionMode, null)
+                .attr("selectionPageOnly", table.isSelectionPageOnly(), true)
                 .attr("rowSelectMode", table.getRowSelectMode(), "new")
                 .attr("nativeElements", table.isNativeElements(), false)
                 .attr("rowSelector", table.getRowSelector(), null)

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -7972,6 +7972,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[When using paginator and checkbox selection mode the select all checkbox in header will select the current page if true or all rows if false. Default true.]]>
+            </description>
+            <name>selectionPageOnly</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Name of iterator to refer each row index.]]>
             </description>
             <name>rowIndexVar</name>

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -764,6 +764,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         this.cfg.rowSelectMode = this.cfg.rowSelectMode||'new';
         this.rowSelector = '> tr.ui-widget-content.ui-datatable-selectable';
         this.cfg.disabledTextSelection = this.cfg.disabledTextSelection === false ? false : true;
+        this.cfg.selectionPageOnly = this.cfg.selectionPageOnly === false ? !this.cfg.paginator : true;
         this.rowSelectorForRowClick = this.cfg.rowSelector||'td:not(.ui-column-unselectable),span:not(.ui-c)';
 
         var preselection = $(this.selectionHolder).val();
@@ -2681,6 +2682,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
      * all rows. When some rows are selected, this will unselect all rows.
      */
     toggleCheckAll: function() {
+        var shouldCheckAll = true;
         if(this.cfg.nativeElements) {
             var checkboxes = this.tbody.find('> tr.ui-datatable-selectable > td.ui-selection-column > :checkbox:visible'),
             checked = this.checkAllToggler.prop('checked'),
@@ -2696,6 +2698,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                     var checkbox = $(this);
                     checkbox.prop('checked', false);
                     $this.unselectRowWithCheckbox(checkbox, true);
+                    shouldCheckAll = false;
                 }
             });
         }
@@ -2707,6 +2710,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             if(checked) {
                 this.checkAllToggler.removeClass('ui-state-active').children('span.ui-chkbox-icon').addClass('ui-icon-blank').removeClass('ui-icon-check');
                 this.checkAllToggler.attr('aria-checked', false);
+                shouldCheckAll = false;
 
                 checkboxes.each(function() {
                     $this.unselectRowWithCheckbox($(this), true);
@@ -2720,6 +2724,11 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                     $this.selectRowWithCheckbox($(this), true);
                 });
             }
+        }
+
+        // GitHub #6730 user wants all rows not just displayed rows
+        if(!this.cfg.selectionPageOnly && shouldCheckAll) {
+            this.selectAllRows();
         }
 
         //save state
@@ -4466,6 +4475,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         if(this.isEmpty()) {
             this.uncheckHeaderCheckbox();
             this.disableHeaderCheckbox();
+        }
+        else if(!this.cfg.selectionPageOnly) {
+            if(this.selection.includes('@all')) {
+                this.enableHeaderCheckbox();
+                this.checkHeaderCheckbox();
+            }
         }
         else {
             var checkboxes, selectedCheckboxes, enabledCheckboxes, disabledCheckboxes;


### PR DESCRIPTION
I sorted the Datatable properties alphabetically because it had so many properties in the enum it was hard to see them.  I feel like its much easier to see now.