### PR TITLE
Fix #7038: Datatable don't display until reflow is complete

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -269,6 +269,10 @@ public class DataTableRenderer extends DataRenderer {
         boolean hasFrozenColumns = (frozenColumns != 0);
         String summary = table.getSummary();
 
+        if (table.isReflow()) {
+            style = style + ";visibility:hidden;";
+        }
+
         //style class
         String containerClass = getStyleClassBuilder(context)
                 .add(DataTable.CONTAINER_CLASS)
@@ -297,7 +301,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("div", table);
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("class", containerClass, "styleClass");
-        if (style != null) {
+        if (LangUtils.isNotBlank(style)) {
             writer.writeAttribute("style", style, "style");
         }
 

--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -309,6 +309,9 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             this.initRowExpansion();
             this.updateExpandedRowsColspan();
         }
+        if(this.cfg.reflow) {
+           this.jq.css('visibility', 'visible');
+        }
     },
 
     /**


### PR DESCRIPTION
Hides the visibility of the datatable so it still takes up space and the DOM and allows the reflow to initialize all the columns and layout before actually displaying it to prevent the flicker and redraw