### PR TITLE
Fix #6982: Schedule don't use default local en_US

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -103,7 +103,7 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
         // #6496 must add all locales
         options.locales = FullCalendar.globalLocales;
 
-        var lang = PrimeFaces.getLocaleSettings(this.cfg.locale);
+        var lang = PrimeFaces.locales[this.cfg.locale];
         if (lang) {
             if (lang.firstDay !== undefined) { options.firstDay = lang.firstDay; }
             if (lang.weekNumberTitle) { options.weekText = lang.weekNumberTitle; }


### PR DESCRIPTION
Failing Integration Test.  Realized schedule has its own built in locales and we only want to override it with ours if found. Do not default to en_US if not found.