### PR TITLE
Fix #7083: CascadeSelect enable/disable widget methods

### DIFF
--- a/docs/10_0_0/components/cascadeselect.md
+++ b/docs/10_0_0/components/cascadeselect.md
@@ -131,6 +131,8 @@ Widget: _PrimeFaces.widget.CascadeSelect_
 | --- | --- | --- | --- | 
 show() | - | void | Shows overlay menu.
 hide() | - | void | Hides overlay menu.
+enable() | - | void | Enables the component.
+disable() | - | void | Disables the component.
 
 ## Skinning
 CascadeSelect resides in a container element that _style_ and _styleClass_ attributes apply. As skinning

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
@@ -183,7 +183,41 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.BaseWidget.extend({
                 e.preventDefault();
             });
     },
-    
+
+    /**
+     * Removes some event listeners when this widget was disabled.
+     * @private
+     */
+    unbindEvents: function() {
+        this.contents.off();
+        this.triggers.off();
+        this.input.off();
+    },
+
+    /**
+     * Disables this widget so that the user cannot select any option.
+     */
+    disable: function() {
+        if (!this.cfg.disabled) {
+            this.cfg.disabled = true;
+            this.jq.addClass('ui-state-disabled');
+            this.input.attr('disabled', 'disabled');
+            this.unbindEvents();
+        }
+    },
+
+    /**
+     * Enables this widget so that the user can select an option.
+     */
+    enable: function() {
+        if (this.cfg.disabled) {
+            this.cfg.disabled = false;
+            this.jq.removeClass('ui-state-disabled');
+            this.input.removeAttr('disabled');
+            this.bindEvents();
+        }
+    },
+
     /**
      * Deactivate siblings and active children of an item.
      * @private


### PR DESCRIPTION
This brings the component more in line with SelectOneMenu.