### PR TITLE
Fix #7078: CommandButton rendering multiple onclick DOM attributes

### DIFF
--- a/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
+++ b/src/main/java/org/primefaces/component/commandbutton/CommandButtonRenderer.java
@@ -93,7 +93,7 @@ public class CommandButtonRenderer extends CoreRenderer {
             else {
                 writer.writeAttribute("onclick", onclick, "onclick");
             }
-            renderPassThruAttributes(context, button, HTML.BUTTON_ATTRS);
+            renderPassThruAttributes(context, button, HTML.BUTTON_WITHOUT_CLICK_ATTRS);
         }
         else {
             renderPassThruAttributes(context, button, HTML.BUTTON_WITH_CLICK_ATTRS);

--- a/src/main/java/org/primefaces/util/HTML.java
+++ b/src/main/java/org/primefaces/util/HTML.java
@@ -250,6 +250,7 @@ public class HTML {
     public static final List<String> LABEL_EVENTS = OUTPUT_EVENTS;
 
     public static final List<String> BUTTON_ATTRS = LangUtils.concat(BUTTON_ATTRS_WITHOUT_EVENTS, BUTTON_EVENTS);
+    public static final List<String> BUTTON_WITHOUT_CLICK_ATTRS = LangUtils.concat(BUTTON_ATTRS_WITHOUT_EVENTS, BUTTON_EVENTS_WITHOUT_CLICK);
     public static final List<String> BUTTON_WITH_CLICK_ATTRS = LangUtils.concat(HTML.BUTTON_ATTRS, HTML.CLICK_EVENT);
 
     public static final List<String> INPUT_TEXT_EVENTS = LangUtils.concat(COMMON_EVENTS, CHANGE_SELECT_EVENTS, BLUR_FOCUS_EVENTS);


### PR DESCRIPTION
OK after more debugging `onClick` was actually being added 3 times.  Because of the way these constants were it was being added by COMMON_EVENTS and by BUTTON_ATTRS.  

I thought this was a bug in PFE but turned out to be still one more onclick here.