### PR TITLE
Fix #7070: TreeTable scrollable hide cloned header

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/treetable/treetable.css
+++ b/src/main/resources/META-INF/resources/primefaces/treetable/treetable.css
@@ -57,7 +57,7 @@
     border:0 none;
 }
 
-.ui-treetable-scrollable .ui-treetable-scrollable-theadclone tr th > * { 
+body .ui-treetable.ui-treetable-scrollable .ui-treetable-scrollable-theadclone tr th > * {
     display: none;
 }
             


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4399574/110113988-eddf0000-7d81-11eb-805b-49e0a28cc7b5.png)

After:
![image](https://user-images.githubusercontent.com/4399574/110114029-f9cac200-7d81-11eb-99fd-22252c77e16d.png)
