### PR TITLE
Fix #2658/#3856: Document rowGroup incompatibilities

### DIFF
--- a/docs/7_0/components/datatable.md
+++ b/docs/7_0/components/datatable.md
@@ -593,6 +593,9 @@ For frozen columns, use _frozenHeader_ , _frozenFooter_ , _scrollableHeader_ and
 Rows can be grouped in two ways, using headerRow, summaryRow components or with groupRow
 attribute on a column.
 
+!> Row Grouping does not work with Lazy loading or LiveScroll as the grouping needs to know about all rows to properly 
+group the rows.
+
 ```xhtml
 <p:dataTable var="car" value="#{dtRowGroupView.cars}" sortBy="#{car.brand}">
     <p:headerRow>

--- a/docs/8_0/components/datatable.md
+++ b/docs/8_0/components/datatable.md
@@ -598,6 +598,9 @@ For frozen columns, use _frozenHeader_ , _frozenFooter_ , _scrollableHeader_ and
 Rows can be grouped in two ways, using headerRow, summaryRow components or with groupRow
 attribute on a column.
 
+!> Row Grouping does not work with Lazy loading or LiveScroll as the grouping needs to know about all rows to properly 
+group the rows.
+
 ```xhtml
 <p:dataTable var="car" value="#{dtRowGroupView.cars}" sortBy="#{car.brand}">
     <p:headerRow>

--- a/docs/9_0/components/datatable.md
+++ b/docs/9_0/components/datatable.md
@@ -634,6 +634,9 @@ For frozen columns, use _frozenHeader_ , _frozenFooter_ , _scrollableHeader_ and
 Rows can be grouped in two ways, using headerRow, summaryRow components or with groupRow
 attribute on a column.
 
+!> Row Grouping does not work with Lazy loading or LiveScroll as the grouping needs to know about all rows to properly 
+group the rows.
+
 ```xhtml
 <p:dataTable var="car" value="#{dtRowGroupView.cars}">
     <p:headerRow field="brand" />


### PR DESCRIPTION
Added Doscify documentation warning for Row Grouping similar to warning in TextEditor..

![image](https://user-images.githubusercontent.com/4399574/103356063-eb101800-4a7d-11eb-9d05-d6eb724c2d2e.png)
