### PR TITLE
Fix #7462: Wizard enable/disable widget methods

### DIFF
--- a/docs/11_0_0/components/wizard.md
+++ b/docs/11_0_0/components/wizard.md
@@ -211,8 +211,12 @@ back() | - | void | Goes back in flow.
 getStepIndex() | - | Number | Returns the index of current step.
 showNextNav() | - | void | Shows next button.
 hideNextNav() | - | void | Hides next button.
+enableNextNav() | - | void | Enables next button.
+disableNextNav() | - | void | Disables next button.
 showBackNav() | - | void | Shows back button.
 hideBackNav() | - | void | Hides back button.
+enableBackNav() | - | void | Enables back button.
+disableBackNav() | - | void | Disables back button
 
 ## Skinning
 Wizard resides in a container element that _style_ and _styleClass_ attributes apply. Following is the list

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -652,6 +652,30 @@ if (!PrimeFaces.utils) {
         },
 
         /**
+         * Enables a button.
+         *
+         * @param {JQuery} jq a required jQuery element to enable
+         */
+        enableButton: function(jq) {
+            if (jq) {
+                jq.removeClass('ui-state-disabled').removeAttr('disabled');
+            }
+        },
+
+        /**
+         * Disables a button from being clicked.
+         *
+         * @param {JQuery} jq a required jQuery button to disable
+         */
+        disableButton: function(jq) {
+            if (jq) {
+                jq.removeClass('ui-state-hover ui-state-focus ui-state-active')
+                  .addClass('ui-state-disabled')
+                  .attr('disabled', 'disabled');
+            }
+        },
+
+        /**
          * Enables CSS and jQuery animation.
          */
         enableAnimations: function() {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.button.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.button.js
@@ -25,15 +25,14 @@ PrimeFaces.widget.Button = PrimeFaces.widget.BaseWidget.extend({
      * Enables this button so that the user cannot press it.
      */
     disable: function() {
-        this.jq.removeClass('ui-state-hover ui-state-focus ui-state-active')
-                .addClass('ui-state-disabled').attr('disabled', 'disabled');
+        PrimeFaces.utils.disableButton(this.jq);
     },
 
     /**
      * Enables this button so that the user can press it.
      */
     enable: function() {
-        this.jq.removeClass('ui-state-disabled').removeAttr('disabled');
+        PrimeFaces.utils.enableButton(this.jq);
     }
 
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandbutton.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandbutton.js
@@ -25,15 +25,14 @@ PrimeFaces.widget.CommandButton = PrimeFaces.widget.BaseWidget.extend({
      * Disables this button so that the user cannot press the button anymore.
      */
     disable: function() {
-        this.jq.removeClass('ui-state-hover ui-state-focus ui-state-active')
-                .addClass('ui-state-disabled').attr('disabled', 'disabled');
+        PrimeFaces.utils.disableButton(this.jq);
     },
 
     /**
      * Enables this button so that the user can press the button.
      */
     enable: function() {
-        this.jq.removeClass('ui-state-disabled').removeAttr('disabled');
+        PrimeFaces.utils.enableButton(this.jq);
     }
 
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.linkbutton.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.linkbutton.js
@@ -47,15 +47,14 @@ PrimeFaces.widget.LinkButton = PrimeFaces.widget.BaseWidget.extend({
      * Disables this link button so that it cannot be clicked.
      */
     disable: function () {
-        this.jq.removeClass('ui-state-hover ui-state-focus ui-state-active')
-                .addClass('ui-state-disabled').attr('disabled', 'disabled');
+        PrimeFaces.utils.disableButton(this.jq);
     },
 
     /**
      * Enables this link button so that it can be clicked.
      */
     enable: function () {
-        this.jq.removeClass('ui-state-disabled').removeAttr('disabled');
+        PrimeFaces.utils.enableButton(this.jq);
     }
 
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/wizard/wizard.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/wizard/wizard.js
@@ -222,6 +222,20 @@ PrimeFaces.widget.Wizard = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
+     * Enables the button for navigating to the next wizard step.
+     */
+    enableNextNav: function() {
+        PrimeFaces.utils.enableButton(this.nextNav);
+    },
+
+    /**
+     * Disables the button for navigating to the next wizard step.
+     */
+    disableNextNav: function() {
+        PrimeFaces.utils.disableButton(this.nextNav);
+    },
+
+    /**
      * Shows the button for navigating to the previous wizard step.
      */
     showBackNav: function() {
@@ -233,6 +247,20 @@ PrimeFaces.widget.Wizard = PrimeFaces.widget.BaseWidget.extend({
      */
     hideBackNav: function() {
         this.backNav.fadeOut();
+    },
+
+    /**
+     * Enables the button for navigating to the previous wizard step.
+     */
+    enableBackNav: function() {
+        PrimeFaces.utils.enableButton(this.backNav);
+    },
+
+    /**
+     * Disables the button for navigating to the previous wizard step.
+     */
+    disableBackNav: function() {
+        PrimeFaces.utils.disableButton(this.backNav);
     }
 
 });


### PR DESCRIPTION
Refactored enable/disable button into utility methods.  reused in Button, LinkButton, CommandButton and Wizard back and next buttons.