### PR TITLE
Fix #6870 BreadCrumb: should not render separators in HTML

### DIFF
--- a/src/main/java/org/primefaces/component/breadcrumb/BreadCrumb.java
+++ b/src/main/java/org/primefaces/component/breadcrumb/BreadCrumb.java
@@ -35,6 +35,5 @@ public class BreadCrumb extends BreadCrumbBase {
 
     public static final String CONTAINER_CLASS = "ui-breadcrumb ui-module ui-widget ui-widget-header ui-helper-clearfix ui-corner-all";
     public static final String ITEMS_CLASS = "ui-breadcrumb-items";
-    public static final String CHEVRON_CLASS = "ui-breadcrumb-chevron ui-icon ui-icon-triangle-1-e";
     public static final String OPTIONS_CLASS = "ui-breadcrumb-options";
 }

--- a/src/main/java/org/primefaces/component/breadcrumb/BreadCrumbRenderer.java
+++ b/src/main/java/org/primefaces/component/breadcrumb/BreadCrumbRenderer.java
@@ -44,8 +44,10 @@ public class BreadCrumbRenderer extends BaseMenuRenderer {
         ResponseWriter writer = context.getResponseWriter();
         BreadCrumb breadCrumb = (BreadCrumb) menu;
         String clientId = breadCrumb.getClientId(context);
-        String styleClass = breadCrumb.getStyleClass();
-        styleClass = styleClass == null ? BreadCrumb.CONTAINER_CLASS : BreadCrumb.CONTAINER_CLASS + " " + styleClass;
+        String styleClass = getStyleClassBuilder(context)
+                    .add(BreadCrumb.CONTAINER_CLASS)
+                    .add(breadCrumb.getStyleClass())
+                    .build();
         int elementCount = menu.getElementsCount();
         List<MenuElement> menuElements = menu.getElements();
         boolean isIconHome = breadCrumb.getHomeDisplay().equals("icon");
@@ -74,13 +76,6 @@ public class BreadCrumbRenderer extends BaseMenuRenderer {
 
                 if (element.isRendered() && element instanceof MenuItem) {
                     MenuItem item = (MenuItem) element;
-
-                    //dont render chevron before home icon
-                    if (i != 0) {
-                        writer.startElement("li", null);
-                        writer.writeAttribute("class", BreadCrumb.CHEVRON_CLASS, null);
-                        writer.endElement("li");
-                    }
 
                     writer.startElement("li", null);
 
@@ -133,9 +128,11 @@ public class BreadCrumbRenderer extends BaseMenuRenderer {
         ResponseWriter writer = context.getResponseWriter();
 
         String style = menuItem.getStyle();
-        String styleClass = menuItem.getStyleClass();
-        styleClass = styleClass == null ? BreadCrumb.MENUITEM_LINK_CLASS : BreadCrumb.MENUITEM_LINK_CLASS + " " + styleClass;
-        styleClass += " ui-state-disabled";
+        String styleClass = getStyleClassBuilder(context)
+                    .add(BreadCrumb.MENUITEM_LINK_CLASS)
+                    .add(menuItem.getStyleClass())
+                    .add("ui-state-disabled")
+                    .build();
 
         writer.startElement("span", null); // outer span
         writer.writeAttribute("class", styleClass, null);

--- a/src/main/resources/META-INF/resources/primefaces-saga/theme.css
+++ b/src/main/resources/META-INF/resources/primefaces-saga/theme.css
@@ -4808,56 +4808,6 @@ body .ui-breadcrumb {
   border: 1px solid #dee2e6;
   border-radius: 4px;
   padding: 1rem; }
-  body .ui-breadcrumb ul li {
-    float: none;
-    display: inline-block;
-    vertical-align: middle; }
-    body .ui-breadcrumb ul li .ui-menuitem-link {
-      transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
-      border-radius: 4px;
-      margin: 0; }
-      body .ui-breadcrumb ul li .ui-menuitem-link:focus {
-        outline: 0 none;
-        outline-offset: 0;
-        box-shadow: 0 0 0 0.2rem #a6d5fa; }
-      body .ui-breadcrumb ul li .ui-menuitem-link .ui-menuitem-text {
-        color: #495057; }
-      body .ui-breadcrumb ul li .ui-menuitem-link .ui-menuitem-icon {
-        color: #6c757d; }
-    body .ui-breadcrumb ul li.ui-breadcrumb-chevron {
-      font-family: 'primeicons' !important;
-      speak: none;
-      font-style: normal;
-      font-weight: normal;
-      font-variant: normal;
-      text-transform: none;
-      display: inline-block;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      text-indent: 0 !important;
-      background-image: none !important;
-      margin: 0 0.5rem 0 0.5rem;
-      color: #6c757d; }
-      body .ui-breadcrumb ul li.ui-breadcrumb-chevron:before {
-        content: ""; }
-    body .ui-breadcrumb ul li:first-child a.ui-icon-home {
-      font-family: 'primeicons' !important;
-      speak: none;
-      font-style: normal;
-      font-weight: normal;
-      font-variant: normal;
-      text-transform: none;
-      display: inline-block;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      text-indent: 0 !important;
-      background-image: none !important;
-      color: #6c757d;
-      margin: 0; }
-      body .ui-breadcrumb ul li:first-child a.ui-icon-home:before {
-        content: ""; }
-      body .ui-breadcrumb ul li:first-child a.ui-icon-home span {
-        display: none; }
   body .ui-breadcrumb .ui-breadcrumb-items li .ui-menuitem-link {
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
     border-radius: 4px;
@@ -4870,7 +4820,7 @@ body .ui-breadcrumb {
       color: #495057; }
     body .ui-breadcrumb .ui-breadcrumb-items li .ui-menuitem-link .ui-menuitem-icon {
       color: #6c757d; }
-  body .ui-breadcrumb .ui-breadcrumb-items li.ui-breadcrumb-chevron {
+  body .ui-breadcrumb .ui-breadcrumb-items li:not(:first-child):before {
     font-family: 'primeicons' !important;
     speak: none;
     font-style: normal;
@@ -4883,9 +4833,8 @@ body .ui-breadcrumb {
     text-indent: 0 !important;
     background-image: none !important;
     margin: 0 0.5rem 0 0.5rem;
-    color: #6c757d; }
-    body .ui-breadcrumb .ui-breadcrumb-items li.ui-breadcrumb-chevron:before {
-      content: ""; }
+    color: #6c757d;
+    content: ""; }
   body .ui-breadcrumb .ui-breadcrumb-items li:first-child a.ui-icon-home {
     font-family: 'primeicons' !important;
     speak: none;


### PR DESCRIPTION
Fix #6870.

I know we should not modify the theme CSS files, but I did just one to indicate what should be changed in all of them.

<img width="559" alt="Screen Shot 2021-01-23 at 15 10 17" src="https://user-images.githubusercontent.com/7500178/105580600-9e261580-5d8d-11eb-848a-5e4f7927b7f8.png">
