### PR TITLE
Fix #8039: Fix TOUCHABLE support to work like RTL

### DIFF
--- a/docs/11_0_0/components/calendar.md
+++ b/docs/11_0_0/components/calendar.md
@@ -127,7 +127,7 @@ ajax selection and more.
 | timeOnly | false | Boolean | Shows only timepicker without date.
 | timeZone | null | Time Zone | String or a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault(). (This attribute is only relevant for java.util.Date in combination with the built-in converter.)
 | title | null | String | Advisory tooltip information.
-| touchable | true | Boolean | Enable touch support if browser detection supports it.
+| touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 | type | text | String | Input field type. Default is text.
 | validator | null | Method Expr | A method expression that refers to a method validating the input
 | validatorMessage | null | String | Message to be displayed when validation fails.

--- a/docs/11_0_0/components/carousel.md
+++ b/docs/11_0_0/components/carousel.md
@@ -40,7 +40,7 @@ Carousel is a content slider featuring various customization options.
 | indicatorsContentStyleClass | null | String | Style class of the paginator items.
 | headerText | null | String | Label for header.
 | footerText | null | String | Label for footer.
-| touchable | true | Boolean | Enable touch support if browser detection supports it.
+| touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 
 ## Getting Started
 Carousel requires a collection of items as its `value` along with a visual template to render each item.

--- a/docs/11_0_0/components/contextmenu.md
+++ b/docs/11_0_0/components/contextmenu.md
@@ -32,7 +32,7 @@ ContextMenu provides an overlay menu displayed on mouse right-click event.
 | beforeShow | null | String | Client side callback to execute before showing.
 | selectionMode | multiple | String | Defines the selection behavior, e.g "single" or "multiple".
 | targetFilter | null | String | Selector to filter the elements to attach the menu.
-| touchable | true | Boolean | Enable touch support if browser detection supports it. For long press and hold to bring up menu.
+| touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default. For long press and hold to bring up menu.
 
 ## Getting started with ContextMenu
 ContextMenu is created with submenus and menuitems. Optional for attribute defines which

--- a/docs/11_0_0/components/datagrid.md
+++ b/docs/11_0_0/components/datagrid.md
@@ -46,7 +46,7 @@ lazy | false | Boolean | Defines if lazy loading is enabled for the data compone
 emptyMessage | No records found. | String | Text to display when there is no data to display.
 layout | tabular | String | Layout approach to use, valid values are "tabular" and "grid" for responsive grid.
 multiViewState | false | Boolean | Whether to keep DataGrid state across views, defaults to false.
-touchable | true | Boolean | Enable touch support if browser detection supports it.
+touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 flex | false | Boolean | Use modern PrimeFlex-Grid instead of classic Grid CSS. (primeflex.css must be included into the template.xhtml)
 
 ## Getting started with the DataGrid

--- a/docs/11_0_0/components/datalist.md
+++ b/docs/11_0_0/components/datalist.md
@@ -46,7 +46,7 @@ DataList presents a collection of data in list layout with several display types
 | emptyMessage | No records found. | String | Text to display when there is no data to display.
 | itemStyleClass | null | String | Style class of an item in list.
 | multiViewState | false | Boolean | Whether to keep list state across views, defaults to false.
-| touchable | true | Boolean | Enable touch support if browser detection supports it.
+| touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 
 ## Getting started with the DataList
 Since DataList is a data iteration component, it renders it’s children for each data represented with

--- a/docs/11_0_0/components/datatable.md
+++ b/docs/11_0_0/components/datatable.md
@@ -109,7 +109,7 @@ DataTable displays data in tabular format.
 | var                       | null               | String           | Name of the request-scoped variable used to refer each data.
 | virtualScroll             | false              | Boolean          | Loads data on demand as the scrollbar gets close to the bottom. Default is false.
 | widgetVar                 | null               | String           | Name of the client side widget.
