### PR TITLE
Fix #8311: SelectOneMenu CSV validation

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -108,6 +108,9 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         this.cfg.renderPanelContentOnClient = this.cfg.renderPanelContentOnClient === true;
         this.isDynamicLoaded = false;
 
+        //pfs metadata
+        this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
+
         if(this.cfg.dynamic || (this.itemsWrapper.children().length === 0)) {
             var selectedOption = this.options.filter(':selected'),
             labelVal = this.cfg.editable ? this.label.val() : selectedOption.text();
@@ -180,9 +183,6 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         if(this.cfg.syncTooltip) {
             this.syncTitle(selectedOption);
         }
-
-        //pfs metadata
-        this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
 
         //for Screen Readers
         for(var i = 0; i < this.items.length; i++) {


### PR DESCRIPTION
@tandraschko the issue was this line was moved into `initContents` but that is only called dynamically the first time the dropdown is clicked so the clientId is not set yet.  This line had to be moved back up into the constructor so it is always initialized.

![image](https://user-images.githubusercontent.com/4399574/151023906-ddb9a54e-28a9-409c-ac85-03a2101a43e9.png)
