### PR TITLE
Hibernate Validator 6.2.0 and fix Messages001Test

### DIFF
--- a/primefaces-integration-tests/pom.xml
+++ b/primefaces-integration-tests/pom.xml
@@ -27,7 +27,7 @@
         <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
 
         <!-- dependency versions -->
-        <hibernate-validator.version>7.0.1.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <lombok.version>1.18.20</lombok.version>
         <myfaces.version>2.3.9</myfaces.version>
         <myfaces-next.version>2.3-next-M6</myfaces-next.version>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/messages/Messages001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/messages/Messages001Test.java
@@ -51,7 +51,7 @@ public class Messages001Test extends AbstractPrimePageTest {
         // Assert
         assertDisplayed(messages);
         Assertions.assertEquals(1, messages.getAllMessages().size());
-        Assertions.assertTrue(messages.getMessage(0).getSummary().contains("may not be null")); //Mojarra and MyFaces have slightly different messages
+        Assertions.assertTrue(messages.getMessage(0).getSummary().contains("not be null")); //Mojarra and MyFaces have slightly different messages
         Assertions.assertEquals(Severity.ERROR, messages.getMessage(0).getSeverity());
         Assertions.assertTrue(PrimeSelenium.hasCssClass(page.inputTextVal2, "ui-state-error"));
 


### PR DESCRIPTION
Had to make Messages001Test even more generic for changes in Hibernate version messaging.