### PR TITLE
[Carousel, SpeedDial, Datepicker] Use JQuery for events instead of  native

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/carousel/carousel.js
@@ -493,11 +493,11 @@ PrimeFaces.widget.Carousel = PrimeFaces.widget.DeferredWidget.extend({
         var $this = this;
 
         if (!this.documentResizeListener) {
-            this.documentResizeListener = function (e) {
-                $this.calculatePosition(e);
+            this.documentResizeListener = function () {
+                $this.calculatePosition();
             };
 
-            window.addEventListener('resize', this.documentResizeListener);
+            $(window).on('resize', this.documentResizeListener);
         }
     },
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2171,13 +2171,13 @@
                     $this.datepickerClick = false;
                 };
 
-                document.addEventListener('click', this.documentClickListener);
+                $(document).on('click', this.documentClickListener);
             }
         },
 
         unbindDocumentClickListener: function () {
             if (this.documentClickListener) {
-                document.removeEventListener('click', this.documentClickListener);
+                $(document).off('click', this.documentClickListener);
                 this.documentClickListener = null;
             }
         },
@@ -2210,14 +2210,14 @@
             };
 
             for (var i = 0; i < this.scrollableParents.length; i++) {
-                this.scrollableParents[i].addEventListener('scroll', this.scrollableListener);
+                $(this.scrollableParents[i]).on('scroll', this.scrollableListener);
             }
         },
 
         unbindScrollListener: function() {
             if (this.scrollableParents && this.scrollableListener) {
                 for (var i = 0; i < this.scrollableParents.length; i++) {
-                    this.scrollableParents[i].removeEventListener('scroll', this.scrollableListener);
+                    $(this.scrollableParents[i]).off('scroll', this.scrollableListener);
                 }
 
                 this.scrollableListener = null;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/speeddial/speeddial.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/speeddial/speeddial.js
@@ -218,14 +218,14 @@ PrimeFaces.widget.SpeedDial = PrimeFaces.widget.DeferredWidget.extend({
 
                 $this.isItemClicked = false;
             };
-            document.addEventListener('click', this.documentClickListener);
+            $(document).on('click', this.documentClickListener);
         }
     },
 
     /**
      * Returns whether outside is clicked or not.
      * @private
-     * @param {Event} event Event that occurred.
+     * @param {JQuery.TriggeredEvent} event Event that occurred.
      * @return {boolean} outside is clicked.
      */
     isOutsideClicked: function(event) {


### PR DESCRIPTION
As was discussed we should always use `JQuery(...).on` for listening to events instead of the native `addEventListener`. I also removed the unused event param.

They are three components I found that did not use JQuery
* Carousel
* SpeedDial
* DatePicker JQueryUI widget

Tried it in the playground and does not seem to break anything.