### PR TITLE
Fix #3926: Tree: Fix selection for collapsed vs. filtered

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
@@ -529,7 +529,7 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
         checked = checkbox.find('> .ui-chkbox-box > .ui-chkbox-icon').hasClass('ui-icon-check');
 
         if(this.cfg.propagateDown) {
-            node.children('.ui-treenode-children').find('.ui-treenode:visible').find('.ui-chkbox').each(function() {
+            node.children('.ui-treenode-children').find('.ui-treenode:not(.ui-treenode-hidden)').find('.ui-chkbox').each(function() {
                 $this.toggleCheckboxState($(this), checked);
             });
             children = node.find('> .ui-treenode-children > .ui-treenode');


### PR DESCRIPTION
Fix for #3926 mishandled collapsed nodes and parent selection. This commit addresses that.