### PR TITLE
Fix #3551: Datatable remember range selection rowindex between updates

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -783,8 +783,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         this.selection = (preselection === "") ? [] : preselection.split(',');
 
         //shift key based range selection
-        this.originRowIndex = null;
-        this.cursorIndex = null;
+        if(!this.originRowIndex) {
+            this.originRowIndex = null;
+        }
+        if(!this.cursorIndex) {
+            this.cursorIndex = null;
+        }
 
         this.bindSelectionEvents();
     },


### PR DESCRIPTION
This fix simply sets the shift range index to NULL on first load but will not forget it if the datatable is updated.