### PR TITLE
Fix #1111: SelectManyMenu consistent checkbox width

### DIFF
--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenu.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenu.java
@@ -40,6 +40,7 @@ public class SelectManyMenu extends SelectManyMenuBase {
     public static final String LIST_CONTAINER_CLASS = "ui-selectlistbox-listcontainer";
     public static final String LIST_CLASS = "ui-selectlistbox-list";
     public static final String ITEM_CLASS = "ui-selectlistbox-item ui-corner-all";
+    public static final String CHECKBOX_CLASS = "ui-selectlistbox-chkbox";
     public static final String FILTER_CONTAINER_CLASS = "ui-selectlistbox-filter-container";
     public static final String FILTER_CLASS = "ui-selectlistbox-filter ui-inputfield ui-widget ui-state-default ui-corner-all";
     public static final String FILTER_ICON_CLASS = "ui-icon ui-icon-search";

--- a/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -207,6 +207,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
 
             if (showCheckbox) {
                 writer.startElement("td", null);
+                writer.writeAttribute("class", SelectManyMenu.CHECKBOX_CLASS, "styleClass");
                 RendererUtils.encodeCheckbox(context, selected);
                 writer.endElement("td");
             }

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -60,6 +60,10 @@ input[type=text]::-ms-clear {
     width:100%;
 }
 
+.ui-selectmanymenu .ui-selectlistbox-chkbox {
+   width: 1rem;
+}
+
 .ui-selectlistbox-filter.ui-inputfield {
     padding-right: 12%;
     padding-left: 2%;


### PR DESCRIPTION
had to add a new style class to the checkbox TD element so it can be styled with CSS.

Now the checkbox has a consistent width even if the box grows.

![image](https://user-images.githubusercontent.com/4399574/103547997-21c9a200-4e73-11eb-9a5e-cfd5e8ee4f1b.png)
