### PR TITLE
Fix #7370: Spinner: PrimeFlex input text align

### DIFF
--- a/docs/10_0_0/gettingstarted/whatsnew.md
+++ b/docs/10_0_0/gettingstarted/whatsnew.md
@@ -30,5 +30,5 @@ This page contains a list of big features. Please check the GitHub issues for al
   * supports JSF 3.0 (Jakarta Server Faces, package jakarta.faces)
   * new context-param `primefaces.CLIENT_SIDE_LOCALISATION` to automatically add client side language JS file
 
-Look into [migration guide](https://primefaces.github.io/primefaces/10_0_0/#/../migrationguide/10_0_0?id=datatable) for more enhancements and changes.
+Look into [migration guide](https://primefaces.github.io/primefaces/10_0_0/#/../migrationguide/10_0_0) for more enhancements and changes.
 Or check the list of 600+ issues closed for [10.0.0-RC1](https://github.com/primefaces/primefaces/milestone/12?closed=1), [10.0.0-RC2](https://github.com/primefaces/primefaces/milestone/17?closed=1) and [10.0.0(-Final)](https://github.com/primefaces/primefaces/milestone/18?closed=1).

--- a/docs/11_0_0/components/spinner.md
+++ b/docs/11_0_0/components/spinner.md
@@ -17,7 +17,7 @@ Spinner is an input component to provide a numerical input via increment and dec
 
 ## Attributes
 
-| Name | Default | Type | Description | 
+| Name | Default | Type | Description |
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
@@ -147,26 +147,29 @@ request is done to update the outputtext with new value whenever a spinner butto
 
 ## Ajax Behavior Events
 
-The following AJAX behavior events are available for this component. If no event is specified the default event is called.  
-  
-**Default Event:** `valueChange`  
-**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`  
+The following AJAX behavior events are available for this component. If no event is specified the default event is called.
+
+**Default Event:** `valueChange`
+**Available Events:** `blur, change, click, contextmenu, copy, cut, dblclick, drag, dragend, dragenter, dragleave, dragover, dragstart, drop, focus, input, invalid, keydown, keypress, keyup, mousedown, mousemove, mouseout, mouseover, mouseup, paste, reset, scroll, search, select, valueChange, wheel`
 
 ```xhtml
 <p:ajax event="valueChange" listener="#{bean.handlevalueChange}" update="msgs" />
 ```
 
 ## Skinning
-Spinner resides in a container element that using _style_ and _styleClass_ applies. Following is the list of
-structural style classes;
+Spinner resides in a container element that using `style` and `styleClass` applies. Following is the list of
+structural style classes:
 
-| Class | Applies | 
-| --- | --- | 
+| Class | Applies |
+| --- | --- |
 .ui-spinner | Main container element of spinner
 .ui-spinner-input | Input field
 .ui-spinner-button | Spinner buttons
 .ui-spinner-button-up | Increment button
 .ui-spinner-button-down | Decrement button
+
+### PrimeFlex
+The PrimeFlex classes `p-text-left`, `p-text-center` and `p-text-right` are supported to align the text of the Spinner input field.
 
 As skinning style classes are global, see the main theming section for more information.
 

--- a/docs/11_0_0/gettingstarted/whatsnew.md
+++ b/docs/11_0_0/gettingstarted/whatsnew.md
@@ -6,6 +6,7 @@ This page contains a list of big features. Please check the GitHub issues for al
 
   * AutoComplete: added `footer` facet which will be added to the suggestion list.
   * InputText, InputTextarea: counter can count bytes instead of characters.
+  * Spinner: support for PrimeFlex `p-text-left`, `p-text-center`, `p-text-right`.
 
-Look into [migration guide](https://primefaces.github.io/primefaces/11_0_0/#/../migrationguide/10_0_0?id=datatable) for more enhancements and changes.
-Or check the list of 600+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0),
+Look into [migration guide](https://primefaces.github.io/primefaces/11_0_0/#/../migrationguide/11_0_0) for more enhancements and changes.
+Or check the list of TODO+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0).

--- a/src/main/resources/META-INF/resources/primefaces/spinner/spinner.css
+++ b/src/main/resources/META-INF/resources/primefaces/spinner/spinner.css
@@ -13,6 +13,15 @@
     box-sizing: border-box;
     width: 100%;
 }
+.ui-spinner.p-text-left .ui-spinner-input {
+    text-align: left;
+}
+.ui-spinner.p-text-center .ui-spinner-input {
+    text-align: center;
+}
+.ui-spinner.p-text-right .ui-spinner-input {
+    text-align: right;
+}
 .ui-spinner-button {
     cursor: default;
     display: block;


### PR DESCRIPTION
Fix #7370.

No showcase, just doc. Tested in `primefaces-test`.

```xhtml
<p:spinner styleClass="p-text-left"/>
```

<img width="236" alt="Screenshot 2021-05-28 at 17 23 33" src="https://user-images.githubusercontent.com/7500178/120006781-85e33300-bfd9-11eb-9031-9b25275c0c9c.png">
