### PR TITLE
Fix #6922: SelectOne highlight correct item when grouped

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -399,7 +399,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             this.items.eq(0).addClass('ui-state-active');
         }
         else {
-            this.highlightItem(this.items.eq(this.preShowValue.index()));
+            this.highlightItem(this.items.eq(this.options.index(this.preShowValue)));
         }
     },
 


### PR DESCRIPTION
This uses the same code used in other places in the SelectOne to determine the correct index because Groups throw off the index.