### PR TITLE
Fix #6882: Divider can be used in menus as separator

### DIFF
--- a/docs/10_0_0/components/divider.md
+++ b/docs/10_0_0/components/divider.md
@@ -23,6 +23,7 @@ Divider is used to separate contents.
 | align | null | String | Alignment of the content, options are "left", "center", "right" for horizontal layout and "top", "center", "bottom" for vertical.
 | layout | horizontal | String | Specifies the orientation, valid values are "horizontal" and "vertical".
 | type | solid | String | Border style type, default is "solid" and other options are "dashed" and "dotted".
+| title | null | String | Advisory tooltip information.
 | style | null | String | Style of the Divider.
 | styleClass | null | String | StyleClass of the Divider.
 

--- a/src/main/java/org/primefaces/component/divider/DividerBase.java
+++ b/src/main/java/org/primefaces/component/divider/DividerBase.java
@@ -23,9 +23,11 @@
  */
 package org.primefaces.component.divider;
 
+import org.primefaces.model.menu.Separator;
+
 import javax.faces.component.UIComponentBase;
 
-public abstract class DividerBase extends UIComponentBase {
+public abstract class DividerBase extends UIComponentBase implements Separator {
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
     public static final String DEFAULT_RENDERER = "org.primefaces.component.DividerRenderer";
@@ -34,6 +36,7 @@ public abstract class DividerBase extends UIComponentBase {
         align,
         layout,
         type,
+        title,
         style,
         styleClass
     }
@@ -71,6 +74,7 @@ public abstract class DividerBase extends UIComponentBase {
         getStateHelper().put(PropertyKeys.type, type);
     }
 
+    @Override
     public String getStyle() {
         return (String) getStateHelper().eval(PropertyKeys.style, null);
     }
@@ -79,11 +83,21 @@ public abstract class DividerBase extends UIComponentBase {
         getStateHelper().put(PropertyKeys.style, style);
     }
 
+    @Override
     public String getStyleClass() {
         return (String) getStateHelper().eval(PropertyKeys.styleClass, null);
     }
 
     public void setStyleClass(String styleClass) {
         getStateHelper().put(PropertyKeys.styleClass, styleClass);
+    }
+
+    @Override
+    public String getTitle() {
+        return (String) getStateHelper().eval(PropertyKeys.title, null);
+    }
+
+    public void setTitle(String title) {
+        getStateHelper().put(PropertyKeys.title, title);
     }
 }

--- a/src/main/java/org/primefaces/component/divider/DividerRenderer.java
+++ b/src/main/java/org/primefaces/component/divider/DividerRenderer.java
@@ -64,6 +64,9 @@ public class DividerRenderer extends CoreRenderer {
         if (divider.getStyle() != null) {
             writer.writeAttribute("style", divider.getStyle(), "style");
         }
+        if (divider.getTitle() != null) {
+            writer.writeAttribute("title", divider.getTitle(), "title");
+        }
         if (divider.getChildCount() > 0) {
             writer.startElement("div", null);
             writer.writeAttribute("class", Divider.CONTENT_CLASS, "styleClass");

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -32694,6 +32694,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Advisory tooltip information.]]>
+            </description>
+            <name>title</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Inline style of the component.]]>
             </description>
             <name>style</name>


### PR DESCRIPTION
I have updated the Showcase examples too in Showcase PR.