### PR TITLE
Fix #6700: Core: After updating a component using AJAX in Safari, the current scroll position changes

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -251,7 +251,9 @@ if (!PrimeFaces.ajax) {
                     PrimeFaces.ajax.Utils.updateHead(content);
                 }
                 else {
-                    $(PrimeFaces.escapeClientId(id)).replaceWith(content);
+                    var element = document.getElementById(id);
+                    var fragment = document.createRange().createContextualFragment(content);
+                    element.replaceWith(fragment);
                 }
             }
         },


### PR DESCRIPTION
@sqores, @mertsincan, @tandraschko, @melloware 
My plan "B". We would need to add some if-statement to do this only for Safari and/or browser which support https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/replaceWith.
Not totally sure whether it´s a good idea without side-effects.
And first we should look whether this improves Safari-behaviour.