### PR TITLE
Fix #7932: CSP only call csp.init() if PrimeFaces available

### DIFF
--- a/primefaces/src/main/java/org/primefaces/csp/CspPhaseListener.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspPhaseListener.java
@@ -23,17 +23,17 @@
  */
 package org.primefaces.csp;
 
-import org.owasp.encoder.Encode;
-import org.primefaces.context.PrimeApplicationContext;
-import org.primefaces.context.PrimeFacesContext;
-import org.primefaces.util.LangUtils;
-
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseId;
 import javax.faces.event.PhaseListener;
+
+import org.owasp.encoder.Encode;
 import org.primefaces.PrimeFaces;
+import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.context.PrimeFacesContext;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.Lazy;
 
 public class CspPhaseListener implements PhaseListener {
@@ -69,7 +69,7 @@ public class CspPhaseListener implements PhaseListener {
         String policy = LangUtils.isBlank(customPolicy.get()) ? "script-src 'self'" : customPolicy.get();
         externalContext.addResponseHeader("Content-Security-Policy", policy + " 'nonce-" + state.getNonce() + "'");
 
-        String init = "PrimeFaces.csp.init('" + Encode.forJavaScript(state.getNonce()) + "');";
+        String init = "if(pf){pf.csp.init('" + Encode.forJavaScript(state.getNonce()) + "');};";
         PrimeFaces.current().executeInitScript(init);
     }
 


### PR DESCRIPTION
@tandraschko I fixed the root of the problem of CSP throwing an error on error.xhtml but also fixed the AJAX DebugInfo and put it back.  I tested it with this scenario where it was failing before and it now works.