### PR TITLE
[#7454] added feed reader unit tests

### DIFF
--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -186,6 +186,12 @@
             <version>1.4.01</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.16</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Cache -->
         <dependency>

--- a/primefaces/src/test/java/org/primefaces/component/feedreader/FeedReaderTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/feedreader/FeedReaderTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.feedreader;
+
+import com.rometools.rome.io.ParsingFeedException;
+import java.net.URL;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FeedReaderTest {
+
+    @Test()
+    public void parseXXEbomb() throws Exception {
+        // Check CVE-2021-33813 can not be triggered in Primefaces
+        // See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33813
+        // See https://alephsecurity.com/vulns/aleph-2021003
+        URL feed = FeedReaderTest.class.getResource("/org/primefaces/feeds/XXEbomb.xml");
+        assertThrows(ParsingFeedException.class, () -> new FeedInput().parse(feed.toString(), 1));
+    }
+
+    @Test()
+    public void parseXXE() throws Exception {
+        URL feed = FeedReaderTest.class.getResource("/org/primefaces/feeds/XXE.xml");
+        assertThrows(ParsingFeedException.class, () -> new FeedInput().parse(feed.toString(), 1));
+    }
+
+    @Test()
+    public void parseRSS() throws Exception {
+        URL feed = FeedReaderTest.class.getResource("/org/primefaces/feeds/RSS2.0.xml");
+        List rss = new FeedInput().parse(feed.toString(), 10);
+        assertNotNull(rss);
+        assertEquals(2, rss.size());
+    }
+}

--- a/primefaces/src/test/resources/org/primefaces/feeds/RSS2.0.xml
+++ b/primefaces/src/test/resources/org/primefaces/feeds/RSS2.0.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Example Channel</title>
+    <link>http://example.com/</link>
+    <description>My example channel</description>
+    <item>
+       <title>News for September the Second</title>
+       <link>http://example.com/2002/09/01</link>
+       <description>other things happened today</description>
+    </item>
+    <item>
+       <title>News for September the First</title>
+       <link>http://example.com/2002/09/02</link>
+    </item>
+  </channel>
+</rss>

--- a/primefaces/src/test/resources/org/primefaces/feeds/XXE.xml
+++ b/primefaces/src/test/resources/org/primefaces/feeds/XXE.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE rss [
+   <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+<rss version="2.0">
+  <channel>
+    <title>&xxe;</title>
+  </channel>
+</rss>

--- a/primefaces/src/test/resources/org/primefaces/feeds/XXEbomb.xml
+++ b/primefaces/src/test/resources/org/primefaces/feeds/XXEbomb.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE foo [<!ELEMENT foo ANY><!ENTITY bar "World ">
+	<!ENTITY t1 "&bar;&bar;"><!ENTITY t2 "&t1;&t1;&t1;&t1;">
+	<!ENTITY t3 "&t2;&t2;&t2;&t2;&t2;">]>
+<foo>Hello &t3;</foo>


### PR DESCRIPTION
As far as I can see Primefaces is not affected by CVE-2021-33813. Rometools is only used in feed readers `FeedInput` class.
`FeedInput#parse(String, int)` calls rometools' `SynedFeedInput#build(Reader)` which calls `WireFeed#build(Reader)`
which calls `WireFeedInput#createSAXBuilder()`. In that method a new `SAXBuilder` is created with `setExpandEntities(false)` called.

According to **hunterhacker** in https://github.com/hunterhacker/jdom/issues/189

>  If you call builder.setExpandEntities(false) then JDOM won't expand entities.

Some unit tests were added to prove that statement. 