### PR TITLE
Fix #8071: SelectCheckBoxMenu resetValue

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
@@ -25,7 +25,8 @@
 
                 <h5 class="p-mt-0">Basic</h5>
                 <p:selectCheckboxMenu id="menu" value="#{checkboxView.selectedCities}" label="Cities" style="width: 15rem"
-                                        filter="true" filterMatchMode="startsWith" panelStyle="width: 15rem" scrollHeight="250">
+                                        filter="true" filterMatchMode="startsWith" panelStyle="width: 15rem" scrollHeight="250"
+                                        dynamic="true">
                     <f:selectItems value="#{checkboxView.cities}"/>
                 </p:selectCheckboxMenu>
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js
@@ -160,8 +160,6 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
                 this.label.attr('id', this.labelId);
                 this.keyboardTarget.attr('aria-expanded', false).attr('aria-labelledby', this.labelId);
             }
-
-            this.transition = PrimeFaces.utils.registerCSSTransition(this.panel, 'ui-connected-overlay');
         } else {
             // disabled
             if(!this.cfg.multiple) {
@@ -217,6 +215,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
      */
     renderPanel: function() {
         this.panel = $('<div id="' + this.panelId + '" class="ui-selectcheckboxmenu-panel ui-widget ui-widget-content ui-corner-all ui-helper-hidden ui-input-overlay" role="dialog"></div>');
+        this.transition = PrimeFaces.utils.registerCSSTransition(this.panel, 'ui-connected-overlay');
         if(this.cfg.panelStyle) {
             this.panel.attr('style', this.cfg.panelStyle);
         }
@@ -382,7 +381,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
                     return;
                 }
 
-                if($this.cfg.dynamic && !$this.isDynamicLoaded) {
+                if(!$this.isLoaded()) {
                     $this._renderPanel();
                 }
 
@@ -543,7 +542,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             var keyCode = $.ui.keyCode,
             key = e.which;
 
-            if($this.cfg.dynamic && !$this.isDynamicLoaded) {
+            if(!$this.isLoaded()) {
                 $this._renderPanel();
             }
 
@@ -686,7 +685,7 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
             var itemValue = $(this).parent().data("item-value");
             var item = $this.items.filter('[data-item-value="' + $.escapeSelector(itemValue) +'"]');
             if(item && item.length) {
-                if($this.cfg.dynamic && !$this.isDynamicLoaded) {
+                if(!$this.isLoaded()) {
                     $this._renderPanel();
                 }
 
@@ -825,17 +824,21 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
-     * Selects all available options. Note that this required the overlay panel to be visible, use `show` for that.
+     * Selects all available options.
+     * @param {boolean} silent `true` to suppress triggering event listeners, or `false` otherwise.
      */
-    checkAll: function() {
-        for(var i = 0; i < this.items.length; i++) {
+    checkAll: function(silent) {
+        if (!this.isLoaded()) {
+            this._renderPanel();
+        }
+        var panelVisible = this.panel.is(':visible');
+        for (var i = 0; i < this.items.length; i++) {
             var el = this.items.eq(i);
-
-            if(el.is(':visible')) {
+            if (!panelVisible || (panelVisible && el.is(':visible'))) {
                 var input = this.inputs.eq(i);
                 var inputNative = input[0];
 
-                if(!inputNative.disabled) {
+                if (!inputNative.disabled) {
                     input.prop('checked', true).attr('aria-checked', true);
                     this.check(el.children('.ui-chkbox').children('.ui-chkbox-box'));
 
@@ -848,35 +851,41 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
 
         this.check(this.togglerBox);
 
-        var togglerInput = this.togglerBox.prev().children('input');
-        if(this.cfg.onChange) {
-            this.cfg.onChange.call(this);
-        }
+        if (!silent) {
+           var togglerInput = this.togglerBox.prev().children('input');
+           if(this.cfg.onChange) {
+               this.cfg.onChange.call(this);
+           }
 
-        if(!this.togglerBox.hasClass('ui-state-disabled')) {
-            togglerInput.trigger('focus.selectCheckboxMenu');
-            this.togglerBox.addClass('ui-state-active');
-        }
+           if(!this.togglerBox.hasClass('ui-state-disabled')) {
+               togglerInput.trigger('focus.selectCheckboxMenu');
+               this.togglerBox.addClass('ui-state-active');
+           }
 
-        if(this.cfg.multiple) {
-            this.alignPanel();
-        }
+           if(this.cfg.multiple) {
+               this.alignPanel();
+           }
 
-        this.fireToggleSelectEvent(true);
+           this.fireToggleSelectEvent(true);
+        }
     },
 
     /**
-     * Unselects all available options. Note that this required the overlay panel to be visible, use `show` for that.
+     * Unselects all available options.
+     * @param {boolean} silent `true` to suppress triggering event listeners, or `false` otherwise.
      */
-    uncheckAll: function() {
-        for(var i = 0; i < this.items.length; i++) {
+    uncheckAll: function(silent) {
+        if (!this.isLoaded()) {
+            this._renderPanel();
+        }
+        var panelVisible = this.panel.is(':visible');
+        for (var i = 0; i < this.items.length; i++) {
             var el = this.items.eq(i);
-
-            if(el.is(':visible')) {
+            if (!panelVisible || (panelVisible && el.is(':visible'))) {
                 var input = this.inputs.eq(i);
                 var inputNative = input[0];
 
-                if(!inputNative.disabled) {
+                if (!inputNative.disabled) {
                     this.inputs.eq(i).prop('checked', false).attr('aria-checked', false);
                     this.uncheck(el.children('.ui-chkbox').children('.ui-chkbox-box'));
 
@@ -889,20 +898,22 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
 
         this.uncheck(this.togglerBox);
 
-        var togglerInput = this.togglerBox.prev().children('input');
-        if(this.cfg.onChange) {
-            this.cfg.onChange.call(this);
-        }
+        if (!silent) {
+           var togglerInput = this.togglerBox.prev().children('input');
+           if(this.cfg.onChange) {
+               this.cfg.onChange.call(this);
+           }
 
-        if(!this.togglerBox.hasClass('ui-state-disabled')) {
-            togglerInput.trigger('focus.selectCheckboxMenu');
-        }
+           if(!this.togglerBox.hasClass('ui-state-disabled')) {
+               togglerInput.trigger('focus.selectCheckboxMenu');
+           }
 
-        if(this.cfg.multiple) {
-            this.alignPanel();
-        }
+           if(this.cfg.multiple) {
+               this.alignPanel();
+           }
 
-        this.fireToggleSelectEvent(false);
+           this.fireToggleSelectEvent(false);
+        }
     },
 
     /**
@@ -1263,6 +1274,24 @@ PrimeFaces.widget.SelectCheckboxMenu = PrimeFaces.widget.BaseWidget.extend({
     disable: function() {
         PrimeFaces.utils.disableInputWidget(this.jq, this.inputs);
         this.disabled = true;
+    },
+
+    /**
+     * Has the panel been loaded with checkbox data yet?
+     * @return {boolean} `true` when the panel has been loaded with checkbox items 
+     */
+    isLoaded: function() {
+        return this.cfg.dynamic === false || this.isDynamicLoaded;
+    },
+
+    /**
+     * Resets the input.
+     * @param {boolean} silent `true` to suppress triggering event listeners, or `false` otherwise.
+     */
+    resetValue: function(silent) {
+        if (this.isLoaded()) {
+           this.uncheckAll(silent);
+        }
     }
 
 });


### PR DESCRIPTION
@tandraschko 2 things.

1. I realize its SelectCheckboxMenu we use a lot like this...

```xml
<f:facet name="filter">
	<p:selectCheckboxMenu id="chkProfileStatusFilter" label="All" filter="true" filterMatchMode="startsWith"
						updateLabel="true">
		<p:ajax event="change" process="@this" oncomplete="PF('organizerTable').filter();" />
		<p:ajax event="toggleSelect" process="@this" oncomplete="PF('organizerTable').filter();" />
		<f:selectItems value="#{profileStatusFilterOptions}" />
	</p:selectCheckboxMenu>
</f:facet>
```

2. I added the `resetValue` using the custom code we have already been using but unfortunately it requires the dialog be visible. `Unselects all available options. Note that this required the overlay panel to be visible, use `show` for that.`

