### PR TITLE
Fix #7778: Datatable scrollHeight using CSS units

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -24,7 +24,10 @@
 package org.primefaces.component.datatable;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -530,8 +533,14 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("class", DataTable.SCROLLABLE_BODY_CLASS, null);
         writer.writeAttribute("tabindex", "-1", null);
-        if (LangUtils.isNotBlank(scrollHeight) && scrollHeight.indexOf('%') == -1) {
-            writer.writeAttribute("style", "max-height:" + scrollHeight + "px", null);
+        if (LangUtils.isNotBlank(scrollHeight)) {
+            if (!endsWithLenghtUnit(scrollHeight)) {
+                scrollHeight = scrollHeight + "px";
+            }
+            // % handle specially in the JS code
+            if (scrollHeight.indexOf('%') == -1) {
+                writer.writeAttribute("style", "max-height:" + scrollHeight, null);
+            }
         }
         writer.startElement("table", null);
         writer.writeAttribute("role", "grid", null);


### PR DESCRIPTION
Fixed: 
![image](https://user-images.githubusercontent.com/4399574/131666641-65d50a95-491c-43cf-a0a5-0ff8361840d6.png)
