### PR TITLE
#6973: Disable CSS animations globally

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1143,6 +1143,18 @@
         zindex : 1000,
 
         /**
+         * Global flag for enabling or disabling both jQuery and CSS animations.
+         * @type {boolean}
+         */
+        animationEnabled : true,
+
+         /**
+         * Flag for detecting whether animation is currently running.
+         * @type {boolean}
+         */
+        animationActive : false,
+
+        /**
          * Used to store whether a custom focus has been rendered. This avoids having to retain the last focused element
          * after AJAX update.
          * @type {boolean}

--- a/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -606,6 +606,22 @@ if (!PrimeFaces.utils) {
         },
 
         /**
+         * Enables CSS and jQuery animation.
+         */
+        enableAnimations: function() {
+            $.fx.off = false;
+            PrimeFaces.animationEnabled = true;
+        },
+
+        /**
+         * Disables CSS and jQuery animation.
+         */
+        disableAnimations: function() {
+            $.fx.off = true;
+            PrimeFaces.animationEnabled = false;
+        },
+
+        /**
          * CSS Transition method for overlay panels such as SelectOneMenu/SelectCheckboxMenu/Datepicker's panel etc.
          * @param {JQuery} element An element for which to execute the transition.
          * @param {string} className Class name used for transition phases.
@@ -626,57 +642,81 @@ if (!PrimeFaces.utils) {
                         callbacks[key].call(param);
                     }
                 };
-        
+
                 return {
                     show: function(callbacks) {
                         //clear exit state classes
                         element.removeClass([classNameStates.exit, classNameStates.exitActive, classNameStates.exitDone]);
-        
+
                         if (element.is(':hidden')) {
-                            element.css('display', 'block').addClass(classNameStates.enter);
-                            callTransitionEvent(callbacks, 'onEnter');
-            
-                            requestAnimationFrame(function() {
-                                setTimeout(function() {
-                                    element.addClass(classNameStates.enterActive);
-                                }, 0);
-                
-                                element.one('transitionrun.css-transition-show', function(event) {
-                                    callTransitionEvent(callbacks, 'onEntering', event);
-                                }).one('transitioncancel.css-transition-show', function() {
-                                    element.removeClass([classNameStates.enter, classNameStates.enterActive, classNameStates.enterDone]);
-                                }).one('transitionend.css-transition-show', function(event) {
-                                    element.removeClass([classNameStates.enterActive, classNameStates.enter]).addClass(classNameStates.enterDone);
-                                    callTransitionEvent(callbacks, 'onEntered', event);
+                            if (PrimeFaces.animationEnabled) {
+                                PrimeFaces.animationActive = true;
+                                element.css('display', 'block').addClass(classNameStates.enter);
+                                callTransitionEvent(callbacks, 'onEnter');
+
+                                requestAnimationFrame(function() {
+                                    setTimeout(function() {
+                                        element.addClass(classNameStates.enterActive);
+                                    }, 0);
+
+                                    element.one('transitionrun.css-transition-show', function(event) {
+                                        callTransitionEvent(callbacks, 'onEntering', event);
+                                    }).one('transitioncancel.css-transition-show', function() {
+                                        element.removeClass([classNameStates.enter, classNameStates.enterActive, classNameStates.enterDone]);
+                                        PrimeFaces.animationActive = false;
+                                    }).one('transitionend.css-transition-show', function(event) {
+                                        element.removeClass([classNameStates.enterActive, classNameStates.enter]).addClass(classNameStates.enterDone);
+                                        callTransitionEvent(callbacks, 'onEntered', event);
+                                        PrimeFaces.animationActive = false;
+                                    });
                                 });
-                            });
+                            }
+                            else {
+                                // animation globally disabled still call downstream callbacks
+                                element.css('display', 'block');
+                                callTransitionEvent(callbacks, 'onEnter');
+                                callTransitionEvent(callbacks, 'onEntering');
+                                callTransitionEvent(callbacks, 'onEntered');
+                            }
                         }
                     },
                     hide: function(callbacks) {
                         //clear enter state classes
                         element.removeClass([classNameStates.enter, classNameStates.enterActive, classNameStates.enterDone]);
-        
-                        if (element.is(':visible')) {
-                            element.addClass(classNameStates.exit);
-                            callTransitionEvent(callbacks, 'onExit');
-            
-                            setTimeout(function() {
-                                element.addClass(classNameStates.exitActive);
-                            }, 0);
 
-                            element.one('transitionrun.css-transition-hide', function(event) {
-                                callTransitionEvent(callbacks, 'onExiting', event);
-                            }).one('transitioncancel.css-transition-hide', function() {
-                                element.removeClass([classNameStates.exit, classNameStates.exitActive, classNameStates.exitDone]);
-                            }).one('transitionend.css-transition-hide', function(event) {
-                                element.css('display', 'none').removeClass([classNameStates.exitActive, classNameStates.exit]).addClass(classNameStates.exitDone);
-                                callTransitionEvent(callbacks, 'onExited', event);
-                            });
+                        if (element.is(':visible')) {
+                            if (PrimeFaces.animationEnabled) {
+                                PrimeFaces.animationActive = true;
+                                element.addClass(classNameStates.exit);
+                                callTransitionEvent(callbacks, 'onExit');
+
+                                setTimeout(function() {
+                                    element.addClass(classNameStates.exitActive);
+                                }, 0);
+
+                                element.one('transitionrun.css-transition-hide', function(event) {
+                                    callTransitionEvent(callbacks, 'onExiting', event);
+                                }).one('transitioncancel.css-transition-hide', function() {
+                                    element.removeClass([classNameStates.exit, classNameStates.exitActive, classNameStates.exitDone]);
+                                    PrimeFaces.animationActive = false;
+                                }).one('transitionend.css-transition-hide', function(event) {
+                                    element.css('display', 'none').removeClass([classNameStates.exitActive, classNameStates.exit]).addClass(classNameStates.exitDone);
+                                    callTransitionEvent(callbacks, 'onExited', event);
+                                    PrimeFaces.animationActive = false;
+                                });
+                            }
+                            else {
+                                // animation globally disabled still call downstream callbacks
+                                callTransitionEvent(callbacks, 'onExit');
+                                callTransitionEvent(callbacks, 'onExiting');
+                                callTransitionEvent(callbacks, 'onExited');
+                                element.css('display', 'none');
+                            }
                         }
                     }
                 }
             }
-        
+
             return null;
         }
     };


### PR DESCRIPTION
@mertsincan @christophs78 @tandraschko @Rapster Since for years PF users could globally turn off all animations using `$.fx.off = true;` I added this so our CSS animations now also respect that global flag.

It also add `active` to start of animation and removes it after animation just like jQuery does in case people have already written code.

Thoughts?