### PR TITLE
Fix #7072: Menu gererateUniqueIds must always append number

### DIFF
--- a/src/main/java/org/primefaces/model/menu/BaseMenuModel.java
+++ b/src/main/java/org/primefaces/model/menu/BaseMenuModel.java
@@ -66,8 +66,11 @@ public class BaseMenuModel implements MenuModel, Serializable {
             String id = element.getId();
             if (LangUtils.isValueBlank(id)) {
                 id = (seed == null) ? String.valueOf(counter++) : seed + ID_SEPARATOR + counter++;
-                element.setId(id);
             }
+            else {
+                id = id + ID_SEPARATOR + counter++;
+            }
+            element.setId(id);
 
             if (element instanceof MenuGroup) {
                 generateUniqueIds(((MenuGroup) element).getElements(), id);


### PR DESCRIPTION
So even if an id is set like `id("default")` the menu code is expecting all menu items to end with `_` and a number and Parses the int of the menu item.

So `default_0_0` or `default_1_0` where the numbers are the coordinates of the menu item