### PR TITLE
Fix #7591: CheckboxTreeNode check selectable before propagation

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/CheckboxTreeNode.java
+++ b/primefaces/src/main/java/org/primefaces/model/CheckboxTreeNode.java
@@ -191,6 +191,9 @@ public class CheckboxTreeNode<T> implements TreeNode<T>, Serializable {
     }
 
     protected void propagateSelectionDown(boolean value) {
+        if (!this.isSelectable()) {
+            return;
+        }
         this.selected = value;
         this.partialSelected = false;
 
@@ -200,6 +203,9 @@ public class CheckboxTreeNode<T> implements TreeNode<T>, Serializable {
     }
 
     protected void propagateSelectionUp() {
+        if (!this.isSelectable()) {
+            return;
+        }
         boolean allChildrenSelected = true;
         this.partialSelected = false;
 


### PR DESCRIPTION
Simply check whether the node is selectable or not before trying to propagate up/down