### PR TITLE
Fix #7413 - DataTable: Column FilterFunction not being called

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
@@ -25,6 +25,7 @@ package org.primefaces.model;
 
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
+import org.primefaces.component.api.UITable;
 import org.primefaces.component.column.ColumnBase;
 import org.primefaces.component.datatable.feature.FilterFeature;
 import org.primefaces.model.filter.FilterConstraint;
@@ -35,11 +36,8 @@ import javax.el.ELContext;
 import javax.el.MethodExpression;
 import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Objects;
-import org.primefaces.component.api.UITable;
 
 public class FilterMeta implements Serializable {
 

--- a/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
@@ -52,7 +52,7 @@ public class FilterMeta implements Serializable {
     private ValueExpression filterBy;
     private Object filterValue;
     private MatchMode matchMode = MatchMode.CONTAINS;
-    private transient FilterConstraint constraint;
+    private FilterConstraint constraint;
 
     public FilterMeta() {
         // NOOP
@@ -272,14 +272,5 @@ public class FilterMeta implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(field, columnKey);
-    }
-
-    private void readObject(ObjectInputStream is) throws ClassNotFoundException, IOException {
-        is.defaultReadObject();
-
-        FilterConstraint c = FilterFeature.FILTER_CONSTRAINTS.get(matchMode);
-        if (c != null) {
-            this.constraint = c;
-        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/ComparableFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/ComparableFilterConstraint.java
@@ -25,13 +25,8 @@ package org.primefaces.model.filter;
 
 import javax.faces.context.FacesContext;
 import java.util.Locale;
-import java.util.function.BiPredicate;
 
-public class ComparableFilterConstraint extends StringFilterConstraint {
-
-    public ComparableFilterConstraint(BiPredicate<String, String> predicate) {
-        super(predicate);
-    }
+public abstract class ComparableFilterConstraint extends StringFilterConstraint {
 
     @Override
     public boolean isMatching(FacesContext ctxt, Object value, Object filter, Locale locale) {

--- a/primefaces/src/main/java/org/primefaces/model/filter/ContainsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/ContainsFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class ContainsFilterConstraint extends StringFilterConstraint {
 
-    public ContainsFilterConstraint() {
-        super(String::contains);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return String::contains;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/EndsWithFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/EndsWithFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class EndsWithFilterConstraint extends StringFilterConstraint {
 
-    public EndsWithFilterConstraint() {
-        super(String::endsWith);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return String::endsWith;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class EqualsFilterConstraint extends StringFilterConstraint {
 
-    public EqualsFilterConstraint() {
-        super(String::equals);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return String::equals;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class ExactFilterConstraint extends StringFilterConstraint {
 
-    public ExactFilterConstraint() {
-        super(String::equalsIgnoreCase);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return String::equalsIgnoreCase;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/FilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/FilterConstraint.java
@@ -24,10 +24,11 @@
 package org.primefaces.model.filter;
 
 import javax.faces.context.FacesContext;
+import java.io.Serializable;
 import java.util.Locale;
 
 @FunctionalInterface
-public interface FilterConstraint {
+public interface FilterConstraint extends Serializable {
 
     boolean isMatching(FacesContext ctxt, Object value, Object filter, Locale locale);
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/GlobalFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/GlobalFilterConstraint.java
@@ -26,6 +26,7 @@ package org.primefaces.model.filter;
 public class GlobalFilterConstraint extends ContainsFilterConstraint {
 
     public GlobalFilterConstraint() {
+        // NOOP
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/GreaterThanEqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/GreaterThanEqualsFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class GreaterThanEqualsFilterConstraint extends ComparableFilterConstraint {
 
-    public GreaterThanEqualsFilterConstraint() {
-        super((o1, o2) -> o1.compareTo(o2) == 0);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return (o1, o2) -> o1.compareTo(o2) == 0;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/GreaterThanFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/GreaterThanFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class GreaterThanFilterConstraint extends ComparableFilterConstraint {
 
-    public GreaterThanFilterConstraint() {
-        super((o1, o2) -> o1.compareTo(o2) > 0);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return (o1, o2) -> o1.compareTo(o2) > 0;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/LessThanEqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/LessThanEqualsFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class LessThanEqualsFilterConstraint extends ComparableFilterConstraint {
 
-    public LessThanEqualsFilterConstraint() {
-        super((o1, o2) -> o1.compareTo(o2) <= 0);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return (o1, o2) -> o1.compareTo(o2) <= 0;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/LessThanFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/LessThanFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class LessThanFilterConstraint extends ComparableFilterConstraint {
 
-    public LessThanFilterConstraint() {
-        super((o1, o2) -> o1.compareTo(o2) < 0);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return (o1, o2) -> o1.compareTo(o2) < 0;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/StartsWithFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/StartsWithFilterConstraint.java
@@ -23,9 +23,12 @@
  */
 package org.primefaces.model.filter;
 
+import java.util.function.BiPredicate;
+
 public class StartsWithFilterConstraint extends StringFilterConstraint {
 
-    public StartsWithFilterConstraint() {
-        super(String::startsWith);
+    @Override
+    protected BiPredicate<String, String> getPredicate() {
+        return String::startsWith;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/StringFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/StringFilterConstraint.java
@@ -25,20 +25,20 @@ package org.primefaces.model.filter;
 
 import javax.faces.context.FacesContext;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.BiPredicate;
 
-public class StringFilterConstraint implements FilterConstraint {
-
-    private BiPredicate<String, String> predicate;
-
-    public StringFilterConstraint(BiPredicate<String, String> predicate) {
-        this.predicate = predicate;
-    }
+public abstract class StringFilterConstraint implements FilterConstraint {
 
     @Override
     public boolean isMatching(FacesContext ctxt, Object value, Object filter, Locale locale) {
+        BiPredicate<String, String> predicate = getPredicate();
+        Objects.requireNonNull(predicate);
+
         String str = filter == null ? null : filter.toString().trim().toLowerCase(locale);
         String val = value == null ? null : value.toString().toLowerCase(locale);
         return val != null && predicate.test(val, str);
     }
+
+    protected abstract BiPredicate<String, String> getPredicate();
 }


### PR DESCRIPTION
`FilterMeta#constraint` gets lost after deserialization as it is transient, then `FilterConstraint` must be serializable (as of today, only built-in constraint were retrieved after deserializaton)