### PR TITLE
Fix #8109: ConfirmDialog ARIA role corrected

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -123,8 +123,9 @@ if (!PrimeFaces.utils) {
             var id = widget.id,
                 zIndex = overlay.css('z-index') - 1;
 
+            var role = widget instanceof PrimeFaces.widget.ConfirmDialog ? 'alertdialog' : 'dialog';
             overlay.attr({
-                'role': 'dialog'
+                'role': role
                 ,'aria-hidden': false
                 ,'aria-modal': true
                 ,'aria-live': 'polite'

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -759,8 +759,9 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
      * @protected
      */
     applyARIA: function() {
+        var role = this instanceof PrimeFaces.widget.ConfirmDialog ? 'alertdialog' : 'dialog';
         this.jq.attr({
-            'role': 'dialog'
+            'role': role
             ,'aria-describedby': this.id + '_content'
             ,'aria-hidden': !this.cfg.visible
             ,'aria-modal': this.cfg.modal


### PR DESCRIPTION
It should use `role="alertdialog` for confirm dialogs.