### PR TITLE
Fix #8231: Chips: Chips size and behavior broken

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/chips/chips.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/chips/chips.css
@@ -15,6 +15,7 @@
     overflow: hidden;
     display: flex;
     flex-wrap: wrap;
+    align-content: flex-start;
 }
 
 .ui-chips-token {
@@ -25,7 +26,8 @@
     overflow: hidden;
     padding: 1px 3px;
     position: relative;
-    margin: 2px;
+    margin: .25rem .5rem .25rem 0;
+    height: 1.75rem;
 }
 
 .ui-chips-token .ui-chips-token-label {


### PR DESCRIPTION
Fix #8231

<img width="307" alt="Screenshot 2022-01-09 at 20 17 44" src="https://user-images.githubusercontent.com/7500178/148697314-95386883-0f48-4938-ac9c-fe73cba5f139.png">

This requires a change in the themes as well.

```css
body .ui-chips .ui-chips-container .ui-chips-token {
    margin: 0 0.5rem 0 0;
}
```

should be removed or replaced with `.25rem .5rem .25rem 0`;