### PR TITLE
Fix #7821: InputGroup example use DIV not SPAN

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/input/inputGroup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputGroup.xhtml
@@ -22,22 +22,22 @@
                 <div class="p-grid ui-fluid">
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon"><i class="pi pi-user"></i></span>
+                            <div class="ui-inputgroup-addon"><i class="pi pi-user"></i></div>
                             <p:inputText placeholder="Username"/>
                         </div>
                     </div>
             
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon">$</span>
+                            <div class="ui-inputgroup-addon">$</div>
                             <p:inputText placeholder="Price"/>
-                            <span class="ui-inputgroup-addon">.00</span>
+                            <div class="ui-inputgroup-addon">.00</div>
                         </div>
                     </div>
             
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon">www</span>
+                            <div class="ui-inputgroup-addon">www</div>
                             <p:inputText placeholder="Website"/>
                         </div>
                     </div>
@@ -47,11 +47,11 @@
                 <div class="p-grid ui-fluid">
                     <div class="p-col-12">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon"><i class="pi pi-tags"/></span>
-                            <span class="ui-inputgroup-addon"><i class="pi pi-shopping-cart"/></span>
+                            <div class="ui-inputgroup-addon"><i class="pi pi-tags"/></div>
+                            <div class="ui-inputgroup-addon"><i class="pi pi-shopping-cart"/></div>
                             <p:inputText placeholder="Price"/>
-                            <span class="ui-inputgroup-addon">$</span>
-                            <span class="ui-inputgroup-addon">.00</span>
+                            <div class="ui-inputgroup-addon">$</div>
+                            <div class="ui-inputgroup-addon">.00</div>
                         </div>
                     </div>
                 </div>
@@ -85,21 +85,21 @@
                 <div class="p-grid ui-fluid">
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon"><p:selectBooleanCheckbox/></span>
+                            <div class="ui-inputgroup-addon"><p:selectBooleanCheckbox/></div>
                             <p:inputText placeholder="Username"/>
                         </div>
                     </div>
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
                             <p:inputText placeholder="Username"/>
-                            <span class="ui-inputgroup-addon"><p:radioButton for="radioDemo" itemIndex="0"/></span>
+                            <div class="ui-inputgroup-addon"><p:radioButton for="radioDemo" itemIndex="0"/></div>
                         </div>
                     </div>
                     <div class="p-col-12 p-md-4">
                         <div class="ui-inputgroup">
-                            <span class="ui-inputgroup-addon"><p:selectBooleanCheckbox/></span>
+                            <div class="ui-inputgroup-addon"><p:selectBooleanCheckbox/></div>
                             <p:inputText placeholder="Username"/>
-                            <span class="ui-inputgroup-addon"><p:radioButton for="radioDemo" itemIndex="0"/></span>
+                            <div class="ui-inputgroup-addon"><p:radioButton for="radioDemo" itemIndex="0"/></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Based on this ticket for WCAG compliance.

https://github.com/primefaces/primefaces/issues/7821

The InputGroup example is using SPAN's and should be using DIV's according to WCAG compliance