### PR TITLE
Fix #7695: Tree: ContextMenu unbound when removing all tree nodes

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.base.js
@@ -135,7 +135,7 @@ PrimeFaces.widget.BaseTree = PrimeFaces.widget.BaseWidget.extend({
         });
 
         $(document).off(containerEvent, this.jqTargetId).on(containerEvent, this.jqTargetId, null, function(e) {
-            if(targetWidget.isEmpty()) {
+            if(e.target.id == targetWidget.id && targetWidget.isEmpty()) {
                 menuWidget.show(e);
             }
         });


### PR DESCRIPTION
See #7695 for discussion around solution. Basically there are two "answers" but we went with the one that seemed to fit the current behavior. Original issue contains an alternate MonkeyPatch for altering the behavior.