### PR TITLE
Update OWASP check plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1326,11 +1326,12 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>6.0.3</version>
+                        <version>6.1.5</version>
                         <configuration>
                             <skipProvidedScope>false</skipProvidedScope>
                             <skipRuntimeScope>false</skipRuntimeScope>
                             <failBuildOnCVSS>5</failBuildOnCVSS>
+                             <suppressionFile>${project.basedir}/src/conf/owasp-suppressions.xml</suppressionFile>
                         </configuration>
                         <executions>
                             <execution>

--- a/src/conf/owasp-suppressions.xml
+++ b/src/conf/owasp-suppressions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>
+            <![CDATA[file name: commons-io-2.4.jar. PrimeFaces shades this JAR and does not use the function in this report.]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
+        <cve>CVE-2021-29425</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[file name: url-regex:5.0.0 PrimeFaces uses this from FullCalendar.io but it is a transitive build dependency.]]>
+        </notes>
+        <packageUrl regex="true">^pkg:npm/url\-regex@.*$</packageUrl>
+        <cve>CVE-2020-7661</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
Commons IO is reporting this but we must stay on 2.4 since we shade a few classes.  This supresses this error with a comment on why.

```
Error:  One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '5.0': 
  
Error:  commons-io-2.4.jar: CVE-2021-29425
```