### PR TITLE
Fix #3535: Unselect row after selecting @all rows

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4095,12 +4095,25 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     /**
      * Remove given row from the list of selected rows.
      * @private
-     * @param {string} rowIndex Key of the row to remove.
+     * @param {string} rowKey Key of the row to remove.
      */
-    removeSelection: function(rowIndex) {
-        this.selection = $.grep(this.selection, function(value) {
-            return value != rowIndex;
-        });
+    removeSelection: function(rowKey) {
+        if(this.selection.includes('@all')) {
+            // GitHub #3535 if @all was previously selected just select values on page
+            this.clearSelection();
+            var rows = this.tbody.children('tr');
+            for(var i = 0; i < rows.length; i++) {
+                var rowMeta = this.getRowMeta(rows.eq(i));
+                if(rowMeta.key !== rowKey) {
+                    this.addSelection(rowMeta.key);
+                }
+            }
+        }
+        else {
+            this.selection = $.grep(this.selection, function(value) {
+                return value !== rowKey;
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
Remove the `@all` and selects all the currently selected rowkeys on the page.