### PR TITLE
Fix #7200: Export columns in correct order

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
@@ -26,7 +26,6 @@ package org.primefaces.component.datatable.export;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -109,42 +108,40 @@ public class DataTableCSVExporter extends DataTableExporter {
     protected void addColumnFacets(PrintWriter writer, DataTable table, ColumnType columnType) throws IOException {
         boolean firstCellWritten = false;
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                if (firstCellWritten) {
-                    writer.append(csvOptions.getDelimiterChar());
-                }
-
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = col.getExportHeaderValue() != null ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
-                    case FOOTER:
-                        textValue = col.getExportFooterValue() != null ? col.getExportFooterValue() : col.getFooterText();
-                        break;
-                    default:
-                        textValue = null;
-                        break;
-                }
-
-                if (textValue != null) {
-                    addColumnValue(writer, textValue);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(writer, facet);
-                }
-                else {
-                    addColumnValue(writer, Constants.EMPTY_STRING);
-                }
-
-                firstCellWritten = true;
+            if (firstCellWritten) {
+                writer.append(csvOptions.getDelimiterChar());
             }
+
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = col.getExportHeaderValue() != null ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
+                case FOOTER:
+                    textValue = col.getExportFooterValue() != null ? col.getExportFooterValue() : col.getFooterText();
+                    break;
+                default:
+                    textValue = null;
+                    break;
+            }
+
+            if (textValue != null) {
+                addColumnValue(writer, textValue);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(writer, facet);
+            }
+            else {
+                addColumnValue(writer, Constants.EMPTY_STRING);
+            }
+
+            firstCellWritten = true;
         }
 
         writer.append(csvOptions.getEndOfLineSymbols());
@@ -155,38 +152,26 @@ public class DataTableCSVExporter extends DataTableExporter {
         PrintWriter writer = (PrintWriter) document;
         boolean firstCellWritten = false;
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                if (firstCellWritten) {
-                    writer.append(csvOptions.getDelimiterChar());
-                }
-
-                try {
-                    addColumnValue(writer, table, col.getChildren(), col);
-                }
-                catch (IOException ex) {
-                    throw new FacesException(ex);
-                }
-
-                firstCellWritten = true;
-            }
-        }
-    }
-
-    protected void addColumnValues(PrintWriter writer, DataTable table, List<UIColumn> columns) throws IOException {
-        for (Iterator<UIColumn> iterator = columns.iterator(); iterator.hasNext(); ) {
-            UIColumn col = iterator.next();
-            addColumnValue(writer, table, col.getChildren(), col);
-
-            if (iterator.hasNext()) {
+            if (firstCellWritten) {
                 writer.append(csvOptions.getDelimiterChar());
             }
+
+            try {
+                addColumnValue(writer, table, col.getChildren(), col);
+            }
+            catch (IOException ex) {
+                throw new FacesException(ex);
+            }
+
+            firstCellWritten = true;
         }
     }
+
 
     protected void addColumnValue(PrintWriter writer, UIComponent component) throws IOException {
         String value = component == null ? Constants.EMPTY_STRING : exportValue(FacesContext.getCurrentInstance(), component);

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -95,15 +95,9 @@ public class DataTableExcelExporter extends DataTableExporter {
 
         if (options == null || options.isAutoSizeColumn()) {
             short colIndex = 0;
-            for (UIColumn col : table.getColumns()) {
-                if (col instanceof DynamicColumn) {
-                    ((DynamicColumn) col).applyStatelessModel();
-                }
-
-                if (col.isRendered() && col.isExportable()) {
-                    sheet.autoSizeColumn(colIndex);
-                    colIndex++;
-                }
+            for (UIColumn col : getExportableColumns(table)) {
+                sheet.autoSizeColumn(colIndex);
+                colIndex++;
             }
         }
     }
@@ -126,14 +120,12 @@ public class DataTableExcelExporter extends DataTableExporter {
         int sheetRowIndex = sheet.getLastRowNum() + 1;
         Row row = sheet.createRow(sheetRowIndex);
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                addColumnValue(table, row, col.getChildren(), col);
-            }
+            addColumnValue(table, row, col.getChildren(), col);
         }
     }
 
@@ -141,37 +133,35 @@ public class DataTableExcelExporter extends DataTableExporter {
         int sheetRowIndex = sheet.getLastRowNum() + 1;
         Row rowHeader = sheet.createRow(sheetRowIndex);
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
 
-                    case FOOTER:
-                        textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
-                        break;
+                case FOOTER:
+                    textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
+                    break;
 
-                    default:
-                        textValue = null;
-                        break;
-                }
+                default:
+                    textValue = null;
+                    break;
+            }
 
