### PR TITLE
Revert "Fix #7724: DataTable: components can't overflow in editable cells"

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -198,7 +198,6 @@
     padding-bottom:0;
     margin-top:0;
     margin-bottom:0;
-    overflow: visible;
 }
 
 .ui-row-editor-outline {


### PR DESCRIPTION
Reverts primefaces/primefaces#7726