### PR TITLE
Fix #7349: DefaultMenuItem default global=true

### DIFF
--- a/docs/migrationguide/11_0_0.md
+++ b/docs/migrationguide/11_0_0.md
@@ -31,6 +31,9 @@ and you can remove:
 ## Dialog
 - Now `responsive="true"` by default.
 
+## DefaultMenuItem
+- Now `global="true"` by default.
+
 ## Charts
 - Chart.js 2.9.4 was replaced with Chart.js 3.2.1
 - Chart.js comes with breaking changes. When you only work with PrimeFaces-Charts-components and classes most things should work as with PrimeFaces 10.  

--- a/src/main/java/org/primefaces/model/menu/DefaultMenuItem.java
+++ b/src/main/java/org/primefaces/model/menu/DefaultMenuItem.java
@@ -61,7 +61,7 @@ public class DefaultMenuItem implements MenuItem, UIOutcomeTarget, AjaxSource, S
     private String update;
     private String process;
     private boolean partialSubmit;
-    private boolean global;
+    private boolean global = true;
     private boolean async;
     private boolean partialSubmitSet;
     private boolean resetValues;


### PR DESCRIPTION
This makes UIMenuItemBase and DefaultMenuItem have a consistent default.