### PR TITLE
DataTable/TreeTable: cellEditor saves changes too late #7776

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3211,7 +3211,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                             }
                         });
 
-            // save/cancel on mouseup to que the event request before whatever was clicked reacts
+            // save/cancel on mouseup to queue the event request before whatever was clicked reacts
             $(document).off('mouseup.datatable-cell-blur' + this.id)
                         .on('mouseup.datatable-cell-blur' + this.id, function(e) {
                             // ignore if not editing

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -32,7 +32,6 @@
  * @prop {JQuery} bodyTable The DOM element for the main TABLE element.
  * @prop {JQuery} clone The DOM element for the  clone of the table head.
  * @prop {boolean} columnWidthsFixed Whether the width of all columns needs to stay fixed.
- * @prop {boolean} contextMenuClick Whether a click was performed on the context menu.
  * @prop {JQuery} currentCell The DOM element for the currently selected cell, when using inline editing.
  * @prop {JQuery} cursorNode The DOM element for the row at the cursor position, used for selecting multiple rows when
  * holding the shift key.
@@ -41,7 +40,6 @@
  * @prop {JQuery} footerTable The DOM element for the TABLE element of the footer.
  * @prop {JQuery} headerCols The DOM element for the TH columns in the header.
  * @prop {JQuery} headerTable The DOM element for the TABLE element of the header.
- * @prop {boolean} incellClick Whether a click was performed inside a cell.
  * @prop {JQuery} jqSelection The DOM element for the hidden input storing the selected rows.
  * @prop {string} marginRight CSS unit for the right margin of this tree table, determined from the scrollbar width.
  * @prop {PrimeFaces.widget.Paginator} paginator The paginator widget instance used for filtering.
@@ -699,38 +697,46 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
             this.tbody.off(editEvent, cellSelector)
                 .on(editEvent, cellSelector, null, function(e) {
                     if(!$(e.target).is('span.ui-treetable-toggler.ui-c')) {
-                        $this.incellClick = true;
-
                         var item = $(this);
                         var cell = item.hasClass('ui-editable-column') ? item : item.closest('.ui-editable-column');
 
                         if(!cell.hasClass('ui-cell-editing') && e.type === $this.cfg.editInitEvent) {
                             $this.showCellEditor($(this));
-
-                            if($this.cfg.editInitEvent === "dblclick") {
-                                $this.incellClick = false;
-                            }
                         }
                      }
                 });
 
-            $(document).off('click.treetable-cell-blur' + this.id)
-                        .on('click.treetable-cell-blur' + this.id, function(e) {
-                            var target = $(e.target);
-                            if(!$this.incellClick && (target.is('.ui-input-overlay') || target.closest('.ui-input-overlay').length || target.closest('.ui-datepicker-buttonpane').length)) {
-                                $this.incellClick = true;
-                            }
-                            
-                            if(!$this.incellClick && $this.currentCell && !$this.contextMenuClick && !$.datepicker._datepickerShowing && $('.p-datepicker-panel:visible').length === 0) {
-                                if($this.cfg.saveOnCellBlur)
-                                    $this.saveCell($this.currentCell);
-                                else
-                                    $this.doCellEditCancelRequest($this.currentCell);
-                            }
-                            
-                            $this.incellClick = false;
-                            $this.contextMenuClick = false;
-                        });
+            // save/cancel on mouseup to queue the event request before whatever was clicked reacts
+            $(document).off('mouseup.treetable-cell-blur' + this.id)
+                .on('mouseup.treetable-cell-blur' + this.id, function(e) {
+                    // ignore if not editing
+                    if(!$this.currentCell)
+                        return;
+
+                    var currentCell = $($this.currentCell);
+                    var target = $(e.target);
+
+                    // ignore clicks inside edited cell
+                    if(currentCell.is(target) || currentCell.has(target).length)
+                        return;
+
+                    // ignore clicks inside input overlays like calendar popups etc
+                    var ignoredOverlay = '.ui-input-overlay, .ui-editor-popup, #keypad-div, .ui-colorpicker-container';
+                    // and menus - in case smth like menubutton is inside the table
+                    ignoredOverlay += ', .ui-datepicker-buttonpane, .ui-menuitem, .ui-menuitem-link';
+                    // and blockers
+                    ignoredOverlay += ', .ui-blockui, .blockUI';
+                    if(target.is(ignoredOverlay) || target.closest(ignoredOverlay).length)
+                        return;
+
+                    if($.datepicker._datepickerShowing || $('.p-datepicker-panel:visible').length)
+                        return;
+
+                    if($this.cfg.saveOnCellBlur)
+                        $this.saveCell($this.currentCell);
+                    else
+                        $this.doCellEditCancelRequest($this.currentCell);
+                });
         }
     },
 
@@ -2019,8 +2025,6 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
      * @param {JQuery} c The cell TD element for which to activate the inline editor.
      */
     showCellEditor: function(c) {
-        this.incellClick = true;
-
         var cell = null;
 
         if(c) {


### PR DESCRIPTION
Save/cancel on mouseup to que the event request before whatever was clicked reacts.

Got rid of incellClick and contextMenuClick, since the order of events changed. `if (currentCell.is(target) || currentCell.has(target).length)` takes care of their logic.
This does mean right clicking another cell would now end editing, but that seems acceptable.