### PR TITLE
Fix #7613: Tree: Focus / Navigation broken if tree is droppable

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree003.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree003.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tree;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.faces.view.ViewScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.primefaces.model.TreeNode;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class Tree003 implements Serializable {
+
+    @Inject
+    private TreeNodeService treeNodeService;
+
+    private TreeNode<String> root1;
+    private TreeNode<String> root2;
+
+    @PostConstruct
+    public void init() {
+        root1 = treeNodeService.createNodes();
+        root2 = treeNodeService.createNodes();
+    }
+
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree003.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree003.java
@@ -42,13 +42,11 @@ public class Tree003 implements Serializable {
     @Inject
     private TreeNodeService treeNodeService;
 
-    private TreeNode<String> root1;
-    private TreeNode<String> root2;
+    private TreeNode<String> root;
 
     @PostConstruct
     public void init() {
-        root1 = treeNodeService.createNodes();
-        root2 = treeNodeService.createNodes();
+        root = treeNodeService.createNodes();
     }
 
 }

--- a/primefaces-integration-tests/src/main/webapp/tree/tree003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tree/tree003.xhtml
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate />
+            </p:messages>
+
+            <h:panelGrid id="pnlDnd" columns="3">
+                <p:tree id="tree1" value="#{tree003.root2}" var="document1" widgetVar="tree1" draggable="true"
+                    droppable="true" dragdropScope="tree003" style="width:16rem">
+                    <p:treeNode>
+                        <h:outputText value="#{document1}" />
+                    </p:treeNode>
+                </p:tree>
+
+                <h:outputText styleClass="pi pi-sort-alt p-mx-5 text-secondary"
+                    style="transform: rotate(90deg); font-size: 3rem" />
+
+                <p:tree id="tree2" value="#{tree003.root2}" var="document2" widgetVar="tree2" draggable="true"
+                    droppable="true" dragdropScope="tree003" style="width:16rem">
+                    <p:treeNode>
+                        <h:outputText value="#{document2}" />
+                    </p:treeNode>
+                </p:tree>
+
+            </h:panelGrid>
+
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/tree/tree003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tree/tree003.xhtml
@@ -13,25 +13,11 @@
                 <p:autoUpdate />
             </p:messages>
 
-            <h:panelGrid id="pnlDnd" columns="3">
-                <p:tree id="tree1" value="#{tree003.root2}" var="document1" widgetVar="tree1" draggable="true"
-                    droppable="true" dragdropScope="tree003" style="width:16rem">
-                    <p:treeNode>
-                        <h:outputText value="#{document1}" />
-                    </p:treeNode>
-                </p:tree>
-
-                <h:outputText styleClass="pi pi-sort-alt p-mx-5 text-secondary"
-                    style="transform: rotate(90deg); font-size: 3rem" />
-
-                <p:tree id="tree2" value="#{tree003.root2}" var="document2" widgetVar="tree2" draggable="true"
-                    droppable="true" dragdropScope="tree003" style="width:16rem">
-                    <p:treeNode>
-                        <h:outputText value="#{document2}" />
-                    </p:treeNode>
-                </p:tree>
-
-            </h:panelGrid>
+            <p:tree id="tree" value="#{tree003.root}" var="document" widgetVar="tree" draggable="true" droppable="true">
+                <p:treeNode>
+                    <h:outputText value="#{document}" />
+                </p:treeNode>
+            </p:tree>
 
         </h:form>
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/AbstractTreeTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/AbstractTreeTest.java
@@ -32,9 +32,13 @@ import org.primefaces.selenium.component.model.Msg;
 public abstract class AbstractTreeTest extends AbstractPrimePageTest {
 
     protected void assertConfiguration(JSONObject cfg) {
+        assertConfiguration(cfg, "tree");
+    }
+
+    protected void assertConfiguration(JSONObject cfg, String widgetVar) {
         assertNoJavascriptErrors();
         System.out.println("Tree Config = " + cfg);
-        Assertions.assertEquals("tree", cfg.getString("widgetVar"));
+        Assertions.assertEquals(widgetVar, cfg.getString("widgetVar"));
     }
 
     protected void assertMessage(Messages messages, int index, String summary, String detail) {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree001Test.java
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Action;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.PrimeSelenium;
@@ -140,6 +143,39 @@ public class Tree001Test extends AbstractTreeTest {
 
         firstOfFirst = firstChildren.get(0);
         Assertions.assertTrue(firstOfFirst.getWebElement().isDisplayed());
+
+        assertConfiguration(tree.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Tree: Tab and arrow keys to select")
+    public void testTabbing(Page page) {
+        // Arrange
+        Tree tree = page.tree;
+        Assertions.assertNotNull(tree);
+
+        // Act
+        Actions actions = new Actions(page.getWebDriver());
+        Action actionUnselect = actions.sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_RIGHT).build();
+        PrimeSelenium.guardAjax(actionUnselect).perform();
+
+        // Assert
+        List<TreeNode> children = tree.getChildren();
+        Assertions.assertNotNull(children);
+        Assertions.assertEquals(3, children.size());
+
+        TreeNode second = children.get(1);
+        Assertions.assertEquals("Events", second.getLabelText());
+        Assertions.assertTrue(second.getWebElement().isDisplayed());
+
+        List<TreeNode> secondChildren = second.getChildren();
+        Assertions.assertNotNull(secondChildren);
+        Assertions.assertEquals(3, secondChildren.size());
+
+        Assertions.assertTrue(secondChildren.get(0).getWebElement().isDisplayed());
+        Assertions.assertTrue(secondChildren.get(1).getWebElement().isDisplayed());
+        Assertions.assertTrue(secondChildren.get(2).getWebElement().isDisplayed());
 
         assertConfiguration(tree.getWidgetConfiguration());
     }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree003Test.java
@@ -47,16 +47,16 @@ public class Tree003Test extends AbstractTreeTest {
     @DisplayName("Tree: Drag and drop still allows tab and arrow keys to select")
     public void testTabbing(Page page) {
         // Arrange
-        Tree tree1 = page.tree1;
-        Assertions.assertNotNull(tree1);
+        Tree tree = page.tree;
+        Assertions.assertNotNull(tree);
 
         // Act
         Actions actions = new Actions(page.getWebDriver());
         Action actionUnselect = actions.sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_RIGHT).build();
-        PrimeSelenium.guardAjax(actionUnselect).perform();
+        actionUnselect.perform();
 
         // Assert
-        List<TreeNode> children = tree1.getChildren();
+        List<TreeNode> children = tree.getChildren();
         Assertions.assertNotNull(children);
         Assertions.assertEquals(3, children.size());
 
@@ -72,15 +72,12 @@ public class Tree003Test extends AbstractTreeTest {
         Assertions.assertTrue(secondChildren.get(1).getWebElement().isDisplayed());
         Assertions.assertTrue(secondChildren.get(2).getWebElement().isDisplayed());
 
-        assertConfiguration(tree1.getWidgetConfiguration());
+        assertConfiguration(tree.getWidgetConfiguration());
     }
 
     public static class Page extends AbstractPrimePage {
-        @FindBy(id = "form:pnlDnd:tree1")
-        Tree tree1;
-
-        @FindBy(id = "form:pnlDnd:tree2")
-        Tree tree2;
+        @FindBy(id = "form:tree")
+        Tree tree;
 
         @FindBy(id = "form:msgs")
         Messages messages;

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree003Test.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tree;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Action;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.Tree;
+import org.primefaces.selenium.component.model.tree.TreeNode;
+
+public class Tree003Test extends AbstractTreeTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Tree: Drag and drop still allows tab and arrow keys to select")
+    public void testTabbing(Page page) {
+        // Arrange
+        Tree tree1 = page.tree1;
+        Assertions.assertNotNull(tree1);
+
+        // Act
+        Actions actions = new Actions(page.getWebDriver());
+        Action actionUnselect = actions.sendKeys(Keys.TAB, Keys.ARROW_DOWN, Keys.ARROW_RIGHT).build();
+        PrimeSelenium.guardAjax(actionUnselect).perform();
+
+        // Assert
+        List<TreeNode> children = tree1.getChildren();
+        Assertions.assertNotNull(children);
+        Assertions.assertEquals(3, children.size());
+
+        TreeNode second = children.get(1);
+        Assertions.assertEquals("Events", second.getLabelText());
+        Assertions.assertTrue(second.getWebElement().isDisplayed());
+
+        List<TreeNode> secondChildren = second.getChildren();
+        Assertions.assertNotNull(secondChildren);
+        Assertions.assertEquals(3, secondChildren.size());
+
+        Assertions.assertTrue(secondChildren.get(0).getWebElement().isDisplayed());
+        Assertions.assertTrue(secondChildren.get(1).getWebElement().isDisplayed());
+        Assertions.assertTrue(secondChildren.get(2).getWebElement().isDisplayed());
+
+        assertConfiguration(tree1.getWidgetConfiguration());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:pnlDnd:tree1")
+        Tree tree1;
+
+        @FindBy(id = "form:pnlDnd:tree2")
+        Tree tree2;
+
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @Override
+        public String getLocation() {
+            return "tree/tree003.xhtml";
+        }
+    }
+}

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Tree.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Tree.java
@@ -43,7 +43,7 @@ public abstract class Tree extends AbstractComponent {
     public static final String NODE_CONTENT_CLASS = "ui-treenode-content";
     public static final String LEAF_NODE_CLASS = "ui-treenode-leaf";
 
-    public static final String CHILD_SELECTOR = ".ui-tree-container>li";
+    public static final String CHILD_SELECTOR = ".ui-tree-container>.ui-treenode";
 
     public List<TreeNode> getChildren() {
         return findElements(By.cssSelector(CHILD_SELECTOR)).stream().map(e -> new TreeNode(e, CHILD_SELECTOR, this))

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/tree/TreeNode.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/tree/TreeNode.java
@@ -42,14 +42,14 @@ public class TreeNode {
     public TreeNode(WebElement webElement, String selector, Tree tree) {
         this.webElement = webElement;
         this.selector = selector;
-        this.childSelector = selector + ">.ui-treenode-children>li";
+        this.childSelector = selector + ">.ui-treenode-children>.ui-treenode";
         this.tree = tree;
     }
 
     public TreeNode(WebElement webElement, String selector, TreeNode parent) {
         this.webElement = webElement;
         this.selector = selector;
-        this.childSelector = selector + ">.ui-treenode-children>li";
+        this.childSelector = selector + ">.ui-treenode-children>.ui-treenode";
         this.parent = parent;
         this.tree = parent.getTree();
     }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
@@ -1349,7 +1349,7 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
      * @return {JQuery} The first node of this tree.
      */
     getFirstNode: function() {
-        return this.jq.find('> ul.ui-tree-container > li:first-child');
+        return this.jq.find("> ul.ui-tree-container > li.ui-treenode").first();
     },
 
     /**
@@ -1358,7 +1358,7 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
      * @return {JQuery} The element with the label for the given node.
      */
     getNodeLabel: function(node) {
-        return node.find('> span.ui-treenode-content > span.ui-treenode-label');
+        return node.find('> div.ui-treenode-content > span.ui-treenode-label');
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
@@ -217,10 +217,10 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
 
                 case keyCode.UP:
                     var nodeToFocus = null,
-                    prevNode = $this.focusedNode.prev();
+                    prevNode = $this.previousNode($this.focusedNode);
 
                     if(prevNode.length) {
-                        nodeToFocus = prevNode.find('li.ui-treenode:visible:last');
+                        nodeToFocus = prevNode.find('li.ui-treenode:visible:not(.ui-tree-droppoint)').last();
                         if(!nodeToFocus.length) {
                             nodeToFocus = prevNode;
                         }
@@ -238,13 +238,13 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
 
                 case keyCode.DOWN:
                     var nodeToFocus = null,
-                    firstVisibleChildNode = $this.focusedNode.find("> ul > li:visible:first");
+                    firstVisibleChildNode = $this.focusedNode.find("> ul > li:visible:not(.ui-tree-droppoint)").first();
 
                     if(firstVisibleChildNode.length) {
                         nodeToFocus = firstVisibleChildNode;
                     }
-                    else if($this.focusedNode.next().length) {
-                        nodeToFocus = $this.focusedNode.next();
+                    else if($this.nextNode($this.focusedNode).length) {
+                        nodeToFocus = $this.nextNode($this.focusedNode);
                     }
                     else {
                         var rowkey = $this.focusedNode.data('rowkey').toString();
@@ -325,13 +325,41 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
     },
 
     /**
+     * Returns the previous node, skipping droppoints (if present), starting at the given node.
+     * @private
+     * @param {JQuery} node Node where to start the search.
+     * @return {JQuery} The previous node.
+     */
+    previousNode: function(node) {
+        var prevNode = node.prev();
+        if (prevNode.length && prevNode.hasClass("ui-tree-droppoint")) {
+            prevNode = prevNode.prev();
+        }
+        return prevNode;
+    },
+
+    /**
+     * Returns the next node, skipping droppoints (if present), starting at the given node.
+     * @private
+     * @param {JQuery} node Node where to start the search.
+     * @return {JQuery} The next node.
+     */
+    nextNode: function(node) {
+        var nextNode = node.next();
+        if (nextNode.length && nextNode.hasClass("ui-tree-droppoint")) {
+            nextNode = nextNode.next();
+        }
+        return nextNode;
+    },
+
+    /**
      * Searches for a node to focus, starting at the given node.
      * @private
      * @param {JQuery} node Node where to start the search.
      * @return {JQuery} A node to focus.
      */
     searchDown: function(node) {
-        var nextOfParent = node.closest('ul').parent('li').next(),
+        var nextOfParent = $this.nextNode(node.closest('ul').parent('li')),
         nodeToFocus = null;
 
         if(nextOfParent.length) {


### PR DESCRIPTION
Drag/Drop mode on tree adds extra `li` elements that wreak havoc within the js keybinds. `getFirstNode`, `getNodeLabel`, and tree traversal with arrow keys were broken for both normal trees and Drag/Drop trees. This PR adds new integration tests that reveal the issue, as well as the fixes that make them green.