### PR TITLE
Fix #7457 DatePicker lazy model

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker011.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker011.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import javax.annotation.PostConstruct;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.event.AjaxBehaviorEvent;
+
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+
+import lombok.Data;
+import org.primefaces.event.DateViewChangeEvent;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.model.datepicker.DateMetadataModel;
+import org.primefaces.model.datepicker.DefaultDateMetadata;
+import org.primefaces.model.datepicker.DefaultDateMetadataModel;
+import org.primefaces.model.datepicker.LazyDateMetadataModel;
+
+@Named
+@ViewScoped
+@Data
+public class DatePicker011 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private LocalDate date0, date1, date2, date3;
+    private LocalDate date4, date5, date6, date7;
+    private DateMetadataModel model;
+    private DateMetadataModel modelLazy;
+
+    @PostConstruct
+    public void init() {
+        DefaultDateMetadata disabled = DefaultDateMetadata.builder().disabled(true).styleClass("tst-disabled").build();
+        DefaultDateMetadata begin = DefaultDateMetadata.builder().styleClass("tst-begin").build();
+        DefaultDateMetadata end = DefaultDateMetadata.builder().styleClass("tst-end").build();
+
+        LocalDate start = LocalDate.now().withDayOfMonth(1);
+        model = new DefaultDateMetadataModel();
+        model.add(start.minusMonths(1).plusDays(1), disabled); // 2nd of previous month
+        model.add(start, disabled); // 1st of this month
+        model.add(start.plusMonths(1).plusDays(2), disabled); // 3rd of next month
+        model.add(start.plusDays(1), begin); // 2nd of this month
+        model.add(start.plusDays(2), end); //3rd of this month
+
+        modelLazy = new LazyDateMetadataModel() {
+            private static final long serialVersionUID = 1L;
+            @Override
+            public void loadDateMetadata(LocalDate d1, LocalDate d2) {
+                LocalDate start = LocalDate.now().withDayOfMonth(1);
+                add(start.minusMonths(1).plusDays(1), disabled); // 2nd of previous month
+                add(start, disabled); // 1st of this month
+                add(start.plusMonths(1).plusDays(2), disabled); // 3rd of next month
+                add(start.plusDays(1), begin); // 2nd of this month
+                add(start.plusDays(2), end); //3rd of this month
+            }
+        };
+    }
+
+    public void onDateSelect(SelectEvent event) {
+        String summary = "dateSelect " + event.getObject();
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, null);
+        FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+
+    public void onViewChange(DateViewChangeEvent event) {
+        String summary = "viewChange Year: " + event.getYear() + ", month: " + (event.getMonth() + 1);
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, null);
+        FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+
+    public void onClose(AjaxBehaviorEvent event) {
+        String summary = "close";
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, null);
+        FacesContext.getCurrentInstance().addMessage(null, message);
+    }
+    public void onSelect(AjaxBehaviorEvent event) {
+        // do nothing
+    }
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker012.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker012.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import javax.annotation.PostConstruct;
+
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import lombok.Data;
+import org.primefaces.event.DateViewChangeEvent;
+import org.primefaces.event.SelectEvent;
+import org.primefaces.model.datepicker.DefaultDateMetadata;
+import org.primefaces.model.datepicker.LazyDateMetadataModel;
+
+@Named
+@ViewScoped
+@Data
+public class DatePicker012 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private LocalDate date1;
+    private LocalDate date2;
+    private SimpleLazyDateMetadataModel lazyModel1;
+    private SimpleLazyDateMetadataModel lazyModel2;
+
+    @PostConstruct
+    public void init() {
+        lazyModel1 = new SimpleLazyDateMetadataModel();
+        lazyModel2 = new SimpleLazyDateMetadataModel();
+    }
+
+    public void onDateSelect(SelectEvent event) {
+        if ("datepicker1".equals(event.getComponent().getId())) {
+            lazyModel2.setDisabledDate(date1);
+        }
+        else {
+            lazyModel1.setDisabledDate(date2);
+        }
+    }
+
+    public void onViewChange(DateViewChangeEvent event) {
+        // nothing to do
+    }
+
+    private static final class SimpleLazyDateMetadataModel extends LazyDateMetadataModel {
+        private static final long serialVersionUID = 1L;
+        private static final DefaultDateMetadata DISABLED = DefaultDateMetadata.builder()
+                .disabled(true).styleClass("tst-disabled").build();
+        private LocalDate disabledDate;
+        @Override
+        public void loadDateMetadata(LocalDate start, LocalDate end) {
+            if (disabledDate != null) {
+                add(disabledDate, DISABLED);
+            }
+        }
+        public void setDisabledDate(LocalDate disabledDate) {
+            this.disabledDate = disabledDate;
+        }
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker011.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker011.xhtml
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true" redisplay="false">
+                <p:autoUpdate/>
+            </p:messages>
+            <div>
+                <h:outputText id="outside" value="Click me"/>
+                <p:commandButton id="clean" value="Clear msgs">
+                    <p:ajax event="click" listener="#{datePicker011.onSelect}"/>
+                </p:commandButton>
+            </div>
+            <div>
+                <p:datePicker id="datepicker0" pattern="yyyy-MM-dd" value="#{datePicker011.date0}"
+                              model="#{datePicker011.model}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                </p:datePicker>
+                <p:datePicker id="datepicker1" pattern="yyyy-MM-dd" value="#{datePicker011.date1}"
+                              model="#{datePicker011.model}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="dateSelect" listener="#{datePicker011.onDateSelect}"/>
+                </p:datePicker>
+                <p:datePicker id="datepicker2" pattern="yyyy-MM-dd" value="#{datePicker011.date2}"
+                              model="#{datePicker011.model}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="viewChange" listener="#{datePicker011.onViewChange}"/>
+                </p:datePicker>
+                <p:datePicker id="datepicker3" pattern="yyyy-MM-dd" value="#{datePicker011.date3}"
+                              model="#{datePicker011.model}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="close" listener="#{datePicker011.onClose}"/>
+                </p:datePicker>
+            </div>
+            <div>
+                <p:datePicker id="datepicker4" pattern="yyyy-MM-dd" value="#{datePicker011.date4}"
+                              model="#{datePicker011.modelLazy}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                </p:datePicker>
+                <p:datePicker id="datepicker5" pattern="yyyy-MM-dd" value="#{datePicker011.date5}"
+                              model="#{datePicker011.modelLazy}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="dateSelect" listener="#{datePicker011.onDateSelect}"/>
+                </p:datePicker>
+                <p:datePicker id="datepicker6" pattern="yyyy-MM-dd" value="#{datePicker011.date6}"
+                              model="#{datePicker011.modelLazy}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="viewChange" listener="#{datePicker011.onViewChange}"/>
+                </p:datePicker>
+                <p:datePicker id="datepicker7" pattern="yyyy-MM-dd" value="#{datePicker011.date7}"
+                              model="#{datePicker011.modelLazy}" monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                    <p:ajax event="close" listener="#{datePicker011.onClose}"/>
+                </p:datePicker>
+            </div>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker012.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker012.xhtml
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:datePicker id="datepicker1" value="#{datePicker012.date1}"
+                          model="#{datePicker012.lazyModel1}" refreshLazyModel="true"
+                          monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                <p:ajax event="dateSelect" listener="#{datePicker012.onDateSelect}"/>
+                <p:ajax event="viewChange" listener="#{datePicker012.onViewChange}"/>
+            </p:datePicker>
+            <p:datePicker id="datepicker2" value="#{datePicker012.date2}"
+                          model="#{datePicker012.lazyModel2}" refreshLazyModel="true"
+                          monthNavigator="true" yearNavigator="true" showButtonBar="true">
+                <p:ajax event="dateSelect" listener="#{datePicker012.onDateSelect}"/>
+                <p:ajax event="viewChange" listener="#{datePicker012.onViewChange}"/>
+            </p:datePicker>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker011Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker011Test.java
@@ -1,0 +1,523 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DatePicker;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.model.Msg;
+import org.primefaces.selenium.component.model.Severity;
+
+public class DatePicker011Test extends AbstractDatePickerTest {
+
+    private enum DatePickerBehaviour {
+        _none, dateSelect, viewChange, close;
+    };
+
+    @Test
+    @Order(1)
+    @DisplayName("DatePicker: meta data model without behaviour")
+    public void testMetaDataNoBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker0, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DatePicker: meta data model with dateSelect behaviour")
+    public void testMetaDataDateSelectBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker1, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("DatePicker: meta data model with viewChange behaviour")
+    public void testMetaDataViewChangeBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker2, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("DatePicker: meta data model with close behaviour")
+    public void testMetaDataCloseBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker3, page, DatePickerBehaviour.close);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("DatePicker: meta data model without behaviour")
+    public void testMetaDataNoBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker0, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("DatePicker: meta data model with dateSelect behaviour")
+    public void testMetaDataDateSelectBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker1, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("DatePicker: meta data model with viewChange behaviour")
+    public void testMetaDataViewChangeBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker2, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("DatePicker: meta data model with close behaviour")
+    public void testMetaDataCloseBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker3, page, DatePickerBehaviour.close);
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("DatePicker: meta data model without behaviour")
+    public void testBasicMetaBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker0, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("DatePicker: meta data model with dateSelect behaviour")
+    public void testMetaDataDateSelectBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker1, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("DatePicker: meta data model with viewChange behaviour")
+    public void testMetaDataViewChangeBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker2, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("DatePicker: meta data model with close behaviour")
+    public void testMetaDataCloseBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker3, page, DatePickerBehaviour.close);
+    }
+
+    @Test
+    @Order(13)
+    @DisplayName("DatePicker: lazy meta data model without behaviour")
+    public void testLazyMetaDataNoBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker4, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(14)
+    @DisplayName("DatePicker: lazy meta data model with dateSelect behaviour")
+    public void testLazyMetaDataDateSelectBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker5, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(15)
+    @DisplayName("DatePicker: lazy meta data model with viewChange behaviour")
+    public void testLazyMetaDataViewChangeBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker6, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(16)
+    @DisplayName("DatePicker: lazy meta data model with close behaviour")
+    public void testLazyMetaDataCloseBehaviour1(Page page) {
+        testDatePickerPart1(page.datePicker7, page, DatePickerBehaviour.close);
+    }
+
+    @Test
+    @Order(17)
+    @DisplayName("DatePicker: lazy meta data model without behaviour")
+    public void testLazyMetaDataNoBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker4, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(18)
+    @DisplayName("DatePicker: lazy meta data model with dateSelect behaviour")
+    public void testLazyMetaDataDateSelectBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker5, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(19)
+    @DisplayName("DatePicker: lazy meta data model with viewChange behaviour")
+    public void testLazyMetaDataViewChangeBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker6, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(20)
+    @DisplayName("DatePicker: lazy meta data model with close behaviour")
+    public void testLazyMetaDataCloseBehaviour2(Page page) {
+        testDatePickerPart2(page.datePicker7, page, DatePickerBehaviour.close);
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("DatePicker: lazy meta data model without behaviour")
+    public void testLazyBasicMetaBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker4, page, DatePickerBehaviour._none);
+    }
+
+    @Test
+    @Order(22)
+    @DisplayName("DatePicker: lazy meta data model with dateSelect behaviour")
+    public void testLazyMetaDataDateSelectBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker5, page, DatePickerBehaviour.dateSelect);
+    }
+
+    @Test
+    @Order(23)
+    @DisplayName("DatePicker: lazy meta data model with viewChange behaviour")
+    public void testLazyMetaDataViewChangeBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker6, page, DatePickerBehaviour.viewChange);
+    }
+
+    @Test
+    @Order(24)
+    @DisplayName("DatePicker: lazy meta data model with close behaviour")
+    public void testLazyMetaDataCloseBehaviour3(Page page) {
+        testDatePickerPart3(page.datePicker7, page, DatePickerBehaviour.close);
+    }
+
+    private void testDatePickerPart1(DatePicker datePicker, Page page, DatePickerBehaviour behaviour) {
+        // Assert initial state
+        Messages messages = page.messages;
+        assertEmptyMessages(messages);
+
+        // Act - 1st show panel
+        datePicker.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        assertEmptyMessages(messages);
+        assertCalendarDate(datePicker, ".tst-disabled", "1");
+        assertCalendarDate(datePicker, ".tst-begin", "2");
+        assertCalendarDate(datePicker, ".tst-end", "3");
+
+        // Act - 2nd previous month
+        datePicker.getPreviousMonthLink().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+        assertCalendarDate(datePicker, ".tst-disabled", "2");
+
+        // Act - 3rd next month
+        datePicker.getNextMonthLink().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 4th next month
+        datePicker.getNextMonthLink().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+        assertCalendarDate(datePicker, ".tst-disabled", "3");
+
+        // Act - 5th previous month
+        datePicker.getPreviousMonthLink().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 6th next month via month drop down
+        datePicker.selectMonthDropdown(LocalDate.now().getMonth().getValue() % 12);
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 7th next year via year drop down
+        datePicker.selectYearDropdown(LocalDate.now().getYear() + 1);
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 8th clear
+        datePicker.getClearButton().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+            case dateSelect:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 9th select 5th of current month
+        datePicker.getPanel().findElement(By.linkText("5")).click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker));
+        switch (behaviour) {
+            case viewChange: // why is this?
+            case dateSelect:
+            case close:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        assertConfiguration(datePicker.getWidgetConfiguration(), behaviour);
+    }
+
+    private void testDatePickerPart2(DatePicker datePicker, Page page, DatePickerBehaviour behaviour) {
+        // Assert initial state
+        Messages messages = page.messages;
+        assertEmptyMessages(messages);
+
+        // Act - 1st show panel
+        datePicker.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        assertEmptyMessages(messages);
+
+        // Act - 2nd today
+        datePicker.getTodayButton().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker));
+        switch (behaviour) {
+            case viewChange:
+            case dateSelect:
+            case close:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+    }
+
+    private void testDatePickerPart3(DatePicker datePicker, Page page, DatePickerBehaviour behaviour) {
+        // Assert initial state
+        Messages messages = page.messages;
+        assertEmptyMessages(messages);
+
+        // Act - 1st show panel
+        datePicker.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        assertEmptyMessages(messages);
+
+        // Act - 2nd clear
+        datePicker.getClearButton().click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker.getPanel()));
+        switch (behaviour) {
+            case viewChange:
+            case dateSelect:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 3rd click outside panel
+        if (DatePickerBehaviour.close == behaviour) {
+            page.outside.click();
+        }
+        else {
+            PrimeSelenium.guardAjax(page.outsideClean).click();
+        }
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker));
+        switch (behaviour) {
+            case close:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+
+        // Act - 4th show panel
+        PrimeSelenium.guardAjax(page.outsideClean).click();
+        datePicker.click();
+
+        // Assert
+        assertEmptyMessages(messages);
+
+        // Act - 5th input date
+        String inputDate = LocalDate.now().withDayOfMonth(6).format(DateTimeFormatter.ISO_DATE);
+        datePicker.getInput().sendKeys(inputDate + Keys.TAB);
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(datePicker));
+        switch (behaviour) {
+            case viewChange:
+            // case dateSelect: why does manual input not trigger dateSelect?
+            case close:
+                assertMessage(messages, behaviour);
+                break;
+            default:
+                assertEmptyMessages(messages);
+                break;
+        }
+    }
+
+    private void assertMessage(Messages messages, DatePickerBehaviour behaviour) {
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(messages));
+        List<Msg> msgs = messages.getMessagesBySeverity(Severity.INFO);
+        Assertions.assertEquals(1, msgs.size());
+        Assertions.assertTrue(msgs.get(0).getSummary().contains(behaviour.name()),
+                behaviour.name() + " not in " + messages.getAllMessages().toString());
+    }
+
+    private void assertEmptyMessages(Messages messages) {
+        Assertions.assertTrue(messages.getAllMessages().isEmpty(), messages.getAllMessages().toString());
+
+    }
+
+    private void assertCalendarDate(DatePicker datePicker, String styleClass, String day) {
+        List<WebElement> days = datePicker.getPanel().findElements(
+                By.cssSelector(".ui-datepicker-calendar td:not(.ui-datepicker-other-month) " + styleClass));
+        Assertions.assertEquals(1, days.size(), days.toString());
+        Assertions.assertEquals(day, days.get(0).getText());
+        if (".tst-disabled".equals(styleClass)) {
+            Assertions.assertTrue(days.get(0).getAttribute("class").contains("ui-state-disabled"));
+        }
+    }
+
+    private void assertConfiguration(JSONObject cfg, DatePickerBehaviour behaviour) {
+        assertNoJavascriptErrors();
+        System.out.println("DatePicker Config = " + cfg);
+        Assertions.assertEquals("yy-mm-dd", cfg.getString("dateFormat"));
+        Assertions.assertEquals(3, cfg.getJSONArray("disabledDates").length());
+        Assertions.assertFalse(cfg.getBoolean("inline"));
+        if (behaviour != DatePickerBehaviour._none) {
+            Assertions.assertTrue(cfg.getJSONObject("behaviors").getString(behaviour.name()).contains(behaviour.name()),
+                    "missing behaviour " + behaviour.name());
+        }
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:datepicker0")
+        DatePicker datePicker0;
+        @FindBy(id = "form:datepicker1")
+        DatePicker datePicker1;
+        @FindBy(id = "form:datepicker2")
+        DatePicker datePicker2;
+        @FindBy(id = "form:datepicker3")
+        DatePicker datePicker3;
+        @FindBy(id = "form:datepicker4")
+        DatePicker datePicker4;
+        @FindBy(id = "form:datepicker5")
+        DatePicker datePicker5;
+        @FindBy(id = "form:datepicker6")
+        DatePicker datePicker6;
+        @FindBy(id = "form:datepicker7")
+        DatePicker datePicker7;
+
+        @FindBy(id = "form:outside")
+        WebElement outside;
+        @FindBy(id = "form:clean")
+        CommandButton outsideClean;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker011.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker012Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker012Test.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+
+import java.time.LocalDate;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.DatePicker;
+
+public class DatePicker012Test extends AbstractDatePickerTest {
+
+    private enum DatePickerBehaviour {
+        _none, dateSelect, viewChange, close;
+    };
+
+    @Test
+    @Order(1)
+    @DisplayName("DatePicker: refresh lazy meta data model on show panel; see #7457")
+    public void testRefreshLazyModel(Page page) {
+        // Assert initial state
+        Assertions.assertNull(page.datePicker1.getValue());
+        Assertions.assertNull(page.datePicker2.getValue());
+
+        // Act - 1st show panel
+        page.datePicker1.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker1.getPanel()));
+        assertNoDisablebCalendarDates(page.datePicker1);
+
+        // Act - 2nd show other panel
+        page.datePicker2.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker2.getPanel()));
+        assertNoDisablebCalendarDates(page.datePicker2);
+
+        // Act - 3rd show panel and select 5th of current month
+        page.datePicker1.click();
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker1.getPanel()));
+        page.datePicker1.getPanel().findElement(By.linkText("5")).click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker1));
+        Assertions.assertEquals(LocalDate.now().withDayOfMonth(5).atStartOfDay(), page.datePicker1.getValue());
+
+        // Act - 4th show other panel
+        page.datePicker2.click();
+
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker2.getPanel()));
+        assertDisabledCalendarDate(page.datePicker2, "5");
+        JSONObject cfg2 = page.datePicker2.getWidgetConfiguration();
+
+        // Act - 5th elect 6th of current month
+        page.datePicker2.getPanel().findElement(By.linkText("6")).click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker2));
+        Assertions.assertEquals(LocalDate.now().withDayOfMonth(6).atStartOfDay(), page.datePicker2.getValue());
+
+        // Act - 6th show panel
+        page.datePicker1.click();
+
+        // Assert
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(page.datePicker1.getPanel()));
+        assertDisabledCalendarDate(page.datePicker1, "6");
+        JSONObject cfg1 = page.datePicker2.getWidgetConfiguration();
+
+        assertConfiguration(cfg1);
+        assertConfiguration(cfg2);
+    }
+
+    private void assertNoDisablebCalendarDates(DatePicker datePicker) {
+        List<WebElement> days = datePicker.getPanel().findElements(
+                By.cssSelector(".ui-datepicker-calendar td:not(.ui-datepicker-other-month) .tst-disabled"));
+        Assertions.assertTrue(days.isEmpty(), days.toString());
+    }
+
+    private void assertDisabledCalendarDate(DatePicker datePicker, String day) {
+        List<WebElement> days = datePicker.getPanel().findElements(
+                By.cssSelector(".ui-datepicker-calendar td:not(.ui-datepicker-other-month) .tst-disabled"));
+        Assertions.assertEquals(1, days.size(), days.toString());
+        Assertions.assertEquals(day, days.get(0).getText());
+        Assertions.assertTrue(days.get(0).getAttribute("class").contains("ui-state-disabled"));
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("DatePicker Config = " + cfg);
+        Assertions.assertTrue(cfg.getBoolean("refreshLazyModel"));
+        Assertions.assertFalse(cfg.getBoolean("inline"));
+        Assertions.assertTrue(cfg.getJSONObject("behaviors").getString("dateSelect").contains("dateSelect"),
+                "missing behaviour dateSelect");
+        Assertions.assertTrue(cfg.getJSONObject("behaviors").getString("viewChange").contains("viewChange"),
+                "missing behaviour viewChange");
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datepicker1")
+        DatePicker datePicker1;
+        @FindBy(id = "form:datepicker2")
+        DatePicker datePicker2;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker012.xhtml";
+        }
+    }
+}

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
@@ -31,6 +31,7 @@ import java.time.ZoneId;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.Select;
 import org.primefaces.selenium.PrimeExpectedConditions;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.base.AbstractInputComponent;
