### PR TITLE
Fix for #7008 - DataScroller with SelectBooleanCheckbox: Initial checked value is overwritten for loaded chunks during first decode

### DIFF
--- a/src/main/java/org/primefaces/component/api/UIData.java
+++ b/src/main/java/org/primefaces/component/api/UIData.java
@@ -178,6 +178,10 @@ public class UIData extends javax.faces.component.UIData {
         }
     }
 
+    protected boolean shouldProcessChild(FacesContext context, int rowIndex, PhaseId phaseId ) {
+        return true;
+    }
+
     protected void processChildren(FacesContext context, PhaseId phaseId) {
         int first = getFirst();
         int rows = getRows();
@@ -190,6 +194,10 @@ public class UIData extends javax.faces.component.UIData {
 
             if (!isRowAvailable()) {
                 break;
+            }
+
+            if (!shouldProcessChild(context, rowIndex, phaseId)) {
+                continue;
             }
 
             if (iterableChildren == null) {

--- a/src/main/java/org/primefaces/component/datascroller/DataScroller.java
+++ b/src/main/java/org/primefaces/component/datascroller/DataScroller.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import javax.faces.application.ResourceDependency;
 import javax.faces.context.FacesContext;
 import javax.faces.event.BehaviorEvent;
+import javax.faces.event.PhaseId;
 
 import org.primefaces.util.MapBuilder;
 
@@ -79,5 +80,19 @@ public class DataScroller extends DataScrollerBase {
 
     public boolean isVirtualScrollingRequest(FacesContext context) {
         return context.getExternalContext().getRequestParameterMap().containsKey(getClientId(context) + "_virtualScrolling");
+    }
+
+    @Override
+    protected boolean shouldProcessChild(FacesContext context, int rowIndex, PhaseId phaseId) {
+        if (isLoadRequest()) {
+            // if rowIndex of child is after offset of current load request do not process decode, validator
+            // and updateModel phases since components were just added to parent
+            String clientId = this.getClientId(context);
+            int offset = Integer.parseInt(context.getExternalContext().getRequestParameterMap().get(clientId + "_offset"));
+            return rowIndex < offset;
+        }
+        else {
+            return super.shouldProcessChild(context, rowIndex, phaseId);
+        }
     }
 }


### PR DESCRIPTION
processing of children is skipped if the current request is a loadrequest and rowindex is largetr then offset (this is a new child that was added in this loadrequest)
This fix should work for all kind of children that were prone to this problem, since the decode method of the child is never called.