### PR TITLE
Fix #7174: DatePicker focus issue

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2262,9 +2262,6 @@
             }
 
             if (!this.options.inline && this.isSingleSelection() && (!this.options.showTime || this.options.hideOnDateTimeSelect)) {
-                //put the focus back to the inputfield
-                this.inputfield.trigger('focus');
-
                 setTimeout(function () {
                     $this.hideOverlay();
                 }, 100);


### PR DESCRIPTION
We already have the property `focusOnSelect="false"` to allow the user to specify if they want the input refocused after selecting a date.  This is handled in the `1-datepicker.js` widget already.  The `0-datepicker.js` was always calling 'focus` regardless of this property and triggering the window to appear again.

```xml
<p:datePicker value="#{testView.localDate}" focusOnSelect="false"
```