### PR TITLE
Fix #7576 UICalendar.validateMinMax

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker010.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker010.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:datePicker id="datepicker" value="02.06.2021"
+                          mindate="27.05.2021" maxdate="10.06.2021" pattern="dd.MM.yyyy"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker010Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker010Test.java
@@ -1,0 +1,129 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.time.LocalDate;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.component.DatePicker;
+
+public class DatePicker010Test extends AbstractDatePickerTest {
+
+    @Test
+    @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    public void testMinMax(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Act
+        datePicker.click(); // focus to bring up panel
+
+        // Assert (some days of june active)
+        WebElement panel = datePicker.getPanel();
+        Assertions.assertNotNull(panel);
+        Assertions.assertEquals(10, panel.findElements(By.cssSelector("a.ui-state-default")).size());
+        Assertions.assertEquals(20 + 5, panel.findElements(By.cssSelector("td > span.ui-state-disabled")).size()); //includes invisible days of other months
+
+        // Act - previous month
+        panel.findElement(By.className("ui-datepicker-prev")).click();
+
+        // Assert (some days of May active)
+        Assertions.assertEquals(26 + 11, panel.findElements(By.cssSelector("td > span.ui-state-disabled")).size()); //includes invisible days of other months
+        Assertions.assertEquals(5, panel.findElements(By.cssSelector("td > a.ui-state-default")).size());
+
+        assertConfiguration(datePicker.getWidgetConfiguration());
+    }
+
+    @Test
+    @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    public void testMinMaxValueInside(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Act
+        datePicker.setValue(LocalDate.of(2021, 06, 02));
+
+        // Assert
+        WebElement panel = datePicker.getPanel();
+        Assertions.assertNotNull(panel);
+        Assertions.assertEquals(LocalDate.of(2021, 6, 02), datePicker.getValue().toLocalDate());
+
+        // Act
+        datePicker.setValue(LocalDate.of(2021, 05, 29));
+
+        // Assert
+        Assertions.assertEquals(LocalDate.of(2021, 5, 29), datePicker.getValue().toLocalDate());
+
+        assertConfiguration(datePicker.getWidgetConfiguration());
+    }
+
+    @Test
+    @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    public void testMinMaxValueOutside(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Act
+        datePicker.setValue(LocalDate.of(2021, 07, 20));
+
+        // Assert
+        WebElement panel = datePicker.getPanel();
+        Assertions.assertNotNull(panel);
+        Assertions.assertEquals(LocalDate.of(2021, 6, 10), datePicker.getValue().toLocalDate());
+
+        // Act
+        datePicker.setValue(LocalDate.of(2021, 04, 30));
+
+        // Assert
+        Assertions.assertEquals(LocalDate.of(2021, 5, 27), datePicker.getValue().toLocalDate());
+
+        assertConfiguration(datePicker.getWidgetConfiguration());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("DatePicker Config = " + cfg);
+        Assertions.assertEquals("dd.mm.yy", cfg.getString("dateFormat"));
+        Assertions.assertEquals("27.05.2021", cfg.getString("minDate"));
+        Assertions.assertEquals("10.06.2021", cfg.getString("maxDate"));
+        Assertions.assertEquals("single", cfg.getString("selectionMode"));
+        Assertions.assertFalse(cfg.getBoolean("inline"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datepicker")
+        DatePicker datePicker;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker010.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -23,6 +23,7 @@
  */
 package org.primefaces.component.api;
 
+import java.time.LocalDate;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
@@ -368,10 +369,9 @@ public abstract class UICalendar extends AbstractPrimeHtmlInputText implements I
         }
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public void validateMinMax(FacesContext context) {
-        Comparable minDate = (Comparable) getMindate();
-        Comparable maxDate = (Comparable) getMaxdate();
+        LocalDate minDate = CalendarUtils.getObjectAsLocalDate(context, this, getMindate());
+        LocalDate maxDate = CalendarUtils.getObjectAsLocalDate(context, this, getMaxdate());
         if (minDate != null && maxDate != null && maxDate.compareTo(minDate) < 0) {
             String id = getClientId(context);
             String component = this.getClass().getSimpleName();

--- a/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -24,16 +24,11 @@
 package org.primefaces.component.api;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.time.format.ResolverStyle;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
@@ -42,7 +37,6 @@ import javax.faces.FacesException;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
-import org.primefaces.component.datepicker.DatePicker;
 import org.primefaces.util.*;
 
 public abstract class UICalendar extends AbstractPrimeHtmlInputText implements InputHolder, TouchAware {
@@ -376,53 +370,12 @@ public abstract class UICalendar extends AbstractPrimeHtmlInputText implements I
     }
 
     public void validateMinMax(FacesContext context) {
-        Instant minDate = toInstant(context, getMindate(), "minimum");
-        Instant maxDate = toInstant(context, getMaxdate(), "maximum");
+        Instant minDate = CalendarUtils.getObjectAsInstant(context, this, getMindate(), PropertyKeys.mindate.name());
+        Instant maxDate = CalendarUtils.getObjectAsInstant(context, this, getMaxdate(), PropertyKeys.maxdate.name());
         if (minDate != null && maxDate != null && maxDate.compareTo(minDate) < 0) {
             String id = getClientId(context);
             String component = this.getClass().getSimpleName();
             throw new FacesException(component + " : \"" + id + "\" minimum date must be less than maximum date.");
         }
-    }
-
-    private Instant toInstant(FacesContext context, Object date, String attr) {
-        if (date == null) {
-            return null;
-        }
-        if (date instanceof LocalDateTime) {
-            return ((LocalDateTime) date).toInstant(ZoneOffset.UTC);
-        }
-        if (date instanceof LocalDate) {
-            return ((LocalDate) date).atStartOfDay().toInstant(ZoneOffset.UTC);
-        }
-        if (date instanceof LocalTime) {
-            LocalDate now = LocalDate.now();
-            return now.atTime(((LocalTime) date)).toInstant(ZoneOffset.UTC);
-        }
-        if (date instanceof Date) {
-            if (date instanceof java.sql.Date) {
-                // java.sql.Date does not support toInstant
-                return new Date(((java.sql.Date) date).getTime()).toInstant();
-            }
-            return ((Date) date).toInstant(); // implied UTC
-        }
-        if (date instanceof String) {
-            boolean hasTime = isTimeOnly() || hasTime() ||
-                    (this instanceof DatePicker && ((DatePicker) this).isShowTime());
-            LocalDate datePart = isTimeOnly() ? null : CalendarUtils.getObjectAsLocalDate(context, this, date);
-            LocalTime timePart = hasTime ? CalendarUtils.getObjectAsLocalTime(context, this, date) : null;
-            if (datePart == null) {
-                datePart = LocalDate.now();
-            }
-            if (timePart == null) {
-                return datePart.atStartOfDay().toInstant(ZoneOffset.UTC);
-            }
-            return datePart.atTime(timePart).toInstant(ZoneOffset.UTC);
-        }
-
-        String id = getClientId(context);
-        String component = this.getClass().getSimpleName();
-        String type = date.getClass().getName();
-        throw new FacesException(component + " : \"" + id + "\"" + attr + " date unsupported type " + type);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -42,6 +42,7 @@ import javax.faces.FacesException;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
+import org.primefaces.component.datepicker.DatePicker;
 import org.primefaces.util.*;
 
 public abstract class UICalendar extends AbstractPrimeHtmlInputText implements InputHolder, TouchAware {
@@ -406,7 +407,17 @@ public abstract class UICalendar extends AbstractPrimeHtmlInputText implements I
             return ((Date) date).toInstant(); // implied UTC
         }
         if (date instanceof String) {
-            return CalendarUtils.getObjectAsLocalDate(context, this, date).atStartOfDay().toInstant(ZoneOffset.UTC);
+            boolean hasTime = isTimeOnly() || hasTime() ||
+                    (this instanceof DatePicker && ((DatePicker) this).isShowTime());
+            LocalDate datePart = isTimeOnly() ? null : CalendarUtils.getObjectAsLocalDate(context, this, date);
+            LocalTime timePart = hasTime ? CalendarUtils.getObjectAsLocalTime(context, this, date) : null;
+            if (datePart == null) {
+                datePart = LocalDate.now();
+            }
+            if (timePart == null) {
+                return datePart.atStartOfDay().toInstant(ZoneOffset.UTC);
+            }
+            return datePart.atTime(timePart).toInstant(ZoneOffset.UTC);
         }
 
         String id = getClientId(context);

--- a/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
@@ -1109,8 +1109,8 @@ public class DatePickerTest {
 
     @Test
     public void validateMinMax_LocalDateTime_differentDay() {
-        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 11, 10, 0));
-        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 11, 59));
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 11, 11, 59));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 00));
         doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
