### PR TITLE
Fix #7963: SelectBooleanButton default labels only if not defined.

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/selectbooleanbutton/selectBooleanButton001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectbooleanbutton/selectBooleanButton001.xhtml
@@ -15,6 +15,7 @@
                 <p:autoUpdate/>
             </p:messages>
 
+            <h5>Full Button</h5>
             <p:selectBooleanButton id="selectBooleanButton" value="#{selectBooleanButton001.value}"
                                    onLabel="Yes"
                                    offLabel="No"
@@ -23,7 +24,11 @@
                                    style="width:60px">
                 <p:ajax listener="#{selectBooleanButton001.addMessage}" update="@form"/>
             </p:selectBooleanButton>
+            
+            <h5>Icon Only</h5>
+            <p:selectBooleanButton id="iconOnly" onIcon="pi pi-check" offIcon="pi pi-times" />
 
+            <br/>
             <p:commandButton id="submit" update="@form" value="Submit" actionListener="#{selectBooleanButton001.addMessage}"/>
         </h:form>
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectbooleanbutton/SelectBooleanButton001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectbooleanbutton/SelectBooleanButton001Test.java
@@ -116,6 +116,24 @@ public class SelectBooleanButton001Test extends AbstractPrimePageTest {
         // Assert
         assertChecked(page, true);
     }
+    
+    @Test
+    @Order(5)
+    @DisplayName("SelectBooleanButton: GitHub #7963 icon only should have no default labels")
+    public void testIconOnly(Page page) {
+        // Arrange
+        SelectBooleanButton selectBooleanButton = page.iconOnly;
+        selectBooleanButton.setValue(false);
+        Assertions.assertFalse(selectBooleanButton.isSelected());
+        Assertions.assertEquals("ui-button", selectBooleanButton.getLabel());
+
+        // Act
+        selectBooleanButton.check();
+
+        // Assert
+        Assertions.assertEquals("ui-button", selectBooleanButton.getLabel());
+        Assertions.assertTrue(selectBooleanButton.isSelected());
+    }
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
@@ -138,6 +156,9 @@ public class SelectBooleanButton001Test extends AbstractPrimePageTest {
     public static class Page extends AbstractPrimePage {
         @FindBy(id = "form:selectBooleanButton")
         SelectBooleanButton selectBooleanButton;
+        
+        @FindBy(id = "form:iconOnly")
+        SelectBooleanButton iconOnly;
 
         @FindBy(id = "form:msgs")
         Messages messages;

--- a/primefaces/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonBase.java
@@ -26,7 +26,6 @@ package org.primefaces.component.selectbooleanbutton;
 import javax.faces.component.html.HtmlSelectBooleanCheckbox;
 
 import org.primefaces.component.api.Widget;
-import org.primefaces.util.MessageFactory;
 
 public abstract class SelectBooleanButtonBase extends HtmlSelectBooleanCheckbox implements Widget {
 
@@ -64,7 +63,7 @@ public abstract class SelectBooleanButtonBase extends HtmlSelectBooleanCheckbox 
     }
 
     public String getOnLabel() {
-        return (String) getStateHelper().eval(PropertyKeys.onLabel, MessageFactory.getMessage(LABEL_ON));
+        return (String) getStateHelper().eval(PropertyKeys.onLabel, null);
     }
 
     public void setOnLabel(String onLabel) {
@@ -72,7 +71,7 @@ public abstract class SelectBooleanButtonBase extends HtmlSelectBooleanCheckbox 
     }
 
     public String getOffLabel() {
-        return (String) getStateHelper().eval(PropertyKeys.offLabel, MessageFactory.getMessage(LABEL_OFF));
+        return (String) getStateHelper().eval(PropertyKeys.offLabel, null);
     }
 
     public void setOffLabel(String offLabel) {

--- a/primefaces/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectbooleanbutton/SelectBooleanButtonRenderer.java
@@ -34,6 +34,7 @@ import javax.faces.convert.ConverterException;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
+import org.primefaces.util.MessageFactory;
 import org.primefaces.util.WidgetBuilder;
 
 public class SelectBooleanButtonRenderer extends InputRenderer {
@@ -70,11 +71,12 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         String inputId = clientId + "_input";
         String label = checked ? button.getOnLabel() : button.getOffLabel();
         String icon = checked ? button.getOnIcon() : button.getOffIcon();
+        boolean hasIcon = icon != null;
         String title = button.getTitle();
         String style = button.getStyle();
         String styleClass = "ui-selectbooleanbutton " + button.resolveStyleClass(checked, disabled);
 
-        //button
+        // button
         writer.startElement("div", null);
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("class", styleClass, null);
@@ -88,7 +90,7 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("class", "ui-helper-hidden-accessible", null);
 
-        //input
+        // input
         writer.startElement("input", null);
         writer.writeAttribute("id", inputId, "id");
         writer.writeAttribute("name", inputId, null);
@@ -109,19 +111,26 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
 
         writer.endElement("div");
 
-        //icon
-        if (icon != null) {
+        // icon
+        if (hasIcon) {
             writer.startElement("span", null);
             writer.writeAttribute("class", HTML.BUTTON_LEFT_ICON_CLASS + " " + icon, null);
             writer.endElement("span");
         }
 
-        //label
+        // label
         writer.startElement("span", null);
         writer.writeAttribute("class", HTML.BUTTON_TEXT_CLASS, null);
 
         if (isValueBlank(label)) {
-            writer.write("ui-button");
+            if (!hasIcon) {
+                // no icon or label use defaults
+                label = checked ? MessageFactory.getMessage(SelectBooleanButtonBase.LABEL_ON) : MessageFactory.getMessage(SelectBooleanButtonBase.LABEL_OFF);
+                writer.writeText(label, "value");
+            }
+            else {
+                writer.write("ui-button");
+            }
         }
         else {
             writer.writeText(label, "value");
@@ -139,10 +148,10 @@ public class SelectBooleanButtonRenderer extends InputRenderer {
 
         WidgetBuilder wb = getWidgetBuilder(context);
         wb.init("SelectBooleanButton", button)
-                .attr("onLabel", isValueBlank(onLabel) ? "ui-button" : onLabel)
-                .attr("offLabel", isValueBlank(offLabel) ? "ui-button" : offLabel)
-                .attr("onIcon", button.getOnIcon(), null)
-                .attr("offIcon", button.getOffIcon(), null);
+                    .attr("onLabel", isValueBlank(onLabel) ? "ui-button" : onLabel)
+                    .attr("offLabel", isValueBlank(offLabel) ? "ui-button" : offLabel)
+                    .attr("onIcon", button.getOnIcon(), null)
+                    .attr("offIcon", button.getOffIcon(), null);
 
         wb.finish();
     }


### PR DESCRIPTION
Integration test for `iconOnly` scenario added along with this this fix