### PR TITLE
Fix #8024: SelectOne javascript error on keypress

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -288,9 +288,12 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             e.preventDefault();
         });
 
-        this.focusInput.on('focus.ui-selectonemenu', function() {
+        this.focusInput.on('focus.ui-selectonemenu', function(e) {
             $this.jq.addClass('ui-state-focus');
             $this.menuIcon.addClass('ui-state-focus');
+            if(!$this.cfg.dynamic && !$this.items) {
+                $this.callHandleMethod($this.handleTabKey(), e);
+            }
         })
         .on('blur.ui-selectonemenu', function(){
             $this.jq.removeClass('ui-state-focus');


### PR DESCRIPTION
On focus we need to load the panel ONLY if its not an AJAX panel as that gets loaded dynamically when you click the drodpwn.
