### PR TITLE
Remove `p-sr-only` from cli migration tool

### DIFF
--- a/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
+++ b/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
@@ -178,7 +178,6 @@ public class PrimeFlexMigration extends AbstractPrimeMigration implements Runnab
         replaceRegex.put("p-field", "field");
         replaceRegex.put("p-formgrid", "formgrid");
         replaceRegex.put("p-formgroup-inline", "formgroup-inline");
-        replaceRegex.put("p-sr-only", "sr-only"); // TODO - To remove : not a PrimeFlex Class
         replaceRegex.put("p-field-checkbox", "field-checkbox");
         replaceRegex.put("p-field-radiobutton", "field-radiobutton");
 

--- a/primefaces-cli/src/test/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigrationTest.java
+++ b/primefaces-cli/src/test/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigrationTest.java
@@ -58,6 +58,13 @@ class PrimeFlexMigrationTest {
     }
 
     @Test
+    void noMigrationSrOnly() {
+        String source = "<div class=\"p-sr-only\"></div>";
+        String result = migration.migrateSource(source);
+        Assertions.assertEquals("<div class=\"p-sr-only\"></div>", result);
+    }
+
+    @Test
     void migrateV2ToV3SpacingCornerCase() {
         String source = "<div class=\"p-p-lg-3\"></div>";
         String result = migration.migrateSource(source);


### PR DESCRIPTION
The CSS class `p-sr-only` is from PrimeNG and not a part of PrimeFlex 3. No migration is necessary for this class.