### PR TITLE
CLI: Migrate alternative justify content classes

### DIFF
--- a/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
+++ b/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
@@ -101,6 +101,13 @@ public class PrimeFlexMigration extends AbstractPrimeMigration implements Runnab
         replaceRegex.put("p-flex-(xl|lg|md|sm)-wrap", "$1:flex-wrap");
         replaceRegex.put("p-flex-(xl|lg|md|sm)-wrap-reverse", "$1:flex-wrap-reverse");
 
+        replaceRegex.put("p-justify-start", "justify-content-start");
+        replaceRegex.put("p-justify-end", "justify-content-end");
+        replaceRegex.put("p-justify-center", "justify-content-center");
+        replaceRegex.put("p-justify-between", "justify-content-between");
+        replaceRegex.put("p-justify-around", "justify-content-around");
+        replaceRegex.put("p-justify-even", "justify-content-evenly"); // Note: even -> evenly
+
         replaceRegex.put("p-jc-start", "justify-content-start");
         replaceRegex.put("p-jc-end", "justify-content-end");
         replaceRegex.put("p-jc-center", "justify-content-center");

--- a/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
+++ b/primefaces-cli/src/main/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigration.java
@@ -101,19 +101,13 @@ public class PrimeFlexMigration extends AbstractPrimeMigration implements Runnab
         replaceRegex.put("p-flex-(xl|lg|md|sm)-wrap", "$1:flex-wrap");
         replaceRegex.put("p-flex-(xl|lg|md|sm)-wrap-reverse", "$1:flex-wrap-reverse");
 
-        replaceRegex.put("p-justify-start", "justify-content-start");
-        replaceRegex.put("p-justify-end", "justify-content-end");
-        replaceRegex.put("p-justify-center", "justify-content-center");
-        replaceRegex.put("p-justify-between", "justify-content-between");
-        replaceRegex.put("p-justify-around", "justify-content-around");
-        replaceRegex.put("p-justify-even", "justify-content-evenly"); // Note: even -> evenly
-
-        replaceRegex.put("p-jc-start", "justify-content-start");
-        replaceRegex.put("p-jc-end", "justify-content-end");
-        replaceRegex.put("p-jc-center", "justify-content-center");
-        replaceRegex.put("p-jc-between", "justify-content-between");
-        replaceRegex.put("p-jc-around", "justify-content-around");
+        replaceRegex.put("p-(jc|justify)-start", "justify-content-start");
+        replaceRegex.put("p-(jc|justify)-end", "justify-content-end");
+        replaceRegex.put("p-(jc|justify)-center", "justify-content-center");
+        replaceRegex.put("p-(jc|justify)-between", "justify-content-between");
+        replaceRegex.put("p-(jc|justify)-around", "justify-content-around");
         replaceRegex.put("p-jc-evenly", "justify-content-evenly");
+        replaceRegex.put("p-justify-even", "justify-content-evenly"); // Note: even -> evenly
 
         replaceRegex.put("p-jc-(xl|lg|md|sm)-start", "$1:justify-content-start");
         replaceRegex.put("p-jc-(xl|lg|md|sm)-end", "$1:justify-content-end");

--- a/primefaces-cli/src/test/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigrationTest.java
+++ b/primefaces-cli/src/test/java/org/primefaces/cli/migration/primeflex/PrimeFlexMigrationTest.java
@@ -65,6 +65,13 @@ class PrimeFlexMigrationTest {
     }
 
     @Test
+    void migrateV2ToV3AlternativeJustifyContentClasses() {
+        String source = "<div class=\"p-justify-start p-justify-end p-justify-center p-justify-between p-justify-around p-justify-even\"></div>";
+        String result = migration.migrateSource(source);
+        Assertions.assertEquals("<div class=\"justify-content-start justify-content-end justify-content-center justify-content-between justify-content-around justify-content-evenly\"></div>", result);
+    }
+
+    @Test
     void migrateV2ToV3SpacingCornerCase() {
         String source = "<div class=\"p-p-lg-3\"></div>";
         String result = migration.migrateSource(source);


### PR DESCRIPTION
There are alternative justify content classes that are not migrated. This pull request adds them to the migration.