### PR TITLE
Fix #7255: Column Group breaks visibility

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -278,6 +278,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     _render: function() {
         this.isRTL = this.jq.hasClass('ui-datatable-rtl');
         this.cfg.partialUpdate = (this.cfg.partialUpdate === false) ? false : true;
+        this.hasColumnGroup = this.hasColGroup();
 
         if(this.cfg.scrollable) {
             this.setupScrolling();
@@ -3906,7 +3907,6 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
         this.fixColumnWidths();
 
-        this.hasColumnGroup = this.hasColGroup();
         if(this.hasColumnGroup) {
             this.addGhostRow();
         }
@@ -5126,8 +5126,8 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             return;
         }
 
-        // update the visibility of columns but ignore expanded rows
-        if(this.headers) {
+        // update the visibility of columns but ignore expanded rows and GitHub #7255 grouped headers
+        if(this.headers && !this.hasColumnGroup) {
             for(var i = 0; i < this.headers.length; i++) {
                 var header = this.headers.eq(i),
                     col = this.tbody.find('> tr:not(.ui-expanded-row-content) > td:nth-child(' + (header.index() + 1) + ')');


### PR DESCRIPTION
Ticket is related to this one: #7051

Basically grouped rows don't play nicely with Column Toggler and column visibility because in the test there are 5 row headers and 3 columns and the code is trying to figure out which ones are visible but the columns don't line up 5 vs 3 so it thinks column 2 is visible when its not.