### PR TITLE
Add missing type references to type declarations file

### DIFF
--- a/primefaces/src/main/type-definitions/core.d.ts
+++ b/primefaces/src/main/type-definitions/core.d.ts
@@ -6,8 +6,10 @@
 /// <reference types="cropperjs" />
 /// <reference types="downloadjs" />
 /// <reference types="google.maps" />
+/// <reference types="inputmask" />
 /// <reference types="jquery" />
 /// <reference types="jqueryui" />
+/// <reference types="js-cookie" />
 /// <reference types="moment-timezone" />
 /// <reference path="PrimeFaces-module.d.ts" />
 


### PR DESCRIPTION
We reference the global inputmask and js-cookie types, so we need to add a triple slash reference for them. Compiling a project that uses primefaces with skipLibCheck: false (and doesn't include these types itself already) will result in a compiler error

```text
node_modules/primefaces/PrimeFaces.d.ts:7318:62 - error TS2503: Cannot find namespace 'Cookies'.

7318     export function deleteCookie(name: string, cfg?: Partial<Cookies.CookieAttributes>): void;
                                                                  ~~~~~~~

node_modules/primefaces/PrimeFaces.d.ts:7566:74 - error TS2503: Cannot find namespace 'Cookies'.

7566     export function setCookie(name: string, value: string, cfg?: Partial<Cookies.CookieAttributes>): void;
                                                                              ~~~~~~~

node_modules/primefaces/PrimeFaces.d.ts:21324:43 - error TS2503: Cannot find namespace 'Inputmask'.

21324     export interface InputMaskCfg extends Inputmask.Options, PrimeFaces.widget.BaseWidgetCfg {
                                                ~~~~~~~~~
```