### PR TITLE
Fix #7448: added milliseconds to datepicker

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker004.java
@@ -39,12 +39,15 @@ public class DatePicker004 implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    private LocalDateTime localDateTimeMilliseconds;
+
     private LocalDateTime localDateTimeSeconds;
 
     private LocalDateTime localDateTimeHours;
 
     @PostConstruct
     public void init() {
+        localDateTimeMilliseconds = LocalDateTime.of(2021, 6, 25, 23, 22, 21, 19_000_000);
         localDateTimeSeconds = LocalDateTime.of(2020, 8, 20, 22, 20, 19);
         localDateTimeHours = LocalDateTime.of(2020, 10, 31, 13, 13, 13);
     }

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker004.xhtml
@@ -29,6 +29,15 @@
                           showButtonBar="true"/>
             <p:commandButton id="btnSeconds" value="Seconds" update="@form"/>
         </h:form>
+        <br/>
+        <h:form id="form3">
+            <!-- #7448 showMilliseconds="true" automatically detected because of pattern contains 'S'-->
+            <p:datePicker id="dpMilliseconds"
+                          value="#{datePicker004.localDateTimeMilliseconds}"
+                          pattern="MM/dd/yyyy HH:mm:ss.SSS"
+                          showButtonBar="true"/>
+            <p:commandButton id="btnMilliseconds" value="Milliseconds" update="@form"/>
+        </h:form>
 
     </h:body>
 </f:view>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/AbstractDatePickerTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/AbstractDatePickerTest.java
