### PR TITLE
Fix #6912: FileUpload global attribute

### DIFF
--- a/docs/10_0_0/components/fileupload.md
+++ b/docs/10_0_0/components/fileupload.md
@@ -21,60 +21,61 @@ powered rich solution with graceful degradation for legacy browsers.
 | Name | Default | Type | Description|
 | --- | --- | --- | --- |
 | id | null | String | Unique identifier of the component.
-| rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
-| binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean.
-| value | null | Object | Value of the component than can be either an EL expression of a literal text.
-| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id.
-| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
-| required | false | Boolean | Marks component as required.
-| validator | null | MethodExpr | A method expression that refers to a method validating the input.
-| valueChangeListener | null | MethodExpr | A method expression that refers to a method for handling a valuchangeevent.
-| requiredMessage | null | String | Message to be displayed when required field validation fails.
-| converterMessage | null | String | Message to be displayed when conversion fails.
-| validatorMessage | null | String | Message to be displayed when validation fails.
-| widgetVar | null | String | Name of the client side widget.
-| update | @none | String | Component(s) to update after fileupload completes.
-| process | @all | String | Component(s) to process in fileupload request.
-| listener | null | MethodExpr | Method to invoke when a file is uploaded.
-| multiple | false | Boolean | Allows choosing of multi file uploads from native file browse dialog
-| auto | false | Boolean | When set to true, selecting a file starts the upload process implicitly.
-| label | Choose | String | Label of the browse button.
-| allowTypes | null | String | Regular expression for accepted file types, e.g. /(\\.\|\\/)(gif\|jpe?g\|png)$/
-| sizeLimit | null | Long | Individual file size limit in bytes.
-| fileLimit | null | Integer | Maximum number of files allowed to upload.
-| style | null | String | Inline style of the component.
-| styleClass | null | String | Style class of the component.
-| mode | advanced | String | Mode of the fileupload, can be _simple_ or _advanced_.
-| uploadLabel | Upload | String | Label of the upload button.
-| cancelLabel | Cancel | String | Label of the cancel button.
-| invalidSizeMessage | Invalid file size | String | Message to display when size limit exceeds.
-| invalidFileMessage | Invalid file type | String | Message to display when file is not accepted.
-| fileLimitMessage | Maximum number of files exceeded | String | Message to display when file limit exceeds.
-| dragDropSupport | true | Boolean | Specifies dragdrop based file selection from filesystem, default is true and works only on supported browsers.
-| onAdd | null | String | Callback to execute before adding a file.
-| onupload | null | String | Callback to execute before the files are sent. If this callback returns false, the file upload request is not started.
-| onstart | null | String | Client side callback to execute when upload begins.
-| onerror | null | String | Callback to execute if fileupload request fails.
-| oncomplete | null | String | Client side callback to execute when upload ends.
-| onvalidationfailure | null | String | Handler called when client-side validation fails.
-| disabled | false | Boolean | Disables component when set true.
-| messageTemplate | {name} {size} | String | Message template to use when displaying file validation errors.
-| previewWidth | 80 | Integer | Width for image previews in pixels.
-| skinSimple | false | Boolean | Applies theming to simple uploader.
 | accept | null | String | Filters files in native file browser dialog.
-| sequential | false | Boolean | Uploads are concurrent by default, set this option to true for sequential uploads.
-| chooseIcon | ui-icon-plusthick | String | The icon of choose button
-| uploadIcon | ui-icon-arrowreturnthick-1-n | String | The icon of upload button
-| cancelIcon | ui-icon-cancel | String | The icon of cancel button
-| title | null | String | Native title tooltip for simple mode
-| chooseButtonTitle | null | String | Native title tooltip for choose button
-| uploadButtonTitle | null | String | Native title tooltip for upload button
+| allowTypes | null | String | Regular expression for accepted file types, e.g. /(\\.\|\\/)(gif\|jpe?g\|png)$/
+| auto | false | Boolean | When set to true, selecting a file starts the upload process implicitly.
+| binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean.
 | cancelButtonTitle | null | String | Native title tooltip for cancel button
