### PR TITLE
Fix #7225 ContextMenu iPad OS

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -34,7 +34,7 @@ if (!PrimeFaces.env) {
             this.browser = $.browser;
             this.mobile = this.browser.mobile;
             this.touch = 'ontouchstart' in window || window.navigator.msMaxTouchPoints || PrimeFaces.env.mobile;
-            this.ios = /iPhone|iPad|iPod/i.test(window.navigator.userAgent);
+            this.ios = /iPhone|iPad|iPod/i.test(window.navigator.userAgent) || (/mac/i.test(window.navigator.userAgent) && PrimeFaces.env.touch);
         },
 
         /**


### PR DESCRIPTION
iPad OS was not recognized as an iOS device since Apple messed up the user agent: https://developer.apple.com/forums/thread/119186

This fix adds a test for "mac" in the user agent in combination with touch ability. This seems to be the only possibility to check for iPad OS at the moment.

Resolves #7225 