### PR TITLE
Fix NotSerializableException 

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/PrimeClientBehaviorHolder.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/PrimeClientBehaviorHolder.java
@@ -27,7 +27,9 @@ import java.util.Map;
 
 import javax.faces.event.BehaviorEvent;
 
-public interface PrimeClientBehaviorHolder {
+import java.io.Serializable;
+
+public interface PrimeClientBehaviorHolder extends Serializable {
 
     Map<String, Class<? extends BehaviorEvent>> getBehaviorEventMapping();
 }


### PR DESCRIPTION
Fix Exception when context parameter (javax.faces.SERIALIZE SERVER STATE=true) of web.xml is used.
The parameter javax.faces.SERIALIZE SERVER STATE=true was used to resolve a memory leak in com.sun.faces.util.LRUMap. 