### PR TITLE
Fix #7395: Firefox FOUC Fix

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/AgentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/AgentUtils.java
@@ -45,6 +45,10 @@ public class AgentUtils {
         }
     }
 
+    public static boolean isFirefox(FacesContext context) {
+        return userAgentContains(context, "Firefox");
+    }
+
     public static boolean isEdge(FacesContext context) {
         return userAgentContains(context, "Edge");
     }

--- a/primefaces/src/test/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriterTest.java
+++ b/primefaces/src/test/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriterTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import javax.faces.context.ResponseWriter;
 import java.io.IOException;
@@ -52,6 +53,8 @@ public class MoveScriptsToBottomResponseWriterTest {
         wrappedWriter = mock(ResponseWriter.class);
         state = new MoveScriptsToBottomState();
         writer = new MoveScriptsToBottomResponseWriter(wrappedWriter, state);
+        writer = Mockito.spy(writer);
+        Mockito.doReturn(Boolean.FALSE).when(writer).isFirefox();
     }
 
     @Test


### PR DESCRIPTION
Renders `<body><script>/*FIREFOX_FOUC_FIX*/</script>` right after the BODY tag only if browser is Firefox.