### PR TITLE
#7339 DataTable:filterAndSort - only apply filter (and sort?) when DataTable is already filtered and/or sorted

### DIFF
--- a/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1116,8 +1116,10 @@ public class DataTable extends DataTableBase {
             return;
         }
 
-        FilterFeature filterFeature = (FilterFeature) getFeature(DataTableFeatureKey.FILTER);
-        filterFeature.filter(FacesContext.getCurrentInstance(), this);
+        if (getFilteredValue() != null) {
+            FilterFeature filterFeature = (FilterFeature) getFeature(DataTableFeatureKey.FILTER);
+            filterFeature.filter(FacesContext.getCurrentInstance(), this);
+        }
         SortFeature sortFeature = (SortFeature) getFeature(DataTableFeatureKey.SORT);
         sortFeature.sort(FacesContext.getCurrentInstance(), this);
     }


### PR DESCRIPTION
Not sure how to do this. Just tried something.