### PR TITLE
Fix #6798: Schedule allow background events

### DIFF
--- a/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -122,9 +122,27 @@ public class ScheduleRenderer extends CoreRenderer {
                     jsonObject.put("durationEditable", event.isResizable());
                 }
                 jsonObject.put("overlap", event.isOverlapAllowed());
-                jsonObject.put("classNames", event.getStyleClass());
-                jsonObject.put("description", event.getDescription());
-                jsonObject.put("url", event.getUrl());
+                if (event.getStyleClass() != null) {
+                    jsonObject.put("classNames", event.getStyleClass());
+                }
+                if (event.getDescription() != null) {
+                    jsonObject.put("description", event.getDescription());
+                }
+                if (event.getUrl() != null) {
+                    jsonObject.put("url", event.getUrl());
+                }
+                if (event.getDisplay() != null) {
+                    jsonObject.put("display", event.getDisplay());
+                }
+                if (event.getBackgroundColor() != null) {
+                    jsonObject.put("backgroundColor", event.getBackgroundColor());
+                }
+                if (event.getBorderColor() != null) {
+                    jsonObject.put("borderColor", event.getBorderColor());
+                }
+                if (event.getTextColor() != null) {
+                    jsonObject.put("textColor", event.getTextColor());
+                }
                 jsonObject.put("rendering", Objects.toString(event.getRenderingMode(), null));
 
                 if (event.getDynamicProperties() != null) {

--- a/src/main/java/org/primefaces/model/DefaultScheduleEvent.java
+++ b/src/main/java/org/primefaces/model/DefaultScheduleEvent.java
@@ -34,18 +34,22 @@ public class DefaultScheduleEvent<T> implements ScheduleEvent<T>, Serializable {
     private static final long serialVersionUID = 1L;
 
     private String id;
+    private T data;
     private String groupId;
     private String title;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private boolean allDay;
-    private String styleClass;
-    private T data;
+    private boolean overlapAllowed;
     private Boolean resizable;
     private Boolean draggable;
-    private boolean overlapAllowed;
+    private String styleClass;
     private String description;
     private String url;
+    private String display;
+    private String backgroundColor;
+    private String borderColor;
+    private String textColor;
     private ScheduleRenderingMode renderingMode;
     private Map<String, Object> dynamicProperties;
 
@@ -236,6 +240,42 @@ public class DefaultScheduleEvent<T> implements ScheduleEvent<T>, Serializable {
     }
 
     @Override
+    public String getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(String display) {
+        this.display = display;
+    }
+
+    @Override
+    public String getBackgroundColor() {
+        return backgroundColor;
+    }
+
+    public void setBackgroundColor(String backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
+    @Override
+    public String getBorderColor() {
+        return borderColor;
+    }
+
+    public void setBorderColor(String borderColor) {
+        this.borderColor = borderColor;
+    }
+
+    @Override
+    public String getTextColor() {
+        return textColor;
+    }
+
+    public void setTextColor(String textColor) {
+        this.textColor = textColor;
+    }
+
+    @Override
     public ScheduleRenderingMode getRenderingMode() {
         return renderingMode;
     }
@@ -384,8 +424,30 @@ public class DefaultScheduleEvent<T> implements ScheduleEvent<T>, Serializable {
             return this;
         }
 
+        public DefaultScheduleEvent.Builder<T> display(String display) {
+            scheduleEvent.setDisplay(display);
+            return this;
+        }
+
+        public DefaultScheduleEvent.Builder<T> backgroundColor(String backgroundColor) {
+            scheduleEvent.setBackgroundColor(backgroundColor);
+            return this;
+        }
+
+        public DefaultScheduleEvent.Builder<T> borderColor(String borderColor) {
+            scheduleEvent.setBorderColor(borderColor);
+            return this;
+        }
+
+        public DefaultScheduleEvent.Builder<T> textColor(String textColor) {
+            scheduleEvent.setTextColor(textColor);
+            return this;
+        }
+
         public DefaultScheduleEvent<T> build() {
             return scheduleEvent;
         }
     }
+
+
 }

--- a/src/main/java/org/primefaces/model/ScheduleEvent.java
+++ b/src/main/java/org/primefaces/model/ScheduleEvent.java
@@ -53,12 +53,17 @@ public interface ScheduleEvent<T> {
     String getStyleClass();
 
     /**
-     * @deprecated Use {@link #isResizable()} or {@link #isDraggable()} instead.
+     * The rendering type of this event. Can be 'auto', 'block', 'list-item', 'background', 'inverse-background', or 'none'.
+     * Events that appear as background highlights can be achieved by setting an Event Object’s display property
+     * to "background" or "inverse-background".
      */
-    @Deprecated
-    default boolean isEditable() {
-        return isDraggable() != null && isResizable() != null && (isDraggable() || isResizable());
-    }
+    String getDisplay();
+
+    String getBackgroundColor();
+
+    String getBorderColor();
+
+    String getTextColor();
 
     /**
      * @return Whether the event should be draggable. Returning {@code null}
@@ -83,4 +88,13 @@ public interface ScheduleEvent<T> {
     ScheduleRenderingMode getRenderingMode();
 
     Map<String, Object> getDynamicProperties();
+
+    /**
+     * @deprecated Use {@link #isResizable()} or {@link #isDraggable()} instead.
+     */
+    @Deprecated
+    default boolean isEditable() {
+        return isDraggable() != null && isResizable() != null && (isDraggable() || isResizable());
+    }
+
 }


### PR DESCRIPTION
From the FullSchedule docs added a few more properties to allow background events.

Usage:
```java
event = DefaultScheduleEvent.builder()
				.title("")
				.startDate(LocalDateTime.now().minusDays(4))
				.endDate(LocalDateTime.now().minusDays(3))
				.overlapAllowed(true)
				.editable(false)
				.resizable(false)
				.display("background")
				.backgroundColor("lightgreen")
				.build();
eventModel.addEvent(event);
```

Screenshot:
![image](https://user-images.githubusercontent.com/4399574/104373920-1c153180-54ef-11eb-8719-724605c32c4b.png)