-| validateContentType | false | Boolean | Whether content type validation should be performed, based on the types defined in the accept attribute. Default is false.
-| virusScan | false | Boolean | Whether virus scan should be performed. Default is false.
+| cancelIcon | ui-icon-cancel | String | The icon of cancel button
+| cancelLabel | Cancel | String | Label of the cancel button.
+| chooseButtonTitle | null | String | Native title tooltip for choose button
+| chooseIcon | ui-icon-plusthick | String | The icon of choose button
+| converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id.
+| converterMessage | null | String | Message to be displayed when conversion fails.
+| disabled | false | Boolean | Disables component when set true.
+| dragDropSupport | true | Boolean | Specifies dragdrop based file selection from filesystem, default is true and works only on supported browsers.
+| fileLimit | null | Integer | Maximum number of files allowed to upload.
+| fileLimitMessage | Maximum number of files exceeded | String | Message to display when file limit exceeds.
+| global | true | Boolean | Global AJAX requests are listened by ajaxStatus component, setting global to false will not trigger ajaxStatus. Default is false.
+| immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
+| invalidFileMessage | Invalid file type | String | Message to display when file is not accepted.
+| invalidSizeMessage | Invalid file size | String | Message to display when size limit exceeds.
+| label | Choose | String | Label of the browse button.
+| listener | null | MethodExpr | Method to invoke when a file is uploaded.
 | maxChunkSize | 0 | Long | To upload large files in smaller chunks, set this option to a preferred maximum chunk size. If set to 0 (default), null or undefined, or the browser does not support the required Blob API, files will be uploaded as a whole. Only works in "advanced" mode.
 | maxRetries | 30 | Integer | Only for chunked file upload: Amount of retries when upload get´s interrupted due to e.g. unstable network connection.
+| messageTemplate | {name} {size} | String | Message template to use when displaying file validation errors.
+| mode | advanced | String | Mode of the fileupload, can be _simple_ or _advanced_.
+| multiple | false | Boolean | Allows choosing of multi file uploads from native file browse dialog
+| onAdd | null | String | Callback to execute before adding a file.
+| oncomplete | null | String | Client side callback to execute when upload ends.
+| onerror | null | String | Callback to execute if fileupload request fails.
+| onstart | null | String | Client side callback to execute when upload begins.
+| onupload | null | String | Callback to execute before the files are sent. If this callback returns false, the file upload request is not started.
+| onvalidationfailure | null | String | Handler called when client-side validation fails.
+| previewWidth | 80 | Integer | Width for image previews in pixels.
+| process | @all | String | Component(s) to process in fileupload request.
+| rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
+| required | false | Boolean | Marks component as required.
+| requiredMessage | null | String | Message to be displayed when required field validation fails.
 | retryTimeout | 1000 | Integer | Only for chunked file upload: (Base-)Timeout in milliseconds to wait until the next retry. It is multiplied with the retry count. (first retry: retryTimeout * 1, second retry: retryTimeout *2, ...)
+| sequential | false | Boolean | Uploads are concurrent by default, set this option to true for sequential uploads.
+| sizeLimit | null | Long | Individual file size limit in bytes.
+| skinSimple | false | Boolean | Applies theming to simple uploader.
+| style | null | String | Inline style of the component.
+| styleClass | null | String | Style class of the component.
+| title | null | String | Native title tooltip for simple mode
+| update | @none | String | Component(s) to update after fileupload completes.
+| uploadButtonTitle | null | String | Native title tooltip for upload button
+| uploadIcon | ui-icon-arrowreturnthick-1-n | String | The icon of upload button
+| uploadLabel | Upload | String | Label of the upload button.
+| validateContentType | false | Boolean | Whether content type validation should be performed, based on the types defined in the accept attribute. Default is false.
+| validator | null | MethodExpr | A method expression that refers to a method validating the input.
+| validatorMessage | null | String | Message to be displayed when validation fails.
+| value | null | Object | Value of the component than can be either an EL expression of a literal text.
+| valueChangeListener | null | MethodExpr | A method expression that refers to a method for handling a valuchangeevent.
+| virusScan | false | Boolean | Whether virus scan should be performed. Default is false.
+| widgetVar | null | String | Name of the client side widget.
 
 ## Getting started with FileUpload
 FileUpload engine on the server side can either be servlet 3.0 or commons fileupload. PrimeFaces

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
@@ -39,6 +39,7 @@ public abstract class FileUploadBase extends UIInput implements Widget {
         style,
         styleClass,
         update,
+        global,
         process,
         listener,
         multiple,
@@ -441,6 +442,14 @@ public abstract class FileUploadBase extends UIInput implements Widget {
 
     public void setCancelButtonTitle(String cancelButtonTitle) {
         getStateHelper().put(PropertyKeys.cancelButtonTitle, cancelButtonTitle);
+    }
+
+    public boolean isGlobal() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.global, true);
+    }
+
+    public void setGlobal(boolean global) {
+        getStateHelper().put(PropertyKeys.global, global);
     }
 
 }

