### PR TITLE
Fix #6919: Password allow unmasking

### DIFF
--- a/docs/10_0_0/components/password.md
+++ b/docs/10_0_0/components/password.md
@@ -90,7 +90,7 @@ style | null | String | Inline style of the input element.
 styleClass | null | String | Style class of the input element.
 tabindex | null | Integer | Position of the input element in the tabbing order.
 title | null | String | Advisory tooltip information.
-unmaskable | false | Boolean | Adds a show/hide icon to the password to allow the password to be unmasked/remasked. Default is false.
+toggleMask | false | Boolean | Adds a show/hide icon to the password to allow the password to be unmasked/remasked. Default is false.
 
 ## Getting Started with Password
 Password is an input component and used just like a standard input text. When _feedback_ option is

--- a/docs/10_0_0/components/password.md
+++ b/docs/10_0_0/components/password.md
@@ -90,6 +90,7 @@ style | null | String | Inline style of the input element.
 styleClass | null | String | Style class of the input element.
 tabindex | null | Integer | Position of the input element in the tabbing order.
 title | null | String | Advisory tooltip information.
+unmaskable | false | Boolean | Adds a show/hide icon to the password to allow the password to be unmasked/remasked. Default is false.
 
 ## Getting Started with Password
 Password is an input component and used just like a standard input text. When _feedback_ option is
@@ -144,6 +145,15 @@ The following AJAX behavior events are available for this component. If no event
 ```xhtml
 <p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
 ```
+
+## Client Side API
+Widget: _PrimeFaces.widget.Password_
+
+| Method | Params | Return Type | Description | 
+| --- | --- | --- | --- | 
+show() | - | void | Shows password feedback panel.
+hide() | - | void | Hides password feedback panel.
+toggleMask() | - | void | Toggle masking and unmasking the password.
 
 ## Skinning
 Structural selectors for password are;

--- a/src/main/java/org/primefaces/component/password/Password.java
+++ b/src/main/java/org/primefaces/component/password/Password.java
@@ -42,6 +42,8 @@ public class Password extends PasswordBase {
     public static final String COMPONENT_TYPE = "org.primefaces.component.Password";
 
     public static final String STYLE_CLASS = "ui-inputfield ui-password ui-widget ui-state-default ui-corner-all";
+    public static final String MASKED_CLASS = "ui-password ui-icon ui-password-masked";
+    public static final String UNMASKED_CLASS = "ui-password ui-icon ui-password-unmasked";
 
     public static final String INVALID_MATCH_KEY = "primefaces.password.INVALID_MATCH";
 

--- a/src/main/java/org/primefaces/component/password/PasswordBase.java
+++ b/src/main/java/org/primefaces/component/password/PasswordBase.java
@@ -48,7 +48,7 @@ public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements
         showEvent,
         hideEvent,
         ignoreLastPass,
-        unmaskable
+        toggleMask
     }
 
     public PasswordBase() {
@@ -164,11 +164,11 @@ public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements
         getStateHelper().put(PropertyKeys.ignoreLastPass, ignoreLastPass);
     }
 
-    public boolean isUnmaskable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.unmaskable, false);
+    public boolean isToggleMask() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.toggleMask, false);
     }
 
-    public void setUnmaskable(boolean unmaskable) {
-        getStateHelper().put(PropertyKeys.unmaskable, unmaskable);
+    public void setToggleMask(boolean toggleMask) {
+        getStateHelper().put(PropertyKeys.toggleMask, toggleMask);
     }
 }

--- a/src/main/java/org/primefaces/component/password/PasswordBase.java
+++ b/src/main/java/org/primefaces/component/password/PasswordBase.java
@@ -24,9 +24,10 @@
 package org.primefaces.component.password;
 
 import org.primefaces.component.api.AbstractPrimeHtmlInputText;
+import org.primefaces.component.api.RTLAware;
 import org.primefaces.component.api.Widget;
 
-public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements Widget {
+public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements Widget, RTLAware  {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -46,7 +47,8 @@ public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements
         match,
         showEvent,
         hideEvent,
-        ignoreLastPass
+        ignoreLastPass,
+        unmaskable
     }
 
     public PasswordBase() {
@@ -160,5 +162,13 @@ public abstract class PasswordBase extends AbstractPrimeHtmlInputText implements
 
     public void setIgnoreLastPass(boolean ignoreLastPass) {
         getStateHelper().put(PropertyKeys.ignoreLastPass, ignoreLastPass);
+    }
+
+    public boolean isUnmaskable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.unmaskable, false);
+    }
+
+    public void setUnmaskable(boolean unmaskable) {
+        getStateHelper().put(PropertyKeys.unmaskable, unmaskable);
     }
 }

