### PR TITLE
Fix #7391: Datatable encode selected row keys

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable004.java
@@ -61,12 +61,17 @@ public class DataTable004 implements Serializable {
         TestUtils.addMessage("ProgrammingLanguage Unselected", event.getObject().getId() + " - " + event.getObject().getName());
     }
 
+    public void unselectRow() {
+        selectedProgLanguage = null;
+        TestUtils.addMessage("NO ProgrammingLanguage selected", "");
+    }
+
     public void submit() {
         if (selectedProgLanguage != null) {
             TestUtils.addMessage("Selected ProgrammingLanguage", selectedProgLanguage.getId() + " - " + selectedProgLanguage.getName());
         }
         else {
-            TestUtils.addMessage("no ProgrammingLanguage selected", "");
+            TestUtils.addMessage("NO ProgrammingLanguage selected", "");
         }
     }
 }

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable004.xhtml
@@ -39,6 +39,7 @@
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable004.submit}"/>
             <p:commandButton id="buttonMsgOnly" value="Submit - update card only" process="form:datatable" update="form:card"/>
+            <p:commandButton id="buttonUnselect" value="Unselect" update="@form" action="#{dataTable004.unselectRow}"/>
 
             <p:card id="card" style="width: 25rem; margin-top: 2em">
                 <f:facet name="title">
@@ -48,7 +49,7 @@
                     #{dataTable004.selectedProgLanguage.name}
                 </p:outputPanel>
                 <p:outputPanel rendered="#{empty dataTable004.selectedProgLanguage}">
-                    no ProgrammingLanguage selected
+                    NO ProgrammingLanguage selected
                 </p:outputPanel>
             </p:card>
         </h:form>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable004Test.java
@@ -82,8 +82,8 @@ public class DataTable004Test extends AbstractDataTableTest {
         page.button.click();
 
         // Assert (no row selected)
-        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected")));
-        assertMessage(page, "no ProgrammingLanguage selected", "");
+        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected"), "Found a selected row!"));
+        assertMessage(page, "NO ProgrammingLanguage selected", "");
         assertConfiguration(dataTable.getWidgetConfiguration());
     }
 
@@ -100,7 +100,7 @@ public class DataTable004Test extends AbstractDataTableTest {
         page.buttonMsgOnly.click();
 
         // Assert
-        WebElement card = page.getWebDriver().findElement(By.id("form:card"));
+        WebElement card = page.card;
         Assertions.assertTrue(card.getText().contains(languages.get(2).getName()));
 
         // Act - unselect row
@@ -109,9 +109,34 @@ public class DataTable004Test extends AbstractDataTableTest {
         page.buttonMsgOnly.click();
 
         // Assert (no row selected)
-        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected")));
-        card = page.getWebDriver().findElement(By.id("form:card"));
-        Assertions.assertTrue(card.getText().contains("no ProgrammingLanguage selected"));
+        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected"), "Found a selected row!"));
+        Assertions.assertTrue(card.getText().contains("NO ProgrammingLanguage selected"));
+        assertConfiguration(dataTable.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("DataTable: selection - single - unselect programmatically; https://github.com/primefaces/primefaces/issues/7391")
+    public void testSelectionSingleUnselectProgrammatically(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        Assertions.assertNotNull(dataTable);
+
+        // Act
+        dataTable.getCell(2, 0).getWebElement().click();
+        page.buttonMsgOnly.click();
+
+        // Assert
+        WebElement card = page.card;
+        Assertions.assertTrue(card.getText().contains(languages.get(2).getName()));
+
+        // Act - unselect row programmatically
+        page.buttonUnselect.click();
+
+        // Assert (no row selected)
+        assertMessage(page, "NO ProgrammingLanguage selected", "");
+        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected"), "Found a selected row!"));
+        Assertions.assertTrue(card.getText().contains("NO ProgrammingLanguage selected"));
         assertConfiguration(dataTable.getWidgetConfiguration());
     }
 
@@ -138,6 +163,12 @@ public class DataTable004Test extends AbstractDataTableTest {
 
         @FindBy(id = "form:buttonMsgOnly")
         CommandButton buttonMsgOnly;
+
+        @FindBy(id = "form:buttonUnselect")
+        CommandButton buttonUnselect;
+
+        @FindBy(id = "form:card")
+        WebElement card;
 
         @Override
         public String getLocation() {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/SelectionFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/SelectionFeature.java
@@ -82,12 +82,13 @@ public class SelectionFeature implements DataTableFeature {
     }
 
     public void decodeSelectionRowKeys(FacesContext context, DataTable table) {
+        Set<String> rowKeys = null;
         ValueExpression selectionByVE = table.getValueExpression(DataTableBase.PropertyKeys.selection.name());
         if (selectionByVE != null) {
             Object selection = selectionByVE.getValue(context.getELContext());
 
             if (selection != null) {
-                Set<String> rowKeys = new HashSet<>();
+                rowKeys = new HashSet<>();
 
                 if (table.isSingleSelectionMode()) {
                     rowKeys.add(table.getRowKey(selection));
@@ -106,10 +107,9 @@ public class SelectionFeature implements DataTableFeature {
                         rowKeys.add(table.getRowKey(o));
                     }
                 }
-
-                table.setSelectedRowKeys(rowKeys);
             }
         }
+        table.setSelectedRowKeys(rowKeys);
     }
 
     protected void decodeSingleSelection(FacesContext context, DataTable table, Set<String> rowKeys) {


### PR DESCRIPTION
Failing test proving the issue

```
DataTable004Test.testSelectionSingleUnselectProgrammatically:
138->lambda$testSelectionSingleUnselectProgrammatically$2:138 Found a selected row! ==> expected: <false> but was: <true>
```