### PR TITLE
Fix #6940: InputNumber firing change event when value not changed

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -57,6 +57,8 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
         if (this.valueToRender !== "") {
             //set the value to the input the plugin will format it.
             this.autonumeric.set(this.valueToRender);
+            // GitHub #6940 blur firing too many change events
+            this.autonumeric.rawValueOnFocus = this.valueToRender;
         }
 
         this.copyValueToHiddenInput();
@@ -160,7 +162,7 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
 
         var newVal = this.getValue();
 
-        if (oldVal !== newVal) {
+        if (Number(oldVal) !== Number(newVal)) {
             this.setValueToHiddenInput(newVal);
         }
 


### PR DESCRIPTION
This issue is that `set` does not initialize the `rawValueOnFocus` so we simply need to initialize it when we are setting the value the first time the autonumeric is created.

Also I noticed in CopyValueToHiddenInput if comparing "1.20" to "1.2" it was triggering the copy and making no difference. It should be comparing the numerical values not the String values.