### PR TITLE
Fixing global attribute default value

### DIFF
--- a/docs/10_0_0/components/fileupload.md
+++ b/docs/10_0_0/components/fileupload.md
@@ -36,7 +36,7 @@ powered rich solution with graceful degradation for legacy browsers.
 | dragDropSupport | true | Boolean | Specifies dragdrop based file selection from filesystem, default is true and works only on supported browsers.
 | fileLimit | null | Integer | Maximum number of files allowed to upload.
 | fileLimitMessage | Maximum number of files exceeded | String | Message to display when file limit exceeds.
-| global | true | Boolean | Global AJAX requests are listened by ajaxStatus component, setting global to false will not trigger ajaxStatus. Default is false.
+| global | true | Boolean | Global AJAX requests are listened by ajaxStatus component, setting global to false will not trigger ajaxStatus. Default is true.
 | immediate | false | Boolean | When set true, process validations logic is executed at apply request values phase for this component.
 | invalidFileMessage | Invalid file type | String | Message to display when file is not accepted.
 | invalidSizeMessage | Invalid file size | String | Message to display when size limit exceeds.


### PR DESCRIPTION
Reading the docs, the default value for `global` attribute is false. And reading the source code, actually the default value is true. Looks like a typo since in the default value column is also true.

For reference: https://github.com/primefaces/primefaces/blob/master/primefaces/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java#L450