### PR TITLE
Fix #7020: TriStateCheckbox add 'escape' attribute

### DIFF
--- a/docs/10_0_0/components/tristatecheckbox.md
+++ b/docs/10_0_0/components/tristatecheckbox.md
@@ -17,7 +17,7 @@ TriStateCheckbox adds a new state to a checkbox value.
 
 ## Attributes
 
-| Name | Default | Type | Description | 
+| Name | Default | Type | Description |
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
@@ -45,6 +45,7 @@ onchange | null | String | Client side callback to execute on state change.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 label | null | String | A localized user presentable name.
+escape | true | Boolean | Defines whether HTML in label would be escaped or not.
 
 ## Getting started with TriStateCheckbox
 TriStateCheckbox passes values “0”, “1”, “2” by default for each state and this can be customized
@@ -62,8 +63,8 @@ public class Bean {
 ## Client Side API
 Widget: _PrimeFaces.widget.TriStateCheckbox_
 
-| Method | Params | Return Type | Description | 
-| --- | --- | --- | --- | 
+| Method | Params | Return Type | Description |
+| --- | --- | --- | --- |
 toggle() | - | void | Switches to next state.
 
 ## Skinning
@@ -71,8 +72,8 @@ TriStateCheckbox resides in a main container which _style_ and _styleClass_ attr
 skinning style classes are global, see the main theming section for more information. Following is
 the list of structural style classes;
 
-| Class | Applies | 
-| --- | --- | 
+| Class | Applies |
+| --- | --- |
 .ui-chkbox | Main container element.
 .ui-chkbox-box | Container of checkbox icon.
 .ui-chkbox-icon | Checkbox icon.

--- a/docs/10_0_0/components/tristatecheckbox.md
+++ b/docs/10_0_0/components/tristatecheckbox.md
@@ -26,7 +26,7 @@ value | null | Object | Value of the component referring to a List.
 converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
 immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
 required | false | Boolean | Marks component as required
-validator | null | MethodExpr | A method expression that refers to a method validationg the input
+validator | null | MethodExpr | A method expression that refers to a method validating the input
 valueChangeListener | null | MethodExpr | A method expression that refers to a method for handling a valuechangeevent
 requiredMessage | null | String | Message to be displayed when required field validation fails.
 converterMessage | null | String | Message to be displayed when conversion fails.

--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxBase.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxBase.java
@@ -39,6 +39,7 @@ public abstract class TriStateCheckboxBase extends AbstractPrimeHtmlInputText im
         stateTwoIcon,
         stateThreeIcon,
         itemLabel,
+        escape,
         stateOneTitle,
         stateTwoTitle,
         stateThreeTitle;
@@ -91,6 +92,14 @@ public abstract class TriStateCheckboxBase extends AbstractPrimeHtmlInputText im
 
     public void setItemLabel(String itemLabel) {
         getStateHelper().put(PropertyKeys.itemLabel, itemLabel);
+    }
+
+    public boolean isEscape() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.escape, true);
+    }
+
+    public void setEscape(boolean escape) {
+        getStateHelper().put(PropertyKeys.escape, escape);
     }
 
     public String getStateOneTitle() {

--- a/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -187,7 +187,13 @@ public class TriStateCheckboxRenderer extends InputRenderer {
             String styleClass = HTML.CHECKBOX_LABEL_CLASS;
             styleClass = disabled ? styleClass + " ui-state-disabled" : styleClass;
             writer.writeAttribute("class", styleClass, null);
-            writer.writeText(label, "itemLabel");
+
+            if (checkbox.isEscape()) {
+                writer.writeText(label, "itemLabel");
+            }
+            else {
+                writer.write(label);
+            }
             writer.endElement("span");
         }
     }

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -30110,6 +30110,12 @@
             <type>java.lang.String</type>
         </attribute>
         <attribute>
+            <description>Escape the label attribute.</description>
+            <name>escape</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
             <description>
                 <![CDATA[Boolean value to specify the rendering of the component, when set to false component will not be rendered.]]>
             </description>


### PR DESCRIPTION
Add escape attribute similiar to SelectBooleanCheckbox