### PR TITLE
Documentation updates for nullSortOrder

### DIFF
--- a/docs/10_0_0/components/column.md
+++ b/docs/10_0_0/components/column.md
@@ -43,7 +43,7 @@ treetable and more.
 | footerText | null | String | Shortcut for footer facet.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
 | headerText | null | String | Shortcut for header facet.
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"
+| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | resizable | true | Boolean | Specifies resizable feature at column level. Datatable's resizableColumns must be enabled to use this option.
 | responsivePriority | 0 | Integer | Responsive priority of the column, lower values have more priority.
 | rowspan | 1 | Integer | Defines the number of rows the column spans.

--- a/docs/10_0_0/components/columns.md
+++ b/docs/10_0_0/components/columns.md
@@ -54,7 +54,7 @@ Columns is used by datatable to create columns dynamically.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
 | exportHeaderValue | null | String | Defines if the header value of column to be exported.
 | exportFooterValue | null | String | Defines if the footer value of column to be exported.
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"
+| nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | sortOrder                 | asc                | String           | Sets sorting order in 'single' sortMode. Default is "ascending"
 | sortFunction              | null               | MethodExpression | Custom pluggable sortFunction.
 | sortPriority              | Integer.MAX_VALUE  | Integer          | Sets default sorting priority over the other columns. Lower values have more priority.

--- a/docs/11_0_0/components/column.md
+++ b/docs/11_0_0/components/column.md
@@ -43,7 +43,7 @@ treetable and more.
 | footerText | null | String | Shortcut for footer facet.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
 | headerText | null | String | Shortcut for header facet.
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"
+| nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | resizable | true | Boolean | Specifies resizable feature at column level. Datatable's resizableColumns must be enabled to use this option.
 | responsivePriority | 0 | Integer | Responsive priority of the column, lower values have more priority.
 | rowspan | 1 | Integer | Defines the number of rows the column spans.

--- a/docs/11_0_0/components/columns.md
+++ b/docs/11_0_0/components/columns.md
@@ -54,7 +54,7 @@ Columns is used by datatable to create columns dynamically.
 | groupRow | false | Boolean | Speficies whether to group rows based on the column data.
 | exportHeaderValue | null | String | Defines if the header value of column to be exported.
 | exportFooterValue | null | String | Defines if the footer value of column to be exported.
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"
+| nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | sortOrder                 | asc                | String           | Sets sorting order in 'single' sortMode. Default is "ascending"
 | sortFunction              | null               | MethodExpression | Custom pluggable sortFunction.
 | sortPriority              | Integer.MAX_VALUE  | Integer          | Sets default sorting priority over the other columns. Lower values have more priority.

--- a/docs/7_0/components/datatable.md
+++ b/docs/7_0/components/datatable.md
@@ -57,7 +57,7 @@ DataTable displays data in tabular format.
 | meaning                   | null               | String           | Values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | multiViewState            | false              | Boolean          | Whether to keep table state across views, defaults to false.                                      
 | nativeElements            | false              | Boolean          | Uses native radio-checkbox elements for row selection.                                            
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"            
+| nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | onExpandStart             | null               | String           | Client side callback to execute before expansion.                                                 
 | onRowClick                | null               | String           | Client side callback to execute after clicking row.                                               
 | pageLinks                 | 10                 | Integer          | Maximum number of page links to display.                                                          

--- a/docs/8_0/components/datatable.md
+++ b/docs/8_0/components/datatable.md
@@ -57,7 +57,7 @@ DataTable displays data in tabular format.
 | liveScrollBuffer          | 0                  | Integer          | Percentage height of the buffer between the bottom of the page and the scroll position to initiate the load for the new chunk. Value is defined in integer and default is 0.
 | multiViewState            | false              | Boolean          | Whether to keep table state across views, defaults to false.
 | nativeElements            | false              | Boolean          | Uses native radio-checkbox elements for row selection.
-| nullSortOrder             | 1                  | Integer          | Defines where the null values are placed in ascending sort order. Default value is "1"
+| nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | onExpandStart             | null               | String           | Client side callback to execute before expansion.
 | onRowClick                | null               | String           | Client side callback to execute after clicking row.
 | pageLinks                 | 10                 | Integer          | Maximum number of page links to display.

--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -159,6 +159,13 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+
+        <!-- JAXB required for JDK9+ -->
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.5</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Documentation was correct in the Taglib but was lacking in MD files. I was confused on the values for this property when looking at the MD docs.

Also fixed Showcase to work in JDK11 by adding JAXB.

@Rapster right now we support `1` and `-1`.  I wonder if we need a third state like `0` which ALWAYS sorts the nulls at the bottom even if descending or ascending order.  Meaning when I sort either direction I always want the values at the top.  

For example I have a "Sort Order" column with 100 rows and 4 of the rows have the values 1,2,3,4.  The other 96 rows have NULL for this value.

If I sort the column ascending I see the 1,2,3,4 first at the top with all the NULLS below it. When I sort descending I now get the 96 NULLS and then 4,3,2,1all the way at the bottom of the list.  I want an option where the NULLS are always sorted on the bottom so the 1,2,3,4 and 4,3,2,1 are always at the top. Thoughts?