### PR TITLE
Fix #7176/#6445: DatePicker not handling events properly with mask

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1752,7 +1752,10 @@
         },
 
         onInputKeyDown: function (event) {
-            this.isKeydown = true;
+            if (PrimeFaces.env.isIE()) {
+                this.isKeydown = true;
+            }
+
             if (event.keyCode === 27) {
                 //put the focus back to the inputfield
                 this.inputfield.trigger('focus');
@@ -1768,11 +1771,13 @@
         },
 
         onUserInput: function (event) {
-            // IE 11 Workaround for input placeholder
-            if (!this.isKeydown) {
-                return;
+            if (PrimeFaces.env.isIE()) {
+                // IE 11 Workaround for input placeholder
+                if (!this.isKeydown) {
+                   return;
+                }
+                this.isKeydown = false;
             }
-            this.isKeydown = false;
 
             var rawValue = event.target.value;
 

--- a/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -122,8 +122,8 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.rangeSeparator = this.cfg.rangeSeparator||'-';
         this.cfg.timeSeparator = this.cfg.timeSeparator||':';
 
+        this.applyMask(); // must be before datepicker see #6445 and #7176
         this.jq.datePicker(this.cfg);
-        this.applyMask(); // moved below datapicker initialization because of race condition in event handling. See https://github.com/primefaces/primefaces/issues/6445
 
         //extensions
         if(!this.cfg.inline && this.cfg.showIcon) {


### PR DESCRIPTION
- Wrapped IE specific code in IE so we know to remove it later on when we remove IE.
- Fixes both issues properly
- The onchange event will still not fire in IE but honestly every month that goes by IE is going to drift further and further away from supportability.