### PR TITLE
Fix #5094: Datatable sticky properly resize on window resize

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -357,7 +357,7 @@ if (!PrimeFaces.utils) {
 
         /**
          * Sets up an overlay widget. Appends the overlay widget to the element as specified by the `appendTo`
-         * attribute. Also makes sure the overlay widget is handled propertly during AJAX updates.
+         * attribute. Also makes sure the overlay widget is handled properly during AJAX updates.
          * @param {PrimeFaces.widget.DynamicOverlayWidget} widget An overlay widget instance.
          * @param {JQuery} overlay The DOM element for the overlay.
          * @param {string} overlayId The ID of the overlay, usually the widget ID.

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4810,7 +4810,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         });
 
         PrimeFaces.utils.registerResizeHandler(this, 'resize.sticky-' + this.id, null, function(e) {
-            var _delay = e.data.delay;
+            var _delay = e.data.delay || 0;
 
             if (_delay !== null && typeof _delay === 'number' && _delay > -1) {
                 if ($this.resizeTimeout) {


### PR DESCRIPTION
Datatable sticky already had the window resize handler it just wasn't doing the right thing.  Tested with showcase scenario in this ticket.