### PR TITLE
Fix #7966/#7964: Exporter `visibleOnly`, `exportHeader` and `exportFooter`

### DIFF
--- a/conf/checkstyle.xml
+++ b/conf/checkstyle.xml
@@ -69,7 +69,7 @@
 
         <module name="ModifierOrderCheck" />
 
-		<module name="HideUtilityClassConstructor"/>
+        <module name="HideUtilityClassConstructor"/>
 
         <module name="MethodLength">
             <property name="max" value="300" />
@@ -135,7 +135,7 @@
         -->
         <module name="EqualsAvoidNullCheck"/>
         <module name="UpperEll"/>
-		<module name="ArrayTypeStyle"/>
+        <module name="ArrayTypeStyle"/>
 
         <module name="WhitespaceAround">
             <property name="tokens" value=""/>

--- a/docs/12_0_0/gettingstarted/whatsnew.md
+++ b/docs/12_0_0/gettingstarted/whatsnew.md
@@ -6,3 +6,6 @@ This page contains a list of big features. Please check the GitHub issues for al
 
 
 Look into [migration guide](https://primefaces.github.io/primefaces/12_0_0/#/../migrationguide/12_0_0) for more enhancements and changes.
+
+## Exporter
+  * Added new options for `visibleOnly`, `exportHeader` and `exportFooter` to give better control over output

--- a/docs/migrationguide/12.0.0.md
+++ b/docs/migrationguide/12.0.0.md
@@ -1,0 +1,4 @@
+# Migration guide 11.0.0 -> 12.0.0
+
+
+

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
@@ -27,7 +27,7 @@
                 </p:commandButton>
 
                 <p:commandButton value="PDF" styleClass="p-mr-2 p-mb-2">
-                    <p:dataExporter type="pdf" target="tbl" fileName="products"/>
+                    <p:dataExporter type="pdf" target="tbl" fileName="products" exportHeader="false"/>
                 </p:commandButton>
 
                 <p:commandButton value="CSV" styleClass="p-mr-2 p-mb-2">

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
@@ -70,7 +70,9 @@ public class DataTableCSVExporter extends DataTableExporter {
                 exportConfiguration.getPreProcessor().invoke(context.getELContext(), new Object[]{writer});
             }
 
-            addColumnFacets(writer, table, ColumnType.HEADER);
+            if (exportConfiguration.isExportHeader()) {
+                addColumnFacets(writer, table, ColumnType.HEADER);
+            }
 
             if (exportConfiguration.isPageOnly()) {
                 exportPageOnly(context, table, writer);
@@ -82,7 +84,7 @@ public class DataTableCSVExporter extends DataTableExporter {
                 exportAll(context, table, writer);
             }
 
-            if (table.hasFooterColumn()) {
+            if (exportConfiguration.isExportFooter() && table.hasFooterColumn()) {
                 addColumnFacets(writer, table, ColumnType.FOOTER);
             }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -389,10 +389,13 @@ public class DataTableExcelExporter extends DataTableExporter {
 
     public void exportTable(FacesContext context, UIComponent component, Sheet sheet, ExportConfiguration exportConfiguration) {
         DataTable table = (DataTable) component;
-        addTableFacets(context, table, sheet, DataTableExporter.ColumnType.HEADER);
-        boolean headerGroup = addColumnGroup(table, sheet, DataTableExporter.ColumnType.HEADER);
-        if (!headerGroup) {
-            addColumnFacets(table, sheet, DataTableExporter.ColumnType.HEADER);
+
+        if (exportConfiguration.isExportHeader()) {
+            addTableFacets(context, table, sheet, DataTableExporter.ColumnType.HEADER);
+            boolean headerGroup = addColumnGroup(table, sheet, DataTableExporter.ColumnType.HEADER);
+            if (!headerGroup) {
+                addColumnFacets(table, sheet, DataTableExporter.ColumnType.HEADER);
+            }
         }
 
         if (exportConfiguration.isPageOnly()) {
@@ -405,11 +408,13 @@ public class DataTableExcelExporter extends DataTableExporter {
             exportAll(context, table, sheet);
         }
 
-        addColumnGroup(table, sheet, DataTableExporter.ColumnType.FOOTER);
-        if (table.hasFooterColumn()) {
-            addColumnFacets(table, sheet, DataTableExporter.ColumnType.FOOTER);
+        if (exportConfiguration.isExportFooter()) {
+            addColumnGroup(table, sheet, DataTableExporter.ColumnType.FOOTER);
+            if (table.hasFooterColumn()) {
+                addColumnFacets(table, sheet, DataTableExporter.ColumnType.FOOTER);
+            }
+            addTableFacets(context, table, sheet, DataTableExporter.ColumnType.FOOTER);
         }
-        addTableFacets(context, table, sheet, DataTableExporter.ColumnType.FOOTER);
 
         table.setRowIndex(-1);
     }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -147,10 +147,12 @@ public class DataTablePDFExporter extends DataTableExporter {
             config.getOnTableRender().invoke(context.getELContext(), new Object[]{pdfTable, table});
         }
 
-        addTableFacets(context, table, pdfTable, ColumnType.HEADER);
-        boolean headerGroup = addColumnGroup(table, pdfTable, ColumnType.HEADER);
-        if (!headerGroup) {
-            addColumnFacets(table, pdfTable, ColumnType.HEADER);
+        if (config.isExportHeader()) {
+            addTableFacets(context, table, pdfTable, ColumnType.HEADER);
+            boolean headerGroup = addColumnGroup(table, pdfTable, ColumnType.HEADER);
+            if (!headerGroup) {
+                addColumnFacets(table, pdfTable, ColumnType.HEADER);
+            }
         }
 
         if (config.isPageOnly()) {
@@ -163,11 +165,13 @@ public class DataTablePDFExporter extends DataTableExporter {
             exportAll(context, table, pdfTable);
         }
 
-        addColumnGroup(table, pdfTable, ColumnType.FOOTER);
-        if (table.hasFooterColumn()) {
-            addColumnFacets(table, pdfTable, ColumnType.FOOTER);
+        if (config.isExportFooter()) {
+            addColumnGroup(table, pdfTable, ColumnType.FOOTER);
+            if (table.hasFooterColumn()) {
+                addColumnFacets(table, pdfTable, ColumnType.FOOTER);
+            }
+            addTableFacets(context, table, pdfTable, ColumnType.FOOTER);
         }
-        addTableFacets(context, table, pdfTable, ColumnType.FOOTER);
 
         table.setRowIndex(-1);
 

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
@@ -59,6 +59,9 @@ public class DataExporter implements ActionListener, StateHolder {
     private ValueExpression encoding;
     private ValueExpression pageOnly;
     private ValueExpression selectionOnly;
+    private ValueExpression visibleOnly;
+    private ValueExpression exportHeader;
+    private ValueExpression exportFooter;
     private MethodExpression preProcessor;
     private MethodExpression postProcessor;
     private ValueExpression options;
@@ -67,22 +70,6 @@ public class DataExporter implements ActionListener, StateHolder {
 
     public DataExporter() {
         ResourceUtils.addComponentResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
-    }
-
-    public DataExporter(ValueExpression target, ValueExpression type, ValueExpression fileName, ValueExpression pageOnly,
-                        ValueExpression selectionOnly, ValueExpression encoding, MethodExpression preProcessor,
-                        MethodExpression postProcessor, ValueExpression options, MethodExpression onTableRender) {
-        this();
-        this.target = target;
-        this.type = type;
-        this.fileName = fileName;
-        this.pageOnly = pageOnly;
-        this.selectionOnly = selectionOnly;
-        this.preProcessor = preProcessor;
-        this.postProcessor = postProcessor;
-        this.encoding = encoding;
-        this.options = options;
-        this.onTableRender = onTableRender;
     }
 
     @Override
@@ -102,15 +89,36 @@ public class DataExporter implements ActionListener, StateHolder {
         boolean isPageOnly = false;
         if (pageOnly != null) {
             isPageOnly = pageOnly.isLiteralText()
-                         ? Boolean.parseBoolean(pageOnly.getValue(context.getELContext()).toString())
-                         : (Boolean) pageOnly.getValue(context.getELContext());
+                        ? Boolean.parseBoolean(pageOnly.getValue(context.getELContext()).toString())
+                        : (Boolean) pageOnly.getValue(context.getELContext());
         }
 
         boolean isSelectionOnly = false;
         if (selectionOnly != null) {
             isSelectionOnly = selectionOnly.isLiteralText()
-                              ? Boolean.parseBoolean(selectionOnly.getValue(context.getELContext()).toString())
-                              : (Boolean) selectionOnly.getValue(context.getELContext());
+                        ? Boolean.parseBoolean(selectionOnly.getValue(context.getELContext()).toString())
+                        : (Boolean) selectionOnly.getValue(context.getELContext());
+        }
+
+        boolean isVisibleOnly = false;
+        if (visibleOnly != null) {
+            isVisibleOnly = visibleOnly.isLiteralText()
+                        ? Boolean.parseBoolean(visibleOnly.getValue(context.getELContext()).toString())
+                        : (Boolean) visibleOnly.getValue(context.getELContext());
+        }
+
+        boolean isExportHeader = true;
+        if (exportHeader != null) {
+            isExportHeader = exportHeader.isLiteralText()
+                        ? Boolean.parseBoolean(exportHeader.getValue(context.getELContext()).toString())
+                        : (Boolean) exportHeader.getValue(context.getELContext());
+        }
+
+        boolean isExportFooter = true;
+        if (exportFooter != null) {
+            isExportFooter = exportFooter.isLiteralText()
+                        ? Boolean.parseBoolean(exportFooter.getValue(context.getELContext()).toString())
+                        : (Boolean) exportFooter.getValue(context.getELContext());
         }
 
         ExporterOptions exporterOptions = null;
@@ -127,15 +135,19 @@ public class DataExporter implements ActionListener, StateHolder {
             List<UIComponent> components = SearchExpressionFacade.resolveComponents(context, event.getComponent(), tables);
             Class<? extends UIComponent> targetClass = guessTargetClass(components);
             Exporter exporterInstance = getExporter(exportAs, exporterOptions, customExporterInstance, targetClass);
-            ExportConfiguration config = new ExportConfiguration()
-                    .setOutputFileName(outputFileName)
-                    .setEncodingType(encodingType)
-                    .setPageOnly(isPageOnly)
-                    .setSelectionOnly(isSelectionOnly)
-                    .setOptions(exporterOptions)
-                    .setPreProcessor(preProcessor)
-                    .setPostProcessor(postProcessor)
-                    .setOnTableRender(onTableRender);
+            ExportConfiguration config = ExportConfiguration.builder()
+                        .outputFileName(outputFileName)
+                        .encodingType(encodingType)
+                        .pageOnly(isPageOnly)
+                        .selectionOnly(isSelectionOnly)
+                        .visibleOnly(isVisibleOnly)
+                        .exportHeader(isExportHeader)
+                        .exportFooter(isExportFooter)
+                        .options(exporterOptions)
+                        .preProcessor(preProcessor)
+                        .postProcessor(postProcessor)
+                        .onTableRender(onTableRender)
+                        .build();
 
             ExternalContext externalContext = context.getExternalContext();
             String filenameWithExtension = config.getOutputFileName() + exporterInstance.getFileExtension();
@@ -156,6 +168,7 @@ public class DataExporter implements ActionListener, StateHolder {
                 addResponseCookie(context);
             }
 
+            exporterInstance.setExportConfiguration(config);
             exporterInstance.export(context, components, outputStream, config);
 
             if (PrimeFaces.current().isAjaxRequest()) {
@@ -193,7 +206,7 @@ public class DataExporter implements ActionListener, StateHolder {
             }
             else {
                 throw new FacesException("Component " + getClass().getName() + " customExporterInstance="
-                       + customExporterInstance.getClass().getName() + " does not implement Exporter!");
+                            + customExporterInstance.getClass().getName() + " does not implement Exporter!");
             }
         }
 
@@ -210,10 +223,10 @@ public class DataExporter implements ActionListener, StateHolder {
 
         String monitorKeyCookieName = ResourceUtils.getMonitorKeyCookieName(context, null);
         PrimeFaces.current().executeScript(String.format("PrimeFaces.download('%s', '%s', '%s', '%s')",
-                data, contentType, filenameWithExtension, monitorKeyCookieName));
+                    data, contentType, filenameWithExtension, monitorKeyCookieName));
     }
 
-    protected void setResponseHeader(ExternalContext externalContext , String contentDisposition) {
+    protected void setResponseHeader(ExternalContext externalContext, String contentDisposition) {
         ResourceUtils.addNoCacheControl(externalContext);
         externalContext.setResponseHeader("Content-disposition", contentDisposition);
     }
@@ -232,14 +245,6 @@ public class DataExporter implements ActionListener, StateHolder {
         // NOOP
     }
 
-    public ValueExpression getExporter() {
-        return exporter;
-    }
-
-    public void setExporter(ValueExpression exporter) {
-        this.exporter = exporter;
-    }
-
     @Override
     public void restoreState(FacesContext context, Object state) {
         Object[] values = (Object[]) state;
@@ -249,30 +254,159 @@ public class DataExporter implements ActionListener, StateHolder {
         fileName = (ValueExpression) values[2];
         pageOnly = (ValueExpression) values[3];
         selectionOnly = (ValueExpression) values[4];
-        preProcessor = (MethodExpression) values[5];
-        postProcessor = (MethodExpression) values[6];
-        encoding = (ValueExpression) values[7];
-        options = (ValueExpression) values[8];
-        onTableRender = (MethodExpression) values[9];
-        exporter = (ValueExpression) values[10];
+        visibleOnly = (ValueExpression) values[5];
+        exportHeader = (ValueExpression) values[6];
+        exportFooter = (ValueExpression) values[7];
+        preProcessor = (MethodExpression) values[8];
+        postProcessor = (MethodExpression) values[9];
+        encoding = (ValueExpression) values[10];
+        options = (ValueExpression) values[11];
+        onTableRender = (MethodExpression) values[12];
+        exporter = (ValueExpression) values[13];
     }
 
     @Override
     public Object saveState(FacesContext context) {
-        Object[] values = new Object[12];
+        Object[] values = new Object[14];
 
         values[0] = target;
         values[1] = type;
         values[2] = fileName;
         values[3] = pageOnly;
         values[4] = selectionOnly;
-        values[5] = preProcessor;
-        values[6] = postProcessor;
-        values[7] = encoding;
-        values[8] = options;
-        values[9] = onTableRender;
-        values[10] = exporter;
+        values[5] = visibleOnly;
+        values[6] = exportHeader;
+        values[7] = exportFooter;
+        values[8] = preProcessor;
+        values[9] = postProcessor;
+        values[10] = encoding;
+        values[11] = options;
+        values[12] = onTableRender;
+        values[13] = exporter;
 
         return (values);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private ValueExpression target;
+        private ValueExpression type;
+        private ValueExpression fileName;
+        private ValueExpression encoding;
+        private ValueExpression pageOnly;
+        private ValueExpression selectionOnly;
+        private ValueExpression visibleOnly;
+        private ValueExpression exportHeader;
+        private ValueExpression exportFooter;
+        private MethodExpression preProcessor;
+        private MethodExpression postProcessor;
+        private ValueExpression options;
+        private MethodExpression onTableRender;
+        private ValueExpression exporter;
+
+        Builder() {
+        }
+
+        public Builder target(ValueExpression target) {
+            this.target = target;
+            return this;
+        }
+
+        public Builder type(ValueExpression type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder fileName(ValueExpression fileName) {
+            this.fileName = fileName;
+            return this;
+        }
+
+        public Builder encoding(ValueExpression encoding) {
+            this.encoding = encoding;
+            return this;
+        }
+
+        public Builder pageOnly(ValueExpression pageOnly) {
+            this.pageOnly = pageOnly;
+            return this;
+        }
+
+        public Builder selectionOnly(ValueExpression selectionOnly) {
+            this.selectionOnly = selectionOnly;
+            return this;
+        }
+
+        public Builder visibleOnly(ValueExpression visibleOnly) {
+            this.visibleOnly = visibleOnly;
+            return this;
+        }
+
+        public Builder exportHeader(ValueExpression exportHeader) {
+            this.exportHeader = exportHeader;
+            return this;
+        }
+
+        public Builder exportFooter(ValueExpression exportFooter) {
+            this.exportFooter = exportFooter;
+            return this;
+        }
+
+        public Builder preProcessor(MethodExpression preProcessor) {
+            this.preProcessor = preProcessor;
+            return this;
+        }
+
+        public Builder postProcessor(MethodExpression postProcessor) {
+            this.postProcessor = postProcessor;
+            return this;
+        }
+
+        public Builder options(ValueExpression options) {
+            this.options = options;
+            return this;
+        }
+
+        public Builder onTableRender(MethodExpression onTableRender) {
+            this.onTableRender = onTableRender;
+            return this;
+        }
+
+        public Builder exporter(ValueExpression exporter) {
+            this.exporter = exporter;
+            return this;
+        }
+
+        public DataExporter build() {
+            DataExporter exporter = new DataExporter();
+            exporter.target = this.target;
+            exporter.type = this.type;
+            exporter.fileName = this.fileName;
+            exporter.encoding = this.encoding;
+            exporter.pageOnly = this.pageOnly;
+            exporter.selectionOnly = this.selectionOnly;
+            exporter.visibleOnly = this.visibleOnly;
+            exporter.exportHeader = this.exportHeader;
+            exporter.exportFooter = this.exportFooter;
+            exporter.preProcessor = this.preProcessor;
+            exporter.postProcessor = this.postProcessor;
+            exporter.options = this.options;
+            exporter.onTableRender = this.onTableRender;
+            exporter.exporter = this.exporter;
+            return exporter;
+        }
+
+        @Override
+        public String toString() {
+            return "DataExporter.DataExporterBuilder(target=" + this.target + ", type=" + this.type + ", fileName=" + this.fileName + ", encoding="
+                        + this.encoding + ", pageOnly=" + this.pageOnly + ", selectionOnly=" + this.selectionOnly + ", visibleOnly=" + this.visibleOnly
+                        + ", exportHeader=" + this.exportHeader + ", exportFooter=" + this.exportFooter + ", preProcessor=" + this.preProcessor
+                        + ", postProcessor=" + this.postProcessor + ", options=" + this.options + ", onTableRender=" + this.onTableRender + ", exporter="
+                        + this.exporter + ")";
+        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporterTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporterTagHandler.java
@@ -37,6 +37,9 @@ public class DataExporterTagHandler extends TagHandler {
     private final TagAttribute fileName;
     private final TagAttribute pageOnly;
     private final TagAttribute selectionOnly;
+    private final TagAttribute visibleOnly;
+    private final TagAttribute exportHeader;
+    private final TagAttribute exportFooter;
     private final TagAttribute preProcessor;
     private final TagAttribute postProcessor;
     private final TagAttribute encoding;
@@ -51,6 +54,9 @@ public class DataExporterTagHandler extends TagHandler {
         fileName = getRequiredAttribute("fileName");
         pageOnly = getAttribute("pageOnly");
         selectionOnly = getAttribute("selectionOnly");
+        visibleOnly = getAttribute("visibleOnly");
+        exportHeader = getAttribute("exportHeader");
+        exportFooter = getAttribute("exportFooter");
         encoding = getAttribute("encoding");
         preProcessor = getAttribute("preProcessor");
         postProcessor = getAttribute("postProcessor");
@@ -70,6 +76,9 @@ public class DataExporterTagHandler extends TagHandler {
         ValueExpression fileNameVE = fileName.getValueExpression(faceletContext, Object.class);
         ValueExpression pageOnlyVE = null;
         ValueExpression selectionOnlyVE = null;
+        ValueExpression visibleOnlyVE = null;
+        ValueExpression exportHeaderVE = null;
+        ValueExpression exportFooterVE = null;
         ValueExpression encodingVE = null;
         MethodExpression preProcessorME = null;
         MethodExpression postProcessorME = null;
@@ -85,6 +94,15 @@ public class DataExporterTagHandler extends TagHandler {
         }
         if (selectionOnly != null) {
             selectionOnlyVE = selectionOnly.getValueExpression(faceletContext, Object.class);
+        }
+        if (visibleOnly != null) {
+            visibleOnlyVE = visibleOnly.getValueExpression(faceletContext, Object.class);
+        }
+        if (exportHeader != null) {
+            exportHeaderVE = exportHeader.getValueExpression(faceletContext, Object.class);
+        }
+        if (exportFooter != null) {
+            exportFooterVE = exportFooter.getValueExpression(faceletContext, Object.class);
         }
         if (preProcessor != null) {
             preProcessorME = preProcessor.getMethodExpression(faceletContext, null, new Class[]{Object.class});
@@ -102,9 +120,22 @@ public class DataExporterTagHandler extends TagHandler {
             exporterVE = exporter.getValueExpression(faceletContext, Object.class);
         }
         ActionSource actionSource = (ActionSource) parent;
-        DataExporter dataExporter = new DataExporter(targetVE, typeVE, fileNameVE, pageOnlyVE, selectionOnlyVE,
-                encodingVE, preProcessorME, postProcessorME, optionsVE, onTableRenderME);
-        dataExporter.setExporter(exporterVE);
+        DataExporter dataExporter = DataExporter.builder()
+                    .target(targetVE)
+                    .type(typeVE)
+                    .fileName(fileNameVE)
+                    .encoding(encodingVE)
+                    .exporter(exporterVE)
+                    .exportFooter(exportFooterVE)
+                    .exportHeader(exportHeaderVE)
+                    .onTableRender(onTableRenderME)
+                    .options(optionsVE)
+                    .pageOnly(pageOnlyVE)
+                    .postProcessor(postProcessorME)
+                    .preProcessor(preProcessorME)
+                    .selectionOnly(selectionOnlyVE)
+                    .visibleOnly(visibleOnlyVE)
+                    .build();
         actionSource.addActionListener(dataExporter);
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/export/ExportConfiguration.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/ExportConfiguration.java
@@ -30,81 +30,170 @@ public class ExportConfiguration {
     private String outputFileName;
     private boolean pageOnly;
     private boolean selectionOnly;
+    private boolean visibleOnly;
+    private boolean exportHeader;
+    private boolean exportFooter;
     private String encodingType;
     private MethodExpression preProcessor;
     private MethodExpression postProcessor;
     private ExporterOptions options;
     private MethodExpression onTableRender;
 
-    public String getOutputFileName() {
-        return outputFileName;
+    public ExportConfiguration() {
+        // NOOP
     }
 
-    public ExportConfiguration setOutputFileName(String outputFileName) {
-        this.outputFileName = outputFileName;
-        return this;
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String outputFileName;
+        private boolean pageOnly;
+        private boolean selectionOnly;
+        private boolean visibleOnly;
+        private boolean exportHeader;
+        private boolean exportFooter;
+        private String encodingType;
+        private MethodExpression preProcessor;
+        private MethodExpression postProcessor;
+        private ExporterOptions options;
+        private MethodExpression onTableRender;
+
+        Builder() {
+        }
+
+        public Builder outputFileName(String outputFileName) {
+            this.outputFileName = outputFileName;
+            return this;
+        }
+
+        public Builder pageOnly(boolean pageOnly) {
+            this.pageOnly = pageOnly;
+            return this;
+        }
+
+        public Builder selectionOnly(boolean selectionOnly) {
+            this.selectionOnly = selectionOnly;
+            return this;
+        }
+
+        public Builder visibleOnly(boolean visibleOnly) {
+            this.visibleOnly = visibleOnly;
+            return this;
+        }
+
+        public Builder exportHeader(boolean exportHeader) {
+            this.exportHeader = exportHeader;
+            return this;
+        }
+
+        public Builder exportFooter(boolean exportFooter) {
+            this.exportFooter = exportFooter;
+            return this;
+        }
+
+        public Builder encodingType(String encodingType) {
+            this.encodingType = encodingType;
+            return this;
+        }
+
+        public Builder preProcessor(MethodExpression preProcessor) {
+            this.preProcessor = preProcessor;
+            return this;
+        }
+
+        public Builder postProcessor(MethodExpression postProcessor) {
+            this.postProcessor = postProcessor;
+            return this;
+        }
+
+        public Builder options(ExporterOptions options) {
+            this.options = options;
+            return this;
+        }
+
+        public Builder onTableRender(MethodExpression onTableRender) {
+            this.onTableRender = onTableRender;
+            return this;
+        }
+
+        public ExportConfiguration build() {
+            ExportConfiguration config = new ExportConfiguration();
+            config.outputFileName = this.outputFileName;
+            config.pageOnly = this.pageOnly;
+            config.selectionOnly = this.selectionOnly;
+            config.visibleOnly = this.visibleOnly;
+            config.exportHeader = this.exportHeader;
+            config.exportFooter = this.exportFooter;
+            config.encodingType = this.encodingType;
+            config.preProcessor = this.preProcessor;
+            config.postProcessor = this.postProcessor;
+            config.options = this.options;
+            config.onTableRender = this.onTableRender;
+            return config;
+        }
+
+        @Override
+        public String toString() {
+            return "ExportConfiguration.ExportConfigurationBuilder(outputFileName=" + this.outputFileName + ", pageOnly=" + this.pageOnly + ", selectionOnly="
+                        + this.selectionOnly + ", visibleOnly=" + this.visibleOnly + ", exportHeader=" + this.exportHeader + ", exportFooter="
+                        + this.exportFooter + ", encodingType=" + this.encodingType + ", preProcessor=" + this.preProcessor + ", postProcessor="
+                        + this.postProcessor + ", options=" + this.options + ", onTableRender=" + this.onTableRender + ")";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ExportConfiguration(outputFileName=" + this.outputFileName + ", pageOnly=" + this.pageOnly + ", selectionOnly=" + this.selectionOnly
+                    + ", visibleOnly=" + this.visibleOnly + ", exportHeader=" + this.exportHeader + ", exportFooter=" + this.exportFooter + ", encodingType="
+                    + this.encodingType + ", preProcessor=" + this.preProcessor + ", postProcessor=" + this.postProcessor + ", options=" + this.options
+                    + ", onTableRender=" + this.onTableRender + ")";
+    }
+
+    public String getOutputFileName() {
+        return outputFileName;
     }
 
     public boolean isPageOnly() {
         return pageOnly;
     }
 
-    public ExportConfiguration setPageOnly(boolean pageOnly) {
-        this.pageOnly = pageOnly;
-        return this;
-    }
-
     public boolean isSelectionOnly() {
         return selectionOnly;
     }
 
-    public ExportConfiguration setSelectionOnly(boolean selectionOnly) {
-        this.selectionOnly = selectionOnly;
-        return this;
+    public boolean isVisibleOnly() {
+        return visibleOnly;
+    }
+
+    public boolean isExportHeader() {
+        return exportHeader;
+    }
+
+    public boolean isExportFooter() {
+        return exportFooter;
     }
 
     public String getEncodingType() {
         return encodingType;
     }
 
-    public ExportConfiguration setEncodingType(String encodingType) {
-        this.encodingType = encodingType;
-        return this;
-    }
-
     public MethodExpression getPreProcessor() {
         return preProcessor;
-    }
-
-    public ExportConfiguration setPreProcessor(MethodExpression preProcessor) {
-        this.preProcessor = preProcessor;
-        return this;
     }
 
     public MethodExpression getPostProcessor() {
         return postProcessor;
     }
 
-    public ExportConfiguration setPostProcessor(MethodExpression postProcessor) {
-        this.postProcessor = postProcessor;
-        return this;
-    }
-
     public ExporterOptions getOptions() {
         return options;
-    }
-
-    public ExportConfiguration setOptions(ExporterOptions options) {
-        this.options = options;
-        return this;
     }
 
     public MethodExpression getOnTableRender() {
         return onTableRender;
     }
 
-    public ExportConfiguration setOnTableRender(MethodExpression onTableRender) {
-        this.onTableRender = onTableRender;
-        return this;
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/export/Exporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/Exporter.java
@@ -23,24 +23,28 @@
  */
 package org.primefaces.component.export;
 
-import javax.faces.component.UIComponent;
-import javax.faces.context.FacesContext;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.faces.FacesException;
 import javax.faces.component.EditableValueHolder;
+import javax.faces.component.UIComponent;
 import javax.faces.component.UISelectMany;
 import javax.faces.component.ValueHolder;
 import javax.faces.component.html.HtmlCommandLink;
 import javax.faces.component.html.HtmlGraphicImage;
+import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
+
 import org.primefaces.component.celleditor.CellEditor;
 import org.primefaces.component.overlaypanel.OverlayPanel;
 import org.primefaces.util.Constants;
 
 public abstract class Exporter<T extends UIComponent> {
+
+    private ExportConfiguration exportConfiguration;
 
     public abstract void export(FacesContext facesContext, List<T> component, OutputStream outputStream,
             ExportConfiguration exportConfiguration) throws IOException;
@@ -153,5 +157,13 @@ public abstract class Exporter<T extends UIComponent> {
                 return Constants.EMPTY_STRING;
             }
         }
+    }
+
+    public ExportConfiguration getExportConfiguration() {
+        return exportConfiguration;
+    }
+
+    public void setExportConfiguration(ExportConfiguration exportConfiguration) {
+        this.exportConfiguration = exportConfiguration;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/export/TableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/TableExporter.java
@@ -82,7 +82,7 @@ public abstract class TableExporter<T extends UIComponent & UITable> extends Exp
     }
 
     /**
-     * Gets and caches the list of UIColumns that are exportable="true" and rendered="true".
+     * Gets and caches the list of UIColumns that are exportable="true", visible="true", and rendered="true".
      * Orders them by displayPriority so they match the UI display of the columns.
      *
      * @param table the Table with columns to export
@@ -96,10 +96,12 @@ public abstract class TableExporter<T extends UIComponent & UITable> extends Exp
         List<UIColumn> allColumns = table.getColumns();
         List<UIColumn> exportcolumns = new ArrayList<>(allColumns.size());
         Map<String, ColumnMeta> columnMetadata = table.getColumnMeta();
+        boolean visibleColumnsOnly = getExportConfiguration().isVisibleOnly();
 
         if (columnMetadata == null || columnMetadata.isEmpty()) {
             table.forEachColumn(col -> {
-                if (col.isRendered() && col.isExportable()) {
+                if (col.isRendered() && col.isExportable() &&
+                            (!visibleColumnsOnly || (visibleColumnsOnly && col.isVisible()))) {
                     exportcolumns.add(col);
                 }
                 return true;
@@ -115,7 +117,8 @@ public abstract class TableExporter<T extends UIComponent & UITable> extends Exp
             for (ColumnMeta meta : columnMetas) {
                 String metaColumnKey = meta.getColumnKey();
                 table.invokeOnColumn(metaColumnKey, ((UIData) table).getRowIndex(), column -> {
-                    if (column.isRendered() && column.isExportable()) {
+                    if (column.isRendered() && column.isExportable() &&
+                                (!visibleColumnsOnly || (visibleColumnsOnly && column.isVisible()))) {
                         exportcolumns.add(column);
                     }
                 });

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
@@ -70,7 +70,9 @@ public class TreeTableCSVExporter extends TreeTableExporter {
                 exportConfiguration.getPreProcessor().invoke(context.getELContext(), new Object[]{writer});
             }
 
-            addColumnFacets(writer, table, ColumnType.HEADER);
+            if (exportConfiguration.isExportHeader()) {
+                addColumnFacets(writer, table, ColumnType.HEADER);
+            }
 
             if (exportConfiguration.isPageOnly()) {
                 exportPageOnly(context, table, writer);
@@ -82,7 +84,7 @@ public class TreeTableCSVExporter extends TreeTableExporter {
                 exportAll(context, table, writer);
             }
 
-            if (table.hasFooterColumn()) {
+            if (exportConfiguration.isExportFooter() && table.hasFooterColumn()) {
                 addColumnFacets(writer, table, ColumnType.FOOTER);
             }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
@@ -392,10 +392,13 @@ public class TreeTableExcelExporter extends TreeTableExporter {
 
     public void exportTable(FacesContext context, UIComponent component, Sheet sheet, ExportConfiguration exportConfiguration) {
         TreeTable table = (TreeTable) component;
-        addTableFacets(context, table, sheet, TreeTableExporter.ColumnType.HEADER);
-        boolean headerGroup = addColumnGroup(table, sheet, TreeTableExporter.ColumnType.HEADER);
-        if (!headerGroup) {
-            addColumnFacets(table, sheet, TreeTableExporter.ColumnType.HEADER);
+
+        if (exportConfiguration.isExportHeader()) {
+            addTableFacets(context, table, sheet, TreeTableExporter.ColumnType.HEADER);
+            boolean headerGroup = addColumnGroup(table, sheet, TreeTableExporter.ColumnType.HEADER);
+            if (!headerGroup) {
+                addColumnFacets(table, sheet, TreeTableExporter.ColumnType.HEADER);
+            }
         }
 
         if (exportConfiguration.isPageOnly()) {
@@ -408,11 +411,13 @@ public class TreeTableExcelExporter extends TreeTableExporter {
             exportAll(context, table, sheet);
         }
 
-        addColumnGroup(table, sheet, TreeTableExporter.ColumnType.FOOTER);
-        if (table.hasFooterColumn()) {
-            addColumnFacets(table, sheet, TreeTableExporter.ColumnType.FOOTER);
+        if (exportConfiguration.isExportFooter()) {
+            addColumnGroup(table, sheet, TreeTableExporter.ColumnType.FOOTER);
+            if (table.hasFooterColumn()) {
+                addColumnFacets(table, sheet, TreeTableExporter.ColumnType.FOOTER);
+            }
+            addTableFacets(context, table, sheet, TreeTableExporter.ColumnType.FOOTER);
         }
-        addTableFacets(context, table, sheet, TreeTableExporter.ColumnType.FOOTER);
     }
 
     protected void applyOptions(Workbook wb, TreeTable table, Sheet sheet, ExporterOptions options) {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
@@ -43,14 +43,7 @@ import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
-import com.lowagie.text.Document;
-import com.lowagie.text.DocumentException;
-import com.lowagie.text.Element;
-import com.lowagie.text.Font;
-import com.lowagie.text.FontFactory;
-import com.lowagie.text.PageSize;
-import com.lowagie.text.Paragraph;
-import com.lowagie.text.Phrase;
+import com.lowagie.text.*;
 import com.lowagie.text.pdf.PdfPCell;
 import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfWriter;
@@ -154,10 +147,12 @@ public class TreeTablePDFExporter extends TreeTableExporter {
             config.getOnTableRender().invoke(context.getELContext(), new Object[]{pdfTable, table});
         }
 
-        addTableFacets(context, table, pdfTable, ColumnType.HEADER);
-        boolean headerGroup = addColumnGroup(table, pdfTable, ColumnType.HEADER);
-        if (!headerGroup) {
-            addColumnFacets(table, pdfTable, ColumnType.HEADER);
+        if (config.isExportHeader()) {
+            addTableFacets(context, table, pdfTable, ColumnType.HEADER);
+            boolean headerGroup = addColumnGroup(table, pdfTable, ColumnType.HEADER);
+            if (!headerGroup) {
+                addColumnFacets(table, pdfTable, ColumnType.HEADER);
+            }
         }
 
         if (config.isPageOnly()) {
@@ -170,11 +165,13 @@ public class TreeTablePDFExporter extends TreeTableExporter {
             exportAll(context, table, pdfTable);
         }
 
-        addColumnGroup(table, pdfTable, ColumnType.FOOTER);
-        if (table.hasFooterColumn()) {
-            addColumnFacets(table, pdfTable, ColumnType.FOOTER);
+        if (config.isExportFooter()) {
+            addColumnGroup(table, pdfTable, ColumnType.FOOTER);
+            if (table.hasFooterColumn()) {
+                addColumnFacets(table, pdfTable, ColumnType.FOOTER);
+            }
+            addTableFacets(context, table, pdfTable, ColumnType.FOOTER);
         }
-        addTableFacets(context, table, pdfTable, ColumnType.FOOTER);
 
         return pdfTable;
     }

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -168,6 +168,24 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <description>When enabled, only visible data would be exported.</description>
+            <name>visibleOnly</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>When enabled, the header will be exported. Default is true</description>
+            <name>exportHeader</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>When enabled, the footer will be exported. Default is true.</description>
+            <name>exportFooter</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
             <description>Exports the header and cell content according to the option.</description>
             <name>options</name>
             <required>false</required>


### PR DESCRIPTION
Do not export columns that are not visible.