--- a/src/main/java/org/primefaces/component/password/PasswordRenderer.java
+++ b/src/main/java/org/primefaces/component/password/PasswordRenderer.java
@@ -66,6 +66,7 @@ public class PasswordRenderer extends InputRenderer {
         boolean feedback = password.isFeedback();
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("Password", password);
+        wb.attr("unmaskable", password.isUnmaskable(), false);
 
         if (feedback) {
             wb.attr("feedback", true)
@@ -84,13 +85,27 @@ public class PasswordRenderer extends InputRenderer {
     protected void encodeMarkup(FacesContext context, Password password) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = password.getClientId(context);
-        String styleClass = createStyleClass(password, Password.STYLE_CLASS) ;
+        boolean unmaskable = password.isUnmaskable();
+
+        if (unmaskable) {
+            writer.startElement("span", null);
+            boolean isRTL = ComponentUtils.isRTL(context, password);
+            String positionClass = getStyleClassBuilder(context)
+                        .add("ui-password")
+                        .add(isRTL, "ui-input-icon-left", "ui-input-icon-right")
+                        .build();
+            writer.writeAttribute("class", positionClass, null);
+            writer.startElement("i", null);
+            writer.writeAttribute("id", clientId + "_mask", "id");
+            writer.writeAttribute("class", Password.MASKED_CLASS, null);
+            writer.endElement("i");
+        }
 
         writer.startElement("input", password);
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("name", clientId, null);
         writer.writeAttribute("type", "password", null);
-        writer.writeAttribute("class", styleClass, null);
+        writer.writeAttribute("class", createStyleClass(password, Password.STYLE_CLASS), null);
         if (password.getStyle() != null) {
             writer.writeAttribute("style", password.getStyle(), null);
         }
@@ -104,10 +119,15 @@ public class PasswordRenderer extends InputRenderer {
         }
 
         renderAccessibilityAttributes(context, password);
+        renderRTLDirection(context, password);
         renderPassThruAttributes(context, password, HTML.INPUT_TEXT_ATTRS_WITHOUT_EVENTS);
         renderDomEvents(context, password, HTML.INPUT_TEXT_EVENTS);
         renderValidationMetadata(context, password);
 
         writer.endElement("input");
+
+        if (unmaskable) {
+            writer.endElement("span");
+        }
     }
 }

--- a/src/main/java/org/primefaces/component/password/PasswordRenderer.java
+++ b/src/main/java/org/primefaces/component/password/PasswordRenderer.java
@@ -66,7 +66,7 @@ public class PasswordRenderer extends InputRenderer {
         boolean feedback = password.isFeedback();
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("Password", password);
-        wb.attr("unmaskable", password.isUnmaskable(), false);
+        wb.attr("unmaskable", password.isToggleMask(), false);
 
         if (feedback) {
             wb.attr("feedback", true)
@@ -85,9 +85,9 @@ public class PasswordRenderer extends InputRenderer {
     protected void encodeMarkup(FacesContext context, Password password) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = password.getClientId(context);
-        boolean unmaskable = password.isUnmaskable();
+        boolean toggleMask = password.isToggleMask();
 
-        if (unmaskable) {
+        if (toggleMask) {
             writer.startElement("span", null);
             boolean isRTL = ComponentUtils.isRTL(context, password);
             String positionClass = getStyleClassBuilder(context)
@@ -126,7 +126,7 @@ public class PasswordRenderer extends InputRenderer {
 
         writer.endElement("input");
 
-        if (unmaskable) {
+        if (toggleMask) {
             writer.endElement("span");
         }
     }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -19783,6 +19783,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Adds a show/hide icon to the password to allow the password to be unmasked/remasked. Default is false.]]>
+            </description>
+            <name>unmaskable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -19787,7 +19787,7 @@
             <description>
                 <![CDATA[Adds a show/hide icon to the password to allow the password to be unmasked/remasked. Default is false.]]>
             </description>
-            <name>unmaskable</name>
+            <name>toggleMask</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>


### PR DESCRIPTION
Allows unmasking and masking of the password with `unmaskable="true"` also had to add support for RTL was surprised it was missing.

**Masked:**
![image](https://user-images.githubusercontent.com/4399574/106523594-5864fd80-64af-11eb-9221-043118fd2d52.png)

**Unmasked:**
![image](https://user-images.githubusercontent.com/4399574/106523642-69ae0a00-64af-11eb-94d3-6390bf7c9d77.png)

**RTL:**
![image](https://user-images.githubusercontent.com/4399574/106523438-1fc52400-64af-11eb-8716-42a4ec16fb97.png)
