### PR TITLE
Fix #7075: Overlays resize/scroll handling for mobile

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -292,12 +292,26 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
             });
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', this.panel, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
 
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            this.hide();
+        }
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
+++ b/src/main/resources/META-INF/resources/primefaces/calendar/calendar.js
@@ -183,10 +183,10 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
             };
 
             PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', $('#ui-datepicker-div'), function() {
-                $.datepicker._hideDatepicker();
+                $this.handleViewportChange();
             });
             PrimeFaces.utils.registerScrollHandler(this, 'scroll.' + this.id + '_hide', function() {
-                $.datepicker._hideDatepicker();
+                $this.handleViewportChange();
             });
         }
 
@@ -275,6 +275,20 @@ PrimeFaces.widget.Calendar = PrimeFaces.widget.BaseWidget.extend({
                 maskCfg.mask = this.cfg.mask;
             }
             this.input.inputmask('remove').inputmask(maskCfg);
+        }
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            $.datepicker._hideDatepicker();
         }
     },
 

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2133,7 +2133,11 @@
 
             var $this = this;
             $(window).on('resize.' + this.options.id, function() {
-                $this.hideOverlay();
+                if (PrimeFaces.env.mobile) {
+                   $this.alignPanel();
+                } else {
+                   $this.hideOverlay();
+                }
             });
         },
 

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
@@ -255,12 +255,26 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.BaseWidget.extend({
             });
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', this.panel, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
 
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            this.hide();
+        }
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -472,12 +472,26 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             });
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', this.panel, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
 
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            this.hide();
+        }
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -369,13 +369,27 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             });
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', this.panel, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
 
         // GitHub #1173/#4609 keep panel with select while scrolling
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            this.hide();
+        }
     },
 
     /**

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
@@ -155,6 +155,20 @@ PrimeFaces.widget.Menu = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.align();
+        } else {
+            this.hide();
+        }
+    },
+
+    /**
      * Performs some setup required to make this overlay menu work with dialogs.
      * @protected
      */

--- a/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -202,11 +202,11 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
         }
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_align', this.menu, function() {
-            $this.hide();
+            $this.handleOverlayViewportChange();
         });
 
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleOverlayViewportChange();
         });
     },
 
@@ -226,6 +226,20 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
     
         if (this.scrollHandler) {
             this.scrollHandler.unbind();
+        }
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleOverlayViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.alignPanel();
+        } else {
+            this.hide();
         }
     },
 

--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -221,12 +221,26 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
         }
 
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_hide', this.jq, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
 
         this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.target, function() {
-            $this.hide();
+            $this.handleViewportChange();
         });
+    },
+
+    /**
+     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
+     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
+     * resize immediately and close the overlay. See GitHub #7075.
+     * @private
+     */
+    handleViewportChange() {
+        if (PrimeFaces.env.mobile) {
+            this.align(this.target);
+        } else {
+            this.hide();
+        }
     },
 
     /**


### PR DESCRIPTION
Because certain mobile devices, and screen size and settings may trigger either a scroll or a resize when an overlay is displayed we must use `align` instead of hiding the panel.  This is how PF 8 and before worked it always called align but in 10 we decided to make it work like PrimeReact/Vue/NG and `hide` the overlay.  I still think hiding is fine for non-mobile.