### PR TITLE
Fix #7332: InputMask server validation for 'A'

### DIFF
--- a/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -111,6 +111,9 @@ public class InputMaskRenderer extends InputRenderer {
         else if (c == 'a') {
             translated = "[A-Za-z]";
         }
+        else if (c == 'A') {
+            translated = "[A-Z]";
+        }
         else if (c == '*') {
             translated = "[A-Za-z0-9]";
         }


### PR DESCRIPTION
 Integration Test was failing and now is passing...
```xml
<p:inputMask id="alphanumeric" value="#{inputMask001.alphanumeric}" mask="aa-999-A999" validateMask="true"/>
```

```java
@Test
    @Order(2)
    @DisplayName("InputMask: Alphanumeric mask with valid value")
    public void testAlphanumericValid(final Page page) {
        // Arrange
        final InputMask inputMask = page.alphanumeric;
        Assertions.assertEquals("", inputMask.getValue());

        // Act
        inputMask.setValue("ab-123-c456");
        page.button.click();

        // Assert
        Assertions.assertEquals("ab-123-C456", inputMask.getValue());
        assertConfiguration(inputMask.getWidgetConfiguration(), "aa-999-A999");
    }
```