### PR TITLE
Fix bad property name in virtual scroll example

### DIFF
--- a/docs/10_0_0/components/datatable.md
+++ b/docs/10_0_0/components/datatable.md
@@ -694,7 +694,7 @@ useful to deal with huge data, in this case data is fetched on-demand. Set _virt
 option and provide LazyDataModel;
 
 ```xhtml
-<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtual="true">
+<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtualScroll="true">
     <p:column />
     //columns
 </p:dataTable>

--- a/docs/11_0_0/components/datatable.md
+++ b/docs/11_0_0/components/datatable.md
@@ -696,7 +696,7 @@ useful to deal with huge data, in this case data is fetched on-demand. Set _virt
 option and provide LazyDataModel;
 
 ```xhtml
-<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtual="true">
+<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtualScroll="true">
     <p:column />
     //columns
 </p:dataTable>

--- a/docs/12_0_0/components/datatable.md
+++ b/docs/12_0_0/components/datatable.md
@@ -696,7 +696,7 @@ useful to deal with huge data, in this case data is fetched on-demand. Set _virt
 option and provide LazyDataModel;
 
 ```xhtml
-<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtual="true">
+<p:dataTable var="car" value="#{bean.data}" scrollable="true" scrollHeight="150" virtualScroll="true">
     <p:column />
     //columns
 </p:dataTable>


### PR DESCRIPTION
The DataTable documentation for PrimeFaces 10 shows an example of virtual scrolling with a wrong property: it says virtual instead of virtualScroll.