### PR TITLE
Fix #7486: AutoComplete unique keep list order

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/autocomplete/AutoComplete003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/autocomplete/AutoComplete003Test.java
@@ -60,9 +60,9 @@ public class AutoComplete003Test extends AbstractPrimePageTest {
         // Assert
         values = autoComplete.getValues();
         Assertions.assertEquals(3, values.size());
-        Assertions.assertEquals("George", values.get(0));
+        Assertions.assertEquals("Ringo", values.get(0));
         Assertions.assertEquals("John", values.get(1));
-        Assertions.assertEquals("Ringo", values.get(2));
+        Assertions.assertEquals("George", values.get(2));
         assertConfiguration(autoComplete.getWidgetConfiguration());
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -413,7 +413,7 @@ public class AutoCompleteRenderer extends InputRenderer {
             String var = ac.getVar();
             boolean pojo = var != null;
 
-            Collection<Object> items = ac.isUnique() ? new HashSet<>(values) : values;
+            Collection<Object> items = ac.isUnique() ? new LinkedHashSet<>(values) : values;
             for (Object value : items) {
                 Object itemValue = null;
                 String itemLabel = null;


### PR DESCRIPTION
We already had an integration test proving the problem and didn't realize it!  So I updated the integration test which now proves the order is the same as added to the list.