### PR TITLE
Fix #6711: Autocomplete change event with CSP

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -110,9 +110,6 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         this.touchToDropdownButton = false;
         this.isTabPressed = false;
         this.isDynamicLoaded = false;
-        
-        this.cfg.onChange = this.input.prop('onchange');
-        this.input.prop('onchange', null).off('change');
 
         if(this.cfg.cache) {
             this.initCache();
@@ -338,6 +335,19 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
      */
     bindKeyEvents: function() {
         var $this = this;
+
+        // GitHub #6711 use DOM if non-CSP and JQ event if CSP
+        var originalOnchange = this.input.prop('onchange');
+        if (!originalOnchange) {
+            var events = $._data(this.input[0], "events");
+            if(events.change) {
+                originalOnchange = events.change[0].handler;
+            }
+        }
+        this.cfg.onChange = originalOnchange;
+        if (originalOnchange) {
+            this.input.prop('onchange', null).off('change');
+        }
 
         if(this.cfg.queryEvent !== 'enter') {
             this.input.on('input propertychange', function(e) {


### PR DESCRIPTION
This is exactly like the fix I made for InputNumber: https://github.com/primefaces/primefaces/issues/6142

Basically CSP has already stripped off the "onchange" event from the Input so we need to inspect Jquery events to see if change is registered when using CSP.

I have scanned the codebase and it looks like only InputNumber and AutoComplete do this so there should be no where else this is happening.

@christophs78 @tandraschko 

I have tested in CSP=true and CSP=false mode with the reproducer and everything is working properly again,