@@ -129,6 +130,26 @@ public abstract class DatePicker extends AbstractInputComponent {
         }
         link.click();
         return link;
+    }
+
+    public void toggleMonthDropdown() {
+        WebElement monthDropDown = showPanel().findElement(By.cssSelector("select.ui-datepicker-month"));
+        monthDropDown.click();
+    }
+
+    public void selectMonthDropdown(int month) {
+        Select monthDropDown = new Select(showPanel().findElement(By.cssSelector("select.ui-datepicker-month")));
+        monthDropDown.selectByValue(Integer.toString(month));
+    }
+
+    public void toggleYearDropdown() {
+        WebElement yearDropDown = showPanel().findElement(By.cssSelector("select.ui-datepicker-year"));
+        yearDropDown.click();
+    }
+
+    public void selectYearDropdown(int year) {
+        Select yearDropDown = new Select(showPanel().findElement(By.cssSelector("select.ui-datepicker-year")));
+        yearDropDown.selectByValue(Integer.toString(year));
     }
 
     /**

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -90,7 +90,8 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         timeInput,
         showWeek,
         weekCalculator,
-        model
+        model,
+        refreshLazyModel
     }
 
     public DatePickerBase() {
@@ -457,6 +458,14 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
 
     public void setModel(DateMetadataModel model) {
         getStateHelper().put(PropertyKeys.model, model);
+    }
+
+    public boolean isRefreshLazyModel() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.refreshLazyModel, false);
+    }
+
+    public void setRefreshLazyModel(boolean refreshLazyModel) {
+        getStateHelper().put(PropertyKeys.refreshLazyModel, refreshLazyModel);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -205,7 +205,8 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("fractionSeparator", datePicker.getFractionSeparator(), ".")
             .attr("timeInput", datePicker.isTimeInput())
             .attr("touchable", ComponentUtils.isTouchable(context, datePicker), true)
-            .attr("lazyModel", datePicker.getModel() instanceof LazyDateMetadataModel, false);
+            .attr("lazyModel", datePicker.getModel() instanceof LazyDateMetadataModel, false)
+            .attr("refreshLazyModel", datePicker.getModel() instanceof LazyDateMetadataModel && datePicker.isRefreshLazyModel(), false);
 
         List<Integer> disabledDays = datePicker.getDisabledDays();
         if (disabledDays != null) {

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -32050,6 +32050,14 @@
             <required>false</required>
             <type>org.primefaces.model.datepicker.DateMetadataModel</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Whether lazy meta data model should be refreshed before date panel is opened.]]>
+            </description>
+            <name>refreshLazyModel</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2108,6 +2108,9 @@
                         if ($this.options.onBeforeShow) {
                             $this.options.onBeforeShow.call($this);
                         }
+                        if ($this.options.onViewDateChange && $this.options.refreshLazyModel) {
+                            $this.options.onViewDateChange.call(this, null, $this.viewDate);
+                        }
 
                         $this.alignPanel();
                     },
@@ -2735,7 +2738,7 @@
         },
 
         updateViewDate: function (event, value) {
-            if (this.options.onViewDateChange) {
+            if (this.options.onViewDateChange && event) {
                 this.options.onViewDateChange.call(this, event, value);
             }
 


### PR DESCRIPTION
View changed is not triggered any more if no event is present. This effects 2 JS functions `setDate` and `hideOverlay.onExited`. So view changed is not triggered any more by closing the popup.

Added attribute `refreshLazyModel` (default false). If `refreshLazyModel` is set to true and DatePicker has `viewChange` behaviour this behaviour is triggered before date panel is opened.

Added some DatePicker behaviour integration tests. 