### PR TITLE
Fix #7213: Added panelFooter facet to AutoComplete

### DIFF
--- a/docs/11_0_0/components/autocomplete.md
+++ b/docs/11_0_0/components/autocomplete.md
@@ -28,7 +28,7 @@ AutoComplete provides live suggestions while an input is being typed.
 | autoHighlight | true | Boolean | Highlights the first suggested item automatically.
 | autoSelection | true | Boolean | Defines if auto selection of items that are equal to the typed input is enabled. If true, an item that is equal to the typed input is selected.
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean.
-| completeEndpoint | null | String | REST-endpoint for fetching autocomplete-suggestions. (instead of completeMethod) Can´t be combined with dynamic=true, queryMode!=server, cache=true. 
+| completeEndpoint | null | String | REST-endpoint for fetching autocomplete-suggestions. (instead of completeMethod) Can´t be combined with dynamic=true, queryMode!=server, cache=true.
 | completeMethod | null | Method Expr | Method providing suggestions.
 | converter | null | Object | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id.
 | converterMessage | null | String | Message to be displayed when conversion fails.
@@ -200,6 +200,7 @@ AutoComplete can display custom content by nesting columns.
     </p:column>
 </p:autoComplete>
 ```
+
 ## Dropdown Mode
 When dropdown mode is enabled, a dropdown button is displayed next to the input field.
 Depending on dropdownMode configuration, clicking this button will either do a search with an
@@ -208,9 +209,23 @@ empty query or search with the current value in input.
 ```xhtml
 <p:autoComplete value="#{bean.text}" completeMethod="#{bean.complete}" dropdown="true" />
 ```
+
+## Footer
+A footer can be added to the suggestion list using the `panelFooter` facet. You could use this for example to offer
+UI to add a new item. For example:
+
+```xhtml
+<f:facet name="panelFooter">
+    <p:button value="Add new" onclick="..."/>
+</f:facet>
+```
+
+Note that the panel is placed at the end of the body in the DOM tree, so not in the same form as the `AutoComplete`
+component is in. So you might want to wrap the contents of this facet in a form if needed.
+
 ## Multiple Selection
-AutoComplete supports multiple selection as well, to use this feature set multiple option to true and
-define a list as your back-end model. Use BACKSPACE key to remove a selected item and CTRL or SHIFT+BACKSPACE 
+`AutoComplete` supports multiple selection as well, to use this feature set multiple option to true and
+define a list as your back-end model. Use BACKSPACE key to remove a selected item and CTRL or SHIFT+BACKSPACE
 to remove all items at once.
 Following example demonstrates multiple selection with custom content support.
 
@@ -249,13 +264,13 @@ Or existing REST-endpoints may be re-used.
 
 AutoComplete does a HTTP-GET against the REST-endpoint and passes query-url-parameter. (eg `/rest/theme/autocomplete?query=lu`)
 
-The REST-endpoint has to return following JSON-response: 
+The REST-endpoint has to return following JSON-response:
 ```json
 {"suggestions":[{"value":"0","label":"Nova-Light"},{"value":"1","label":"Nova-Dark"},{"value":"2","label":"Nova-Colored"}],"moreAvailable":false}
 ```
-Each suggestion-item needs to have value- and label-property. In most cases you can simply use `org.primefaces.model.rest.AutoCompleteSuggestionResponse` as response as the following example shows. 
+Each suggestion-item needs to have value- and label-property. In most cases you can simply use `org.primefaces.model.rest.AutoCompleteSuggestionResponse` as response as the following example shows.
 
-Sample REST-service based one JAX-RS and CDI: 
+Sample REST-service based one JAX-RS and CDI:
 
 ```java
 import org.primefaces.model.rest.AutoCompleteSuggestion;
@@ -289,17 +304,17 @@ public class ThemeService {
                 .collect(Collectors.toList()));
     }
 }
-``` 
+```
 
