### PR TITLE
SpeedDial: Fix documentation link

### DIFF
--- a/docs/11_0_0/menu.md
+++ b/docs/11_0_0/menu.md
@@ -196,6 +196,7 @@
   - [SlideMenu](/components/slidemenu.md)
   - [Slider](/components/slider.md)
   - [Spacer](/components/spacer.md)
+  - [SpeedDial](/components/speeddial.md)
   - [Spinner](/components/spinner.md)
   - [SplitButton](/components/splitbutton.md)
   - [Splitter](/components/splitter.md)

--- a/primefaces-showcase/src/main/webapp/ui/button/speedDial.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/speedDial.xhtml
@@ -11,7 +11,7 @@
         When pressed, a floating action button can display multiple primary actions that can be performed on a page.
     </ui:define>
 
-    <ui:param name="documentationLink" value="/components/speedDial"/>
+    <ui:param name="documentationLink" value="/components/speeddial"/>
     <ui:param name="widgetLink" value="SpeedDial-1"/>
 
     <ui:define name="head">


### PR DESCRIPTION
Link to documentation was broken and not in the menu.

Link to client API is still broken, but I don't know how to fix that.