### PR TITLE
Fix #6752: LetterAvatar port of dynamic color and label

### DIFF
--- a/docs/10_0_0/components/avatar.md
+++ b/docs/10_0_0/components/avatar.md
@@ -24,9 +24,9 @@ Avatar represents people using icons, labels and images.
 | icon | null | String | Defines the icon to display.
 | size | null | String | Size of the element, valid options are "large" and "xlarge".
 | shape | square | String | Shape of the element, valid options are "square" and "circle".
-| dynamicColor | false | Boolean | Dynamically assign contrasting foreground and background colors based on the label. Default is false.
 | style | null | String | Style of the avatar.
 | styleClass | null | String | StyleClass of the avatar.
+| dynamicColor | false | Boolean | Dynamically assign contrasting foreground and background colors based on the label. Default is false.
 
 ## Getting Started
 Avatar has three built-in display modes; "label", "icon" and custom content.

--- a/docs/10_0_0/components/avatar.md
+++ b/docs/10_0_0/components/avatar.md
@@ -24,6 +24,7 @@ Avatar represents people using icons, labels and images.
 | icon | null | String | Defines the icon to display.
 | size | null | String | Size of the element, valid options are "large" and "xlarge".
 | shape | square | String | Shape of the element, valid options are "square" and "circle".
+| dynamicColor | false | Boolean | Dynamically assign contrasting foreground and background colors based on the label. Default is false.
 | style | null | String | Style of the avatar.
 | styleClass | null | String | StyleClass of the avatar.
 

--- a/src/main/java/org/primefaces/component/avatar/Avatar.java
+++ b/src/main/java/org/primefaces/component/avatar/Avatar.java
@@ -34,6 +34,6 @@ public class Avatar extends AvatarBase {
     public static final String SIZE_LARGE_CLASS = "ui-avatar-lg";
     public static final String SIZE_XLARGE_CLASS = "ui-avatar-xl";
     public static final String SIZE_TEXT_CLASS = "ui-avatar-text";
-    public static final String DYNAMIC_TEXT_CLASS = "ui-avatar-dynamic";
+    public static final String DYNAMIC_COLOR_CLASS = "ui-avatar-dynamic";
     public static final String ICON_CLASS = "ui-avatar-icon";
 }

--- a/src/main/java/org/primefaces/component/avatar/Avatar.java
+++ b/src/main/java/org/primefaces/component/avatar/Avatar.java
@@ -34,5 +34,6 @@ public class Avatar extends AvatarBase {
     public static final String SIZE_LARGE_CLASS = "ui-avatar-lg";
     public static final String SIZE_XLARGE_CLASS = "ui-avatar-xl";
     public static final String SIZE_TEXT_CLASS = "ui-avatar-text";
+    public static final String DYNAMIC_TEXT_CLASS = "ui-avatar-dynamic";
     public static final String ICON_CLASS = "ui-avatar-icon";
 }

--- a/src/main/java/org/primefaces/component/avatar/AvatarBase.java
+++ b/src/main/java/org/primefaces/component/avatar/AvatarBase.java
@@ -36,6 +36,7 @@ public abstract class AvatarBase extends UIComponentBase {
         icon,
         size,
         shape,
+        dynamicColor,
         style,
         styleClass
     }
