### PR TITLE
Fix #7072: Better error message when menu id is invalid

### DIFF
--- a/src/main/java/org/primefaces/renderkit/MenuItemAwareRenderer.java
+++ b/src/main/java/org/primefaces/renderkit/MenuItemAwareRenderer.java
@@ -176,7 +176,14 @@ public class MenuItemAwareRenderer extends OutcomeTargetRenderer {
                 return null;
             }
 
-            int childIndex = Integer.parseInt(paths[0]);
+            int childIndex;
+            try {
+                childIndex = Integer.parseInt(paths[0]);
+            }
+            catch (NumberFormatException e) {
+                throw new FacesException("Menu ID '" +  id +  "' is not valid for this component. Remove any manually set IDs from the MenuModel.");
+            }
+
             if (childIndex >= elements.size()) {
                 return null;
             }


### PR DESCRIPTION
javax.faces.FacesException: Menu ID 'default' is not valid for this component. Remove any manually set IDs from the MenuModel.