-                if (textValue != null) {
-                    addColumnValue(rowHeader, textValue);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(rowHeader, facet);
-                }
-                else {
-                    addColumnValue(rowHeader, Constants.EMPTY_STRING);
-                }
+            if (textValue != null) {
+                addColumnValue(rowHeader, textValue);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(rowHeader, facet);
+            }
+            else {
+                addColumnValue(rowHeader, Constants.EMPTY_STRING);
             }
         }
     }
@@ -198,14 +188,7 @@ public class DataTableExcelExporter extends DataTableExporter {
         }
 
         if (facetText != null) {
-            int colspan = 0;
-
-            for (UIColumn col : table.getColumns()) {
-                if (col.isRendered() && col.isExportable()) {
-                    colspan++;
-                }
-            }
-
+            int colspan = getExportableColumns(table).size();
             int rowIndex = sheet.getLastRowNum() + 1;
             Row rowHeader = sheet.createRow(rowIndex);
 

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -26,14 +26,10 @@ package org.primefaces.component.datatable.export;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+import java.util.*;
 import javax.el.MethodExpression;
 import javax.faces.FacesException;
-import javax.faces.component.*;
+import javax.faces.component.UIComponent;
 import javax.faces.component.visit.VisitCallback;
 import javax.faces.component.visit.VisitContext;
 import javax.faces.component.visit.VisitResult;
@@ -70,14 +66,7 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
         }
     }
 
-    protected List<UIColumn> getColumnsToExport(UIData table) {
-        return table.getChildren().stream()
-                .filter(UIColumn.class::isInstance)
-                .map(UIColumn.class::cast)
-                .collect(Collectors.toList());
-    }
-
-    protected boolean hasColumnFooter(List<UIColumn> columns) {
+    protected boolean hasColumnFooter(List<javax.faces.component.UIColumn> columns) {
         return columns.stream().anyMatch(c -> c.getFooter() != null);
     }
 
@@ -207,6 +196,8 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
     }
 
     protected abstract void exportCells(DataTable table, Object document);
+
+
 
     @Override
     public void export(FacesContext context, List<DataTable> tables, OutputStream outputStream, ExportConfiguration exportConfiguration) throws IOException {

--- a/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -196,13 +196,7 @@ public class DataTablePDFExporter extends DataTableExporter {
         }
 
         if (facetText != null) {
-            int colspan = 0;
-
-            for (UIColumn col : table.getColumns()) {
-                if (col.isRendered() && col.isExportable()) {
-                    colspan++;
-                }
-            }
+            int colspan = getExportableColumns(table).size();
 
             PdfPCell cell = new PdfPCell(new Paragraph(facetText, facetFont));
             if (facetBgColor != null) {
@@ -218,49 +212,45 @@ public class DataTablePDFExporter extends DataTableExporter {
     @Override
     protected void exportCells(DataTable table, Object document) {
         PdfPTable pdfTable = (PdfPTable) document;
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                addColumnValue(table, pdfTable, col.getChildren(), cellFont, col);
-            }
+            addColumnValue(table, pdfTable, col.getChildren(), cellFont, col);
         }
     }
 
     protected void addColumnFacets(DataTable table, PdfPTable pdfTable, ColumnType columnType) {
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
 
-                    case FOOTER:
-                        textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
-                        break;
+                case FOOTER:
+                    textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
+                    break;
 
-                    default:
-                        textValue = null;
-                        break;
-                }
+                default:
+                    textValue = null;
+                    break;
+            }
 
-                if (textValue != null) {
-                    addColumnValue(pdfTable, textValue, 1, 1);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(pdfTable, facet);
-                }
-                else {
-                    addColumnValue(pdfTable, Constants.EMPTY_STRING, 1, 1);
-                }
+            if (textValue != null) {
+                addColumnValue(pdfTable, textValue, 1, 1);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(pdfTable, facet);
+            }
+            else {
+                addColumnValue(pdfTable, Constants.EMPTY_STRING, 1, 1);
             }
         }
     }
