### PR TITLE
Fix #6804: Calendar alignPanel increase delay before rendering

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -168,7 +168,7 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
                     }
                     
                     $this.alignPanel();
-                }, 1);
+                }, 50);
 
                 // touch support - prevents keyboard popup
                 if(touchEnabled) {


### PR DESCRIPTION
1ms was not enough before rendering for the Calendar panel to properly use `flipfit` logic from Jquery.  Increasing this to 50ms provides no noticeable UI delay but does cause the popup panel to do collision detection correctly.