### PR TITLE
Fix #6776: ContextMenu IOS fixes

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
@@ -100,6 +100,10 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                 if (targetWidget) {
                     if (typeof targetWidget.bindContextMenu === 'function') {
                         targetWidget.bindContextMenu(this, targetWidget, this.jqTargetId, this.cfg);
+                        // GitHub #6776 IOS needs long touch on table/tree but Android does not
+                        if(PrimeFaces.env.ios) {
+                            $this.bindTouchEvents();
+                        }
                         binded = true;
                     }
                 }
@@ -115,13 +119,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
                     $this.show(e);
                 });
 
-                if (PrimeFaces.env.isTouchable(this.cfg)) {
-                    $(this.jqTargetId).swipe({
-                        longTap:function(e, target) {
-                           $this.show(e);
-                        }
-                    });
-                }
+                $this.bindTouchEvents();
             }
         }
 
@@ -137,6 +135,27 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
         PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_align', this.jq, function() {
             $this.hide();
         });
+    },
+
+    /**
+     * Binds mobile touch events.
+     * @protected
+     */
+    bindTouchEvents: function() {
+        if (PrimeFaces.env.isTouchable(this.cfg)) {
+             var $this = this;
+
+             // GitHub #6776 turn off Copy/Paste menu for IOS
+             if(PrimeFaces.env.ios) {
+                $(document.body).addClass('ui-touch-selection-disabled');
+             }
+
+             $this.jqTarget.swipe({
+                 longTap:function(e, target) {
+                      $this.show(e);
+                 }
+             });
+        }
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.css
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.css
@@ -524,3 +524,15 @@
     -moz-box-sizing: border-box;
 }
 
+/** Disable mobile browser right click when using context menu */
+.ui-touch-selection-disabled {
+	-webkit-touch-callout:none;
+    -webkit-user-select:none;
+    -khtml-user-select:none;
+    -moz-user-select:none;
+    -ms-user-select:none;
+    user-select:none;
+    -webkit-tap-highlight-color:rgba(0,0,0,0);
+}
+
+


### PR DESCRIPTION
OK there were multiple issues with IOS.  to repeat everything is working in Android but IOS is much different.

1. Using this CSS fix to disable IOS from bringing up the "Copy/Paste/Share" menu on long tap.
https://stackoverflow.com/a/11237968/502366

2. IOS needed to load the TouchSwipe longtap for Datatable, TreeTable, etc that use Contextmenu. Android does not because it interprets Long tap as a "rght click" so our normal Context menu stuff is all working.

Tested in Chrome Desktop, Chrome Mobile, and IOS 14 mobile.