### PR TITLE
Fix #6810: Datepicker clear button reset overlay popup

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2533,6 +2533,7 @@
         },
 
         onClearButtonClick: function (event) {
+            this.updateViewDate(event, new Date());
             this.updateModel(event, null);
 
             if (this.options.onClearButtonClick) {


### PR DESCRIPTION
Resets the popup panel back to today at NOW when clicking "Clear" button