### PR TITLE
Fix #6867: DatePicker show/hide/disable/enable

### DIFF
--- a/docs/10_0_0/components/datepicker.md
+++ b/docs/10_0_0/components/datepicker.md
@@ -334,7 +334,7 @@ The TimePicker pattern can be modified with the properties _hourFormat_ and _sho
 ```
 
 ## Client Side API
-Widget: _PrimeFaces.widget.Calendar_
+Widget: _PrimeFaces.widget.DatePicker_
 
 | Method | Params | Return Type | Description |
 | --- | --- | --- | --- |
@@ -343,6 +343,10 @@ Widget: _PrimeFaces.widget.Calendar_
 | setDisabledDates(dates) | dates: Array of dates to disable | void | Sets disabled dates and update panel. Accepts array of date objects and strings formatted as M/d/yyyy.
 | setDisabledDays(days) | days: Array of days to disable | void | Sets disabled days and update panel. Accepts array of numbers, Sunday = 0.
 | updatePanel() | - | void | Update panel.
+| show() | - | void | Show the overlay panel.
+| hide() | - | void | Hide the overlay panel.
+| disable() | - | void | Disables DatePicker.
+| enable() | - | void | Enables DatePicker.
 
 ## Skinning
 DatePicker resides in a container element which _style_ and _styleClass_ options apply.

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1145,6 +1145,13 @@
         renderPanelElements: function () {
             var elementsHtml = '';
 
+            if(this.options.disabled) {
+                this.panel.addClass('ui-state-disabled');
+            }
+            else {
+                this.panel.removeClass('ui-state-disabled');
+            }
+
             if (!this.options.timeOnly) {
                 if (this.options.view == 'date') {
                     elementsHtml += this.renderDateView();
@@ -1714,13 +1721,13 @@
                 this.datepickerClick = true;
             }
 
-            if (this.options.showOnFocus && !this.panel.is(':visible')) {
+            if (this.options.showOnFocus && !this.isPanelVisible()) {
                 this.showOverlay();
             }
         },
 
         onInputFocus: function (event) {
-            if (this.options.showOnFocus && !this.panel.is(':visible')) {
+            if (this.options.showOnFocus && !this.isPanelVisible()) {
                 this.showOverlay();
             }
 
@@ -1785,7 +1792,7 @@
         },
 
         onButtonClick: function (event) {
-            if (!this.panel.is(':visible')) {
+            if (!this.isPanelVisible()) {
                 this.inputfield.trigger('focus');
                 this.showOverlay();
             }
@@ -2034,28 +2041,30 @@
         },
 
         showOverlay: function () {
-            if (this.options.onBeforeShow) {
-                this.options.onBeforeShow.call(this);
-            }
+            if (!this.options.inline && !this.isPanelVisible()) {
+                if (this.options.onBeforeShow) {
+                    this.options.onBeforeShow.call(this);
+                }
 
-            this.panel.show();
-            this.alignPanel();
+                this.panel.show();
+                this.alignPanel();
 
-            if (!this.options.touchUI) {
-                var $this = this;
-                setTimeout(function () {
-                    $this.bindDocumentClickListener();
-                    $this.bindWindowResizeListener();
-                }, 10);
-            }
+                if (!this.options.touchUI) {
+                    var $this = this;
+                    setTimeout(function () {
+                        $this.bindDocumentClickListener();
+                        $this.bindWindowResizeListener();
+                    }, 10);
+                }
 
-            if ((this.options.showTime || this.options.timeOnly) && this.options.timeInput) {
-                this.panel.find('.ui-hour-picker input').trigger('focus');
+                if ((this.options.showTime || this.options.timeOnly) && this.options.timeInput) {
+                    this.panel.find('.ui-hour-picker input').trigger('focus');
+                }
             }
         },
 
         hideOverlay: function () {
-            if (this.isPanelVisible()) {
+            if (!this.options.inline && this.isPanelVisible()) {
                 if (this.options.onBeforeHide) {
                     this.options.onBeforeHide.call(this);
                 }
@@ -2114,7 +2123,7 @@
         },
 
         isPanelVisible: function () {
-           return this.panel && this.panel.is(":visible");
+           return !this.options.disabled && this.panel && this.panel.is(":visible");
         },
 
         isDate: function (value) {

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -452,4 +452,37 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         pdp.panel.get(0).innerHTML = pdp.renderPanelElements();
     },
 
+    /**
+     * Shows the popup panel.
+     */
+    show: function() {
+        this.jq.data().primeDatePicker.showOverlay();
+    },
+
+    /**
+     * Hide the popup panel.
+     */
+    hide: function() {
+        this.jq.data().primeDatePicker.hideOverlay();
+    },
+
+    /**
+     * Enables the datepicker, so that the user can select a date.
+     */
+    enable: function() {
+        this.jq.data().primeDatePicker.options.disabled = false;
+        this.updatePanel();
+        this.input.prop('disabled', false).removeClass('ui-state-disabled');
+    },
+
+    /**
+     * Disables the datepicker, so that the user can no longer select any date.
+     */
+    disable: function() {
+        this.hide();
+        this.jq.data().primeDatePicker.options.disabled = true;
+        this.updatePanel();
+        this.input.prop('disabled', true).addClass('ui-state-disabled');
+    }
+
 });


### PR DESCRIPTION
Integration Tests written to prove the methods are working properly.

```java
   @Test
    @Order(5)
    @DisplayName("DatePicker: Use disable() widget method to disable DatePicker")
    public void testDisable(Page page) {
        // Arrange
        DatePicker datePicker = page.datePicker;
        Assertions.assertEquals(LocalDate.now(), datePicker.getValue().toLocalDate());

        // Act
        datePicker.disable();
        datePicker.showPanel();

        // Assert
        Assertions.assertFalse(datePicker.isEnabled());
        assertNotDisplayed(datePicker.getPanel());
        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
        assertConfiguration(datePicker.getWidgetConfiguration(), LocalDate.now().format(dateTimeFormatter));
    }

    @Test
    @Order(6)
    @DisplayName("DatePicker: Use enable() widget method to enable DatePicker")
    public void testEnable(Page page) {
        // Arrange
        DatePicker datePicker = page.datePicker;
        datePicker.disable();
        Assertions.assertFalse(datePicker.isEnabled());

        // Act
        datePicker.enable();
        datePicker.showPanel();

        // Assert
        Assertions.assertTrue(datePicker.isEnabled());
        assertDisplayed(datePicker.getPanel());
        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
        assertConfiguration(datePicker.getWidgetConfiguration(), LocalDate.now().format(dateTimeFormatter));
    }
```