### PR TITLE
Fix #7628: Spinner: remove p- prefix from text alignment classes

### DIFF
--- a/docs/11_0_0/components/spinner.md
+++ b/docs/11_0_0/components/spinner.md
@@ -185,8 +185,7 @@ structural style classes:
 .ui-spinner-button-up | Increment button
 .ui-spinner-button-down | Decrement button
 
-### PrimeFlex
-The PrimeFlex classes `p-text-left`, `p-text-center` and `p-text-right` are supported to align the text of the Spinner input field.
+### Text alignment
+The PrimeFlex classes `text-left`, `text-center` and `text-right` are supported to align the text of the Spinner input field.
 
 As skinning style classes are global, see the main theming section for more information.
-

--- a/docs/11_0_0/gettingstarted/whatsnew.md
+++ b/docs/11_0_0/gettingstarted/whatsnew.md
@@ -10,7 +10,7 @@ This page contains a list of big features. Please check the GitHub issues for al
   * InputText, InputTextarea: counter can count bytes instead of characters.
   * Spinner
     * Added buttons modes: `horizontal`, `horizontal-after` and `vertical`.
-    * Added support for PrimeFlex to align input text: `text-left`, `text-center`, `text-right`.
+    * Added support to align input text using classes: `text-left`, `text-center`, `text-right`.
 
 Look into [migration guide](https://primefaces.github.io/primefaces/11_0_0/#/../migrationguide/11_0_0) for more enhancements and changes.
 Or check the list of TODO+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0).

--- a/docs/11_0_0/gettingstarted/whatsnew.md
+++ b/docs/11_0_0/gettingstarted/whatsnew.md
@@ -10,7 +10,7 @@ This page contains a list of big features. Please check the GitHub issues for al
   * InputText, InputTextarea: counter can count bytes instead of characters.
   * Spinner
     * Added buttons modes: `horizontal`, `horizontal-after` and `vertical`.
-    * Added support for PrimeFlex to align input text: `p-text-left`, `p-text-center`, `p-text-right`.
+    * Added support for PrimeFlex to align input text: `text-left`, `text-center`, `text-right`.
 
 Look into [migration guide](https://primefaces.github.io/primefaces/11_0_0/#/../migrationguide/11_0_0) for more enhancements and changes.
 Or check the list of TODO+ issues closed for [11.0.0](https://github.com/primefaces/primefaces/issues?q=is%3Aclosed+milestone%3A11.0.0).

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.css
@@ -14,13 +14,13 @@ input.ui-spinner-input {
     box-sizing: border-box;
     width: 100%;
 }
-.ui-spinner.p-text-left .ui-spinner-input {
+.ui-spinner.text-left .ui-spinner-input {
     text-align: left;
 }
-.ui-spinner.p-text-center .ui-spinner-input {
+.ui-spinner.text-center .ui-spinner-input {
     text-align: center;
 }
-.ui-spinner.p-text-right .ui-spinner-input {
+.ui-spinner.text-right .ui-spinner-input {
     text-align: right;
 }
 .ui-spinner-button {


### PR DESCRIPTION
Fix #7628