### PR TITLE
Fix #7167: Dynamic overlay not handling deferred widgets

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -475,6 +475,8 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
                 {name: this.id + '_contentLoad', value: true}
             ],
             onsuccess: function(responseXML, status, xhr) {
+                // must show the overlay first so deferred wigets can render
+                $this._show(target);
                 PrimeFaces.ajax.Response.handle(responseXML, status, xhr, {
                         widget: $this,
                         handle: function(content) {
@@ -484,9 +486,6 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
                     });
 
                 return true;
-            },
-            oncomplete: function() {
-                $this._show(target);
             }
         };
 


### PR DESCRIPTION
OK this was tricky to debug but what is happening is that Datatable is a deferred widget which sets up its scrolling in the `_render` method.  The `_render` method was never being called and when I debugged its because the `jq.is(':visible')` was returning FALSE and thus the _render method was never being called to setup scrolling.

This was all part of the CSS refactoring for animations and what I had to do was call `show` before processing the AJAX response so the DeferredWidget would test  `jq.is(':visible')` was TRUE and then finishing setting up the datatable.

Attached is reproducer.
[pf-7167.zip](https://github.com/primefaces/primefaces/files/6223602/pf-7167.zip)
