### PR TITLE
Fix #7029: LinkButton allow content

### DIFF
--- a/src/main/java/org/primefaces/component/linkbutton/LinkButton.java
+++ b/src/main/java/org/primefaces/component/linkbutton/LinkButton.java
@@ -23,14 +23,14 @@
  */
 package org.primefaces.component.linkbutton;
 
-import java.util.List;
-import java.util.Map;
+import org.primefaces.util.ComponentUtils;
 
 import javax.faces.application.ResourceDependency;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UIParameter;
 
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.HTML;
-import org.primefaces.util.LangUtils;
+import java.util.List;
+import java.util.Map;
 
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")
@@ -45,30 +45,17 @@ public class LinkButton extends LinkButtonBase {
         return ComponentUtils.getUIParams(this);
     }
 
-    public String resolveStyleClass() {
-        String icon = getIcon();
-        Object value = getValue();
-        String styleClass = "";
-
-        if (value != null && LangUtils.isValueBlank(icon)) {
-            styleClass = HTML.BUTTON_TEXT_ONLY_BUTTON_CLASS;
-        }
-        else if (value != null && !LangUtils.isValueBlank(icon)) {
-            styleClass = getIconPos().equals("left") ? HTML.BUTTON_TEXT_ICON_LEFT_BUTTON_CLASS : HTML.BUTTON_TEXT_ICON_RIGHT_BUTTON_CLASS;
-        }
-        else if (value == null && !LangUtils.isValueBlank(icon)) {
-            styleClass = HTML.BUTTON_ICON_ONLY_BUTTON_CLASS;
+    public boolean hasDisplayedChildren() {
+        if (getChildCount() == 0) {
+            return false;
         }
 
-        if (isDisabled()) {
-            styleClass = styleClass + " ui-state-disabled";
+        for (int i = 0; i < getChildCount(); i++) {
+            UIComponent child = getChildren().get(i);
+            if (!(child instanceof UIParameter)) {
+                return true;
+            }
         }
-
-        String userStyleClass = getStyleClass();
-        if (userStyleClass != null) {
-            styleClass = styleClass + " " + userStyleClass;
-        }
-
-        return "ui-linkbutton " + styleClass;
+        return false;
     }
 }

--- a/src/main/java/org/primefaces/component/linkbutton/LinkButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/linkbutton/LinkButtonRenderer.java
@@ -31,6 +31,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.renderkit.OutcomeTargetRenderer;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class LinkButtonRenderer extends OutcomeTargetRenderer {
@@ -47,10 +48,20 @@ public class LinkButtonRenderer extends OutcomeTargetRenderer {
         ResponseWriter writer = context.getResponseWriter();
 
         boolean disabled = linkButton.isDisabled();
+        boolean hasIcon = LangUtils.isNotBlank(linkButton.getIcon());
+        boolean hasValue = LangUtils.isNotBlank((String) linkButton.getValue()) || linkButton.hasDisplayedChildren();
+        boolean isTextAndIcon = hasValue && hasIcon;
 
         String style = linkButton.getStyle();
-        String styleClass = linkButton.resolveStyleClass();
         String title = linkButton.getTitle();
+        String styleClass = getStyleClassBuilder(context)
+                    .add("ui-linkbutton")
+                    .add(linkButton.getStyleClass())
+                    .add(hasValue && !hasIcon, HTML.BUTTON_TEXT_ONLY_BUTTON_CLASS)
+                    .add(!hasValue && hasIcon, HTML.BUTTON_ICON_ONLY_BUTTON_CLASS)
+                    .add(isTextAndIcon && "left".equals(linkButton.getIconPos()), HTML.BUTTON_TEXT_ICON_LEFT_BUTTON_CLASS, HTML.BUTTON_TEXT_ICON_RIGHT_BUTTON_CLASS)
+                    .add(disabled, "ui-state-disabled")
+                    .build();
 
         writer.startElement("span", linkButton);
         writer.writeAttribute("id", linkButton.getClientId(context), "id");
@@ -107,7 +118,12 @@ public class LinkButtonRenderer extends OutcomeTargetRenderer {
 
         String value = (String) linkButton.getValue();
         if (value == null) {
-            writer.write("ui-button");
+            if (linkButton.hasDisplayedChildren()) {
+                renderChildren(context, linkButton);
+            }
+            else {
+                writer.write("ui-button");
+            }
         }
         else {
             if (linkButton.isEscape()) {


### PR DESCRIPTION
Refactored to use `StyleClassBuilder` and allow child content.

![image](https://user-images.githubusercontent.com/4399574/108741224-7cdb5500-7504-11eb-8c1b-b4a55c0fe3d0.png)

```xml
            <p:linkButton outcome="productDetail" icon="pi pi-star"  style="margin-right:20px;">
                <f:param name="productId" value="50"/>
                <span>Content</span>
            </p:linkButton>
```