### PR TITLE
Fix #7049: Datatable CellEditInit on first row

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3214,7 +3214,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             cellIndex = (this.scrollTbody.is(cell.closest('tbody'))) ? (cellIndex + $this.cfg.frozenColumns) : cellIndex;
         }
 
-        if (!rowMeta || !rowMeta.index) {
+        if (rowMeta === undefined || rowMeta.index === undefined) {
             return null;
         }
         var cellInfo = rowMeta.index + ',' + cellIndex;


### PR DESCRIPTION
JS truthiness issue where row 0 was returning false.  Need to check for undefined instead.