### PR TITLE
Fix #7153: Sidebar baseZIndex documentation

### DIFF
--- a/docs/10_0_0/components/sidebar.md
+++ b/docs/10_0_0/components/sidebar.md
@@ -29,7 +29,7 @@ visible | false | Boolean | Specifies the visibility of the sidebar.
 position | left | String | Position of the sidebar.
 fullScreen | false | Boolean | Whether to enable the whole screen.
 blockScroll | false | Boolean | Whether to block scrolling of the document when sidebar is active.
-baseZIndex | 0 | Integer | Base zIndex value to use in layering.
+baseZIndex | 0 | Integer | Base zIndex value to use in layering. Only use this attribute if you are having issues with your sidebar displaying as this may cause issues with overlay components inside the sidebar.
 appendTo | null | String | Appends the sidebar to the given search expression.
 dynamic | false | Boolean | Defines if dynamic loading is enabled for the element's panel. If the value is "true", the sidebar is not rendered on page load to improve performance. Default is false.
 onShow | null | String | Client side callback to execute when sidebar is displayed.

--- a/docs/11_0_0/components/sidebar.md
+++ b/docs/11_0_0/components/sidebar.md
@@ -29,7 +29,7 @@ visible | false | Boolean | Specifies the visibility of the sidebar.
 position | left | String | Position of the sidebar.
 fullScreen | false | Boolean | Whether to enable the whole screen.
 blockScroll | false | Boolean | Whether to block scrolling of the document when sidebar is active.
-baseZIndex | 0 | Integer | Base zIndex value to use in layering.
+baseZIndex | 0 | Integer | Base zIndex value to use in layering. Only use this attribute if you are having issues with your sidebar displaying as this may cause issues with overlay components inside the sidebar.
 appendTo | null | String | Appends the sidebar to the given search expression.
 dynamic | false | Boolean | Defines if dynamic loading is enabled for the element's panel. If the value is "true", the sidebar is not rendered on page load to improve performance. Default is false.
 onShow | null | String | Client side callback to execute when sidebar is displayed.

--- a/docs/7_0/components/sidebar.md
+++ b/docs/7_0/components/sidebar.md
@@ -27,7 +27,7 @@ visible | false | Boolean | Specifies the visibility of the sidebar.
 position | left | String | Position of the sidebar.
 fullScreen | false | Boolean | Whether to enable the whole screen.
 blockScroll | false | Boolean | Whether to block scrolling of the document when sidebar is active.
-baseZIndex | 0 | Integer | Base zIndex value to use in layering.
+baseZIndex | 0 | Integer | Base zIndex value to use in layering. Only use this attribute if you are having issues with your sidebar displaying as this may cause issues with overlay components inside the sidebar.
 appendTo | null | String | Appends the sidebar to the given search expression.
 onShow | null | String | Client side callback to execute when sidebar is displayed.
 onHide | null | String | Client side callback to execute when sidebar is hidden.

--- a/docs/8_0/components/sidebar.md
+++ b/docs/8_0/components/sidebar.md
@@ -27,7 +27,7 @@ visible | false | Boolean | Specifies the visibility of the sidebar.
 position | left | String | Position of the sidebar.
 fullScreen | false | Boolean | Whether to enable the whole screen.
 blockScroll | false | Boolean | Whether to block scrolling of the document when sidebar is active.
-baseZIndex | 0 | Integer | Base zIndex value to use in layering.
+baseZIndex | 0 | Integer | Base zIndex value to use in layering. Only use this attribute if you are having issues with your sidebar displaying as this may cause issues with overlay components inside the sidebar.
 appendTo | null | String | Appends the sidebar to the given search expression.
 onShow | null | String | Client side callback to execute when sidebar is displayed.
 onHide | null | String | Client side callback to execute when sidebar is hidden.

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -24693,7 +24693,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Base zIndex value to use in layering.]]>
+                <![CDATA[Base zIndex value to use in layering. Only use this attribute if you are having issues with your sidebar displaying as this may cause issues with overlay components inside the sidebar.]]>
             </description>
             <name>baseZIndex</name>
             <required>false</required>


### PR DESCRIPTION
This just updates the documentation of the `baseZindex` property to add a warning to only use it if necessary and that it may cause side effects.