### PR TITLE
Fix #7186: DatePicker improved range splitting

### DIFF
--- a/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -293,7 +293,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
 
         String selectionMode = datePicker.getSelectionMode();
         switch (selectionMode) {
-            case "multiple": {
+            case "multiple":
                 String[] parts = submittedValue.split(",");
                 List<Object> multi = new ArrayList<>();
                 for (String part : parts) {
@@ -301,18 +301,16 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                 }
 
                 return multi;
-            }
-            case "range": {
-                String[] parts = submittedValue.split(datePicker.getRangeSeparator());
+            case "range":
+                List<String> rangeStr = CalendarUtils.splitRange(submittedValue, datePicker.calculatePattern(), datePicker.getRangeSeparator());
                 List<Object> range = new ArrayList<>();
-                if (parts.length == 2) {
-                    for (String part : parts) {
-                        range.add(super.getConvertedValue(context, component, part));
+                if (rangeStr.size() == 2) {
+                    for (int i = 0; i < rangeStr.size(); i++) {
+                        range.add(super.getConvertedValue(context, component, rangeStr.get(i)));
                     }
                 }
 
                 return range;
-            }
             default:
                 return super.getConvertedValue(context, component, value);
         }

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -574,7 +574,7 @@ public class CalendarUtils {
     public static List<String> splitRange(final String dateRange, final String pattern, final String separator) {
         final String token = Constants.SPACE + separator + Constants.SPACE;
         if (pattern.contains(token)) {
-            throw new FacesException("Pattern '" + pattern + "' contains separator ' " + separator + " '");
+            throw new FacesException("Pattern '" + pattern + "' contains separator '" + token + "'");
         }
         final List<String> dates = new ArrayList<>();
         if (!dateRange.contains(token)) {

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -582,7 +582,7 @@ public class CalendarUtils {
         }
         final int index = dateRange.indexOf(token);
         dates.add(dateRange.substring(0, index));
-        dates.add(dateRange.substring(index + token.length(), dateRange.length()));
+        dates.add(dateRange.substring(index + token.length()));
         return dates;
     }
 

--- a/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -29,6 +29,7 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -569,4 +570,20 @@ public class CalendarUtils {
         }
         return now;
     }
+
+    public static List<String> splitRange(final String dateRange, final String pattern, final String separator) {
+        final String token = Constants.SPACE + separator + Constants.SPACE;
+        if (pattern.contains(token)) {
+            throw new FacesException("Pattern '" + pattern + "' contains separator ' " + separator + " '");
+        }
+        final List<String> dates = new ArrayList<>();
+        if (!dateRange.contains(token)) {
+            return dates;
+        }
+        final int index = dateRange.indexOf(token);
+        dates.add(dateRange.substring(0, index));
+        dates.add(dateRange.substring(index + token.length(), dateRange.length()));
+        return dates;
+    }
+
 }

--- a/src/test/java/org/primefaces/util/CalendarUtilsTest.java
+++ b/src/test/java/org/primefaces/util/CalendarUtilsTest.java
@@ -202,7 +202,7 @@ public class CalendarUtilsTest {
         Date now = (Date) CalendarUtils.now(datePicker, java.util.Date.class);
         assertTrue(new Date().compareTo(now) >= 0);
     }
-    
+
     @Test
     public void convertPattern() {
         assertNull(CalendarUtils.convertPattern(null));
@@ -210,4 +210,17 @@ public class CalendarUtilsTest {
         assertEquals("mm/dd/yy HH:mm:ss", CalendarUtils.convertPattern("MM/dd/yyyy HH:mm:ss"));
         // more in-depth tests are in DateTimePatternConverterTest
     }
+
+    @Test
+    public void splitRange() {
+        List<String> splitRange = CalendarUtils.splitRange("2021-03-01 - 2021-03-31", "yyyy-MM-dd", "-");
+        assertEquals(2, splitRange.size());
+        assertEquals("2021-03-01", splitRange.get(0));
+        assertEquals("2021-03-31", splitRange.get(1));
+        splitRange = CalendarUtils.splitRange("2021-03-01", "yyyy-MM-dd", "-");
+        assertTrue(splitRange.isEmpty());
+        splitRange = CalendarUtils.splitRange("", "yyyy-MM-dd", "-");
+        assertTrue(splitRange.isEmpty());
+    }
+
 }

--- a/src/test/java/org/primefaces/util/CalendarUtilsTest.java
+++ b/src/test/java/org/primefaces/util/CalendarUtilsTest.java
@@ -37,10 +37,12 @@ import java.time.temporal.Temporal;
 import java.util.*;
 
 import javax.el.ELContext;
+import javax.faces.FacesException;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.primefaces.component.datepicker.DatePicker;
@@ -221,6 +223,10 @@ public class CalendarUtilsTest {
         assertTrue(splitRange.isEmpty());
         splitRange = CalendarUtils.splitRange("", "yyyy-MM-dd", "-");
         assertTrue(splitRange.isEmpty());
+
+        Assertions.assertThrows(FacesException.class, () -> {
+            CalendarUtils.splitRange("2021 - 03 - 01 - 2021 - 03 - 31", "yyyy - MM - dd", "-");
+        });
     }
 
 }


### PR DESCRIPTION
Fix #7186

* Don't use a reg ex to split (you could inject special characters as separator)
* Split on separator padded with spaces (token)
* If the date pattern contains the token, throw an exception