### PR TITLE
Fix #6929: Paginator perf for JumpToPage dropdown

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
+++ b/src/main/resources/META-INF/resources/primefaces/paginator/paginator.js
@@ -347,7 +347,8 @@ PrimeFaces.widget.Paginator = PrimeFaces.widget.BaseWidget.extend({
                     jtpOptions += '<option value="' + i + '">' + (i + 1) + '</option>';
                 }
 
-                this.jtpSelect.html(jtpOptions);
+                // GitHub #6929: performance improvement not using JQ html()
+                this.jtpSelect[0].innerHTML = jtpOptions;
             }
             this.jtpSelect.children('option[value=' + (this.cfg.page) + ']').prop('selected','selected');
         }


### PR DESCRIPTION
This reduces the rendering time for the JumpToPageDrodown based on this stack overflow post:  https://stackoverflow.com/questions/18393981/append-vs-html-vs-innerhtml-performance

Its safe to use here because no JS events are attached to the options only to the Select itself.