@@ -340,21 +330,7 @@ public class DataTablePDFExporter extends DataTableExporter {
     }
 
     protected int getColumnsCount(DataTable table) {
-        int count = 0;
-
-        for (UIColumn col : table.getColumns()) {
-            if (col instanceof DynamicColumn) {
-                ((DynamicColumn) col).applyStatelessModel();
-            }
-
-            if (!col.isRendered() || !col.isExportable()) {
-                continue;
-            }
-
-            count++;
-        }
-
-        return count;
+        return getExportableColumns(table).size();
     }
 
     protected void addEmptyLine(Paragraph paragraph, int number) {

--- a/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
+++ b/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
@@ -101,19 +101,17 @@ public class DataTableXMLExporter extends DataTableExporter {
     @Override
     protected void exportCells(DataTable table, Object document) {
         PrintWriter writer = (PrintWriter) document;
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                String columnTag = getColumnTag(col);
-                try {
-                    addColumnValue(writer, table, col.getChildren(), columnTag, col);
-                }
-                catch (IOException ex) {
-                    throw new FacesException(ex);
-                }
+            String columnTag = getColumnTag(col);
+            try {
+                addColumnValue(writer, table, col.getChildren(), columnTag, col);
+            }
+            catch (IOException ex) {
+                throw new FacesException(ex);
             }
         }
     }

--- a/src/main/java/org/primefaces/component/export/TableExporter.java
+++ b/src/main/java/org/primefaces/component/export/TableExporter.java
@@ -23,18 +23,24 @@
  */
 package org.primefaces.component.export;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 import javax.el.MethodExpression;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
+
+import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.api.UITable;
+import org.primefaces.model.ColumnMeta;
 import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
 public abstract class TableExporter<T extends UIComponent & UITable> extends Exporter<T> {
+
+    private List<UIColumn> exportableColumns;
 
     protected void exportColumn(FacesContext context, T table, UIColumn column, List<UIComponent> components,
             boolean joinComponents, Consumer<String> callback) {
@@ -72,5 +78,42 @@ public abstract class TableExporter<T extends UIComponent & UITable> extends Exp
                 callback.accept(sb == null ? null : sb.toString());
             }
         }
+    }
+
+    /**
+     * Gets and caches the list of UIColumns that are exportable="true" and rendered="true".
+     * Orders them by displayPriority so they match the UI display of the columns.
+     *
+     * @param table the Table with columns to export
+     * @return the List<UIColumn> that are exportable
+     */
+    protected List<UIColumn> getExportableColumns(UITable table) {
+        if (exportableColumns != null) {
+            return exportableColumns;
+        }
+
+        // sort by display priority
+        List<ColumnMeta> columnMeta = table.getColumnMeta().values().stream().
+                    sorted(Comparator.comparingInt(ColumnMeta::getDisplayPriority))
+                    .collect(Collectors.toList());
+
+        List<UIColumn> columns = table.getColumns();
+        exportableColumns = new ArrayList<>(table.getColumns().size());
+        META: for (ColumnMeta meta : columnMeta) {
+            String columnKey = meta.getColumnKey();
+            for (UIColumn col : columns) {
+                if (col instanceof DynamicColumn) {
+                    ((DynamicColumn) col).applyStatelessModel();
+                }
+                if (col.getColumnKey().equals(columnKey)) {
+                    if (col.isRendered() && col.isExportable()) {
+                        exportableColumns.add(col);
+                    }
+                    continue META;
+                }
+            }
+        }
+
+        return exportableColumns;
     }
 }

--- a/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
@@ -26,7 +26,6 @@ package org.primefaces.component.treetable.export;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -109,42 +108,40 @@ public class TreeTableCSVExporter extends TreeTableExporter {
     protected void addColumnFacets(PrintWriter writer, TreeTable table, ColumnType columnType) throws IOException {
         boolean firstCellWritten = false;
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                if (firstCellWritten) {
-                    writer.append(csvOptions.getDelimiterChar());
-                }
-
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = col.getExportHeaderValue() != null ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
-                    case FOOTER:
-                        textValue = col.getExportFooterValue() != null ? col.getExportFooterValue() : col.getFooterText();
-                        break;
-                    default:
-                        textValue = null;
-                        break;
-                }
-
-                if (textValue != null) {
-                    addColumnValue(writer, textValue);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(writer, facet);
-                }
-                else {
-                    addColumnValue(writer, Constants.EMPTY_STRING);
-                }
-
-                firstCellWritten = true;
+            if (firstCellWritten) {
+                writer.append(csvOptions.getDelimiterChar());
             }
+
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = col.getExportHeaderValue() != null ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
+                case FOOTER:
+                    textValue = col.getExportFooterValue() != null ? col.getExportFooterValue() : col.getFooterText();
+                    break;
+                default:
+                    textValue = null;
+                    break;
+            }
+
+            if (textValue != null) {
+                addColumnValue(writer, textValue);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(writer, facet);
+            }
+            else {
+                addColumnValue(writer, Constants.EMPTY_STRING);
+            }
+
+            firstCellWritten = true;
         }
 
         writer.append(csvOptions.getEndOfLineSymbols());