-| touchable                 | true               | Boolean          | Enable touch support if browser detection supports it.
+| touchable                 | false              | Boolean          | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 | partialUpdate             | true               | Boolean          | When disabled, it updates the whole table instead of updating a specific field such as body element in the client requests of the dataTable.
 
 ## Getting started with the DataTable

--- a/docs/11_0_0/components/dataview.md
+++ b/docs/11_0_0/components/dataview.md
@@ -46,7 +46,7 @@ layout | list | String | Layout strategy to use, valid values are "list" and "gr
 gridIcon | null | String | Icon of the grid layout button.
 listIcon | null | String | Icon of the list layout button.
 multiViewState | false | Boolean | Whether to keep DataView state across views, defaults to false.
-touchable | true | Boolean | Enable touch support if browser detection supports it.
+touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 flex | false | Boolean | Use modern PrimeFlex-Grid instead of classic Grid CSS. (primeflex.css must be included into the template.xhtml)
 
 ## Getting started with the DataView

--- a/docs/11_0_0/components/datepicker.md
+++ b/docs/11_0_0/components/datepicker.md
@@ -128,7 +128,7 @@ ajax selection and more.
 | timeZone | null | Time Zone | String a java.time.ZoneId instance or a java.util.TimeZone instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault(). (This attribute is only relevant for java.util.Date in combination with the built-in converter.)
 | title | null | String | Advisory tooltip information.
 | touchUI | false | Boolean | Activates touch friendly mode
-| touchable | true | Boolean | Enable touch support if browser detection supports it.
+| touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 | triggerButtonIcon | null | String | Icon of the datepicker element that toggles the visibility in popup mode.
 | type | text | String | Type of the input field
 | validator | null | Method Expr | A method expression that refers to a method validating the input

--- a/docs/11_0_0/components/selectonemenu.md
+++ b/docs/11_0_0/components/selectonemenu.md
@@ -59,7 +59,7 @@ autoWidth | true | Boolean | Calculates a fixed width based on the width of the 
 dynamic | false | Boolean | Defines if dynamic loading is enabled for the element's panel. If the value is "true", the overlay is not rendered on page load to improve performance.
 dir | ltr | String | Direction indication for text that does not inherit directionality. Valid values are LTR and RTL.
 hideNoSelectionOption | false | boolean  | Flag indicating that, if this component is activated by the user, The "no selection option", if any, must be hidden.
-touchable | true | Boolean | Enable touch support if browser detection supports it.
+touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 
 ## Getting started with SelectOneMenu
 Basic SelectOneMenu usage is same as the standard one.

--- a/docs/11_0_0/components/slider.md
+++ b/docs/11_0_0/components/slider.md
@@ -38,7 +38,7 @@ onSlide | null | String | Client side callback to execute during sliding.
 onSlideEnd | null | String | Client side callback to execute when slide ends.
 range | min | String | When set `true`, two handles are provided for selection a range. Another types `false` for disable range style and `max` for shows range handle to the slider max.
 displayTemplate | null | String | String template to use when updating the display. Valid placeholders are {value}, {min} and {max}.
-touchable | true | Boolean | Enable touch support if browser detection supports it.
+touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 
 ## Getting started with Slider
 Slider requires an input component to work with, _for_ attribute is used to set the id of the input

--- a/docs/11_0_0/components/tabview.md
+++ b/docs/11_0_0/components/tabview.md
@@ -41,7 +41,7 @@ TabView is a container component to group content in tabs.
 | scrollable     | false   | Boolean    | When enabled, tab headers can be scrolled horizontally instead of wrapping.
 | prependId      | true    | Boolean    | TabView is a naming container thus prepends its id to its children by default, a false value turns this behavior off except for dynamic tabs.
 | tabindex       | 0       | String     | Position of the element in the tabbing order.
