### PR TITLE
Fix #8113: Table filters now HTML5 search type

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -792,6 +792,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("input", null);
         writer.writeAttribute("id", filterId, null);
         writer.writeAttribute("name", filterId, null);
+        writer.writeAttribute("type", "search", null);
         writer.writeAttribute("class", filterStyleClass, null);
         writer.writeAttribute("value", filterValue, null);
         writer.writeAttribute("autocomplete", "off", null);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -763,6 +763,7 @@ public class TreeTableRenderer extends DataRenderer {
             writer.startElement("input", null);
             writer.writeAttribute("id", filterId, null);
             writer.writeAttribute("name", filterId, null);
+            writer.writeAttribute("type", "search", null);
             writer.writeAttribute("class", filterStyleClass, null);
             writer.writeAttribute("value", filterValue, null);
             writer.writeAttribute("autocomplete", "off", null);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -668,7 +668,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         filterColumns.children('.ui-column-filter').each(function() {
             var filter = $(this);
 
-            if(filter.is('input:text')) {
+            if(filter.is("input[type='search']")) {
                 PrimeFaces.skinInput(filter);
                 $this.bindTextFilter(filter);
             }
@@ -701,6 +701,9 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             this.bindEnterKeyFilter(filter);
         else
             this.bindFilterEvent(filter);
+
+        // #8113 clear 'x' event handler
+        this.bindClearFilterEvent(filter);
 
         // #7562 draggable columns cannot be filtered with touch
         if (PrimeFaces.env.isTouchable(this.cfg)) {
@@ -739,6 +742,22 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 $this.filter();
 
                 e.preventDefault();
+            }
+        });
+    },
+
+    /**
+     * Sets up the 'search' event which for HTML5 text search fields handles the clear 'x' button.
+     * @private
+     * @param {JQuery} filter INPUT element of the text filter.
+     */
+    bindClearFilterEvent: function(filter) {
+        var $this = this;
+
+        filter.off('search').on('search', function(e) {
+            // only care when 'X'' is clicked
+            if ($(this).val() == "") {
+                $this.filter();
             }
         });
     },

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -249,7 +249,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
         filterColumns.children('.ui-column-filter').each(function() {
             var filter = $(this);
 
-            if(filter.is('input:text')) {
+            if(filter.is("input[type='search']")) {
                 PrimeFaces.skinInput(filter);
                 $this.bindTextFilter(filter);
             }
@@ -307,6 +307,9 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
         else
             this.bindFilterEvent(filter);
 
+        // #8113 clear 'x' event handler
+        this.bindClearFilterEvent(filter);
+
         // #7562 draggable columns cannot be filtered with touch
         if (PrimeFaces.env.isTouchable(this.cfg)) {
             filter.on('touchstart', function(e) {
@@ -342,6 +345,22 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
                 $this.filter();
 
                 e.preventDefault();
+            }
+        });
+    },
+
+    /**
+     * Sets up the 'search' event which for HTML5 text search fields handles the clear 'x' button.
+     * @private
+     * @param {JQuery} filter INPUT element of the text filter.
+     */
+    bindClearFilterEvent: function(filter) {
+        var $this = this;
+
+        filter.off('search').on('search', function(e) {
+            // only care when 'X'' is clicked
+            if ($(this).val() == "") {
+                $this.filter();
             }
         });
     },


### PR DESCRIPTION
Now the browser adds a useful "x" to filters and clicking the X clears the filter and fires the event.

![image](https://user-images.githubusercontent.com/4399574/143590760-1efe6431-d149-4cae-8995-44658db9268e.png)
