### PR TITLE
Fix #6940: InputNumber firing change event when value not changed

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -159,10 +159,9 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
      */
     copyValueToHiddenInput: function() {
         var oldVal = this.hiddenInput.val();
-
         var newVal = this.getValue();
 
-        if (Number(oldVal) !== Number(newVal)) {
+        if (((oldVal === '') ^ (newVal === '')) || Number(oldVal) !== Number(newVal)) {
             this.setValueToHiddenInput(newVal);
         }
 


### PR DESCRIPTION
@fanste I used === instead of == in your example.  But thanks for the suggestion