@@ -155,36 +152,23 @@ public class TreeTableCSVExporter extends TreeTableExporter {
         PrintWriter writer = (PrintWriter) document;
         boolean firstCellWritten = false;
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                if (firstCellWritten) {
-                    writer.append(csvOptions.getDelimiterChar());
-                }
-
-                try {
-                    addColumnValue(writer, table, col.getChildren(), col);
-                }
-                catch (IOException ex) {
-                    throw new FacesException(ex);
-                }
-
-                firstCellWritten = true;
-            }
-        }
-    }
-
-    protected void addColumnValues(PrintWriter writer, TreeTable table, List<UIColumn> columns) throws IOException {
-        for (Iterator<UIColumn> iterator = columns.iterator(); iterator.hasNext(); ) {
-            UIColumn col = iterator.next();
-            addColumnValue(writer, table, col.getChildren(), col);
-
-            if (iterator.hasNext()) {
+            if (firstCellWritten) {
                 writer.append(csvOptions.getDelimiterChar());
             }
+
+            try {
+                addColumnValue(writer, table, col.getChildren(), col);
+            }
+            catch (IOException ex) {
+                throw new FacesException(ex);
+            }
+
+            firstCellWritten = true;
         }
     }
 

--- a/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
@@ -106,15 +106,9 @@ public class TreeTableExcelExporter extends TreeTableExporter {
 
         if (options == null || options.isAutoSizeColumn()) {
             short colIndex = 0;
-            for (UIColumn col : table.getColumns()) {
-                if (col instanceof DynamicColumn) {
-                    ((DynamicColumn) col).applyStatelessModel();
-                }
-
-                if (col.isRendered() && col.isExportable()) {
-                    sheet.autoSizeColumn(colIndex);
-                    colIndex++;
-                }
+            for (UIColumn col : getExportableColumns(table)) {
+                sheet.autoSizeColumn(colIndex);
+                colIndex++;
             }
         }
     }
@@ -137,14 +131,12 @@ public class TreeTableExcelExporter extends TreeTableExporter {
         int sheetRowIndex = sheet.getLastRowNum() + 1;
         Row row = sheet.createRow(sheetRowIndex);
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                addColumnValue(table, row, col.getChildren(), col);
-            }
+            addColumnValue(table, row, col.getChildren(), col);
         }
     }
 
@@ -152,37 +144,35 @@ public class TreeTableExcelExporter extends TreeTableExporter {
         int sheetRowIndex = sheet.getLastRowNum() + 1;
         Row rowHeader = sheet.createRow(sheetRowIndex);
 
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
 
-                    case FOOTER:
-                        textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
-                        break;
+                case FOOTER:
+                    textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
+                    break;
 
-                    default:
-                        textValue = null;
-                        break;
-                }
+                default:
+                    textValue = null;
+                    break;
+            }
 
-                if (textValue != null) {
-                    addColumnValue(rowHeader, textValue);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(rowHeader, facet);
-                }
-                else {
-                    addColumnValue(rowHeader, Constants.EMPTY_STRING);
-                }
+            if (textValue != null) {
+                addColumnValue(rowHeader, textValue);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(rowHeader, facet);
+            }
+            else {
+                addColumnValue(rowHeader, Constants.EMPTY_STRING);
             }
         }
     }