--- a/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -102,6 +102,7 @@ public class FileUploadRenderer extends CoreRenderer {
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
                 .attr("process", SearchExpressionFacade.resolveClientIds(context, fileUpload, process,
                             SearchExpressionUtils.SET_RESOLVE_CLIENT_SIDE), null)
+                .attr("global", fileUpload.isGlobal(), true)
                 .attr("disabled", fileUpload.isDisabled(), false)
                 .attr("invalidSizeMessage", fileUpload.getInvalidSizeMessage(), null)
                 .attr("invalidFileMessage", fileUpload.getInvalidFileMessage(), null)

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -10177,6 +10177,12 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>Global AJAX requests are listened by ajaxStatus component, setting global to false will not trigger ajaxStatus.</description>
+            <name>global</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
             <description>
                 <![CDATA[Method expression to invoke when a file is uploaded.]]>
             </description>

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/2-fileupload.js
@@ -107,6 +107,7 @@
  * retry. It is multiplied with the retry count. (first retry: `retryTimeout * 1`, second retry: `retryTimeout * 2`,
  * ...)
  * @prop {string} cfg.resumeContextPath Server-side path which provides information to resume chunked file upload.
+ * @prop {string} cfg.global Global AJAX requests are listened by ajaxStatus, false will not trigger ajaxStatus.
  */
 PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
 
@@ -145,6 +146,7 @@ PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.previewWidth = this.cfg.previewWidth || 80;
         this.cfg.maxRetries = this.cfg.maxRetries || 30;
         this.cfg.retryTimeout = this.cfg.retryTimeout || 1000;
+        this.cfg.global = (this.cfg.global === true || this.cfg.global === undefined) ? true : false;
         this.uploadedFileCount = 0;
         this.fileId = 0;
 
@@ -173,6 +175,9 @@ PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
                 xhr.setRequestHeader('Faces-Request', 'partial/ajax');
                 xhr.pfSettings = settings;
                 xhr.pfArgs = {}; // default should be an empty object
+                if($this.cfg.global) {
+                     $(document).trigger('pfAjaxSend', [xhr, this]);
+                }
             },
             start: function(e) {
                 if($this.cfg.onstart) {
@@ -329,6 +334,9 @@ PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
             always: function(e, data) {
                 if($this.cfg.oncomplete) {
                     $this.cfg.oncomplete.call($this, data.jqXHR.pfArgs, data);
+                }
+                if($this.cfg.global) {
+                    $(document).trigger('pfAjaxComplete');
                 }
             },
 
@@ -573,6 +581,10 @@ PrimeFaces.widget.FileUpload = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     upload: function() {
+        if(this.cfg.global) {
+            $(document).trigger('pfAjaxStart');
+        }
+        
         for(var i = 0; i < this.files.length; i++) {
             this.files[i].ajaxRequest = this.files[i].row.data('filedata');
             this.files[i].ajaxRequest.submit();

--- a/src/main/resources/META-INF/resources/primefaces/fileupload/3-fileupload.simple.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/3-fileupload.simple.js
@@ -22,6 +22,7 @@
  * @prop {string} cfg.invalidSizeMessage Message to display when size limit exceeds.
  * @prop {number} cfg.maxFileSize Maximum allowed size in bytes for files.
  * @prop {string} cfg.messageTemplate Message template to use when displaying file validation errors.
+ * @prop {string} cfg.global Global AJAX requests are listened by ajaxStatus, false will not trigger ajaxStatus.
  */
 PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
 
@@ -40,6 +41,7 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.invalidSizeMessage = this.cfg.invalidSizeMessage || 'Invalid file size';
         this.cfg.fileLimitMessage = this.cfg.fileLimitMessage || 'Maximum number of files exceeded';
         this.cfg.messageTemplate = this.cfg.messageTemplate || '{name} {size}';
+        this.cfg.global = (this.cfg.global === true || this.cfg.global === undefined) ? true : false;
         this.sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
 
         this.maxFileSize = this.cfg.maxFileSize;
@@ -213,12 +215,14 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
 
         var $this = this,
             files = this.input[0].files;
-
         var parameterPrefix = PrimeFaces.ajax.Request.extractParameterNamespace(this.form);
         var process = this.cfg.process ? this.id + ' ' + PrimeFaces.expressions.SearchExpressionFacade.resolveComponents(this.cfg.process).join(' ') : this.id;
         var update = this.cfg.update ? PrimeFaces.expressions.SearchExpressionFacade.resolveComponents(this.cfg.update).join(' ') : null;
-
         var formData = PrimeFaces.ajax.Request.createFacesAjaxFormData(this.form, parameterPrefix, this.id, process, update);
+
+        if($this.cfg.global) {
+            $(document).trigger('pfAjaxStart');
+        }
 
         // append files
         for (var i = 0; i < files.length; i++) {
@@ -239,6 +243,9 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
                 xhr.setRequestHeader('Faces-Request', 'partial/ajax');
                 xhr.pfSettings = settings;
                 xhr.pfArgs = {}; // default should be an empty object
+                if($this.cfg.global) {
+                     $(document).trigger('pfAjaxSend', [xhr, this]);
+                }
             }
         };
 
@@ -291,6 +298,10 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
                     $this.display.text('');
                 }
                 $this.input.val('');
+
+                if($this.cfg.global) {
+                    $(document).trigger('pfAjaxComplete', [xhr, this]);
+                }
             });
 
         PrimeFaces.ajax.Queue.addXHR(jqXhr);


### PR DESCRIPTION
- Added `global` attribute to FileUpload
- Since it uses a custom $ajax request had to do the AJAX start, send, complete in this request
- Sorted the MD attributes as there are a lot of them.