### PR TITLE
Fix #6873: Use capitalCase field if headerText/facet is null

### DIFF
--- a/src/main/java/org/primefaces/component/column/Column.java
+++ b/src/main/java/org/primefaces/component/column/Column.java
@@ -30,6 +30,7 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 
 import org.primefaces.component.celleditor.CellEditor;
+import org.primefaces.util.LangUtils;
 
 public class Column extends ColumnBase {
 
@@ -87,5 +88,17 @@ public class Column extends ColumnBase {
                 child.encodeAll(context);
             }
         }
+    }
+
+    @Override
+    public String getHeaderText() {
+        String headerText = super.getHeaderText();
+        if (headerText == null) {
+            String field = getField();
+            if (LangUtils.isNotBlank(field)) {
+                headerText = LangUtils.toCapitalCase(field);
+            }
+        }
+        return headerText;
     }
 }

--- a/src/main/java/org/primefaces/component/columns/Columns.java
+++ b/src/main/java/org/primefaces/component/columns/Columns.java
@@ -32,6 +32,7 @@ import javax.faces.context.FacesContext;
 
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.celleditor.CellEditor;
+import org.primefaces.util.LangUtils;
 
 public class Columns extends ColumnsBase {
 
@@ -84,6 +85,18 @@ public class Columns extends ColumnsBase {
     @Override
     public void renderChildren(FacesContext context) throws IOException {
         encodeChildren(context);
+    }
+
+    @Override
+    public String getHeaderText() {
+        String headerText = super.getHeaderText();
+        if (headerText == null) {
+            String field = getField();
+            if (LangUtils.isNotBlank(field)) {
+                headerText = LangUtils.toCapitalCase(field);
+            }
+        }
+        return headerText;
     }
 
     public List<DynamicColumn> getDynamicColumns() {

--- a/src/main/java/org/primefaces/util/LangUtils.java
+++ b/src/main/java/org/primefaces/util/LangUtils.java
@@ -34,6 +34,7 @@ import java.lang.reflect.TypeVariable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import javax.faces.FacesException;
 import javax.xml.bind.DatatypeConverter;
@@ -41,6 +42,7 @@ import javax.xml.bind.DatatypeConverter;
 public class LangUtils {
 
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+    private static final Pattern CAPITAL_CASE = Pattern.compile("(?<=.)(?=\\p{Lu})");
 
     private LangUtils() {
     }
@@ -413,6 +415,30 @@ public class LangUtils {
         catch (NoSuchAlgorithmException e) {
             throw new FacesException(e);
         }
+    }
+
+    /**
+     * Converts a sting to capital case even counting Unicode characters.
+     * <pre>
+     * thisIsMyString = This Is My String
+     * ThisIsATest = This Is A Test
+     * helloWorld = Hello World
+     * </pre>
+     *
+     * @param value the value to capital case
+     * @return the returned value in capital case or empty string if blank
+     */
+    public static String toCapitalCase(String value) {
+        if (LangUtils.isValueBlank(value)) {
+            return Constants.EMPTY_STRING;
+        }
+
+        // split on unicode uppercase characters
+        String[] values = CAPITAL_CASE.split(value);
+        if (values.length > 0) {
+            values[0] = values[0].substring(0 , 1).toUpperCase() + values[0].substring(1).toLowerCase();
+        }
+        return String.join(" ", values);
     }
 
 

--- a/src/test/java/org/primefaces/util/LangUtilsTest.java
+++ b/src/test/java/org/primefaces/util/LangUtilsTest.java
@@ -114,6 +114,16 @@ public class LangUtilsTest {
         assertTrue(LangUtils.isNumeric("-.236"));
     }
 
+    @Test
+    public void toCapitalCase() {
+        assertEquals("", LangUtils.toCapitalCase(null));
+        assertEquals("", LangUtils.toCapitalCase(""));
+        assertEquals("", LangUtils.toCapitalCase(" "));
+        assertEquals("This Is A Test", LangUtils.toCapitalCase("thisIsATest"));
+        assertEquals("Uppercase First Char", LangUtils.toCapitalCase("UppercaseFirstChar"));
+        assertEquals("My Über String", LangUtils.toCapitalCase("myÜberString"));
+    }
+
     class SimpleClass {
         private List<String> strings;
 


### PR DESCRIPTION
@Rapster @tandraschko I have tested this and its working great.  Some notes and a question:

- Unit test provided for `LangUtils.toCapitalCase()` 
- This will only use `field="productName"` as headerText `"Product Name"` only if the header facet is not used AND the headerText == null.  So this is a last resort fallback when using field.
- I check for headerText==null and not `LangUtils.isNotBlank` because I wanted to give someone the option to do this still `<p:column field="productName" headerText="" />` if they truly did not want a header text.

**Question:** I put this in the `Column(s)Base` class when calling `getHeaderText()` because this allows it to work seamlessly in all parts of the code. If I don't do this I have to litter this `capitalCase` check in 5 places DatatableRenderer, CSV ,PDF, XML, XLS Exporter code.  By placing it in the base it just works in all these places that ask for HeaderText.  I know we don't do this a lot but was wondering if this is OK?  Or would you like this check moved to the 5 places instead?