### PR TITLE
Fix #6514: SelectOneMenu not respecting escaped label

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -219,6 +219,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
      */
     refresh: function(cfg) {
         this.panelWidthAdjusted = false;
+        this.items = null;
 
         this._super(cfg);
     },
@@ -1071,7 +1072,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
                     option = this.options.filter(':selected');
                 }
 
-                if (option && option.data('escape') == false) {
+                if (option && option.data('escape') === false) {
                     this.label.html(displayedLabel);
                 } else {
                     this.label.text(displayedLabel);


### PR DESCRIPTION
@christophs78 please review.

What was happening is that after a Update the `this.items` collection is still in the variable.  When calling setLabel it finds the items when it should not upon being initialized again and thus the label is not be displayed properly in this used case its showing its unescaped version `<span>1<\span>` instead of "1".

I have confirmed this fixes it and we have our integration test suite to verify anything else but all i do is reset ``this.items` upon the component being updated.