### PR TITLE
Fix #7352: FileUpload simple mode not registering events

### DIFF
--- a/src/main/resources/META-INF/resources/primefaces/fileupload/3-fileupload.simple.js
+++ b/src/main/resources/META-INF/resources/primefaces/fileupload/3-fileupload.simple.js
@@ -48,7 +48,7 @@ PrimeFaces.widget.SimpleFileUpload = PrimeFaces.widget.BaseWidget.extend({
         this.maxFileSize = this.cfg.maxFileSize;
 
         this.form = this.jq.closest('form');
-        this.input = $(this.jqId + '_input');
+        this.input = $(this.jqId);
 
         if (this.cfg.skinSimple) {
             this.button = this.jq.children('.ui-button');


### PR DESCRIPTION
The input for simple mode is just the ID of the file input which does not have `_input`.