### PR TITLE
Fix #7166: Excel export currency cells

### DIFF
--- a/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
@@ -26,6 +26,7 @@ package org.primefaces.component.treetable.export;
 import java.awt.Color;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import javax.faces.component.UIComponent;
@@ -57,9 +58,7 @@ import org.primefaces.component.export.ExcelOptions;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.component.treetable.TreeTable;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
-import org.primefaces.util.LangUtils;
+import org.primefaces.util.*;
 
 
 public class TreeTableExcelExporter extends TreeTableExporter {
@@ -70,7 +69,9 @@ public class TreeTableExcelExporter extends TreeTableExporter {
     private CellStyle cellStyleCenterAlign;
     private CellStyle cellStyleLeftAlign;
     private CellStyle facetStyle;
+    private CellStyle currencyStyle;
     private boolean stronglyTypedCells;
+    private Locale locale;
 
     @Override
     protected void preExport(FacesContext context, ExportConfiguration exportConfiguration) throws IOException {
@@ -99,6 +100,9 @@ public class TreeTableExcelExporter extends TreeTableExporter {
         }
         else {
             stronglyTypedCells = options.isStronglyTypedCells();
+        }
+        if (stronglyTypedCells) {
+            locale = LocaleUtils.getCurrentLocale(context);
         }
         Sheet sheet = createSheet(wb, sheetName, options);
         applyOptions(wb, table, sheet, options);
@@ -352,17 +356,37 @@ public class TreeTableExcelExporter extends TreeTableExporter {
     }
 
     /**
-     * If ExcelOptions.isStronglyTypedCells = true then for cells that are all numbers make them a numeric cell
-     * instead of a String cell.  Possible future enhancement of Date cells as well.
+     * If ExcelOptions.isStronglyTypedCells = true then for cells check:
+     * <pre>
+     * Numeric - String that are all numbers make them a numeric cell
+     * Currency - Convert to currency cell so math can be done in Excel
+     * String - fallback to just a normal string cell
+     * </pre>
+     * Possible future enhancement of Date cells as well.
      *
      * @param cell the cell to operate on
      * @param value the String value to put in the cell
      */
     protected void updateCell(Cell cell, String value) {
-        if (stronglyTypedCells && LangUtils.isNumeric(value)) {
-            cell.setCellValue(Double.parseDouble(value));
+        boolean printed = false;
+        if (stronglyTypedCells) {
+            if (LangUtils.isNumeric(value)) {
+                cell.setCellValue(Double.parseDouble(value));
+                printed = true;
+            }
+
+            if (!printed) {
+                Number currency = CurrencyValidator.getInstance().validate(value, locale);
+                if (currency != null) {
+                    cell.setCellValue(currency.doubleValue());
+                    cell.setCellStyle(currencyStyle);
+                    printed = true;
+                }
+            }
         }
-        else {
+
+        // fall back to just printing the string value
+        if (!printed) {
             cell.setCellValue(createRichTextString(value));
         }
     }
@@ -443,6 +467,16 @@ public class TreeTableExcelExporter extends TreeTableExporter {
         cellStyleRightAlign.setAlignment(HorizontalAlignment.RIGHT);
         applyCellOptions(wb, options, cellStyleRightAlign);
 
+        if (stronglyTypedCells) {
+            currencyStyle = wb.createCellStyle();
+            currencyStyle.setFont(font);
+            currencyStyle.setAlignment(HorizontalAlignment.RIGHT);
+            String pattern = CurrencyValidator.getInstance().getPattern(locale);
+            short currencyPattern = wb.getCreationHelper().createDataFormat().getFormat(pattern);
+            currencyStyle.setDataFormat(currencyPattern);
+            applyCellOptions(wb, options, currencyStyle);
+        }
+
         PrintSetup printSetup = sheet.getPrintSetup();
         printSetup.setLandscape(true);
         printSetup.setPaperSize(PrintSetup.A4_PAPERSIZE);
@@ -522,6 +556,10 @@ public class TreeTableExcelExporter extends TreeTableExporter {
     }
 
     protected Cell applyColumnAlignments(UIColumn column, Cell cell) {
+        if (cell.getCellStyle() != null) {
+            // don't apply style if cell already has one
+            return cell;
+        }
         String[] styles = new String[] {column.getStyle(), column.getStyleClass()};
         if (LangUtils.containsIgnoreCase(styles, "right")) {
             cell.setCellStyle(cellStyleRightAlign);

--- a/src/main/java/org/primefaces/util/CurrencyValidator.java
+++ b/src/main/java/org/primefaces/util/CurrencyValidator.java
@@ -1,0 +1,250 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.util;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.text.*;
+import java.util.Locale;
+
+/**
+ * <p>
+ * <b>Currency Validation</b> and Conversion routines (<code>java.math.BigDecimal</code>).
+ * </p>
+ * <p>
+ * This is one implementation of a currency validator that has the following features:
+ * </p>
+ * <ul>
+ * <li>It is <i>lenient</i> about the presence of the <i>currency symbol</i></li>
+ * <li>It converts the currency to a <code>java.math.BigDecimal</code></li>
+ * </ul>
+ * @implNote Modified from Commons Validator to fit PF needs
+ * @see <a href="https://github.com/apache/commons-validator">Commons Validator</a>
+ */
+public class CurrencyValidator implements Serializable {
+
+    private static final long serialVersionUID = -4201640771171486514L;
+
+    private static final CurrencyValidator VALIDATOR = new CurrencyValidator();
+
+    /** DecimalFormat's currency symbol */
+    private static final char CURRENCY_SYMBOL = '\u00A4';
+    private static final String CURRENCY_SYMBOL_STR = Character.toString(CURRENCY_SYMBOL);
+    /** Space hack to fix Brazilian Real and maybe others */
+    private static final char NON_BREAKING_SPACE = '\u00A0';
+    private static final String NON_BREAKING_SPACE_STR = Character.toString(NON_BREAKING_SPACE);
+
+    /**
+     * Return a singleton instance of this validator.
+     *
+     * @return A singleton instance of the CurrencyValidator.
+     */
+    public static CurrencyValidator getInstance() {
+        return VALIDATOR;
+    }
+
+    /**
+     * <p>
+     * Validate/convert a <code>BigDecimal</code> using the specified <code>Locale</code>.
+     *
+     * @param value The value validation is being performed on.
+     * @param locale The locale to use for the number format, system default if null.
+     * @return The parsed <code>BigDecimal</code> if valid or <code>null</code> if invalid.
+     */
+    public BigDecimal validate(String value, Locale locale) {
+        return (BigDecimal) parse(value, locale);
+    }
+
+    /**
+     * <p>
+     * Parse the value with the specified <code>Format</code>.
+     * </p>
+     * <p>
+     * This implementation is lenient whether the currency symbol is present or not. The default <code>NumberFormat</code> behavior is for the parsing to "fail"
+     * if the currency symbol is missing. This method re-parses with a format without the currency symbol if it fails initially.
+     * </p>
+     *
+     * @param value The value to be parsed.
+     * @param formatter The Format to parse the value with.
+     * @return The parsed value if valid or <code>null</code> if invalid.
+     */
+    protected Object parse(String value, DecimalFormat formatter) {
+        // check and replace currency symbol
+        if (value.indexOf(CURRENCY_SYMBOL) >= 0) {
+            value = value.replace(CURRENCY_SYMBOL_STR, formatter.getDecimalFormatSymbols().getCurrencySymbol());
+        }
+
+        // between JDK8 and 11 some space characters became non breaking space '\u00A0'
+        if (formatter.getPositivePrefix().indexOf(NON_BREAKING_SPACE) >= 0) {
+            value = value.replaceAll(Constants.SPACE, NON_BREAKING_SPACE_STR);
+        }
+
+        // Initial parse of the value
+        Object parsedValue = parseFormat(value, formatter);
+        if (parsedValue != null || !(formatter instanceof DecimalFormat)) {
+            return parsedValue;
+        }
+
+        // Re-parse using a pattern without the currency symbol
+        String pattern = formatter.toPattern();
+        if (pattern.indexOf(CURRENCY_SYMBOL) >= 0) {
+            StringBuilder buffer = new StringBuilder(pattern.length());
+            for (int i = 0; i < pattern.length(); i++) {
+                if (pattern.charAt(i) != CURRENCY_SYMBOL) {
+                    buffer.append(pattern.charAt(i));
+                }
+            }
+            formatter.applyPattern(buffer.toString());
+            parsedValue = parseFormat(value, formatter);
+        }
+        return parsedValue;
+    }
+
+    /**
+     * <p>
+     * Parse the value with the specified <code>Format</code>.
+     * </p>
+     *
+     * @param value The value to be parsed.
+     * @param formatter The Format to parse the value with.
+     * @return The parsed value if valid or <code>null</code> if invalid.
+     */
+    protected Object parseFormat(String value, DecimalFormat formatter) {
+        ParsePosition pos = new ParsePosition(0);
+        Object parsedValue = formatter.parse(value, pos);
+        if (pos.getErrorIndex() > -1) {
+            return null;
+        }
+
+        if (pos.getIndex() < value.length()) {
+            return null;
+        }
+
+        if (parsedValue != null) {
+            parsedValue = processParsedValue(parsedValue, formatter);
+        }
+
+        return parsedValue;
+
+    }
+
+    /**
+     * Convert the parsed value to a <code>BigDecimal</code>.
+     *
+     * @param value The parsed <code>Number</code> object created.
+     * @param formatter The Format used to parse the value with.
+     * @return The parsed <code>Number</code> converted to a <code>BigDecimal</code>.
+     */
+    protected Object processParsedValue(Object value, DecimalFormat formatter) {
+        BigDecimal decimal = null;
+        if (value instanceof Long) {
+            decimal = BigDecimal.valueOf(((Long) value).longValue());
+        }
+        else {
+            decimal = new BigDecimal(value.toString());
+        }
+
+        int scale = determineScale(formatter);
+        if (scale >= 0) {
+            decimal = decimal.setScale(scale, BigDecimal.ROUND_DOWN);
+        }
+
+        return decimal;
+    }
+
+    /**
+     * <p>
+     * Returns the <i>multiplier</i> of the <code>NumberFormat</code>.
+     * </p>
+     *
+     * @param format The <code>NumberFormat</code> to determine the multiplier of.
+     * @return The multiplying factor for the format..
+     */
+    protected int determineScale(NumberFormat format) {
+        int minimumFraction = format.getMinimumFractionDigits();
+        int maximumFraction = format.getMaximumFractionDigits();
+        if (minimumFraction != maximumFraction) {
+            return -1;
+        }
+        int scale = minimumFraction;
+        if (format instanceof DecimalFormat) {
+            int multiplier = ((DecimalFormat) format).getMultiplier();
+            if (multiplier == 100) { // CHECKSTYLE IGNORE MagicNumber
+                scale += 2; // CHECKSTYLE IGNORE MagicNumber
+            }
+            else if (multiplier == 1000) { // CHECKSTYLE IGNORE MagicNumber
+                scale += 3; // CHECKSTYLE IGNORE MagicNumber
+            }
+        }
+        return scale;
+    }
+
+    /**
+     * <p>
+     * Returns a <code>NumberFormat</code> for the specified Locale.
+     * </p>
+     *
+     * @param locale The locale a <code>NumberFormat</code> is required for, system default if null.
+     * @return The <code>NumberFormat</code> to created.
+     */
+    public DecimalFormat getFormat(Locale locale) {
+        return (DecimalFormat) DecimalFormat.getCurrencyInstance(locale);
+    }
+
+    /**
+     * <p>
+     * Returns a <code>String</code> representing the pattern for this currency.
+     * </p>
+     *
+     * @param locale The locale a <code>NumberFormat</code> is required for, system default if null.
+     * @return The <code>String</code> pattern.
+     */
+    public String getPattern(Locale locale) {
+        DecimalFormat format = getFormat(locale);
+        String pattern = format.toLocalizedPattern();
+        pattern =  pattern.replace(CURRENCY_SYMBOL_STR, format.getDecimalFormatSymbols().getCurrencySymbol());
+        String[] patterns = pattern.split(";");
+        return patterns[0];
+    }
+
+    /**
+     * <p>
+     * Parse the value using the specified pattern.
+     * </p>
+     *
+     * @param value The value validation is being performed on.
+     * @param locale The locale to use for the date format, system default if null.
+     * @return The parsed value if valid or <code>null</code> if invalid.
+     */
+    protected Object parse(String value, Locale locale) {
+        value = (value == null ? null : value.trim());
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        DecimalFormat formatter = getFormat(locale);
+        return parse(value, formatter);
+
+    }
+
+}

--- a/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
+++ b/src/test/java/org/primefaces/util/CurrencyValidatorTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/**
+ * Test Case for CurrencyValidator.
+ */
+public class CurrencyValidatorTest {
+
+    private static String US_DOLLAR;
+    private static String UK_POUND;
+    private static String BRAZIL_REAL;
+    private static Locale BRAZIL = new Locale("pt", "BR");
+
+    @BeforeAll
+    protected static void setUp() throws Exception {
+        US_DOLLAR = (new DecimalFormatSymbols(Locale.US)).getCurrencySymbol();
+        UK_POUND = (new DecimalFormatSymbols(Locale.UK)).getCurrencySymbol();
+        BRAZIL_REAL = (new DecimalFormatSymbols(BRAZIL)).getCurrencySymbol();
+    }
+
+    private static int getVersion() {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        }
+        else {
+            int dot = version.indexOf(".");
+            if (dot != -1) {
+                version = version.substring(0, dot);
+            }
+        }
+        return Integer.parseInt(version);
+    }
+
+    /**
+     * Test Valid currency values
+     */
+    @Test
+    public void testValid() {
+        CurrencyValidator validator = CurrencyValidator.getInstance();
+        BigDecimal expected = new BigDecimal("1234.56");
+        BigDecimal negative = new BigDecimal("-1234.56");
+        BigDecimal noDecimal = new BigDecimal("1234.00");
+        BigDecimal oneDecimal = new BigDecimal("1234.50");
+
+        assertEquals(expected, validator.validate(UK_POUND + "1,234.56", Locale.UK), "UK locale");
+        assertEquals(negative, validator.validate("-" + UK_POUND + "1,234.56", Locale.UK), "UK negative");
+        assertEquals(noDecimal, validator.validate(UK_POUND + "1,234", Locale.UK), "UK no decimal");
+        assertEquals(oneDecimal, validator.validate(UK_POUND + "1,234.5", Locale.UK), "UK 1 decimal");
+        assertEquals(expected, validator.validate(UK_POUND + "1,234.567", Locale.UK), "UK 3 decimal");
+        assertEquals(expected, validator.validate("1,234.56", Locale.UK), "UK no symbol");
+
+        assertEquals(expected, validator.validate(US_DOLLAR + "1,234.56", Locale.US), "US locale");
+        assertEquals(noDecimal, validator.validate(US_DOLLAR + "1,234", Locale.US), "US no decimal");
+        assertEquals(oneDecimal, validator.validate(US_DOLLAR + "1,234.5", Locale.US), "US 1 decimal");
+        assertEquals(expected, validator.validate(US_DOLLAR + "1,234.567", Locale.US), "US 3 decimal");
+        assertEquals(expected, validator.validate("1,234.56", Locale.US), "US no symbol");
+        if (getVersion() > 8) {
+            assertEquals(negative, validator.validate("-" + US_DOLLAR + "1,234.56", Locale.US), "US negative");
+        }
+        else {
+            assertEquals(negative, validator.validate("(" + US_DOLLAR + "1,234.56)", Locale.US), "US negative");
+        }
+    }
+
+    /**
+     * Test Valid integer (non-decimal) currency values
+     */
+    @Test
+    public void testIntegerValid() {
+        CurrencyValidator validator = CurrencyValidator.getInstance();
+        BigDecimal expected = new BigDecimal("1234.00");
+        BigDecimal negative = new BigDecimal("-1234.00");
+
+        assertEquals(expected, validator.validate(UK_POUND + "1,234", Locale.UK), "UK locale");
+        assertEquals(negative, validator.validate("-" + UK_POUND + "1,234", Locale.UK), "UK negative");
+
+        assertEquals(expected, validator.validate(US_DOLLAR + "1,234", Locale.US), "US locale");
+        if (getVersion() > 8) {
+            assertEquals(negative, validator.validate("-" + US_DOLLAR + "1,234", Locale.US), "US negative");
+        }
+        else {
+            assertEquals(negative, validator.validate("(" + US_DOLLAR + "1,234)", Locale.US), "US negative");
+        }
+    }
+
+    /**
+     * Test when using <f:convertNumber type="currency" />
+     */
+    @Test
+    public void testFromCurrency() {
+        CurrencyValidator validator = CurrencyValidator.getInstance();
+        BigDecimal expected = new BigDecimal("20.00");
+
+        assertEquals(expected, validator.validate("¤20.00", Locale.US), "US locale");
+        assertEquals(expected, validator.validate("¤20.00", Locale.UK), "UK locale");
+    }
+
+    /**
+     * Test Patterns
+     */
+    @Test
+    public void testPatterns() {
+        CurrencyValidator validator = CurrencyValidator.getInstance();
+
+        assertEquals(US_DOLLAR + "#,##0.00", validator.getPattern(Locale.US), "US");
+        assertEquals(UK_POUND + "#,##0.00", validator.getPattern(Locale.UK), "UK");
+    }
+
+    @Test
+    public void testBrazilianReal() {
+        // Arrange
+        CurrencyValidator validator = CurrencyValidator.getInstance();
+        BigDecimal expected = new BigDecimal("1234.56");
+
+        // Act
+        Number result = validator.validate(BRAZIL_REAL + " 1.234,56", BRAZIL);
+
+        // Assert
+        assertEquals(expected, result, "Brazilian locale");
+    }
+
+}


### PR DESCRIPTION
I learned more about currency than I ever could have imagined.

Now in a Datatable/TreeTable you can do this..
```xml
                    <p:column styleClass="p-text-right">
                        <f:facet name="header">
                            <h:outputText value="Price"/>
                        </f:facet>
                        <h:outputText value="#{product.price}">
                            <f:convertNumber type="currency" />
                        </h:outputText>
                    </p:column>
```

Which will display like this depending on locale below is US and then DE.
![image](https://user-images.githubusercontent.com/4399574/112486534-56524900-8d52-11eb-8497-cd8ec0760af5.png)

![image](https://user-images.githubusercontent.com/4399574/112486544-59e5d000-8d52-11eb-9dac-18e981c0b9d9.png)

Then the new CurrencyValidator I borrowed from Commons Validator but had to heavily modify for our needs handles detecting and parsing the currency.  And it also handles telling Excel what your currency format is all based on your Locale!

So now these cells are real currency cells that you can do Math and formulas on.
![image](https://user-images.githubusercontent.com/4399574/112486686-800b7000-8d52-11eb-966e-34e3a544e28f.png)
