### PR TITLE
Fix #6561: Menus fix ARIA support

### DIFF
--- a/src/main/java/org/primefaces/component/menu/BaseMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/menu/BaseMenuRenderer.java
@@ -176,6 +176,7 @@ public abstract class BaseMenuRenderer extends MenuItemAwareRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("tabindex", menu.getTabindex(), null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
+        writer.writeAttribute(HTML.ARIA_ROLE, HTML.ARIA_ROLE_NONE, null);
         writer.endElement("div");
     }
 }

--- a/src/main/java/org/primefaces/component/tieredmenu/TieredMenuRenderer.java
+++ b/src/main/java/org/primefaces/component/tieredmenu/TieredMenuRenderer.java
@@ -159,6 +159,7 @@ public class TieredMenuRenderer extends BaseMenuRenderer {
         writer.startElement("a", null);
         writer.writeAttribute(HTML.ARIA_ROLE, HTML.ARIA_ROLE_MENUITEM, null);
         writer.writeAttribute(HTML.ARIA_HASPOPUP, "true", null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, "false", null);
         writer.writeAttribute("href", "#", null);
         writer.writeAttribute("tabindex", "-1", null);
 
@@ -196,6 +197,7 @@ public class TieredMenuRenderer extends BaseMenuRenderer {
                 writer.startElement("ul", null);
                 writer.writeAttribute("class", Menu.TIERED_CHILD_SUBMENU_CLASS, null);
                 writer.writeAttribute(HTML.ARIA_ROLE, HTML.ARIA_ROLE_MENU, null);
+                writer.writeAttribute(HTML.ARIA_LABEL, label, null);
                 encodeElements(context, menu, submenu.getElements());
                 writer.endElement("ul");
             }

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
@@ -1,7 +1,7 @@
 /**
  * __PrimeFaces Menu Widget__
  * 
- * Base class for the different menu widets, such as the `PlainMenu` or the `TieredMenu`.
+ * Base class for the different menu widgets, such as the `PlainMenu` or the `TieredMenu`.
  * 
  * @prop {JQuery} keyboardTarget The DOM element for the form element that can be targeted via arrow or tab keys. 
  * @prop {boolean} itemMouseDown `true` if a menu item was clicked and the mouse button is still pressed.
@@ -156,6 +156,30 @@ PrimeFaces.widget.Menu = PrimeFaces.widget.BaseWidget.extend({
      */
     align: function() {
         this.jq.css({left:'', top:''}).position(this.cfg.pos);
+    },
+
+    /**
+     * Select the menu item link by making it focused and tabindex=0 for ARIA.
+     * @param {JQuery} menulink Menu item (`A`) to select.
+     */
+    focus: function(menulink) {
+        if(!menulink.hasClass('ui-state-disabled')) {
+            menulink.addClass('ui-state-hover ui-state-active').attr('tabindex', 0);
+            if(menulink.attr('aria-expanded') === "false") {
+                menulink.attr('aria-expanded', "true");
+            }
+        }
+    },
+
+    /**
+     * Unselect the menu item link by removing focus and tabindex=-1 for ARIA.
+     * @param {JQuery} menulink Menu item (`A`) to unselect.
+     */
+    unfocus: function(menulink) {
+        menulink.removeClass('ui-state-hover ui-state-active').attr('tabindex', -1);
+        if(menulink.attr('aria-expanded') === "true") {
+            menulink.attr('aria-expanded', "false");    
+        }
     }
 });
 

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.megamenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.megamenu.js
@@ -149,6 +149,7 @@ PrimeFaces.widget.MegaMenu = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
 
         this.keyboardTarget.on('focus.megamenu', function(e) {
+            $this.keyboardTarget.attr('tabindex', '-1');
             $this.highlight($this.rootLinks.eq(0).parent());
         })
         .on('blur.megamenu', function() {
@@ -349,6 +350,7 @@ PrimeFaces.widget.MegaMenu = PrimeFaces.widget.BaseWidget.extend({
     reset: function() {
         var $this = this;
         this.active = false;
+        $this.keyboardTarget.attr('tabindex', '0');
 
         this.jq.find('li.ui-menuitem-active').each(function() {
             $this.deactivate($(this), true);

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
@@ -66,6 +66,7 @@ PrimeFaces.widget.Menubar = PrimeFaces.widget.TieredMenu.extend({
         var $this = this;
 
         this.keyboardTarget.on('focus.menubar', function(e) {
+            $this.keyboardTarget.attr('tabindex', '-1');
             $this.highlight($this.links.eq(0).parent());
         })
         .on('blur.menubar', function() {

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -116,12 +116,9 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
 
         //menuitem visuals
         this.menuitems.on("mouseover", function(e) {
-            var element = $(this);
-            if(!element.hasClass('ui-state-disabled')) {
-                element.addClass('ui-state-hover');
-            }
+            $this.focus($(this));
         }).on("mouseout", function(e) {
-            $(this).removeClass('ui-state-hover');
+            $this.unfocus($(this));
         }).on("click", function() {
             $this.button.removeClass('ui-state-focus');
             $this.hide();
@@ -138,8 +135,8 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
                         prevItems = highlightedItem.length ? highlightedItem.prevAll(':not(.ui-separator)') : null;
 
                         if(prevItems && prevItems.length) {
-                            highlightedItem.removeClass('ui-state-hover');
-                            prevItems.eq(0).addClass('ui-state-hover');
+                            $this.unfocus(highlightedItem);
+                            $this.focus(prevItems.eq(0));
                         }
                     }
                     e.preventDefault();
@@ -151,8 +148,8 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
                         nextItems = highlightedItem.length ? highlightedItem.nextAll(':not(.ui-separator)') : $this.menuitems.eq(0);
 
                         if(nextItems.length) {
-                            highlightedItem.removeClass('ui-state-hover');
-                            nextItems.eq(0).addClass('ui-state-hover');
+                            $this.unfocus(highlightedItem);
+                            $this.focus(nextItems.eq(0));
                         }
                     }
                     e.preventDefault();

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
@@ -50,10 +50,10 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
                 $this.jq.trigger("blur");
             }
 
-            $(this).addClass('ui-state-hover');
+            $this.focus($(this));
         })
         .on("mouseleave", function(e) {
-            $(this).removeClass('ui-state-hover');
+            $this.unfocus($(this));
         });
 
         if(this.cfg.overlay) {
@@ -100,10 +100,10 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
         }
 
         this.keyboardTarget.on('focus.menu', function() {
-            $this.menuitemLinks.eq(0).addClass('ui-state-hover');
+            $this.focus($this.menuitemLinks.eq(0));
         })
         .on('blur.menu', function() {
-            $this.menuitemLinks.filter('.ui-state-hover').removeClass('ui-state-hover');
+            $this.unfocus($this.menuitemLinks.filter('.ui-state-hover'));
         })
         .on('keydown.menu', function(e) {
             var currentLink = $this.menuitemLinks.filter('.ui-state-hover'),
@@ -113,8 +113,8 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
                     case keyCode.UP:
                         var prevItem = currentLink.parent().prevAll('.ui-menuitem:first');
                         if(prevItem.length) {
-                            currentLink.removeClass('ui-state-hover');
-                            prevItem.children('.ui-menuitem-link').addClass('ui-state-hover');
+                            $this.unfocus(currentLink);
+                            $this.focus(prevItem.children('.ui-menuitem-link'));
                         }
 
                         e.preventDefault();
@@ -123,8 +123,8 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
                     case keyCode.DOWN:
                         var nextItem = currentLink.parent().nextAll('.ui-menuitem:first');
                         if(nextItem.length) {
-                            currentLink.removeClass('ui-state-hover');
-                            nextItem.children('.ui-menuitem-link').addClass('ui-state-hover');
+                            $this.unfocus(currentLink);
+                            $this.focus(nextItem.children('.ui-menuitem-link'));
                         }
 
                         e.preventDefault();

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
@@ -100,10 +100,12 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
         }
 
         this.keyboardTarget.on('focus.menu', function() {
+            $this.keyboardTarget.attr('tabindex', '-1');
             $this.focus($this.menuitemLinks.eq(0));
         })
         .on('blur.menu', function() {
             $this.unfocus($this.menuitemLinks.filter('.ui-state-hover'));
+            $this.keyboardTarget.attr('tabindex', '0');
         })
         .on('keydown.menu', function(e) {
             var currentLink = $this.menuitemLinks.filter('.ui-state-hover'),

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
@@ -206,7 +206,7 @@ PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
      */
     deactivate: function(menuitem, animate) {
         this.activeitem = null;
-        menuitem.children('a.ui-menuitem-link').removeClass('ui-state-hover ui-state-active');
+        this.unfocus(menuitem.children('a.ui-menuitem-link'));
         menuitem.removeClass('ui-menuitem-active ui-menuitem-highlight');
 
         if(animate)
@@ -250,7 +250,7 @@ PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
      */
     highlight: function(menuitem) {
         this.activeitem = menuitem;
-        menuitem.children('a.ui-menuitem-link').addClass('ui-state-hover');
+        this.focus(menuitem.children('a.ui-menuitem-link'));
         menuitem.addClass('ui-menuitem-active');
     },
 

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
@@ -273,12 +273,13 @@ PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
     },
 
     /**
-     * Deactivates all items and resets the state of this widget to its orignal state such that only the top-level menu
+     * Deactivates all items and resets the state of this widget to its original state such that only the top-level menu
      * items are shown. 
      */
     reset: function() {
         var $this = this;
         this.active = false;
+        $this.keyboardTarget.attr('tabindex', '0');
 
         this.jq.find('li.ui-menuitem-active').each(function() {
             $this.deactivate($(this), true);


### PR DESCRIPTION
- Adds `aria-label` to submenu `ul` lists as required by the spec
- Adds `tabindex=0` to the focused menu item all others have `-1` see Roving Tabindex https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_roving_tabindex
- Adds `aria-expanded` property to submenus and toggles it `true` and `false`

This fixes MenuBar, TieredMenu, Menu, and MenuButton.