### PR TITLE
Fix #6575: selection could not be restored for lazy-mode + MVS

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable025.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable025.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import lombok.Data;
+import org.primefaces.PrimeFaces;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+
+import javax.annotation.PostConstruct;
+import javax.faces.context.FacesContext;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.io.Serializable;
+import java.util.List;
+
+@Named
+@ViewScoped
+@Data
+public class DataTable025 implements Serializable {
+
+    private static final long serialVersionUID = -7518459955779385834L;
+
+    private List<ProgrammingLanguage> progLanguages;
+    private ProgrammingLanguageLazyDataModel progLanguagesLazyModel;
+
+    private ProgrammingLanguage selectedProgLanguage;
+
+    @Inject
+    private ProgrammingLanguageService service;
+
+    @PostConstruct
+    public void init() {
+        progLanguages = service.getLangs();
+        progLanguagesLazyModel = new ProgrammingLanguageLazyDataModel(true);
+    }
+
+    public void onRowSelect(SelectEvent<ProgrammingLanguage> event) {
+        TestUtils.addMessage("ProgrammingLanguage Selected", event.getObject().getId() + " - " + event.getObject().getName());
+    }
+
+    public void clearTableState() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        String viewId = context.getViewRoot().getViewId();
+        PrimeFaces.current().multiViewState().clearAll(viewId, true);
+
+        //progLanguages = service.getLangs(); //progLanguages may have been sorted from DataTable
+    }
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/ProgrammingLanguageLazyDataModel.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/ProgrammingLanguageLazyDataModel.java
@@ -37,17 +37,32 @@ import org.primefaces.model.SortMeta;
 public class ProgrammingLanguageLazyDataModel extends LazyDataModel<ProgrammingLanguage> {
 
     private static final long serialVersionUID = -3415081263308946252L;
-    private final List<ProgrammingLanguage> langs;
+    private List<ProgrammingLanguage> langs;
 
     public ProgrammingLanguageLazyDataModel() {
+        this(false);
+    }
+
+    public ProgrammingLanguageLazyDataModel(boolean initOnLoad) {
+        if (!initOnLoad) {
+            initLanguages();
+        }
+    }
+
+    private void initLanguages() {
         langs = new ArrayList<>();
         for (int i = 1; i <= 75; i++) {
             langs.add(new ProgrammingLanguage(i, "Language " + i, 1990 + (i % 10), ProgrammingLanguage.ProgrammingLanguageType.COMPILED));
         }
+        setRowCount(langs.size());
     }
 
     @Override
     public List<ProgrammingLanguage> load(int first, int pageSize, Map<String, SortMeta> sortMeta, Map<String, FilterMeta> filterMeta) {
+        if (langs == null) {
+            initLanguages();
+        }
+
         Stream<ProgrammingLanguage> langsStream = langs.stream();
 
         if (filterMeta != null && !filterMeta.isEmpty()) {
@@ -76,11 +91,6 @@ public class ProgrammingLanguageLazyDataModel extends LazyDataModel<ProgrammingL
         return langsStream
                     .skip(first).limit(pageSize)
                     .collect(Collectors.toList());
-    }
-
-    @Override
-    public int getRowCount() {
-        return langs.size();
     }
 
     @Override

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable025_lazy.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable025_lazy.xhtml
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate />
+            </p:messages>
+
+            <p:dataTable id="datatable" value="#{dataTable025.progLanguagesLazyModel}" var="lang"
+                         selectionMode="single" selection="#{dataTable004.selectedProgLanguage}" rowKey="#{lang.id}"
+                         paginator="true" rows="4"
+                         multiViewState="true">
+                <p:ajax event="rowSelect" listener="#{dataTable025.onRowSelect}" />
+
+                <p:column headerText="ID" sortBy="#{lang.id}">
+                    <h:outputText value="#{lang.id}"/>
+                </p:column>
+
+                <p:column headerText="Name">
+                    <h:outputText value="#{lang.name}"/>
+                </p:column>
+
+                <p:column headerText="First appeared">
+                    <h:outputText value="#{lang.firstAppeared}"/>
+                </p:column>
+            </p:dataTable>
+
+            <p:commandButton id="buttonClearTableState" value="clear table state" update="@form" action="#{dataTable025.clearTableState()}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable025_nonLazy.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable025_nonLazy.xhtml
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate />
+            </p:messages>
+
+            <p:dataTable id="datatable" value="#{dataTable025.progLanguages}" var="lang"
+                         selectionMode="single" selection="#{dataTable004.selectedProgLanguage}" rowKey="#{lang.id}"
+                         paginator="true" rows="4"
+                         multiViewState="true">
+                <p:ajax event="rowSelect" listener="#{dataTable025.onRowSelect}" />
+
+                <p:column headerText="ID" sortBy="#{lang.id}">
+                    <h:outputText value="#{lang.id}"/>
+                </p:column>
+
+                <p:column headerText="Name">
+                    <h:outputText value="#{lang.name}"/>
+                </p:column>
+
+                <p:column headerText="First appeared">
+                    <h:outputText value="#{lang.firstAppeared}"/>
+                </p:column>
+            </p:dataTable>
+
+            <p:commandButton id="buttonClearTableState" value="clear table state" update="@form" action="#{dataTable025.clearTableState()}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable025Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable025Test.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DataTable;
+import org.primefaces.selenium.component.Messages;
+
+public class DataTable025Test extends AbstractDataTableTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: MultiViewState - selection with non-lazy-mode")
+    public void multiViewStateSelection(PageNonLazy page, OtherPage otherPage) {
+    	_testImplementation_multiViewStateSelection(page, otherPage, () -> languages);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: MultiViewState - selection with lazy-mode")
+    public void multiViewStateSelection(PageLazy page, OtherPage otherPage) {
+    	_testImplementation_multiViewStateSelection(page, otherPage, model::getLangs);
+    }
+
+    private void _testImplementation_multiViewStateSelection(PageWithMultiViewStateSelection page, OtherPage otherPage, Supplier<List<ProgrammingLanguage>> fnLangGetter) {
+        // Arrange
+        PrimeSelenium.goTo(page);
+        PrimeSelenium.guardAjax(page.buttonClearTableState).click();
+        DataTable dataTable = page.dataTable;
+        Assertions.assertNotNull(dataTable);
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(dataTable));
+
+        // Act
+        PrimeSelenium.guardAjax(dataTable.getCell(2, 0).getWebElement()).click();
+
+        // Assert
+        assertMessage(page, "ProgrammingLanguage Selected", fnLangGetter.get().get(2).getName());
+
+        PrimeSelenium.goTo(otherPage);
+        PrimeSelenium.goTo(page);
+
+        // Assert - selection must not be lost after navigating to another page and back
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(dataTable));
+        Assertions.assertTrue(PrimeSelenium.hasCssClass(dataTable.getRow(2).getWebElement(), "ui-state-highlight"));
+        Assertions.assertEquals("true", dataTable.getRow(2).getWebElement().getAttribute("aria-selected"));
+
+        assertConfiguration(dataTable.getWidgetConfiguration());
+    }
+
+    private void assertMessage(PageWithMultiViewStateSelection page, String summary, String detail) {
+        System.out.println(page.messages.getMessage(0).getSummary());
+        System.out.println("\t" + summary);
+        System.out.println(page.messages.getMessage(0).getDetail());
+        System.out.println("\t" + detail);
+        Assertions.assertTrue(page.messages.getMessage(0).getSummary().contains(summary));
+        Assertions.assertTrue(page.messages.getMessage(0).getDetail().contains(detail));
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("DataTable Config = " + cfg);
+        Assertions.assertTrue(cfg.has("selectionMode"));
+    }
+    
+    public static abstract class PageWithMultiViewStateSelection extends AbstractPrimePage {
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:datatable")
+        DataTable dataTable;
+
+        @FindBy(id = "form:buttonClearTableState")
+        CommandButton buttonClearTableState;
+    }
+
+    public static class PageLazy extends PageWithMultiViewStateSelection {
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable025_lazy.xhtml";
+        }
+    }
+
+    public static class PageNonLazy extends PageWithMultiViewStateSelection {
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable025_nonLazy.xhtml";
+        }
+    }
+
+    public static class OtherPage extends AbstractPrimePage {
+        @Override
+        public String getLocation() {
+            return "clientwindow/clientWindow001.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/MultiViewStateAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/MultiViewStateAware.java
@@ -27,7 +27,11 @@ public interface MultiViewStateAware<T> {
 
     boolean isMultiViewState();
 
-    void restoreMultiViewState();
+    void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore);
+
+    default void restoreMultiViewState() {
+        restoreMultiViewState(true, true);
+    }
 
     T getMultiViewState(boolean create);
 

--- a/primefaces/src/main/java/org/primefaces/component/datagrid/DataGrid.java
+++ b/primefaces/src/main/java/org/primefaces/component/datagrid/DataGrid.java
@@ -138,7 +138,7 @@ public class DataGrid extends DataGridBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         DataGridState ls = getMultiViewState(false);
         if (ls != null && isPaginator()) {
             setFirst(ls.getFirst());

--- a/primefaces/src/main/java/org/primefaces/component/datalist/DataList.java
+++ b/primefaces/src/main/java/org/primefaces/component/datalist/DataList.java
@@ -266,7 +266,7 @@ public class DataList extends DataListBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         DataListState ls = getMultiViewState(false);
         if (ls != null && isPaginator()) {
             setFirst(ls.getFirst());

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -990,32 +990,36 @@ public class DataTable extends DataTableBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         DataTableState ts = getMultiViewState(false);
         if (ts != null) {
-            if (isPaginator()) {
-                setFirst(ts.getFirst());
-                int rows = (ts.getRows() == 0) ? getRows() : ts.getRows();
-                setRows(rows);
+            if (runDataIndepententRestore) {
+                if (isPaginator()) {
+                    setFirst(ts.getFirst());
+                    int rows = (ts.getRows() == 0) ? getRows() : ts.getRows();
+                    setRows(rows);
+                }
+
+                if (ts.getSortBy() != null) {
+                    updateSortByWithMVS(ts.getSortBy());
+                }
+
+                if (ts.getFilterBy() != null) {
+                    updateFilterByWithMVS(getFacesContext(), ts.getFilterBy());
+                }
+
+                if (ts.getExpandedRowKeys() != null) {
+                    updateExpansionWithMVS(ts.getExpandedRowKeys());
+                }
+
+                setColumnMeta(ts.getColumnMeta());
             }
 
-            if (ts.getSortBy() != null) {
-                updateSortByWithMVS(ts.getSortBy());
+            if (runDataDependentRestore) {
+                if (isSelectionEnabled()) {
+                    updateSelectionWithMVS(ts.getSelectedRowKeys());
+                }
             }
-
-            if (ts.getFilterBy() != null) {
-                updateFilterByWithMVS(getFacesContext(), ts.getFilterBy());
-            }
-
-            if (isSelectionEnabled()) {
-                updateSelectionWithMVS(ts.getSelectedRowKeys());
-            }
-
-            if (ts.getExpandedRowKeys() != null) {
-                updateExpansionWithMVS(ts.getExpandedRowKeys());
-            }
-
-            setColumnMeta(ts.getColumnMeta());
         }
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -111,15 +111,15 @@ public class DataTableRenderer extends DataRenderer {
     protected void preRender(FacesContext context, DataTable table) {
         table.initFilterBy(context);
 
-        if (table.isMultiViewState()) {
-            table.restoreMultiViewState();
-        }
-
         if (table.isLiveScroll()) {
             table.setScrollOffset(0);
         }
 
         if (table.isLazy()) {
+            if (table.isMultiViewState()) {
+                table.restoreMultiViewState(true, false);
+            }
+
             if (table.isLiveScroll()) {
                 table.loadLazyScrollData(0, table.getScrollRows());
             }
@@ -134,8 +134,16 @@ public class DataTableRenderer extends DataRenderer {
             else {
                 table.loadLazyData();
             }
+
+            if (table.isMultiViewState()) {
+                table.restoreMultiViewState(false, true);
+            }
         }
         else {
+            if (table.isMultiViewState()) {
+                table.restoreMultiViewState();
+            }
+
             if (table.isDefaultSort()) {
                 SortFeature sortFeature = (SortFeature) table.getFeature(DataTableFeatureKey.SORT);
                 sortFeature.sort(context, table);

--- a/primefaces/src/main/java/org/primefaces/component/dataview/DataView.java
+++ b/primefaces/src/main/java/org/primefaces/component/dataview/DataView.java
@@ -180,7 +180,7 @@ public class DataView extends DataViewBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         DataViewState viewState = getMultiViewState(false);
         if (viewState != null) {
             if (LangUtils.isNotEmpty(viewState.getLayout())) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabView.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabView.java
@@ -224,7 +224,7 @@ public class TabView extends TabViewBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         TabViewState ts = getMultiViewState(false);
         if (ts != null) {
             setActiveIndex(ts.getActiveIndex());

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -530,26 +530,30 @@ public class TreeTable extends TreeTableBase {
     }
 
     @Override
-    public void restoreMultiViewState() {
+    public void restoreMultiViewState(boolean runDataIndepententRestore, boolean runDataDependentRestore) {
         TreeTableState ts = getMultiViewState(false);
         if (ts != null) {
-            if (isPaginator()) {
-                setFirst(ts.getFirst());
-                int rows = (ts.getRows() == 0) ? getRows() : ts.getRows();
-                setRows(rows);
+            if (runDataIndepententRestore) {
+                if (isPaginator()) {
+                    setFirst(ts.getFirst());
+                    int rows = (ts.getRows() == 0) ? getRows() : ts.getRows();
+                    setRows(rows);
+                }
+
+                if (ts.getSortBy() != null) {
+                    updateSortByWithMVS(ts.getSortBy());
+                }
+
+                if (ts.getFilterBy() != null) {
+                    updateFilterByWithMVS(getFacesContext(), ts.getFilterBy());
+                }
+
+                setColumnMeta(ts.getColumnMeta());
             }
 
-            if (ts.getSortBy() != null) {
-                updateSortByWithMVS(ts.getSortBy());
-            }
-
-            if (ts.getFilterBy() != null) {
-                updateFilterByWithMVS(getFacesContext(), ts.getFilterBy());
-            }
-
-            // TODO selection
-
-            setColumnMeta(ts.getColumnMeta());
+//          if (runDataIndepententRestore) {
+//              // TODO selection
+//          }
         }
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -237,7 +237,7 @@ public class TreeTableRenderer extends DataRenderer {
         tt.resetDynamicColumns();
 
         if (tt.isMultiViewState()) {
-            tt.restoreMultiViewState();
+            tt.restoreMultiViewState(); // TODO use #restoreMutliViewState(boolean, boolean) once selection is implemented in MVS
         }
     }
 


### PR DESCRIPTION
This fix adds two flags to restoreMultiViewState which are only relevant
for components that do not have a static data model but use lazy loaded
data. In that case the first flag indicates, that the data independent
state should be restored (e.g. filters in a datatable that is required
to load the data model). The second flag indicates, that the data is
available and the data dependent state could be restored.