@@ -209,14 +199,7 @@ public class TreeTableExcelExporter extends TreeTableExporter {
         }
 
         if (facetText != null) {
-            int colspan = 0;
-
-            for (UIColumn col : table.getColumns()) {
-                if (col.isRendered() && col.isExportable()) {
-                    colspan++;
-                }
-            }
-
+            int colspan = getExportableColumns(table).size();
             int rowIndex = sheet.getLastRowNum() + 1;
             Row rowHeader = sheet.createRow(rowIndex);
 

--- a/src/main/java/org/primefaces/component/treetable/export/TreeTableExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTableExporter.java
@@ -31,13 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import javax.el.MethodExpression;
 import javax.faces.FacesException;
 import javax.faces.component.UIColumn;
 import javax.faces.component.UIComponent;
-import javax.faces.component.UIData;
 import javax.faces.component.visit.VisitCallback;
 import javax.faces.component.visit.VisitContext;
 import javax.faces.component.visit.VisitResult;
@@ -72,13 +69,6 @@ public abstract class TreeTableExporter extends TableExporter<TreeTable> {
         public String toString() {
             return facet;
         }
-    }
-
-    protected List<UIColumn> getColumnsToExport(UIData table) {
-        return table.getChildren().stream()
-                .filter(UIColumn.class::isInstance)
-                .map(UIColumn.class::cast)
-                .collect(Collectors.toList());
     }
 
     protected boolean hasColumnFooter(List<UIColumn> columns) {

--- a/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
@@ -201,14 +201,7 @@ public class TreeTablePDFExporter extends TreeTableExporter {
         }
 
         if (facetText != null) {
-            int colspan = 0;
-
-            for (UIColumn col : table.getColumns()) {
-                if (col.isRendered() && col.isExportable()) {
-                    colspan++;
-                }
-            }
-
+            int colspan = getExportableColumns(table).size();
             PdfPCell cell = new PdfPCell(new Paragraph(facetText, facetFont));
             if (facetBgColor != null) {
                 cell.setBackgroundColor(facetBgColor);
@@ -223,49 +216,45 @@ public class TreeTablePDFExporter extends TreeTableExporter {
     @Override
     protected void exportCells(TreeTable table, Object document) {
         PdfPTable pdfTable = (PdfPTable) document;
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                addColumnValue(table, pdfTable, col.getChildren(), cellFont, col);
-            }
+            addColumnValue(table, pdfTable, col.getChildren(), cellFont, col);
         }
     }
 
     protected void addColumnFacets(TreeTable table, PdfPTable pdfTable, ColumnType columnType) {
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                UIComponent facet = col.getFacet(columnType.facet());
-                String textValue;
-                switch (columnType) {
-                    case HEADER:
-                        textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
-                        break;
+            UIComponent facet = col.getFacet(columnType.facet());
+            String textValue;
+            switch (columnType) {
+                case HEADER:
+                    textValue = (col.getExportHeaderValue() != null) ? col.getExportHeaderValue() : col.getHeaderText();
+                    break;
 
-                    case FOOTER:
-                        textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
-                        break;
+                case FOOTER:
+                    textValue = (col.getExportFooterValue() != null) ? col.getExportFooterValue() : col.getFooterText();
+                    break;
 
-                    default:
-                        textValue = null;
-                        break;
-                }
+                default:
+                    textValue = null;
+                    break;
+            }
 
-                if (textValue != null) {
-                    addColumnValue(pdfTable, textValue, 1, 1);
-                }
-                else if (ComponentUtils.shouldRenderFacet(facet)) {
-                    addColumnValue(pdfTable, facet);
-                }
-                else {
-                    addColumnValue(pdfTable, Constants.EMPTY_STRING, 1, 1);
-                }
+            if (textValue != null) {
+                addColumnValue(pdfTable, textValue, 1, 1);
+            }
+            else if (ComponentUtils.shouldRenderFacet(facet)) {
+                addColumnValue(pdfTable, facet);
+            }
+            else {
+                addColumnValue(pdfTable, Constants.EMPTY_STRING, 1, 1);
             }
         }
     }
@@ -346,21 +335,7 @@ public class TreeTablePDFExporter extends TreeTableExporter {
     }
 
     protected int getColumnsCount(TreeTable table) {
-        int count = 0;
-
-        for (UIColumn col : table.getColumns()) {
-            if (col instanceof DynamicColumn) {
-                ((DynamicColumn) col).applyStatelessModel();
-            }
-
-            if (!col.isRendered() || !col.isExportable()) {
-                continue;
-            }
-
-            count++;
-        }
-
-        return count;
+        return getExportableColumns(table).size();
     }
 
     protected void addEmptyLine(Paragraph paragraph, int number) {

--- a/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
+++ b/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
@@ -101,19 +101,17 @@ public class TreeTableXMLExporter extends TreeTableExporter {
     @Override
     protected void exportCells(TreeTable table, Object document) {
         PrintWriter writer = (PrintWriter) document;
-        for (UIColumn col : table.getColumns()) {
+        for (UIColumn col : getExportableColumns(table)) {
             if (col instanceof DynamicColumn) {
                 ((DynamicColumn) col).applyStatelessModel();
             }
 
-            if (col.isRendered() && col.isExportable()) {
-                String columnTag = getColumnTag(col);
-                try {
-                    addColumnValue(writer, table, col.getChildren(), columnTag, col);
-                }
-                catch (IOException ex) {
-                    throw new FacesException(ex);
-                }
+            String columnTag = getColumnTag(col);
+            try {
+                addColumnValue(writer, table, col.getChildren(), columnTag, col);
+            }
+            catch (IOException ex) {
+                throw new FacesException(ex);
             }
         }
     }


### PR DESCRIPTION
Has to respect the reordered UI columns by using ColumnMeta to determine the column order.  Cache the list so its only calculated once per table.