### PR TITLE
Fix #6700: Remove unnecessary focus

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -462,7 +462,6 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         }
 
         if(!silent) {
-            this.focusInput.trigger('focus');
             this.callBehavior('itemSelect');
         }
 


### PR DESCRIPTION
I have verified this on my Mac and verified the Integration Test we have that was failing on Safari now passes with this fix.

This was recommended by @mertsincan and he is right this line is definitely causing the issue.