-Sample-useage within AutoComplete. Note `completeEndpoint`-attribute. 
+Sample-useage within AutoComplete. Note `completeEndpoint`-attribute.
 ```xhtml
 <p:autoComplete id="themePojoRest" value="#{autoCompleteView.theme}" var="theme" itemLabel="#{theme.displayName}" itemValue="#{theme}" converter="#{themeConverter}" completeEndpoint="#{request.contextPath}/rest/theme/autocomplete" forceSelection="true" />
-``` 
+```
 
 ## Ajax Behavior Events
-The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
-  
-**Default Event:** `valueChange`  
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.
+
+**Default Event:** `valueChange`
 **Available Events:** `blur, change, clear, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, itemSelect, itemUnselect, keydown, keypress, keyup, moreTextSelect, emptyMessageSelect, mousedown, mousemove, mouseout, mouseover, mouseup, paste, query, reset, scroll, search, select, valueChange, wheel`
 
 

--- a/docs/11_0_0/components/autocomplete.md
+++ b/docs/11_0_0/components/autocomplete.md
@@ -315,6 +315,7 @@ Sample-useage within AutoComplete. Note `completeEndpoint`-attribute.
 The following AJAX behavior events are available for this component. If no event is specified the default event is called.
 
 **Default Event:** `valueChange`
+
 **Available Events:** `blur, change, clear, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, itemSelect, itemUnselect, keydown, keypress, keyup, moreTextSelect, emptyMessageSelect, mousedown, mousemove, mouseout, mouseover, mouseup, paste, query, reset, scroll, search, select, valueChange, wheel`
 
 

--- a/docs/11_0_0/gettingstarted/whatsnew.md
+++ b/docs/11_0_0/gettingstarted/whatsnew.md
@@ -4,7 +4,7 @@ This page contains a list of big features. Please check the GitHub issues for al
 
 ## 11.0.0
 
-  * TODO
+  * AutoComplete: added `footer` facet which will be added to the suggestion list.
 
 Look into [migration guide](https://primefaces.github.io/primefaces/11_0_0/#/../migrationguide/10_0_0?id=datatable) for more enhancements and changes.
-Or check the list of 600+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0), 
+Or check the list of 600+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0),

--- a/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -493,6 +493,19 @@ public class AutoCompleteRenderer extends InputRenderer {
         else {
             encodeSuggestionsAsList(context, ac, items, converter);
         }
+
+        encodeFooter(context, ac);
+    }
+
+    protected void encodeFooter(FacesContext context, AutoComplete ac) throws IOException {
+        UIComponent footer = ac.getFacet("panelFooter");
+        if (ComponentUtils.shouldRenderFacet(footer)) {
+            ResponseWriter writer = context.getResponseWriter();
+            writer.startElement("div", null);
+            writer.writeAttribute("class", "ui-autocomplete-footer", null);
+            footer.encodeAll(context);
+            writer.endElement("div");
+        }
     }
 
     protected void encodeSuggestionsAsTable(FacesContext context, AutoComplete ac, Object items, Converter converter) throws IOException {
@@ -740,7 +753,8 @@ public class AutoCompleteRenderer extends InputRenderer {
                 .attr("escape", ac.isEscape(), true)
                 .attr("queryMode", ac.getQueryMode())
                 .attr("completeEndpoint", ac.getCompleteEndpoint())
-                .attr("moreText", ac.getMoreText());
+                .attr("moreText", ac.getMoreText())
+                .attr("hasFooter", ComponentUtils.shouldRenderFacet(ac.getFacet("footer")));
 
         if (ac.isCache()) {
             wb.attr("cache", true).attr("cacheTimeout", ac.getCacheTimeout());

--- a/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -63,6 +63,7 @@
  * the overlay is not rendered on page load to improve performance.
  * @prop {string} cfg.emptyMessage Text to display when there is no data to display.
  * @prop {boolean} cfg.escape Whether the text of the suggestion items is escaped for HTML.
+ * @prop {boolean} cfg.hasFooter Whether a footer facet is present.
  * @prop {boolean} cfg.forceSelection Whether one of the available suggestion items is forced to be preselected.
  * @prop {boolean} cfg.grouping Whether suggestion items are grouped.
  * @prop {boolean} cfg.itemtip Whether a tooltip is shown for the suggestion items.
@@ -114,6 +115,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.dynamic = this.cfg.dynamic === true ? true : false;
         this.cfg.autoSelection = this.cfg.autoSelection === false ? false : true;
         this.cfg.escape = this.cfg.escape === false ? false : true;
+        this.cfg.hasFooter = this.cfg.hasFooter === true ? true : false;
         this.suppressInput = true;
         this.touchToDropdownButton = false;
         this.isTabPressed = false;
@@ -795,9 +797,9 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
         else {
             if(this.cfg.emptyMessage) {
                 var emptyText = '<div class="ui-autocomplete-emptyMessage ui-widget">' + PrimeFaces.escapeHTML(this.cfg.emptyMessage) + '</div>';
-                this.panel.html(emptyText);
+                this.panel.prepend(emptyText);
             }
-            else {
+            else if(!this.cfg.hasFooter){
                 this.panel.hide();
             }
 


### PR DESCRIPTION
Fix #7213

Showcase https://github.com/primefaces/primefaces-showcase/pull/354

```xhtml
<f:facet name="footer">
    <div class="ui-fluid" style="padding:0.5rem 1rem 1rem 1rem">
        <p:button value="Add new" onclick="alert('This could open a dialog')"/>
    </div>
</f:facet>
```

<img width="384" alt="Screenshot 2021-04-25 at 11 55 01" src="https://user-images.githubusercontent.com/7500178/116004702-3093ba80-a604-11eb-85a8-3173d5c892b0.png">
