### PR TITLE
Fix #7325: MultiViewState restore global filter

### DIFF
--- a/src/main/java/org/primefaces/component/api/UITable.java
+++ b/src/main/java/org/primefaces/component/api/UITable.java
@@ -160,7 +160,7 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
             // #7325 restore global filter value
             if (FilterMeta.GLOBAL_FILTER_KEY.equals(entry.getKey())) {
                 UIComponent globalFilterComponent = SearchExpressionFacade
-                            .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_KEY, SearchExpressionUtils.SET_NONE);
+                            .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_COMPONENT_ID, SearchExpressionUtils.SET_NONE);
                 if (globalFilterComponent != null && globalFilterComponent instanceof ValueHolder) {
                     ((ValueHolder) globalFilterComponent).setValue(entry.getValue().getFilterValue());
                 }
@@ -211,7 +211,7 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 ? SearchExpressionUtils.SET_IGNORE_NO_RESULT
                 : SearchExpressionUtils.SET_NONE;
         UIComponent globalFilterComponent = SearchExpressionFacade
-                .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_KEY, hint);
+                .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_COMPONENT_ID, hint);
         if (globalFilterComponent != null) {
             if (globalFilterComponent instanceof ValueHolder) {
                 ((ValueHolder) globalFilterComponent).setValue(globalFilterDefaultValue);

--- a/src/main/java/org/primefaces/component/api/UITable.java
+++ b/src/main/java/org/primefaces/component/api/UITable.java
@@ -58,6 +58,11 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
      */
     Pattern OLD_SYNTAX_COLUMN_PROPERTY_REGEX = Pattern.compile("^#\\{\\w+\\[(.+)]}$");
 
+    /**
+     * ID of the global filter component
+     */
+    String GLOBAL_FILTER_COMPONENT_ID = "globalFilter";
+
     static String resolveStaticField(ValueExpression expression) {
         if (expression != null) {
             String expressionString = expression.getExpressionString();
@@ -160,7 +165,7 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
             // #7325 restore global filter value
             if (FilterMeta.GLOBAL_FILTER_KEY.equals(entry.getKey())) {
                 UIComponent globalFilterComponent = SearchExpressionFacade
-                            .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_COMPONENT_ID, SearchExpressionUtils.SET_NONE);
+                            .resolveComponent(context, (UIComponent) this, GLOBAL_FILTER_COMPONENT_ID, SearchExpressionUtils.SET_NONE);
                 if (globalFilterComponent != null && globalFilterComponent instanceof ValueHolder) {
                     ((ValueHolder) globalFilterComponent).setValue(entry.getValue().getFilterValue());
                 }
@@ -211,7 +216,7 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 ? SearchExpressionUtils.SET_IGNORE_NO_RESULT
                 : SearchExpressionUtils.SET_NONE;
         UIComponent globalFilterComponent = SearchExpressionFacade
-                .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_COMPONENT_ID, hint);
+                .resolveComponent(context, (UIComponent) this, GLOBAL_FILTER_COMPONENT_ID, hint);
         if (globalFilterComponent != null) {
             if (globalFilterComponent instanceof ValueHolder) {
                 ((ValueHolder) globalFilterComponent).setValue(globalFilterDefaultValue);

--- a/src/main/java/org/primefaces/component/api/UITable.java
+++ b/src/main/java/org/primefaces/component/api/UITable.java
@@ -157,6 +157,14 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 intlFilterBy.setFilterValue(tsFilterMeta.getFilterValue());
                 defaultFilter |= intlFilterBy.isActive();
             }
+            // #7325 restore global filter value
+            if (FilterMeta.GLOBAL_FILTER_KEY.equals(entry.getKey())) {
+                UIComponent globalFilterComponent = SearchExpressionFacade
+                            .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_KEY, SearchExpressionUtils.SET_NONE);
+                if (globalFilterComponent != null && globalFilterComponent instanceof ValueHolder) {
+                    ((ValueHolder) globalFilterComponent).setValue(entry.getValue().getFilterValue());
+                }
+            }
         }
 
         setDefaultFilter(defaultFilter);
@@ -203,7 +211,7 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 ? SearchExpressionUtils.SET_IGNORE_NO_RESULT
                 : SearchExpressionUtils.SET_NONE;
         UIComponent globalFilterComponent = SearchExpressionFacade
-                .resolveComponent(context, (UIComponent) this, "globalFilter", hint);
+                .resolveComponent(context, (UIComponent) this, FilterMeta.GLOBAL_FILTER_KEY, hint);
         if (globalFilterComponent != null) {
             if (globalFilterComponent instanceof ValueHolder) {
                 ((ValueHolder) globalFilterComponent).setValue(globalFilterDefaultValue);

--- a/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/src/main/java/org/primefaces/model/FilterMeta.java
@@ -44,7 +44,6 @@ import org.primefaces.component.api.UITable;
 public class FilterMeta implements Serializable {
 
     public static final String GLOBAL_FILTER_KEY = "globalFilter";
-    public static final String GLOBAL_FILTER_COMPONENT_ID = "globalFilter";
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/src/main/java/org/primefaces/model/FilterMeta.java
@@ -44,6 +44,7 @@ import org.primefaces.component.api.UITable;
 public class FilterMeta implements Serializable {
 
     public static final String GLOBAL_FILTER_KEY = "globalFilter";
+    public static final String GLOBAL_FILTER_COMPONENT_ID = "globalFilter";
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Tested using Showcase: https://www.primefaces.org/showcase/ui/data/datatable/multiViewState.xhtml

Type "Argen" for Argentine watch the table get filtered.  Leave the page and come back and the Global Filter has "Argen" in it.