@@ -45,11 +45,16 @@ public class AbstractDatePickerTest extends AbstractPrimePageTest {
     }
 
     protected void assertTime(WebElement panel, String hours, String minutes, String seconds) {
+        assertTime(panel, hours, minutes, seconds, null);
+    }
+
+    protected void assertTime(WebElement panel, String hours, String minutes, String seconds, String milliseconds) {
         Assertions.assertNotNull(panel);
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
         WebElement timePicker = panel.findElement(By.className("ui-timepicker"));
         if (hours != null) {
-            Assertions.assertEquals(Integer.parseInt(hours), Integer.parseInt(timePicker.findElement(By.cssSelector("div.ui-hour-picker > span")).getText()));
+            Assertions.assertEquals(Integer.parseInt(hours),
+                        Integer.parseInt(timePicker.findElement(By.cssSelector("div.ui-hour-picker > span")).getText()));
         }
         if (minutes != null) {
             Assertions.assertEquals(Integer.parseInt(minutes),
@@ -58,6 +63,10 @@ public class AbstractDatePickerTest extends AbstractPrimePageTest {
         if (seconds != null) {
             Assertions.assertEquals(Integer.parseInt(seconds),
                         Integer.parseInt(timePicker.findElement(By.cssSelector("div.ui-second-picker > span")).getText()));
+        }
+        if (milliseconds != null) {
+            Assertions.assertEquals(Integer.parseInt(milliseconds),
+                        Integer.parseInt(timePicker.findElement(By.cssSelector("div.ui-millisecond-picker > span")).getText()));
         }
     }
 }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker004Test.java
@@ -170,10 +170,92 @@ public class DatePicker004Test extends AbstractDatePickerTest {
         panel = datePicker.showPanel();
         datePicker.getTodayButton().click();
 
-        // Assert - clear button reset to NOW
+        // Assert - today button reset to NOW
         LocalDateTime now = LocalDateTime.now();
         assertDate(panel, now.getMonth().name(), Objects.toString(now.getYear()));
         assertTime(panel, "22", "20", "19");
+        Assertions.assertNotNull(datePicker.getValue());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("DatePicker: GitHub #7448 date with time HH:mm:ss.SSS.")
+    public void testDateAndTimeWithMilliseconds(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePickerMilliseconds;
+        Assertions.assertEquals(LocalDateTime.of(2021, 6, 25, 23, 22, 21, 19_000_000), datePicker.getValue());
+        LocalDateTime value = LocalDateTime.of(1979, 3, 14, 13, 12, 11, 123_000_000);
+
+        // Act
+        datePicker.setValue(value);
+        WebElement panel = datePicker.showPanel(); // focus to bring up panel
+
+        // Assert Panel
+        assertDate(panel, "March", "1979");
+        assertTime(panel, "13", "12", "11", "123");
+        datePicker.hidePanel();
+
+        // Assert Submit Value
+        page.submitMilliseconds.click();
+        LocalDateTime newValue = datePicker.getValue();
+        Assertions.assertEquals(value, newValue);
+        // #6459 showTime="true" automatically detected because of LocalDateTime
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss.SSS");
+        assertConfiguration(datePicker.getWidgetConfiguration(), newValue.format(dateTimeFormatter));
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("DatePicker: GitHub #7448 Clear button must clear everything.")
+    public void testClearButtonMilliseconds(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePickerMilliseconds;
+        Assertions.assertEquals(LocalDateTime.of(2021, 6, 25, 23, 22, 21, 19_000_000), datePicker.getValue());
+
+        // Act
+        WebElement panel = datePicker.showPanel();
+
+        // Assert Panel
+        assertDate(panel, "June", "2021");
+        assertTime(panel, "23", "22", "21", "019");
+        datePicker.hidePanel();
+
+        // Act - click Clear button
+        panel = datePicker.showPanel();
+        LocalDateTime now = LocalDateTime.now();
+        datePicker.getClearButton().click();
+
+        // Assert - clear button reset to NOW
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(panel));
+        assertDate(panel, now.getMonth().name(), Objects.toString(now.getYear()));
+        assertTime(panel, Objects.toString(now.getHour()), null, null);
+        Assertions.assertNull(datePicker.getValue());
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("DatePicker: GitHub #7448 Today button must set to now.")
+    public void testTodayButtonMilliseconds(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePickerMilliseconds;
+        Assertions.assertEquals(LocalDateTime.of(2021, 6, 25, 23, 22, 21, 19_000_000), datePicker.getValue());
+
+        // Act
+        WebElement panel = datePicker.showPanel();
+
+        // Assert Panel
+        assertDate(panel, "June", "2021");
+        assertTime(panel, "23", "22", "21", "019");
+        datePicker.hidePanel();
+
+        // Act - click Today button
+        panel = datePicker.showPanel();
+        datePicker.getTodayButton().click();
+
+        // Assert - today button reset to NOW
+        LocalDateTime now = LocalDateTime.now();
+        assertDate(panel, now.getMonth().name(), Objects.toString(now.getYear()));
+        assertTime(panel, "23", "22", "21", "019");
         Assertions.assertNotNull(datePicker.getValue());
     }
 
@@ -200,6 +282,12 @@ public class DatePicker004Test extends AbstractDatePickerTest {
 
         @FindBy(id = "form2:btnSeconds")
         CommandButton submitSeconds;
+
+        @FindBy(id = "form3:dpMilliseconds")
+        DatePicker datePickerMilliseconds;
+
+        @FindBy(id = "form3:btnMilliseconds")
+        CommandButton submitMilliseconds;
 
         @Override
         public String getLocation() {

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
@@ -23,11 +23,10 @@
  */
 package org.primefaces.selenium.component;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -159,12 +158,9 @@ public abstract class DatePicker extends AbstractInputComponent {
             return null;
         }
 
-        String utcTimeString = PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".getDate().toUTCString();");
-
-        // Parse time string and move into server-timezone
-        LocalDateTime dateTime = LocalDateTime.parse(utcTimeString, DateTimeFormatter.RFC_1123_DATE_TIME);
-        dateTime = LocalDateTime.ofInstant(dateTime.toInstant(ZoneOffset.UTC), ZoneId.systemDefault());
-
+        Number epoch = PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".getDate().getTime();");
+        // Move epoch into server-timezone
+        LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(epoch.longValue()), ZoneId.systemDefault());
         return dateTime;
     }
 

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
@@ -67,6 +67,7 @@ public class CalendarJava8View implements Serializable {
     private LocalTime time6;
     private LocalTime time7;
     private LocalTime time8;
+    private LocalTime time9;
     private LocalDateTime dateTime1;
     @Future
     private LocalDateTime dateTime2;
@@ -485,5 +486,13 @@ public class CalendarJava8View implements Serializable {
 
     public void setTime8(LocalTime time8) {
         this.time8 = time8;
+    }
+
+    public LocalTime getTime9() {
+        return time9;
+    }
+
+    public void setTime9(LocalTime time9) {
+        this.time9 = time9;
     }
 }

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarView.java
@@ -61,6 +61,7 @@ public class CalendarView implements Serializable {
     private Date date15;
     private Date date16;
     private Date dateTimeDe;
+    private Date dateTimeMillis;
     private List<Date> multi;
     private List<Date> range;
     private List<Date> invalidDates;
@@ -109,6 +110,7 @@ public class CalendarView implements Serializable {
 
         dateDe = GregorianCalendar.getInstance().getTime();
         dateTimeDe = GregorianCalendar.getInstance().getTime();
+        dateTimeMillis = GregorianCalendar.getInstance().getTime();
     }
 
     public void onDateSelect(SelectEvent<Date> event) {
@@ -304,6 +306,14 @@ public class CalendarView implements Serializable {
 
     public void setDateDe(Date dateDe) {
         this.dateDe = dateDe;
+    }
+
+    public Date getDateTimeMillis() {
+        return dateTimeMillis;
+    }
+
+    public void setDateTimeMillis(Date dateTimeMillis) {
+        this.dateTimeMillis = dateTimeMillis;
     }
 
     public Date getDate15() {

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
@@ -26,6 +26,7 @@
                 hourText: 'Hora',
                 minuteText: 'Minuto',
                 secondText: 'Segundo',
+                millisecondText: 'Milisegundo',
                 currentText: 'Fecha actual',
                 ampm: false,
                 month: 'Mes',
@@ -54,6 +55,7 @@
                 hourText: 'Stunde',
                 minuteText: 'Minute',
                 secondText: 'Sekunde',
+                millisecondText: 'Millisekunde',
                 currentText: 'Aktuelles Datum',
                 ampm: false,
                 month: 'Monat',
@@ -208,6 +210,12 @@
                         <p:outputLabel for="timeonlyMinMax" value="Time Only (Min-Max)"/>
                         <p:datePicker id="timeonlyMinMax" value="#{calendarView.date15}" timeOnly="true" pattern="HH:mm"
                                   mindate="#{calendarView.minTime}" maxdate="#{calendarView.maxTime}"/>
+                    </div>
+
+                    <div class="p-field p-col-12 p-md-4">
+                        <p:outputLabel for="timeonlyMillis" value="Time Only with seconds and milliseconds"/>
+                        <p:datePicker id="timeonlyMillis" value="#{calendarView.date15}" timeOnly="true"
+                                      pattern="HH:mm:ss.SSS" showSeconds="true" showMilliseconds="true"/>
                     </div>
                 </div>
 

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -26,6 +26,7 @@
                 hourText: 'Hora',
                 minuteText: 'Minuto',
                 secondText: 'Segundo',
+                millisecondText: 'Milisegundo',
                 currentText: 'Fecha actual',
                 ampm: false,
                 month: 'Mes',
@@ -54,6 +55,7 @@
                 hourText: 'Stunde',
                 minuteText: 'Minute',
                 secondText: 'Sekunde',
+                millisecondText: 'Millisekunde',
                 currentText: 'Aktuelles Datum',
                 ampm: false,
                 month: 'Monat',
@@ -325,6 +327,12 @@
                     <div class="p-field p-col-12 p-md-4">
                         <p:outputLabel for="timeonly8" value="Time Only (with timeInput)"/>
                         <p:datePicker id="timeonly8" value="#{calendarJava8View.time8}" timeInput="true"/>
+                    </div>
+
+                    <div class="p-field p-col-12 p-md-4">
+                        <p:outputLabel for="timeonlyMilliseconds" value="Time Only (HH:mm:ss.SSS)"/>
+                        <p:datePicker id="timeonlyMilliseconds" value="#{calendarJava8View.time9}"
+                                      showSeconds="true" showMilliseconds="true" pattern="HH:mm:ss.SSS"/>
                     </div>
                 </div>
             </div>

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -23,6 +23,7 @@
  */
 package org.primefaces.component.datepicker;
 
+import java.text.DecimalFormat;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
@@ -42,6 +43,7 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
     public static final String DEFAULT_RENDERER = "org.primefaces.component.DatePickerRenderer";
 
     protected String timeSeparator;
+    protected String fractionSeparator;
 
     public enum PropertyKeys {
 
@@ -64,9 +66,11 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         showTime,
         hourFormat,
         showSeconds,
+        showMilliseconds,
         stepHour,
         stepMinute,
         stepSecond,
+        stepMillisecond,
         showButtonBar,
         panelStyleClass,
         panelStyle,
@@ -251,6 +255,18 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         getStateHelper().put(PropertyKeys.showSeconds, showSeconds);
     }
 
+    public boolean isShowMilliseconds() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.showMilliseconds, false);
+    }
+
+    public Boolean isShowMillisecondsWithoutDefault() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.showMilliseconds);
+    }
+
+    public void setShowMilliseconds(boolean showMilliseconds) {
+        getStateHelper().put(PropertyKeys.showMilliseconds, showMilliseconds);
+    }
+
     public int getStepHour() {
         return (Integer) getStateHelper().eval(PropertyKeys.stepHour, 1);
     }
@@ -273,6 +289,14 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
 
     public void setStepSecond(int stepSecond) {
         getStateHelper().put(PropertyKeys.stepSecond, stepSecond);
+    }
+
+    public int getStepMillisecond() {
+        return (Integer) getStateHelper().eval(PropertyKeys.stepMillisecond, 1);
+    }
+
+    public void setStepMillisecond(int stepMillisecond) {
+        getStateHelper().put(PropertyKeys.stepMillisecond, stepMillisecond);
     }
 
     public boolean isShowButtonBar() {
@@ -463,8 +487,12 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
             boolean ampm = "12".equals(getHourFormat());
             timeOnlyPattern = ampm ? "hh" : "HH";
             timeOnlyPattern += (separator + "mm");
-            if (isShowSeconds()) {
+            if (isShowSeconds() || isShowMilliseconds()) {
                 timeOnlyPattern += (separator + "ss");
+            }
+            if (isShowMilliseconds()) {
+                String fractSeparator = getFractionSeparator();
+                timeOnlyPattern += (fractSeparator + "SSS");
             }
             if (ampm) {
                 timeOnlyPattern += " a";
@@ -483,6 +511,13 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         return timeSeparator;
     }
 
-
-
+    public String getFractionSeparator() {
+        if (fractionSeparator == null) {
+            // Determine separator for locale
+            Locale locale = calculateLocale(getFacesContext());
+            char ds = ((DecimalFormat) DecimalFormat.getInstance(locale)).getDecimalFormatSymbols().getDecimalSeparator();
+            fractionSeparator = Character.toString(ds);
+        }
+        return fractionSeparator;
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -83,7 +83,11 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
         }
 
         if (datePicker.isShowSecondsWithoutDefault() == null) {
-            datePicker.setShowSeconds(pattern.contains("s"));
+            datePicker.setShowSeconds(pattern.contains("s") || pattern.contains("S"));
+        }
+
+        if (datePicker.isShowMillisecondsWithoutDefault() == null) {
+            datePicker.setShowMilliseconds(pattern.contains("S"));
         }
 
         super.encodeEnd(context, component);
@@ -198,6 +202,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("icon", datePicker.getTriggerButtonIcon(), null)
             .attr("rangeSeparator", datePicker.getRangeSeparator(), "-")
             .attr("timeSeparator", datePicker.getTimeSeparator(), ":")
+            .attr("fractionSeparator", datePicker.getFractionSeparator(), ".")
             .attr("timeInput", datePicker.isTimeInput())
             .attr("touchable", ComponentUtils.isTouchable(context, datePicker), true)
             .attr("lazyModel", datePicker.getModel() instanceof LazyDateMetadataModel, false);
@@ -248,9 +253,11 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
                 .attr("hourFormat", datePicker.getHourFormat(), null)
                 .attr("timeOnly", datePicker.isTimeOnly(), false)
                 .attr("showSeconds", datePicker.isShowSeconds(), false)
+                .attr("showMilliseconds", datePicker.isShowMilliseconds(), false)
                 .attr("stepHour", datePicker.getStepHour(), 1)
                 .attr("stepMinute", datePicker.getStepMinute(), 1)
                 .attr("stepSecond", datePicker.getStepSecond(), 1)
+                .attr("stepMillisecond", datePicker.getStepSecond(), 1)
                 .attr("hideOnDateTimeSelect", datePicker.isHideOnDateTimeSelect(), false);
         }
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -31739,6 +31739,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Whether to show the milliseconds in time picker. Default is false.]]>
+            </description>
+            <name>showMilliseconds</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Hours to change per step. Default is 1.]]>
             </description>
             <name>stepHour</name>
