### PR TITLE
Fix #7078: CommandButton rendering multiple onclick DOM attributes

### DIFF
--- a/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
@@ -93,9 +93,12 @@ public class CommandButtonRenderer extends CoreRenderer {
             else {
                 writer.writeAttribute("onclick", onclick, "onclick");
             }
+            renderPassThruAttributes(context, button, HTML.BUTTON_ATTRS);
         }
+        else {
+            renderPassThruAttributes(context, button, HTML.BUTTON_WITH_CLICK_ATTRS);
 
-        renderPassThruAttributes(context, button, HTML.BUTTON_WITH_CLICK_ATTRS);
+        }
 
         if (button.isDisabled()) {
             writer.writeAttribute("disabled", "disabled", "disabled");


### PR DESCRIPTION
This only renders the passthrough OnClick if its not already defined.