### PR TITLE
Fix #8335: Captcha theme aware

### DIFF
--- a/docs/12_0_0/components/captcha.md
+++ b/docs/12_0_0/components/captcha.md
@@ -32,7 +32,7 @@ Captcha is a form validation component based on Recaptcha API V2.
 | converterMessage | null | String | Message to be displayed when conversion fails.
 | validatorMessage | null | String | Message to be displayed when validation fields.
 | publicKey | null | String | Public recaptcha key for a specific domain (deprecated)
-| theme | red | String | Theme of the captcha.
+| theme | auto | String | Theme of the captcha. Values are "light", "dark", or "auto" to try and auto detect based on current theme.
 | language | en | String | Key of the supported languages.
 | tabindex | null | Integer | Position of the input element in the tabbing order.
 | label | null | String | User presentable field name.

--- a/docs/migrationguide/12_0_0.md
+++ b/docs/migrationguide/12_0_0.md
@@ -1,5 +1,8 @@
 # Migration guide 11.0.0 -> 12.0.0
 
 
+## Captcha
+  * Is now theme aware. The default value of `theme` is now `auto` so it will attempt to detect your current theme and set it to `light` or `dark`
+  
 ## TextEditor
   * Is now theme aware. If you are using legacy theme or no theme you may need to add CSS variables to your stylesheet to support it (https://github.com/primefaces/primefaces/issues/8064)

--- a/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaBase.java
@@ -54,7 +54,7 @@ public abstract class CaptchaBase extends UIInput implements Widget {
     }
 
     public String getTheme() {
-        return (String) getStateHelper().eval(PropertyKeys.theme, "light");
+        return (String) getStateHelper().eval(PropertyKeys.theme, "auto");
     }
 
     public void setTheme(String theme) {

--- a/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
@@ -89,7 +89,7 @@ public class CaptchaRenderer extends CoreRenderer {
         wb.init("Captcha", captcha);
 
         wb.attr("sitekey", publicKey)
-                .attr("theme", captcha.getTheme(), "light")
+                .attr("theme", captcha.getTheme(), "auto")
                 .attr("language", captcha.getLanguage(), "en")
                 .attr("tabindex", captcha.getTabindex(), 0)
                 .attr("callback", captcha.getCallback(), null)

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -3738,7 +3738,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Theme of the captcha. Default is light.]]>
+                <![CDATA[Theme of the captcha either 'light', 'dark', or 'auto'. Default is auto.]]>
             </description>
             <name>theme</name>
             <required>false</required>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/captcha/captcha.js
@@ -3,7 +3,7 @@
  *
  * Captcha is a form validation component based on Recaptcha API V2.
  *
- * @typedef {"light" | "dark"} PrimeFaces.widget.Captcha.Theme Captcha features light and dark modes for theme.
+ * @typedef {"auto" | "light" | "dark"} PrimeFaces.widget.Captcha.Theme Captcha features light and dark modes for theme.
  *
  * @interface {PrimeFaces.widget.CaptchaCfg} cfg The configuration for the {@link  Captcha| Captcha widget}.
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this
@@ -31,6 +31,8 @@ PrimeFaces.widget.Captcha = PrimeFaces.widget.BaseWidget.extend({
     init: function(cfg) {
         this._super(cfg);
         this.cfg.language = this.cfg.language||'en';
+        this.cfg.theme = this.cfg.theme || PrimeFaces.env.getThemeContrast();
+
         var $this = this;
 
         window[this.getInitCallbackName()] = function() {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.env.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.env.js
@@ -26,6 +26,16 @@ if (!PrimeFaces.env) {
          * @type {string}
          */
         browser : null,
+        /**
+         * `true` if the user's current OS setting prefers dark mode, `false` otherwise.
+         * @type {boolean}
+         */
+        preferredColorSchemeDark : false,
+        /**
+         * `true` if the user's current OS setting prefers light mode, `false` otherwise.
+         * @type {boolean}
+         */
+        preferredColorSchemeLight : false,
 
         /**
          * Initializes the environment by reading the browser environment.
@@ -35,6 +45,8 @@ if (!PrimeFaces.env) {
             this.mobile = (this.browser.mobile) ? true : false;
             this.touch = 'ontouchstart' in window || window.navigator.msMaxTouchPoints || PrimeFaces.env.mobile;
             this.ios = /iPhone|iPad|iPod/i.test(window.navigator.userAgent) || (/mac/i.test(window.navigator.userAgent) && PrimeFaces.env.touch);
+            this.preferredColorSchemeDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            this.preferredColorSchemeLight = !this.preferredModeDark;
         },
 
         /**
@@ -60,6 +72,23 @@ if (!PrimeFaces.env) {
             return (this.browser.msie) ? parseInt(this.browser.version, 10) < version : false;
         },
 
+       /**
+         * Gets the currently loaded PrimeFaces theme.
+         * @return {string} The current theme, such as `omega` or `luna-amber`. Empty string when no theme is loaded.
+         */
+        getTheme : function() {
+            var themeLink = PrimeFaces.getThemeLink();
+            if (themeLink.length === 0) {
+                return "";
+            }
+
+            var themeURL = themeLink.attr('href'),
+                plainURL = themeURL.split('&')[0],
+                oldTheme = plainURL.split('ln=primefaces-')[1];
+
+            return oldTheme;
+        },
+
         /**
          * A widget is touch enabled if the browser supports touch AND the widget has the touchable property enabled.
          * The default will be true if it widget status can't be determined.
@@ -70,6 +99,26 @@ if (!PrimeFaces.env) {
         isTouchable: function(cfg) {
             var widgetTouchable = (cfg == undefined) || (cfg.touchable != undefined ? cfg.touchable : true);
             return PrimeFaces.env.touch && widgetTouchable;
+        },
+
+        /**
+         * Gets the user's preferred color scheme set in their operating system.
+         * 
+         * @return {string} either 'dark' or 'light'
+         */
+        getOSPreferredColorScheme: function() {
+            return PrimeFaces.env.preferredColorSchemeLight ? 'light' : 'dark';
+        },
+
+       /**
+         * Based on the current PrimeFaces theme determine if light or dark contrast is being applied.
+         * 
+         * @return {string} either 'dark' or 'light'
+         */
+        getThemeContrast: function() {
+            var theme = PrimeFaces.env.getTheme();
+            var darkRegex = /(^(arya|vela|.+-(dim|dark))$)/gm;
+            return darkRegex.test(theme) ? 'dark' : 'light';
         }
     };
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -505,16 +505,7 @@
          * @return {string} The current theme, such as `omega` or `luna-amber`. Empty string when no theme is loaded.
          */
         getTheme : function() {
-            var themeLink = PrimeFaces.getThemeLink();
-            if (themeLink.length === 0) {
-                return "";
-            }
-
-            var themeURL = themeLink.attr('href'),
-                plainURL = themeURL.split('&')[0],
-                oldTheme = plainURL.split('ln=primefaces-')[1];
-
-            return oldTheme;
+            return PrimeFaces.env.getTheme();
         },
 
         /**


### PR DESCRIPTION
Will default to user's OS theme preference for Captcha theme color.  Can still be properly set with the `theme` attribute this just gives a better default