@@ -31758,6 +31766,14 @@
                 <![CDATA[Seconds to change per step. Default is 1.]]>
             </description>
             <name>stepSecond</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Milliseconds to change per step. Default is 1.]]>
+            </description>
+            <name>stepMillisecond</name>
             <required>false</required>
             <type>java.lang.Integer</type>
         </attribute>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1344,6 +1344,7 @@
             hourText: 'Hour',
             minuteText: 'Minute',
             secondText: 'Second',
+            millisecondText: 'Millisecond',
             currentText: 'Current Date',
             ampm: false,
             year: 'Year',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.d.ts
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.d.ts
@@ -39,8 +39,10 @@ declare namespace JQueryPrimeDatePicker {
      * - `0`: Changes the hour.
      * - `1`: Changes the minutes.
      * - `2`: Changes the second.
+     * - `3`: Changes the millisecond.
+     * - `4`: Changes the half day period.
      */
-    export type ChangeTimeType = -1 | 0 | 1 | 2;
+    export type ChangeTimeType = -1 | 0 | 1 | 2 | 3 | 4;
 
     /**
      * Represents a one dimensional direction:
@@ -137,6 +139,11 @@ declare namespace JQueryPrimeDatePicker {
     export type SecondOfTheMinute = number;
 
     /**
+     * Integer value representing the millisecond segment of a time. `0` represents 0 milliseconds past the second.
+     */
+    export type MillisecondOfTheSecond = number;
+
+    /**
      * Represents the time of a day.
      */
     export interface TimeOfTheDay {
@@ -154,6 +161,11 @@ declare namespace JQueryPrimeDatePicker {
          * The second of the minute, between 0 and 59.
          */
         second: SecondOfTheMinute;
+
+        /**
+         * The millisecond of the second, between 0 and 999.
+         */
+        millisecond: MillisecondOfTheSecond;
     }
 
     // Instants representing an instant in time (to a certain precision)
@@ -427,6 +439,11 @@ declare namespace JQueryPrimeDatePicker {
         showSeconds: boolean;
 
         /**
+         * Whether to show the milliseconds in time picker. Default is `false`.
+         */
+        showMilliseconds: boolean;
+
+        /**
          * Defines the hour format, either 12 hour mode or 24 hour mode.
          */
         hourFormat: ClockConvention;
@@ -445,6 +462,11 @@ declare namespace JQueryPrimeDatePicker {
          * Second steps.
          */
         stepSecond: Cardinal;
+
+        /**
+         * Millisecond steps.
+         */
+        stepMillisecond: Cardinal;
 
         /**
          * The cutoff year for determining the century for a date. Any dates entered with a year value less than or
@@ -718,7 +740,7 @@ declare namespace JQueryPrimeDatePicker {
          * of time: repeatedly increment the minute or hour.
          * @param event Event that occurred, such as a click event.
          * @param interval Amount of time between successive increments.
-         * @param type Which part of the time is to be incremented or decremented (hour, minute, or second).
+         * @param type Which part of the time is to be incremented or decremented (hour, minute, second, or millisecond).
          * @param direction Whether to increment or decrement the time part.
          */
         repeat(event: JQuery.TriggeredEvent, interval: Cardinal, type: ChangeTimeType, direction: OneDimensionalDirection): void;
@@ -729,8 +751,9 @@ declare namespace JQueryPrimeDatePicker {
          * @param hour Current hour.
          * @param minute Current minute.
          * @param second Current second.
+         * @param millisecond Current millisecond.
          */
-        updateTime(event: JQuery.TriggeredEvent, hour: HourOfTheDay, minute: MinuteOfTheHour, second: SecondOfTheMinute): void;
+        updateTime(event: JQuery.TriggeredEvent, hour: HourOfTheDay, minute: MinuteOfTheHour, second: SecondOfTheMinute, millsecond: MillisecondOfTheSecond): void;
 
         /**
          * After a time was entered, updates the time display so that is shows the given time.
@@ -1047,7 +1070,7 @@ declare namespace JQueryPrimeDatePicker {
 
         daylightSavingAdjust(date: Date): Date;
         populateTime(value: Date, timeString: string, ampm?: HalfDayPeriod): void;
-        validateTime(hour: HourOfTheDay, minute: MinuteOfTheHour, second: SecondOfTheMinute, value: Date, direction: AlterationMode): boolean;
+        validateTime(hour: HourOfTheDay, minute: MinuteOfTheHour, second: SecondOfTheMinute, millisecond: MillisecondOfTheSecond, value: Date, direction: AlterationMode): boolean;
 
         // =================
         // === Rendering ===
@@ -1232,6 +1255,12 @@ declare namespace JQueryPrimeDatePicker {
         renderSecondPicker(): string;
 
         /**
+         * Creates the HTML snippet for the millisecond picker for selecting a millisecond.
+         * @return The rendered HTML snippet.
+         */
+        renderMillisecondPicker(): string;
+
+        /**
          * Creates the HTML snippet for the picker that lets the user choose between `a.m.` and `p.m.`.
          * @return The rendered HTML snippet.
          */
@@ -1244,22 +1273,28 @@ declare namespace JQueryPrimeDatePicker {
         renderSeparator(): string;
 
         /**
+         * Creates the HTML snippet for separator before fractional seconds (such as a dot).
+         * @return The rendered HTML snippet.
+         */
+        renderFractionSeparator(): string;
+
+        /**
          * Creates the HTML snippet for container with the up and down button.
          * @param containerClass Style class for the container.
          * @param text Text to shown in the time element container.
-         * @param type Whether to render the time elements of a hour, minute, or second.
+         * @param type Whether to render the time elements of a hour, minute, second, or millisecond.
          * @return The rendered HTML snippet.
          */
         renderTimeElements(containerClass: string, text: string, type: ChangeTimeType): string;
 
         /**
-         * Creates the HTML snippet for the button to increment the hour, minutes, or second.
+         * Creates the HTML snippet for the button to increment the hour, minutes, second, or millisecond.
          * @return The rendered HTML snippet.
          */
         renderTimePickerUpButton(): string;
 
         /**
-         * Creates the HTML snippet for the button to decrement the hour, minutes, or second.
+         * Creates the HTML snippet for the button to decrement the hour, minutes, second, or millisecond.
          * @return The rendered HTML snippet.
          */
         renderTimePickerDownButton(): string;
@@ -1343,7 +1378,7 @@ declare namespace JQueryPrimeDatePicker {
          * Callback that is invoked when the left mouse button was pressed down while the cursor is over the time picker
          * element.
          * @param event Event that occurred.
-         * @param type Whether the hour, minute, or second was clicked.
+         * @param type Whether the hour, minute, second, or millisecond was clicked.
          * @param direction Whether the up or down button was clicked.
          */
         onTimePickerElementMouseDown(event: JQuery.TriggeredEvent, type: ChangeTimeType, direction: OneDimensionalDirection): void;
@@ -1396,6 +1431,13 @@ declare namespace JQueryPrimeDatePicker {
         handleSecondsInput(input: HTMLElement, event: JQuery.TriggeredEvent): void;
 
         /**
+         * Callback that is invoked when a value was entered in the millisecond input.
+         * @param input Millisecond input element.
+         * @param event Event that occurred.
+         */
+        handleMillisecondsInput(input: HTMLElement, event: JQuery.TriggeredEvent): void;
+
+        /**
          * Callback that is invoked when the up button of the hour input was pressed.
          * @param event Event that occurred.
          */
@@ -1430,6 +1472,18 @@ declare namespace JQueryPrimeDatePicker {
          * @param event Event that occurred.
          */
         decrementSecond(event: JQuery.TriggeredEvent): void;
+
+        /**
+         * Callback that is invoked when the up button of the millisecond input was pressed.
+         * @param event Event that occurred.
+         */
+        incrementMillisecond(event: JQuery.TriggeredEvent): void;
+
+        /**
+         * Callback that is invoked when the down button of the millisecond input was pressed.
+         * @param event Event that occurred.
+         */
+        decrementMillisecond(event: JQuery.TriggeredEvent): void;
 
         /**
          * Callback that is invoked when button for navigating to the previous month was pressed.

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -33,6 +33,7 @@
             selectionMode: 'single',
             rangeSeparator: '-',
             timeSeparator: ':',
+            fractionSeparator: '.',
             inputId: null,
             inputStyle: null,
             inputStyleClass: null,
@@ -54,10 +55,12 @@
             showTime: false,
             timeOnly: false,
             showSeconds: false,
+            showMilliseconds: false,
             hourFormat: '24',
             stepHour: 1,
             stepMinute: 1,
             stepSecond: 1,
+            stepMillisecond: 1,
             shortYearCutoff: '+10',
             hideOnDateTimeSelect: false,
             userLocale: null,
@@ -163,10 +166,12 @@
                 }
                 if (this.viewDate === null) {
                     this.viewDate = new Date();
-                    if (!this.options.showSeconds) {
+                    if (!this.options.showSeconds && !this.options.showMilliseconds) {
                         this.viewDate.setSeconds(0);
                     }
-                    this.viewDate.setMilliseconds(0);
+                    if (!this.options.showMilliseconds) {
+                        this.viewDate.setMilliseconds(0);
+                    }
                     viewDateDefaultsToNow = true;
                 }
             }
@@ -712,7 +717,8 @@
             var output = '',
                 hours = date.getHours(),
                 minutes = date.getMinutes(),
-                seconds = date.getSeconds();
+                seconds = date.getSeconds(),
+                milliseconds = date.getMilliseconds();
 
             if (this.options.hourFormat == '12' && hours > 11 && hours != 12) {
                 hours -= 12;
@@ -731,6 +737,11 @@
                 output += (seconds < 10) ? '0' + seconds : seconds;
             }
 
+            if (this.options.showMilliseconds) {
+                output += this.options.fractionSeparator;
+                output += (milliseconds < 10) ? '00' + milliseconds : (milliseconds < 100) ? '0' + milliseconds : milliseconds;
+            }
+
             if (this.options.hourFormat == '12') {
                 output += date.getHours() > 11 ? ' PM' : ' AM';
             }
@@ -739,8 +750,10 @@
         },
 
         parseTime: function (value, ampm) {
-            var tokens = value.split(this.options.timeSeparator),
-                validTokenLength = this.options.showSeconds ? 3 : 2;
+            var val = value.replace(this.options.fractionSeparator, this.options.timeSeparator),
+                tokens = val.split(this.options.timeSeparator),
+                showSeconds = this.options.showSeconds || this.options.showMilliseconds
+                validTokenLength = 2 + (showSeconds ? 1 : 0) + (this.options.showMilliseconds ? 1 : 0);
 
             if (tokens.length !== validTokenLength) {
                 throw "Invalid time";
@@ -748,9 +761,10 @@
 
             var h = parseInt(tokens[0]),
                 m = parseInt(tokens[1]),
-                s = this.options.showSeconds ? parseInt(tokens[2]) : null;
+                s = showSeconds ? parseInt(tokens[2]) : null,
+                ms = this.options.showMilliseconds ? parseInt(tokens[3]) : null;
 
-            if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.options.hourFormat == '12' && h > 12) || (this.options.showSeconds && (isNaN(s) || s > 59))) {
+            if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.options.hourFormat == '12' && h > 12) || (this.options.showSeconds && (isNaN(s) || s > 59)) || (this.options.showMilliseconds && (isNaN(ms) || ms > 999))) {
                 throw "Invalid time";
             }
             else {
@@ -758,7 +772,7 @@
                     h += 12;
                 }
 
-                return { hour: h, minute: m, second: s };
+                return { hour: h, minute: m, second: s, millisecond: ms };
             }
         },
 
@@ -992,13 +1006,18 @@
             var time = this.parseTime(timeString, ampm);
             value.setHours(time.hour);
             value.setMinutes(this.stepMinute(time.minute));
-            if (this.options.showSeconds) {
+            if (this.options.showSeconds || this.options.showMilliseconds) {
                 value.setSeconds(time.second);
             }
             else {
                 value.setSeconds(0);
             }
-            value.setMilliseconds(0);
+            if (this.options.showMilliseconds) {
+                value.setMilliseconds(time.millisecond);
+            }
+            else {
+                value.setMilliseconds(0);
+            }
         },
 
         isInMinYear: function() {
@@ -1218,6 +1237,10 @@
             timepicker += this.options.showSeconds ? this.renderSeparator() : '';
             //second
             timepicker += this.renderSecondPicker();
+            //separator
+            timepicker += this.options.showMilliseconds ? this.renderFractionSeparator() : '';
+            //millisecond
+            timepicker += this.renderMillisecondPicker();
             //ampm
             timepicker += this.renderAmPmPicker();
 
@@ -1573,12 +1596,25 @@
             return '';
         },
 
-        renderAmPmPicker: function () {
+        renderMillisecondPicker: function () {
+            if (this.options.showMilliseconds) {
+                var millisecond = this.isDate(this.value) ? this.value.getMilliseconds() : this.viewDate.getMilliseconds(),
+                    millisecondDisplay = millisecond < 10 ? '00' + millisecond : millisecond < 100 ? '0' + millisecond : millisecond;
+
+                //type="number" min="0" max="999" does not work well on Firefox 70, so we don´t use it
+                var html =  this.options.timeInput ? '<input value="' + millisecondDisplay + '" size="3" maxlength="3" tabindex="4"></input>' : '<span>' + millisecondDisplay + '</span>';
+                return this.renderTimeElements("ui-millisecond-picker", html, 3);
+            }
+
+            return '';
+        },
+
+    renderAmPmPicker: function () {
             if (this.options.hourFormat === '12') {
                 var hour = this.isDate(this.value) ? this.value.getHours() : this.viewDate.getHours(),
                     display = hour > 11 ? 'PM' : 'AM';
 
-                return this.renderTimeElements("ui-ampm-picker", '<span>' + display + '</span>', 3);
+                return this.renderTimeElements("ui-ampm-picker", '<span>' + display + '</span>', 4);
             }
 
             return '';
@@ -1588,7 +1624,11 @@
             return this.renderTimeElements("ui-separator", '<span>:</span>', -1);
         },
 
-        renderTimeElements: function (containerClass, text, type) {
+        renderFractionSeparator: function () {
+            return this.renderTimeElements("ui-separator", '<span>.</span>', -1);
+        },
+
+    renderTimeElements: function (containerClass, text, type) {
             var container = '<div class="' + containerClass + '" data-type="' + type + '">';
 
             //up
@@ -1663,7 +1703,7 @@
                 $this.onMonthSelect(e, $(this).index());
             });
 
-            var timeSelector = '.ui-hour-picker > a,  .ui-minute-picker > a, .ui-second-picker > a',
+            var timeSelector = '.ui-hour-picker > a,  .ui-minute-picker > a, .ui-second-picker > a, .ui-millisecond-picker > a',
                 ampmSelector = '.ui-ampm-picker > a';
             this.panel.off('mousedown.datePicker-time mouseup.datePicker-time mouseleave.datePicker-time', timeSelector).off('click.datePicker-ampm', ampmSelector)
                 .on('mousedown.datePicker-time', timeSelector, null, function (event) {
@@ -1691,12 +1731,16 @@
                     $this.oldMinutes = this.value;
                 }).off('focus', '.ui-second-picker input').on('focus', '.ui-second-picker input', null, function (event) {
                     $this.oldSeconds = this.value;
+                }).off('focus', '.ui-millisecond-picker input').on('focus', '.ui-millisecond-picker input', null, function (event) {
+                    $this.oldMilliseconds = this.value;
                 }).off('change', '.ui-hour-picker input').on('change', '.ui-hour-picker input', null, function (event) {
                     $this.handleHoursInput(this, event);
                 }).off('change', '.ui-minute-picker input').on('change', '.ui-minute-picker input', null, function (event) {
                     $this.handleMinutesInput(this, event);
                 }).off('change', '.ui-second-picker input').on('change', '.ui-second-picker input', null, function (event) {
                     $this.handleSecondsInput(this, event);
+                }).off('change', '.ui-millisecond-picker input').on('change', '.ui-millisecond-picker input', null, function (event) {
+                    $this.handleMillisecondsInput(this, event);
                 });
             }
 
@@ -2036,6 +2080,13 @@
                     else
                         this.decrementSecond(event);
                     break;
+
+                case 3:
+                    if (direction === 1)
+                        this.incrementMillisecond(event);
+                    else
+                        this.decrementMillisecond(event);
+                    break;
             }
         },
 
@@ -2293,7 +2344,7 @@
                 date.setHours(time.getHours());
                 date.setMinutes(this.stepMinute(time.getMinutes()));
                 date.setSeconds(time.getSeconds());
-                date.setMilliseconds(0);
+                date.setMilliseconds(time.getMilliseconds());
             }
 
             if (this.options.minDate && this.options.minDate > date) {
@@ -2341,8 +2392,8 @@
                 newHour = currentHour + this.options.stepHour;
             newHour = (newHour >= 24) ? (newHour - 24) : newHour;
 
-            if (this.validateTime(newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime, "INCREMENT")) {
-                this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds());
+            if (this.validateTime(newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime, "INCREMENT")) {
+                this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds());
             }
 
             event.preventDefault();
@@ -2354,8 +2405,8 @@
                 newHour = currentHour - this.options.stepHour;
             newHour = (newHour < 0) ? (newHour + 24) : newHour;
 
-            if (this.validateTime(newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime, "DECREMENT")) {
-                this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds());
+            if (this.validateTime(newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime, "DECREMENT")) {
+                this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds());
             }
 
             event.preventDefault();
@@ -2367,8 +2418,8 @@
                 newMinute = this.stepMinute(currentMinute, this.options.stepMinute);
             newMinute = (newMinute > 59) ? (newMinute - 60) : newMinute;
 
-            if (this.validateTime(currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime, "INCREMENT")) {
-                this.updateTime(event, currentTime.getHours(), newMinute, currentTime.getSeconds());
+            if (this.validateTime(currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime, "INCREMENT")) {
+                this.updateTime(event, currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime.getMilliseconds());
             }
 
             event.preventDefault();
@@ -2380,8 +2431,8 @@
                 newMinute = this.stepMinute(currentMinute, -this.options.stepMinute);
             newMinute = (newMinute < 0) ? (newMinute + 60) : newMinute;
 
-            if (this.validateTime(currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime, "DECREMENT")) {
-                this.updateTime(event, currentTime.getHours(), newMinute, currentTime.getSeconds());
+            if (this.validateTime(currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime, "DECREMENT")) {
+                this.updateTime(event, currentTime.getHours(), newMinute, currentTime.getSeconds(), currentTime.getMilliseconds());
             }
 
             event.preventDefault();
@@ -2413,8 +2464,8 @@
                 newSecond = currentSecond + this.options.stepSecond;
             newSecond = (newSecond > 59) ? (newSecond - 60) : newSecond;
 
-            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime, "INCREMENT")) {
-                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), newSecond);
+            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime.getMilliseconds(), currentTime, "INCREMENT")) {
+                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime.getMilliseconds());
             }
 
             event.preventDefault();
@@ -2426,8 +2477,34 @@
                 newSecond = currentSecond - this.options.stepSecond;
             newSecond = (newSecond < 0) ? (newSecond + 60) : newSecond;
 
-            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime, "DECREMENT")) {
-                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), newSecond);
+            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime.getMilliseconds(), currentTime, "DECREMENT")) {
+                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), newSecond, currentTime.getMilliseconds());
+            }
+
+            event.preventDefault();
+        },
+
+        incrementMillisecond: function (event) {
+            var currentTime = this.isDate(this.value) ? this.value : this.viewDate,
+                currentMillisecond = currentTime.getMilliseconds(),
+                newMillisecond = currentMillisecond + this.options.stepMillisecond;
+            newMillisecond = (newMillisecond > 999) ? (newMillisecond - 1000) : newMillisecond;
+
+            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), currentTime.getSeconds(), newMillisecond, currentTime, "INCREMENT")) {
+                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), currentTime.getSeconds(), newMillisecond);
+            }
+
+            event.preventDefault();
+        },
+
+        decrementMillisecond: function (event) {
+            var currentTime = this.isDate(this.value) ? this.value : this.viewDate,
+                currentMillisecond = currentTime.getMilliseconds(),
+                newMillisecond = currentMillisecond - this.options.stepMillisecond;
+            newMillisecond = (newMillisecond < 0) ? (newMillisecond + 1000) : newMillisecond;
+
+            if (this.validateTime(currentTime.getHours(), currentTime.getMinutes(), currentTime.getSeconds(), newMillisecond, currentTime, "DECREMENT")) {
+                this.updateTime(event, currentTime.getHours(), currentTime.getMinutes(), currentTime.getSeconds(), newMillisecond);
             }
 
             event.preventDefault();
@@ -2438,7 +2515,7 @@
                 currentHour = currentTime.getHours(),
                 newHour = (currentHour >= 12) ? currentHour - 12 : currentHour + 12;
 
-            this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds());
+            this.updateTime(event, newHour, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds());
             event.preventDefault();
         },
 
@@ -2453,11 +2530,11 @@
                 newHours = parseInt(value);
                 if (this.options.hourFormat === '12') {
                     if (newHours >= 1 || newHours <= 12) {
-                        valid = this.validateTime(newHours, currentTime.getMinutes(), currentTime.getSeconds(), currentTime);
+                        valid = this.validateTime(newHours, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime);
                     }
                 } else {
                     if (newHours >= 0 || newHours <= 23) {
-                        valid = this.validateTime(newHours, currentTime.getMinutes(), currentTime.getSeconds(), currentTime);
+                        valid = this.validateTime(newHours, currentTime.getMinutes(), currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime);
                     }
                 }
             }
@@ -2484,7 +2561,7 @@
             if (reg.test(value)) {
                 newMinutes = parseInt(value);
                 if (newMinutes >= 0 || newMinutes <= 59) {
-                    valid = this.validateTime(currentTime.getHours(), newMinutes, currentTime.getSeconds(), currentTime);
+                    valid = this.validateTime(currentTime.getHours(), newMinutes, currentTime.getSeconds(), currentTime.getMilliseconds(), currentTime);
                 }
             }
 
@@ -2510,7 +2587,7 @@
             if (reg.test(value)) {
                 newSeconds = parseInt(value);
                 if (newSeconds >= 0 || newSeconds <= 59) {
-                    valid = this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSeconds, currentTime);
+                    valid = this.validateTime(currentTime.getHours(), currentTime.getMinutes(), newSeconds, currentTime.getMilliseconds(), currentTime);
                 }
             }
 
@@ -2526,9 +2603,35 @@
             this.updateTimeAfterInput(event, newDateTime);
         },
 
-        validateTime: function(hour, minute, second, value, direction) {
+        handleMillisecondsInput: function(input, event) {
+            var currentTime = this.isDate(this.value) ? this.value : this.viewDate,
+                value = input.value,
+                valid = false,
+                newMilliseconds;
+
+            var reg = new RegExp('^([0-9]){1,3}$');
+            if (reg.test(value)) {
+                newMilliseconds = parseInt(value);
+                if (newMilliseconds >= 0 || newMilliseconds <= 999) {
+                    valid = this.validateTime(currentTime.getHours(), currentTime.getMinutes(), currentTime.getSeconds(), newMilliseconds, currentTime);
+                }
+            }
+
+            if (!valid) {
+                event.preventDefault();
+                input.value = this.oldMilliseconds;
+                return;
+            }
+
+            var newDateTime = this.isDate(this.value) ? new Date(this.value) : new Date();
+            newDateTime.setMilliseconds(newMilliseconds);
+
+            this.updateTimeAfterInput(event, newDateTime);
+        },
+
+        validateTime: function(hour, minute, second, millisecond, value, direction) {
             var valid = true;
-            var dateNew = new Date(value.getFullYear(), value.getMonth(), value.getDate(), hour, minute, second, 0);
+            var dateNew = new Date(value.getFullYear(), value.getMonth(), value.getDate(), hour, minute, second, millisecond);
 
             if (this.options.minDate && value) {
                 if (this.options.minDate > dateNew) {
@@ -2555,13 +2658,13 @@
             return valid;
         },
 
-        updateTime: function (event, hour, minute, second) {
+        updateTime: function (event, hour, minute, second, millisecond) {
             var newDateTime = this.isDate(this.value) ? new Date(this.value) : new Date();
 
             newDateTime.setHours(hour);
             newDateTime.setMinutes(minute);
             newDateTime.setSeconds(second);
-            newDateTime.setMilliseconds(0);
+            newDateTime.setMilliseconds(millisecond);
 
             this.updateModel(event, newDateTime);
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
@@ -36,7 +36,8 @@
 }
 
 .p-datepicker-panel .ui-timepicker > .ui-minute-picker, 
-.p-datepicker-panel .ui-timepicker > .ui-second-picker {
+.p-datepicker-panel .ui-timepicker > .ui-second-picker,
+.p-datepicker-panel .ui-timepicker > .ui-millisecond-picker {
     margin-left: 0;
 }
 
@@ -61,6 +62,10 @@
     border-top: 0px;
     border-left: 0px;
     border-right: 0px;
+}
+
+.p-datepicker-panel .ui-timepicker.ui-timepicker-timeinput .ui-millisecond-picker input {
+    width: 2.3em;
 }
 
 .p-datepicker-panel .ui-timepicker.ui-timepicker-timeinput .ui-ampm-picker .ui-picker-up {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ar.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ar.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['ar'] = {
     hourText: 'ساعة',
     minuteText: 'دقيقة',
     secondText: 'ثانية',
+    millisecondText: 'ميلي ثانية',
     ampm: false,
     month: 'الشهر',
     week: 'الأسبوع',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ca.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ca.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['ca'] = {
     hourText: 'Hora',
     minuteText: 'Minut',
     secondText: 'Segon',
+    millisecondText: 'Millisegon',
     currentText: 'Data actual',
     ampm: false,
     month: 'Mes',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-cs.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-cs.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['cs'] = {
     hourText: 'Hodina',
     minuteText: 'Minuta',
     secondText: 'Sekunda',
+    millisecondText: 'Milisekunda',
     currentText: 'Nyní',
     ampm: false,
     month: 'Měsíc',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-de.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-de.js
@@ -19,6 +19,7 @@ PrimeFaces.locales ['de'] = {
     hourText: 'Stunde',
     minuteText: 'Minute',
     secondText: 'Sekunde',
+    millisecondText: 'Millisekunde',
     currentText: 'Aktuelles Datum',
     ampm: false,
     year: 'Jahr',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-el.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-el.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['el'] = {
     hourText: 'Ώρα',
     minuteText: 'Λεπτό',
     secondText: 'Δευτερόλεπτο',
+    millisecondText: 'Μιλιδευτερόλεπτο',
     currentText: 'Σημερινή Ημερομηνία',
     ampm: false,
     month: 'Μήνας',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
@@ -21,6 +21,7 @@
      hourText: 'Hour',
      minuteText: 'Minute',
      secondText: 'Second',
+     millisecondText: 'Millisecond',
      currentText: 'Current Date',
      ampm: false,
      year: 'Year',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-es.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-es.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['es'] = {
     hourText: 'Hora',
     minuteText: 'Minuto',
     secondText: 'Segundo',
+    millisecondText: 'Milisegundo',
     currentText: 'Fecha actual',
     ampm: false,
     month: 'Mes',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-fr.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-fr.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['fr'] = {
     hourText: "Heures",
     minuteText: "Minutes",
     secondText: "Secondes",
+    millisecondText: 'Millisecondes',
     currentText: "Maintenant",
     ampm: false,
     month: "Mois",

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-hr.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-hr.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['hr'] = {
     hourText: 'Sat',
     minuteText: 'Minuta',
     secondText: 'Sekunda',
+    millisecondText: 'Milisekunda',
     currentText: 'Sada',
     ampm: false,
     month: 'Mjesec',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-hu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-hu.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['hu'] = {
     hourText: 'Óra',
     minuteText: 'Perc',
     secondText: 'Másodperc',
+    millisecondText: 'Miliszekundum',
     currentText: 'Ma',
     ampm: false,
     month: 'Hónap',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-in.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-in.js
@@ -21,6 +21,7 @@
      hourText: 'Jam',
      minuteText: 'Menit',
      secondText: 'Detik',
+     millisecondText: 'Mili Detik',
      currentText: 'Tanggal Hari Ini',
      ampm: false,
      year: 'Tahun',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-it.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-it.js
@@ -18,6 +18,7 @@ PrimeFaces.locales ['it'] = {
     hourText: 'Ore',
     minuteText: 'Minuti',
     secondText: 'Secondi',
+    millisecondText: 'Millisecondi',
     currentText: 'Oggi',
     ampm: false,
     year: 'Anno',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-iw.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-iw.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['iw'] = {
     hourText: 'שעה',
     minuteText: 'דקה',
     secondText: 'שניה',
+    millisecondText: 'אלפית השנייה',
     currentText: 'היום',
     ampm: false,
     month: 'חודש',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ka.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ka.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['ka'] = {
     minuteText: 'წუთი',
     secondText: 'წამი',
     currentText: 'დღევანდელი თარიღი',
+    millisecondText: 'მილიწამი',
     ampm: false,
     month: 'თვე',
     week: 'კვირა',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-lv.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-lv.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['lv'] = {
     hourText: 'Stunda',
     minuteText: 'Minūte',
     secondText: 'Sekunde',
+    millisecondText: 'Millisekunde',
     currentText: 'Šodiena',
     ampm: false,
     month: 'Mēnesis',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-nl.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-nl.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['nl'] = {
     hourText: 'Uur',
     minuteText: 'Minuut',
     secondText: 'Seconde',
+    millisecondText: 'Milliseconde',
     ampm: false,
     month: 'Maand',
     week: 'Week',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-no.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-no.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['no'] = {
     hourText: 'Time',
     minuteText: 'Minutt',
     secondText: 'Sekund',
+    millisecondText: 'Millisekund',
     currentText: 'I dag',
     ampm: false,
     month: 'Måned',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-pl.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-pl.js
@@ -21,6 +21,7 @@ PrimeFaces.locales['pl'] = {
   hourText: 'Godzina',
   minuteText: 'Minuta',
   secondText: 'Sekunda',
+  millisecondText: 'Millisekunda',
   currentText: 'Teraz',
   ampm: false,
   month: 'Miesiąc',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-pt.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-pt.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['pt_PT'] = {
     hourText: 'Hora',
     minuteText: 'Minuto',
     secondText: 'Segundo',
+    millisecondText: 'Milissegundo',
     currentText: 'Data atual',
     ampm: false,
     year: 'Ano',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ro.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ro.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['ro'] = {
     hourText: 'Ora',
     minuteText: 'Minut',
     secondText: 'Secunde',
+    millisecondText: 'Milisecunde',
     ampm: false,
     month: 'Luna',
     week: 'Săptămâna',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ru.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-ru.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['ru'] = {
     hourText: 'Час',
     minuteText: 'Минута',
     secondText: 'Секунда',
+    millisecondText: 'Миллисекунда',
     currentText: 'Сегодня',
     ampm: false,
     month: 'Месяц',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sk.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sk.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['sk'] = {
     hourText: 'Hodina',
     minuteText: 'Minúta',
     secondText: 'Sekunda',
+    millisecondText: 'Milisekunda',
     currentText: 'Teraz',
     ampm: false,
     month: 'Mesiac',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sl.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sl.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['sl'] = {
     hourText: '\u010Cas',
     minuteText: 'Minute',
     secondText: 'Sekunde',
+    millisecondText: 'Milisekunda',
     currentText: 'danes',
     ampm: false,
     month: 'mesec',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sr.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sr.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['sr'] = {
     hourText: 'Sat',
     minuteText: 'Minuta',
     secondText: 'Sekunda',
+    millisecondText: 'Milisekunda',
     currentText: 'Danas',
     ampm: false,
     month: 'Mesec',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sv.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-sv.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['sv'] = {
     hourText: 'timmar',
     minuteText: 'minuter',
     secondText: 'sekunder',
+    millisecondText: 'millisekunder',
     currentText: 'Nuvarande datum',
     ampm: false,
     month: 'månad',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-tr.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-tr.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['tr'] = {
     hourText: 'Saat',
     minuteText: 'Dakika',
     secondText: 'Saniye',
+    millisecondText: 'Milisaniye',
     currentText: 'Geçerli Tarih',
     ampm: false,
     year: 'Yıl',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-uk.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-uk.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['uk'] = {
     hourText: 'Година',
     minuteText: 'Хвилина',
     secondText: 'Секунда',
+    millisecondText: 'Мілісекунд',
     currentText: 'Сьогодні',
     ampm: false,
     month: 'Місяць',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-vi.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-vi.js
@@ -18,6 +18,7 @@ PrimeFaces.locales['vi'] = {
     hourText: 'Giờ',
     minuteText: 'Phút',
     secondText: 'Giây',
+    millisecondText: 'Mili giây',
     currentText: 'Giờ hiện hành',
     ampm: false,
     month: 'Tháng',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-zh.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-zh.js
@@ -19,6 +19,7 @@ PrimeFaces.locales['zh_CN'] = {
     hourText: '时',
     minuteText: '分',
     secondText: '秒',
+    millisecondText: '毫秒',
     ampm: false,
     month: '月',
     week: '周',

--- a/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
@@ -113,6 +113,7 @@ public class DatePickerTest {
         when(datePicker.calculateTimeOnlyPattern()).thenCallRealMethod();
         when(datePicker.calculateWidgetPattern()).thenCallRealMethod();
         when(datePicker.getTimeSeparator()).thenCallRealMethod();
+        when(datePicker.getFractionSeparator()).thenCallRealMethod();
         when(datePicker.isValid()).thenCallRealMethod();
         doCallRealMethod().when(datePicker).setValid(anyBoolean());
         when(datePicker.getSelectionMode()).thenReturn("single");
@@ -281,6 +282,18 @@ public class DatePickerTest {
     }
 
     @Test
+    public void convertToJava8DateTimeAPI_LocalTimeWithMilliSeconds() {
+        Class<?> type = LocalTime.class;
+        setupValues(type, Locale.ENGLISH);
+        when(datePicker.isTimeOnly()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowMilliseconds()).thenReturn(Boolean.TRUE);
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "21:31:47.003");
+        assertEquals(type, temporal.getClass());
+        assertEquals(LocalTime.of(21, 31, 47, 3*1000*1000), temporal);
+    }
+
+    @Test
     public void convertToJava8DateTimeAPI_LocalTimeWithAmPm() {
         Class<?> type = LocalTime.class;
         setupValues(type, Locale.ENGLISH);
@@ -301,6 +314,19 @@ public class DatePickerTest {
         Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "09:31:47 PM");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalTime.of(21, 31, 47), temporal);
+    }
+
+    @Test
+    public void convertToJava8DateTimeAPI_LocalTimeWithMillisecondsAndAmPm() {
+         Class<?> type = LocalTime.class;
+        setupValues(type, Locale.ENGLISH);
+        when(datePicker.isTimeOnly()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowMilliseconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.getHourFormat()).thenReturn("12");
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "09:31:47.003 PM");
+        assertEquals(type, temporal.getClass());
+        assertEquals(LocalTime.of(21, 31, 47, 3*1000*1000), temporal);
     }
 
     @Test
@@ -336,6 +362,20 @@ public class DatePickerTest {
         Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/2019 09:31:48 PM");
         assertEquals(type, temporal.getClass());
         assertEquals(LocalDateTime.of(2019, 7, 23,  21, 31, 48), temporal);
+    }
+
+    @Test
+    public void convertToJava8DateTimeAPI_LocalDateTimeMillisecondsAmPm() {
+         Class<?> type = LocalDateTime.class;
+        setupValues(type, Locale.ENGLISH);
+        when(datePicker.hasTime()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
+        when(datePicker.getHourFormat()).thenReturn("12");
+        when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowMilliseconds()).thenReturn(Boolean.TRUE);
+        Temporal temporal = renderer.convertToJava8DateTimeAPI(context, datePicker, type, "7/23/2019 09:31:48.011 PM");
+        assertEquals(type, temporal.getClass());
+        assertEquals(LocalDateTime.of(2019, 7, 23,  21, 31, 48, 11*1000*1000), temporal);
     }
 
     @Test
@@ -1009,12 +1049,31 @@ public class DatePickerTest {
     }
 
     @Test
+    public void calculatePatternWithMilliseconds() {
+        setupValues(null, Locale.ENGLISH);
+        when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowMilliseconds()).thenReturn(Boolean.TRUE);
+        assertEquals("M/d/yyyy HH:mm:ss.SSS", datePicker.calculatePattern());
+    }
+
+    @Test
     public void calculatePatternWithSecondsAndAmPm() {
         setupValues(null, Locale.ENGLISH);
         when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
         when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
         when(datePicker.getHourFormat()).thenReturn("12");
         assertEquals("M/d/yyyy hh:mm:ss a", datePicker.calculatePattern());
+    }
+
+    @Test
+    public void calculatePatternWithMillisecondsAndAmPm() {
+        setupValues(null, Locale.ENGLISH);
+        when(datePicker.isShowTime()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowSeconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.isShowMilliseconds()).thenReturn(Boolean.TRUE);
+        when(datePicker.getHourFormat()).thenReturn("12");
+        assertEquals("M/d/yyyy hh:mm:ss.SSS a", datePicker.calculatePattern());
     }
 
     @Test


### PR DESCRIPTION
Added milliseconds to DatePicker (but not micros nor nonos since JS Date only supports milliseconds). Also added some integration tests and augmented DatePicker showcases. 