-| touchable      | true    | Boolean    | Enable touch support if browser detection supports it.
+| touchable      | false   | Boolean    | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 | multiViewState | false   | Boolean    | Whether to keep TabView state across views, defaults to false.
 
 ## Getting started with the TabView

--- a/docs/11_0_0/components/treetable.md
+++ b/docs/11_0_0/components/treetable.md
@@ -74,7 +74,7 @@ style | null | String | Inline style of the container element.
 styleClass | null | String | Style class of the container element.
 tableStyle | null | String | Inline style of the table element.
 tableStyleClass | null | String | Style class of the table element.
-touchable | true | Boolean | Enable touch support if browser detection supports it.
+touchable | false | Boolean | Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.
 value | null | Object | A TreeNode instance as the backing model.
 var | null | String | Name of the request-scoped variable used to refer each treenode.
 widgetVar | null | String | Name of the client side widget.

--- a/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -285,7 +285,7 @@ public abstract class UICalendar extends AbstractPrimeHtmlInputText implements I
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
@@ -23,14 +23,15 @@
  */
 package org.primefaces.component.api;
 
-import org.primefaces.component.inputtext.InputText;
-import org.primefaces.el.ValueExpressionAnalyzer;
-import org.primefaces.util.MessageFactory;
+import java.util.Map;
 
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
-import java.util.Map;
+
+import org.primefaces.component.inputtext.InputText;
+import org.primefaces.el.ValueExpressionAnalyzer;
+import org.primefaces.util.MessageFactory;
 
 /**
  * UIData for pageable components
@@ -95,7 +96,7 @@ public class UIPageableData extends UIData implements Pageable, TouchAware {
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/carousel/CarouselBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/carousel/CarouselBase.java
@@ -23,14 +23,15 @@
  */
 package org.primefaces.component.carousel;
 
+import java.util.List;
+
+import javax.faces.component.behavior.ClientBehaviorHolder;
+
 import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.TouchAware;
 import org.primefaces.component.api.UITabPanel;
 import org.primefaces.component.api.Widget;
 import org.primefaces.model.ResponsiveOption;
-
-import javax.faces.component.behavior.ClientBehaviorHolder;
-import java.util.List;
 
 public abstract class CarouselBase extends UITabPanel implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder, TouchAware {
 
@@ -198,7 +199,7 @@ public abstract class CarouselBase extends UITabPanel implements Widget, ClientB
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
@@ -154,7 +154,7 @@ public abstract class ContextMenuBase extends AbstractMenu implements Widget, To
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuBase.java
@@ -256,7 +256,7 @@ public abstract class SelectOneMenuBase extends HtmlSelectOneMenu implements Wid
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/slider/SliderBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/slider/SliderBase.java
@@ -210,7 +210,7 @@ public abstract class SliderBase extends UIInput implements Widget, ClientBehavi
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
@@ -152,6 +152,7 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
         getStateHelper().put(PropertyKeys.onTabClose, onTabClose);
     }
 
+    @Override
     public String getDir() {
         return (String) getStateHelper().eval(PropertyKeys.dir, "ltr");
     }
@@ -178,7 +179,7 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
 
     @Override
     public boolean isTouchable() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.touchable, false);
     }
 
     @Override

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3575,7 +3575,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -3932,7 +3932,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -7011,7 +7011,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -7311,7 +7311,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -7570,7 +7570,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -8441,7 +8441,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -8683,7 +8683,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -24532,7 +24532,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -25444,7 +25444,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -27538,7 +27538,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -29917,7 +29917,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>
@@ -32075,7 +32075,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Enable touch support if browser detection supports it. Default is true.]]>
+                <![CDATA[Enable touch support if browser detection supports it. Default is false because it is globally enabled by default.]]>
             </description>
             <name>touchable</name>
             <required>false</required>


### PR DESCRIPTION
This makes it work more like RTL.  It can be globally disabled with `primefaces.TOUCHABLE` but it is globally enabled by default.  Each component is disabled by default because its globally enabled.