### PR TITLE
Stale GitHub Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: stale
+on:
+  schedule:
+    - cron: "0 1 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is marked as stale because there was no activity on it for the last 2 years. Remove stale label or comment or this will be closed in 30 days'
+          stale-pr-message: 'This PR is marked as stale because there was no activity on it for the last 2 years. Remove stale label or comment or this will be closed in 30 days'
+          days-before-stale: 730
+          days-before-close: 30


### PR DESCRIPTION
Adds stale action which will check once a day all Issues and PR's and if no activity in 2 years will add a `stale` label.

If a user comments on the ticket then the `stale` issue is removed the next run.  If no activity in 30 more days the issu/pr is closed.