### PR TITLE
Fix #7114: DatePicker CSS for time icons

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
@@ -25,6 +25,10 @@
     padding: .5em;
 }
 
+.p-datepicker-panel .ui-timepicker .ui-icon {
+    text-indent: 0;
+}
+
 .p-datepicker-panel .ui-timepicker > div {
     display: inline-block;
     margin-left: .5em;


### PR DESCRIPTION
This fix applies it only to DatePicker so it doesn't affect Calendar.