### PR TITLE
Fix #7324: DisplayPriority can be null when comparing

### DIFF
--- a/src/main/java/org/primefaces/component/export/TableExporter.java
+++ b/src/main/java/org/primefaces/component/export/TableExporter.java
@@ -109,8 +109,9 @@ public abstract class TableExporter<T extends UIComponent & UITable> extends Exp
         }
         else {
             // sort by display priority
+            Comparator<Integer> sortIntegersNaturallyWithNullsLast = Comparator.nullsLast(Comparator.naturalOrder());
             List<ColumnMeta> columnMetas = columnMetadata.values().stream().
-                        sorted(Comparator.comparingInt(ColumnMeta::getDisplayPriority))
+                        sorted(Comparator.comparing(ColumnMeta::getDisplayPriority, sortIntegersNaturallyWithNullsLast))
                         .collect(Collectors.toList());
 
             META: for (ColumnMeta meta : columnMetas) {


### PR DESCRIPTION
@tandraschko Since DisplayPriority is an `Integer` not an `int` have to account for NULLS when i am sorting.  I chose to make if any NULLS are found to make them last...
```java
Comparator<Integer> sortIntegersNaturallyWithNullsLast = Comparator.nullsLast(Comparator.naturalOrder())
```

Although in my examples I could never get this to be NULL but @tuerker can somehow so we must account for it.

