### PR TITLE
Fix #6397:Slider with InputNumber two way sync

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -178,7 +178,7 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
      * @param {string} value A value to set on the hidden input.
      */
     setValueToHiddenInput: function(value) {
-        this.hiddenInput.val(value);
+        this.hiddenInput.val(value).trigger('input.slider');
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/slider/slider.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/slider/slider.js
@@ -92,7 +92,7 @@ PrimeFaces.widget.Slider = PrimeFaces.widget.BaseWidget.extend({
         });
 
         if (this.input.parent().hasClass('ui-inputnumber')) {
-            this.input.parent().find('input:hidden').off('change.slider').on('change.slider', function () {
+            this.input.parent().find('input:hidden').off('input.slider').on('input.slider', function () {
                 $this.setValue($(this).val());
             });
         }


### PR DESCRIPTION
Use `input` event instead of `change` event.  The `val` method of Jquery does not fire any events so we must `trigger` one.

Also on the hidden input only call `input.slider` to trigger the slider input and not a general `input`.