### PR TITLE
Fix #6752: Avatar improved color spread for letter avatar

### DIFF
--- a/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
+++ b/src/main/java/org/primefaces/component/avatar/AvatarRenderer.java
@@ -63,7 +63,7 @@ public class AvatarRenderer extends CoreRenderer {
         String label = calculateLabel(context, avatar);
         String style = avatar.getStyle();
         if (avatar.isDynamicColor() && label != null) {
-            String colorCss = generateBackgroundColor(label);
+            String colorCss = generateBackgroundColor(avatar.getLabel());
             style = style == null ? colorCss : colorCss + style;
         }
 


### PR DESCRIPTION
When you have two avatars that have the same initials like...
```xml
<p:avatar label="PrimeFaces Rocks" dynamicColor="true"/>
<p:avatar label="Paul Ruebens" dynamicColor="true" />
```
They should not get the color based on their initials...
![image](https://user-images.githubusercontent.com/4399574/106902900-54132d00-66c7-11eb-96d7-315ebc997466.png)

They should get a better color spread by hashing the full label...
![image](https://user-images.githubusercontent.com/4399574/106902932-5d03fe80-66c7-11eb-8489-6597d4e8df7e.png)
