### PR TITLE
Schedule: Fix views options with extender (#7746)

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -347,7 +347,9 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
             }
         }
 
-        this.cfg.options.views = this.cfg.views||{};
+        // Using this.cfg.views was a bug, but fall back to that for backwards compatibility
+        // Can be removed in the next major release
+        this.cfg.options.views = this.cfg.options.views || this.cfg.views || {};
         $.extend(true, this.cfg.options.views, views);
     }
 


### PR DESCRIPTION
Fixes: #7746 Need to use `this.cfg.options.views` instead of `this.cfg.views`. I kept the fall back to `this.cfg.views` in order not to break existing code. Could be removed in the next major releaes.