### PR TITLE
Fix Spanish translation client side

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/locales/locale-es.js
+++ b/src/main/resources/META-INF/resources/primefaces/locales/locale-es.js
@@ -24,7 +24,7 @@ PrimeFaces.locales['es'] = {
     week: 'Semana',
     day: 'Día',
     today: 'Hoy',
-    clear: 'Claro',
+    clear: 'Limpiar',
     allDayText: 'Todo el día',
     messages: { //optional for Client Side Validation
         'javax.faces.component.UIInput.REQUIRED': '{0}: Error de validación: se necesita un valor.',


### PR DESCRIPTION
In the context of a button clicked to clear the data, the correct Spanish word is "Limpiar"