### PR TITLE
Fix #7311: ToggleSwitch align with SelectBooleanCheckbox

### DIFF
--- a/docs/11_0_0/components/toggleswitch.md
+++ b/docs/11_0_0/components/toggleswitch.md
@@ -42,6 +42,7 @@ styleClass | null | String | Style class of the main container.
 tabindex | null | Integer | The tabindex attribute specifies the tab order of an element when the "tab" button is used for navigating.
 onfocus | null | String | Client side callback to execute when component receives focus.
 onblur | null | Sring | Client side callback to execute when component loses focus.
+ariaLabel | null | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
 
 ## Getting started with ToggleSwitch
 ToggleSwitch requires a boolean reference as the value.

--- a/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchBase.java
+++ b/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchBase.java
@@ -26,10 +26,12 @@ package org.primefaces.component.toggleswitch;
 import javax.faces.component.UIInput;
 import javax.faces.component.behavior.ClientBehaviorHolder;
 
+import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.Widget;
+import org.primefaces.component.selectbooleancheckbox.SelectBooleanCheckboxBase;
 
-public abstract class ToggleSwitchBase extends UIInput implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder {
+public abstract class ToggleSwitchBase extends UIInput implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder, InputHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -39,6 +41,7 @@ public abstract class ToggleSwitchBase extends UIInput implements Widget, Client
 
         widgetVar,
         label,
+        ariaLabel,
         disabled,
         onchange,
         style,
@@ -71,6 +74,14 @@ public abstract class ToggleSwitchBase extends UIInput implements Widget, Client
 
     public void setLabel(String label) {
         getStateHelper().put(PropertyKeys.label, label);
+    }
+
+    public String getAriaLabel() {
+        return (String) getStateHelper().eval(SelectBooleanCheckboxBase.PropertyKeys.ariaLabel, null);
+    }
+
+    public void setAriaLabel(String ariaLabel) {
+        getStateHelper().put(SelectBooleanCheckboxBase.PropertyKeys.ariaLabel, ariaLabel);
     }
 
     public boolean isDisabled() {
@@ -127,5 +138,25 @@ public abstract class ToggleSwitchBase extends UIInput implements Widget, Client
 
     public void setOnblur(String onblur) {
         getStateHelper().put(PropertyKeys.onblur, onblur);
+    }
+
+    @Override
+    public String getInputClientId() {
+        return this.getClientId(getFacesContext()) + "_input";
+    }
+
+    @Override
+    public String getValidatableInputClientId() {
+        return this.getInputClientId();
+    }
+
+    @Override
+    public String getLabelledBy() {
+        return (String) getStateHelper().get("labelledby");
+    }
+
+    @Override
+    public void setLabelledBy(String labelledBy) {
+        getStateHelper().put("labelledby", labelledBy);
     }
 }

--- a/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
+++ b/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
@@ -76,8 +76,7 @@ public class ToggleSwitchRenderer extends InputRenderer {
         writer.startElement("div", toggleSwitch);
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("class", styleClass, "styleClass");
-        writer.writeAttribute("role", "checkbox", null);
-        writer.writeAttribute(HTML.ARIA_CHECKED, checked, null);
+
         if (style != null) {
             writer.writeAttribute("style", style, "style");
         }
@@ -99,6 +98,7 @@ public class ToggleSwitchRenderer extends InputRenderer {
     protected void encodeInput(FacesContext context, ToggleSwitch toggleSwitch, String clientId, boolean checked) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String inputId = clientId + "_input";
+        String ariaLabel = toggleSwitch.getAriaLabel() != null ? toggleSwitch.getAriaLabel() : toggleSwitch.getLabel();
 
         writer.startElement("div", toggleSwitch);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
@@ -107,6 +107,9 @@ public class ToggleSwitchRenderer extends InputRenderer {
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
         writer.writeAttribute("type", "checkbox", null);
+        writer.writeAttribute("autocomplete", "off", null);
+        writer.writeAttribute(HTML.ARIA_CHECKED, checked, null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
 
         if (checked) {
             writer.writeAttribute("checked", "checked", null);

--- a/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -28505,6 +28505,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]>
+            </description>
+            <name>ariaLabel</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Disables or enables the switch.]]>
             </description>
             <name>disabled</name>

--- a/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.js
+++ b/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.js
@@ -1,13 +1,13 @@
 /**
  * __PrimeFaces ToggleSwitch Widget__
- * 
+ *
  * ToggleSwitch is used to select a boolean value.
- * 
+ *
  * > ToggleSwitch is designed to replace the old {@link InputSwitch|InputSwitch component}.
- * 
+ *
  * @prop {JQuery} input The DOM element for the hidden input field storing the value of this switch.
  * @prop {JQuery} slider The DOM element for the slider.
- * 
+ *
  * @interface {PrimeFaces.widget.ToggleSwitchCfg} cfg The configuration for the {@link  ToggleSwitch| ToggleSwitch widget}.
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this
  * configuration is usually meant to be read-only and should not be modified.
@@ -22,13 +22,17 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
      */
     init: function(cfg) {
         this._super(cfg);
-        
+
         this.slider = this.jq.children('.ui-toggleswitch-slider');
         this.input = $(this.jqId + '_input');
+        this.triggerChangeEvent = true;
 
-        if(!this.input.prop('disabled')) {
+        if(!this.input.is(':disabled')) {
             this._bindEvents();
         }
+
+        //pfs metadata
+        this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
     },
 
     /**
@@ -39,8 +43,7 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
 
         this.jq.on('click.toggleSwitch', function(e) {
-            $this.toggle();
-            $this.input.trigger('focus');
+            $this.input.trigger('click.toggleSwitch').trigger('focus.toggleSwitch');
         });
 
         this.input.on('focus.toggleSwitch', function(e) {
@@ -62,14 +65,32 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
 
                 e.preventDefault();
             }
+        })
+        .on('change.toggleSwitch', function(e) {
+            $this.triggerChangeEvent = false;
+            if($this.isChecked()) {
+                $this.check();
+            }
+            else {
+                $this.uncheck();
+            }
+            $this.triggerChangeEvent = true;
         });
+    },
+    
+    /**
+     * Checks whether this checkbox is currently checked.
+     * @return {boolean} `true` if this checkbox is checked, or `false` otherwise.
+     */
+    isChecked: function() {
+        return this.input.prop('checked');
     },
 
     /**
      * Turns this switch in case it is off, or turns of off in case it is on.
      */
     toggle: function() {
-        if(this.input.prop('checked'))
+        if(this.isChecked())
             this.uncheck();
         else
             this.check();
@@ -79,15 +100,21 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
      * Turns this switch on if it is not already turned on.
      */
     check: function() {
-        this.input.prop('checked', true).trigger('change');
-        this.jq.attr('aria-checked', true).addClass('ui-toggleswitch-checked');
+        this.input.prop('checked', true).attr('aria-checked', true);
+        this.jq.addClass('ui-toggleswitch-checked');
+        if(this.triggerChangeEvent && !this.isChecked()) {
+            this.input.trigger('change')
+        }
     },
 
     /**
      * Turns this switch off if it is not already turned of.
      */
     uncheck: function() {
-        this.input.prop('checked', false).trigger('change');
-        this.jq.attr('aria-checked', false).removeClass('ui-toggleswitch-checked');
+        this.input.prop('checked', false).attr('aria-checked', false);
+        this.jq.removeClass('ui-toggleswitch-checked');
+        if(this.triggerChangeEvent && this.isChecked()) {
+            this.input.trigger('change')
+        }
     }
 });


### PR DESCRIPTION
Compared with SelectBooleanCheckbox and aligned the two.  It was missing interface `InputHolder` interface which triggers OutputLabel to look for `_input` instead of the main component.