@@ -79,6 +80,14 @@ public abstract class AvatarBase extends UIComponentBase {
 
     public void setShape(String shape) {
         getStateHelper().put(PropertyKeys.shape, shape);
+    }
+
+    public boolean isDynamicColor() {
+        return (Boolean) getStateHelper().eval(AvatarBase.PropertyKeys.dynamicColor, false);
+    }
+
+    public void setDynamicColor(boolean dynamicColor) {
+        getStateHelper().put(AvatarBase.PropertyKeys.dynamicColor, dynamicColor);
     }
 
     public String getStyle() {

--- a/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
+++ b/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
@@ -24,14 +24,19 @@
 package org.primefaces.component.avatar;
 
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.util.LangUtils;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AvatarRenderer extends CoreRenderer {
+
+    private static final Pattern LETTER_PATTTERN = Pattern.compile("\\b[a-zA-Z]");
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
@@ -45,11 +50,18 @@ public class AvatarRenderer extends CoreRenderer {
                 .add("xlarge".equals(avatar.getSize()), Avatar.SIZE_XLARGE_CLASS)
                 .build();
 
-        writer.startElement("div", null);
+        writer.startElement("div", avatar);
         writer.writeAttribute("id", avatar.getClientId(context), "id");
         writer.writeAttribute("class", styleClass, "styleClass");
-        if (avatar.getStyle() != null) {
-            writer.writeAttribute("style", avatar.getStyle(), "style");
+        String label = calculateLabel(avatar);
+        String style = avatar.getStyle();
+        if (avatar.isDynamicColor() && label != null) {
+            String colorCss = generateBackgroundColor(label);
+            style = style == null ? colorCss : colorCss + style;
+        }
+
+        if (style != null) {
+            writer.writeAttribute("style", style, "style");
         }
 
         if (avatar.getChildCount() > 0) {
@@ -64,11 +76,16 @@ public class AvatarRenderer extends CoreRenderer {
 
     protected void encodeDefaultContent(FacesContext context, Avatar avatar) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
+        String label = avatar.getLabel();
 
-        if (avatar.getLabel() != null) {
+        if (LangUtils.isNotBlank(label)) {
             writer.startElement("span", null);
-            writer.writeAttribute("class", Avatar.SIZE_TEXT_CLASS, "styleClass");
-            writer.write(avatar.getLabel());
+            String textClass = getStyleClassBuilder(context)
+                        .add(Avatar.SIZE_TEXT_CLASS)
+                        .add(avatar.isDynamicColor(), Avatar.DYNAMIC_TEXT_CLASS)
+                        .build();
+            writer.writeAttribute("class", textClass, "styleClass");
+            writer.write(label);
             writer.endElement("span");
         }
         else if (avatar.getIcon() != null) {
@@ -91,5 +108,36 @@ public class AvatarRenderer extends CoreRenderer {
     @Override
     public boolean getRendersChildren() {
         return true;
+    }
+
+    /**
+     * Generates a label based on the text if its more than 2 characters. Example: PrimeFaces Rocks = PR
+     *
+     * @param avatar the Avatar component
+     * @return the calculated label text.
+     */
+    protected String calculateLabel(Avatar avatar) {
+        String value = avatar.getLabel();
+        if (value == null || value.length() <= 2) {
+            return value;
+        }
+        final Matcher m = LETTER_PATTTERN.matcher(value);
+        final StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            sb.append(m.group());
+        }
+        String initials = sb.toString();
+        initials = initials.length() == 1 ? initials : initials.charAt(0) + initials.substring(initials.length() - 1);
+        return initials;
+    }
+
+    /**
+     * Generates a dynamic color based on the hash of the label.
+     *
+     * @param label the label to generate the color for
+     * @return the new color and background color styles
+     */
+    protected String generateBackgroundColor(String label) {
+        return "color:#fff;background-color: hsl(" + Math.abs((label.hashCode() % 40) * 9) + ", 100%, 50%);";
     }
 }

--- a/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
+++ b/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
@@ -25,6 +25,7 @@ package org.primefaces.component.avatar;
 
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.LangUtils;
+import org.primefaces.util.SharedStringBuilder;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -37,6 +38,7 @@ import java.util.regex.Pattern;
 public class AvatarRenderer extends CoreRenderer {
 
     private static final Pattern LETTER_PATTTERN = Pattern.compile("\\b[a-zA-Z]");
+    private static final String SB_AVATAR = AvatarRenderer.class.getName() + "#avatar";
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
@@ -53,7 +55,7 @@ public class AvatarRenderer extends CoreRenderer {
         writer.startElement("div", avatar);
         writer.writeAttribute("id", avatar.getClientId(context), "id");
         writer.writeAttribute("class", styleClass, "styleClass");
-        String label = calculateLabel(avatar);
+        String label = calculateLabel(context, avatar);
         String style = avatar.getStyle();
         if (avatar.isDynamicColor() && label != null) {
             String colorCss = generateBackgroundColor(label);
@@ -82,7 +84,7 @@ public class AvatarRenderer extends CoreRenderer {
             writer.startElement("span", null);
             String textClass = getStyleClassBuilder(context)
                         .add(Avatar.SIZE_TEXT_CLASS)
-                        .add(avatar.isDynamicColor(), Avatar.DYNAMIC_TEXT_CLASS)
+                        .add(avatar.isDynamicColor(), Avatar.DYNAMIC_COLOR_CLASS)
                         .build();
             writer.writeAttribute("class", textClass, "styleClass");
             writer.write(label);
@@ -116,13 +118,13 @@ public class AvatarRenderer extends CoreRenderer {
      * @param avatar the Avatar component
      * @return the calculated label text.
      */
-    protected String calculateLabel(Avatar avatar) {
+    protected String calculateLabel(FacesContext context, Avatar avatar) {
         String value = avatar.getLabel();
         if (value == null || value.length() <= 2) {
             return value;
         }
-        final Matcher m = LETTER_PATTTERN.matcher(value);
-        final StringBuilder sb = new StringBuilder();
+        Matcher m = LETTER_PATTTERN.matcher(value);
+        StringBuilder sb = SharedStringBuilder.get(context, SB_AVATAR);
         while (m.find()) {
             sb.append(m.group());
         }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -32224,6 +32224,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Dynamically assign contrasting foreground and background colors based on the label. Default is false.]]>
+            </description>
+            <name>dynamicColor</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Inline style of the component.]]>
             </description>
             <name>style</name>

--- a/src/main/resources/META-INF/resources/primefaces/avatar/avatar.css
+++ b/src/main/resources/META-INF/resources/primefaces/avatar/avatar.css
@@ -19,3 +19,7 @@
     width: 100%;
     height: 100%;
 }
+
+.ui-avatar .ui-avatar-dynamic {
+    mix-blend-mode: difference;
+}


### PR DESCRIPTION
Uses CSS `mix-blend-mode: difference;` and a dynamic calculation of the background color to dynamically assign a color and background color based on the text label.

![image](https://user-images.githubusercontent.com/4399574/103463494-c2488680-4cfa-11eb-8ca2-0aa240b7452a.png)

Also will abbreviate names like "Optimus Prime" to "OP" and can handle long names like "Johann Chrysostom Wolfgang Amadeus Mozart"