### PR TITLE
#7336: DataTable: Removed data (rows) remain after update when filtered before

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -527,6 +527,14 @@ public class DataTable extends DataTableBase {
         setScrollOffset(0);
     }
 
+    /**
+     * Recalculates filteredValue (for a non-lazy value) after adding or removing rows to a filtered DataTable
+     */
+    public void reapplyFilter() {
+        FilterFeature filterFeature = (FilterFeature) getFeature(DataTableFeatureKey.FILTER);
+        filterFeature.filter(FacesContext.getCurrentInstance(), this);
+    }
+
     public RowExpansion getRowExpansion() {
         for (int i = 0; i < getChildCount(); i++) {
             UIComponent child = getChildren().get(i);

--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -528,11 +528,13 @@ public class DataTable extends DataTableBase {
     }
 
     /**
-     * Recalculates filteredValue (for a non-lazy value) after adding or removing rows to a filtered DataTable
+     * Recalculates filteredValue (for a non-lazy DataTable eg bound to a java.util.List) after adding, updating or removing rows to/from a filtered DataTable.
      */
-    public void reapplyFilter() {
+    public void filterAndSort() {
         FilterFeature filterFeature = (FilterFeature) getFeature(DataTableFeatureKey.FILTER);
         filterFeature.filter(FacesContext.getCurrentInstance(), this);
+        SortFeature sortFeature = (SortFeature) getFeature(DataTableFeatureKey.SORT);
+        sortFeature.sort(FacesContext.getCurrentInstance(), this);
     }
 
     public RowExpansion getRowExpansion() {


### PR DESCRIPTION
May be called after adding, removing or updating rows.

```java
DataTable dataTable = (DataTable)FacesContext.getCurrentInstance().getViewRoot().findComponent("form:dt-products");
dataTable.reapplyFilter();
```

If we like this, we should add it to docu.

And we need to check corner cases like paging. (eg 10 rows per page, 11 rows in list, user on page 2, we remove row #11, ...)