@@ -1316,139 +1316,471 @@ public class DatePickerTest {
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
+    // Support string based date and time minDate/maxDate setups
+    private void setupMinMaxDateTime(Class type, Locale locale, String pattern) {
+        when(datePicker.calculateLocale(any())).thenReturn(locale);
+        when(valueExpression.getType(elContext)).thenReturn(type);
+        when(datePicker.getPattern()).thenReturn(pattern);
+        when(datePicker.isShowTime()).thenReturn(true);
+        when(datePicker.calculateLocalizedPattern()).thenCallRealMethod();
+        doCallRealMethod().when(datePicker).validateMinMax(any());
+    }
+
+    // Support string based date minDate/maxDate setups
+    private void setupMinMaxDate(Class type, Locale locale, String pattern) {
+        when(datePicker.calculateLocale(any())).thenReturn(locale);
+        when(valueExpression.getType(elContext)).thenReturn(type);
+        when(datePicker.getPattern()).thenReturn(pattern);
+        when(datePicker.isShowTime()).thenReturn(false);
+        when(datePicker.calculateLocalizedPattern()).thenCallRealMethod();
+        doCallRealMethod().when(datePicker).validateMinMax(any());
+    }
+
+    // Support string based date time minDate/maxDate setups
+    private void setupMinMaxTime(Class type, Locale locale, String pattern) {
+        when(datePicker.calculateLocale(any())).thenReturn(locale);
+        when(valueExpression.getType(elContext)).thenReturn(type);
+        when(datePicker.getPattern()).thenReturn(pattern);
+        when(datePicker.isTimeOnly()).thenReturn(true);
+        when(datePicker.calculateLocalizedPattern()).thenCallRealMethod();
+        doCallRealMethod().when(datePicker).validateMinMax(any());
+    }
+
     @Test
-    public void validateMinMax_String() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_DateTime_sameDay() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11/11/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_differentDay() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11/11/2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11/12/2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_sameDateTime() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11/11/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_wrongTime() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11/11/2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_wrongDate() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11/12/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 11:59");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_explicitPattern_sameDay() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, "MM/dd/yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11/11/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_explicitPattern_differentDay() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, "MM/dd/yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11/11/2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11/12/2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_explicitPattern_sameDateTime() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, "MM/dd/yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11/11/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_explicitPattern_wrongTime() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, "MM/dd/yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11/11/2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_explicitPattern_wrongDate() {
+        setupMinMaxDateTime(String.class, Locale.ENGLISH, "MM/dd/yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11/12/2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019 11:59");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_sameDay() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("11.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_differentDay() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("11.11.2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("12.11.2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_sameDateTime() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("11.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_wrongTime() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("11.11.2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_wrongDate() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("12.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 11:59");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_explicitPattern_sameDay() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, "dd.MM.yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_explicitPattern_differentDay() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, "dd.MM.yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11.11.2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("12.11.2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_explicitPattern_sameDateTime() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, "dd.MM.yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_explicitPattern_wrongTime() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, "dd.MM.yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("11.11.2019 11:59");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_DateTime_German_explicitPattern_wrongDate() {
+        setupMinMaxDateTime(String.class, Locale.GERMAN, "dd.MM.yyyy HH:mm");
+        when(datePicker.getMindate()).thenReturn("12.11.2019 10:00");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019 11:59");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Date() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, null);
         when(datePicker.getMindate()).thenReturn("11/11/2019");
         when(datePicker.getMaxdate()).thenReturn("11/12/2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_sameDate() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_Date_sameDate() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, null);
         when(datePicker.getMindate()).thenReturn("11/11/2019");
         when(datePicker.getMaxdate()).thenReturn("11/11/2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_wrongDate() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_Date_wrongDate() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, null);
         when(datePicker.getMindate()).thenReturn("11/12/2019");
         when(datePicker.getMaxdate()).thenReturn("11/11/2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_explicitPattern() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_Date_explicitPattern() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, "MM/dd/yyyy");
         when(datePicker.getMindate()).thenReturn("11/11/2019");
         when(datePicker.getMaxdate()).thenReturn("11/12/2019");
-        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_explicitPattern_sameDate() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_Date_explicitPattern_sameDate() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, "MM/dd/yyyy");
         when(datePicker.getMindate()).thenReturn("11/11/2019");
         when(datePicker.getMaxdate()).thenReturn("11/11/2019");
-        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_explicitPattern_wrongDate() {
-        setupValues(String.class, Locale.ENGLISH);
+    public void validateMinMax_String_Date_explicitPattern_wrongDate() {
+        setupMinMaxDate(String.class, Locale.ENGLISH, "MM/dd/yyyy");
         when(datePicker.getMindate()).thenReturn("11/12/2019");
         when(datePicker.getMaxdate()).thenReturn("11/11/2019");
-        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German() {
+        setupMinMaxDate(String.class, Locale.GERMAN, null);
         when(datePicker.getMindate()).thenReturn("11.11.2019");
         when(datePicker.getMaxdate()).thenReturn("12.11.2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German_sameDate() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German_sameDate() {
+        setupMinMaxDate(String.class, Locale.GERMAN, null);
         when(datePicker.getMindate()).thenReturn("11.11.2019");
         when(datePicker.getMaxdate()).thenReturn("11.11.2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German_wrongDate() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German_wrongDate() {
+        setupMinMaxDate(String.class, Locale.GERMAN, null);
         when(datePicker.getMindate()).thenReturn("12.11.2019");
         when(datePicker.getMaxdate()).thenReturn("11.11.2019");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German_explicitPattern() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German_explicitPattern() {
+        setupMinMaxDate(String.class, Locale.GERMAN, "dd.MM.yyyy");
         when(datePicker.getMindate()).thenReturn("11.11.2019");
         when(datePicker.getMaxdate()).thenReturn("12.11.2019");
-        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German_explicitPattern_sameDate() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German_explicitPattern_sameDate() {
+        setupMinMaxDate(String.class, Locale.GERMAN, "dd.MM.yyyy");
         when(datePicker.getMindate()).thenReturn("11.11.2019");
         when(datePicker.getMaxdate()).thenReturn("11.11.2019");
-        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
         datePicker.validateMinMax(context);
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();
     }
 
     @Test
-    public void validateMinMax_String_German_explicitPattern_wrongDate() {
-        setupValues(String.class, Locale.GERMAN);
+    public void validateMinMax_String_Date_German_explicitPattern_wrongDate() {
+        setupMinMaxDate(String.class, Locale.GERMAN, "dd.MM.yyyy");
         when(datePicker.getMindate()).thenReturn("12.11.2019");
         when(datePicker.getMaxdate()).thenReturn("11.11.2019");
-        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
-        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_sameTime() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_wrongDate() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, null);
+        when(datePicker.getMindate()).thenReturn("11:59");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_explicitPattern() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_explicitPattern_sameTime() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_explicitPattern_wrongTime() {
+        setupMinMaxTime(String.class, Locale.ENGLISH, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("11:59");
+        when(datePicker.getMaxdate()).thenReturn("11:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German() {
+        setupMinMaxTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German_sameTime() {
+        setupMinMaxTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German_wrongTime() {
+        setupMinMaxTime(String.class, Locale.GERMAN, null);
+        when(datePicker.getMindate()).thenReturn("11:59");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German_explicitPattern() {
+        setupMinMaxTime(String.class, Locale.GERMAN, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("11:59");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German_explicitPattern_sameTime() {
+        setupMinMaxTime(String.class, Locale.GERMAN, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("10:00");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_Time_German_explicitPattern_wrongTime() {
+        setupMinMaxTime(String.class, Locale.GERMAN, "HH:mm");
+        when(datePicker.getMindate()).thenReturn("11:59");
+        when(datePicker.getMaxdate()).thenReturn("10:00");
         assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
         verify(datePicker, atLeastOnce()).getMindate();
         verify(datePicker, atLeastOnce()).getMaxdate();

--- a/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datepicker/DatePickerTest.java
@@ -26,14 +26,17 @@ package org.primefaces.component.datepicker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,6 +47,7 @@ import java.util.*;
 
 import javax.el.ELContext;
 import javax.el.ValueExpression;
+import javax.faces.FacesException;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
@@ -1093,4 +1097,360 @@ public class DatePickerTest {
         assertEquals("yyyy-MM-dd HH:mm", datePicker.calculatePattern());
     }
 
+    @Test
+    public void validateMinMax_LocalDateTime_sameDay() {
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 0));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 11, 59));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDateTime_differentDay() {
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 11, 10, 0));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 11, 59));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDateTime_sameDateTime() {
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 0));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 0));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDateTime_wrongTime() {
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 12, 11, 59));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 00));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDateTime_wrongDate() {
+        when(datePicker.getMindate()).thenReturn(LocalDateTime.of(2019, 11, 12, 10, 0));
+        when(datePicker.getMaxdate()).thenReturn(LocalDateTime.of(2019, 11, 11, 11, 59));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDate() {
+        when(datePicker.getMindate()).thenReturn(LocalDate.of(2019, 11, 11));
+        when(datePicker.getMaxdate()).thenReturn(LocalDate.of(2019, 11, 12));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDate_sameDate() {
+        when(datePicker.getMindate()).thenReturn(LocalDate.of(2019, 11, 12));
+        when(datePicker.getMaxdate()).thenReturn(LocalDate.of(2019, 11, 12));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalDate_wrongDate() {
+        when(datePicker.getMindate()).thenReturn(LocalDate.of(2019, 11, 12));
+        when(datePicker.getMaxdate()).thenReturn(LocalDate.of(2019, 11, 11));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalTime() {
+        when(datePicker.getMindate()).thenReturn(LocalTime.of(10, 00));
+        when(datePicker.getMaxdate()).thenReturn(LocalTime.of(11, 59));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalTime_sameTime() {
+        when(datePicker.getMindate()).thenReturn(LocalTime.of(10, 00));
+        when(datePicker.getMaxdate()).thenReturn(LocalTime.of(10, 00));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_LocalTime_wrongTime() {
+        when(datePicker.getMindate()).thenReturn(LocalTime.of(11, 59));
+        when(datePicker.getMaxdate()).thenReturn(LocalTime.of(10, 00));
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_Date_sameDay() {
+        java.util.Calendar minDate = GregorianCalendar.getInstance();
+        minDate.set(2019, 10, 12);
+        minDate.set(Calendar.HOUR_OF_DAY, 10);
+        minDate.set(Calendar.MINUTE, 00);
+        minDate.set(Calendar.SECOND, 00);
+        minDate.set(Calendar.MILLISECOND, 0);
+        java.util.Calendar maxDate = GregorianCalendar.getInstance();
+        maxDate.set(2019, 10, 12);
+        maxDate.set(Calendar.HOUR_OF_DAY, 11);
+        maxDate.set(Calendar.MINUTE, 59);
+        maxDate.set(Calendar.SECOND, 00);
+        maxDate.set(Calendar.MILLISECOND, 0);
+
+        when(datePicker.getMindate()).thenReturn(minDate.getTime());
+        when(datePicker.getMaxdate()).thenReturn(maxDate.getTime());
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_Date_differentDay() {
+        java.util.Calendar minDate = GregorianCalendar.getInstance();
+        minDate.set(2019, 10, 11);
+        minDate.set(Calendar.HOUR_OF_DAY, 10);
+        minDate.set(Calendar.MINUTE, 00);
+        minDate.set(Calendar.SECOND, 00);
+        minDate.set(Calendar.MILLISECOND, 0);
+        java.util.Calendar maxDate = GregorianCalendar.getInstance();
+        maxDate.set(2019, 10, 12);
+        maxDate.set(Calendar.HOUR_OF_DAY, 11);
+        maxDate.set(Calendar.MINUTE, 59);
+        maxDate.set(Calendar.SECOND, 00);
+        maxDate.set(Calendar.MILLISECOND, 0);
+
+        when(datePicker.getMindate()).thenReturn(minDate.getTime());
+        when(datePicker.getMaxdate()).thenReturn(maxDate.getTime());
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_Date_sameDateTime() {
+        java.util.Calendar date = GregorianCalendar.getInstance();
+        date.set(2019, 10, 12);
+        date.set(Calendar.HOUR_OF_DAY, 10);
+        date.set(Calendar.MINUTE, 00);
+        date.set(Calendar.SECOND, 00);
+        date.set(Calendar.MILLISECOND, 0);
+
+        when(datePicker.getMindate()).thenReturn(date.getTime());
+        when(datePicker.getMaxdate()).thenReturn(date.getTime());
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_Date_wrongTime() {
+        java.util.Calendar minDate = GregorianCalendar.getInstance();
+        minDate.set(2019, 10, 12);
+        minDate.set(Calendar.HOUR_OF_DAY, 11);
+        minDate.set(Calendar.MINUTE, 59);
+        minDate.set(Calendar.SECOND, 00);
+        minDate.set(Calendar.MILLISECOND, 0);
+        java.util.Calendar maxDate = GregorianCalendar.getInstance();
+        maxDate.set(2019, 10, 12);
+        maxDate.set(Calendar.HOUR_OF_DAY, 10);
+        maxDate.set(Calendar.MINUTE, 00);
+        maxDate.set(Calendar.SECOND, 00);
+        maxDate.set(Calendar.MILLISECOND, 0);
+
+        when(datePicker.getMindate()).thenReturn(minDate.getTime());
+        when(datePicker.getMaxdate()).thenReturn(maxDate.getTime());
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_Date_wrongDate() {
+        java.util.Calendar minDate = GregorianCalendar.getInstance();
+        minDate.set(2019, 10, 12);
+        minDate.set(Calendar.HOUR_OF_DAY, 10);
+        minDate.set(Calendar.MINUTE, 00);
+        minDate.set(Calendar.SECOND, 00);
+        minDate.set(Calendar.MILLISECOND, 0);
+        java.util.Calendar maxDate = GregorianCalendar.getInstance();
+        maxDate.set(2019, 10, 11);
+        maxDate.set(Calendar.HOUR_OF_DAY, 11);
+        maxDate.set(Calendar.MINUTE, 59);
+        maxDate.set(Calendar.SECOND, 00);
+        maxDate.set(Calendar.MILLISECOND, 0);
+
+        when(datePicker.getMindate()).thenReturn(minDate.getTime());
+        when(datePicker.getMaxdate()).thenReturn(maxDate.getTime());
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/11/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/12/2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_sameDate() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/11/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_wrongDate() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/12/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_explicitPattern() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/11/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/12/2019");
+        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_explicitPattern_sameDate() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/11/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019");
+        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_explicitPattern_wrongDate() {
+        setupValues(String.class, Locale.ENGLISH);
+        when(datePicker.getMindate()).thenReturn("11/12/2019");
+        when(datePicker.getMaxdate()).thenReturn("11/11/2019");
+        when(datePicker.getPattern()).thenReturn("MM/dd/yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("11.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("12.11.2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German_sameDate() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("11.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German_wrongDate() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("12.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German_explicitPattern() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("11.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("12.11.2019");
+        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German_explicitPattern_sameDate() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("11.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019");
+        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        datePicker.validateMinMax(context);
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
+
+    @Test
+    public void validateMinMax_String_German_explicitPattern_wrongDate() {
+        setupValues(String.class, Locale.GERMAN);
+        when(datePicker.getMindate()).thenReturn("12.11.2019");
+        when(datePicker.getMaxdate()).thenReturn("11.11.2019");
+        when(datePicker.getPattern()).thenReturn("dd.MM.yyyy");
+        doCallRealMethod().when(datePicker).validateMinMax(context);
+        assertThrows(FacesException.class, () -> datePicker.validateMinMax(context));
+        verify(datePicker, atLeastOnce()).getMindate();
+        verify(datePicker, atLeastOnce()).getMaxdate();
+    }
 }


### PR DESCRIPTION
`UICalendar#validateMinMax(FaceContext)` compared strings instead of formated dates.