### PR TITLE
Fix #8186: OutputLabel prevent duplicate DOM events

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/HTML.java
+++ b/primefaces/src/main/java/org/primefaces/util/HTML.java
@@ -247,7 +247,7 @@ public class HTML {
     public static final List<String> LINK_ATTRS = LangUtils.concat(LINK_ATTRS_WITHOUT_EVENTS, OUTPUT_EVENTS);
     public static final List<String> LINK_WITHOUT_CLICK_ATTRS = LangUtils.concat(LINK_ATTRS_WITHOUT_EVENTS, OUTPUT_EVENTS_WITHOUT_CLICK);
 
-    public static final List<String> LABEL_ATTRS = LangUtils.concat(LABEL_ATTRS_WITHOUT_EVENTS, OUTPUT_EVENTS);
+    public static final List<String> LABEL_ATTRS = LABEL_ATTRS_WITHOUT_EVENTS;
     public static final List<String> LABEL_EVENTS = OUTPUT_EVENTS;
 
     public static final List<String> BUTTON_ATTRS = LangUtils.concat(BUTTON_ATTRS_WITHOUT_EVENTS, BUTTON_EVENTS);


### PR DESCRIPTION
I can confirm this issue.  It looks like ` HTML.LABEL_EVENTS` was being added twice and I can confirm that `LABEL_ATTRS` is only being used in OutputLabelRenderer