### PR TITLE
Fix #6829: PanelGrid do not error a row exists but not rendered

### DIFF
--- a/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
+++ b/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
@@ -198,6 +198,10 @@ public class PanelGridRenderer extends CoreRenderer {
                     child.encodeAll(context);
                 }
             }
+            else if (child instanceof Row) {
+                // #6829 count row even though its not rendered
+                i++;
+            }
         }
 
         if (i == 0) {


### PR DESCRIPTION
We have to count rows even if they aren't rendered as this is not what the error was for.