### PR TITLE
Fix #6828: Treetable select event was not getting node

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -970,7 +970,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
     fireSelectEvent: function(nodeKey, behaviorEvent) {
         if(this.hasBehavior(behaviorEvent)) {
             var ext = {
-                    params: [{name: this.id + '_instantSelectedRowKey', value: nodeKey}
+                    params: [{name: this.id + '_instantSelection', value: nodeKey}
                 ]
             };
 


### PR DESCRIPTION
This was a copy and paste from Datatable that uses a different identifier than treetable