### PR TITLE
Fix #8359: FileUploadUtils handle tilde on Windows

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -27,7 +27,10 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -71,7 +74,9 @@ public class FileUploadUtils {
 
         if (isSystemWindows()) {
             if (!filename.contains("\\\\")) {
-                String[] parts = filename.substring(FilenameUtils.getPrefixLength(filename)).split(Pattern.quote(File.separator));
+                int length = FilenameUtils.getPrefixLength(filename);
+                String prefix = LangUtils.substring(filename, 0, length);
+                String[] parts = prefix.split(Pattern.quote(File.separator));
                 for (String part : parts) {
                     if (INVALID_FILENAME_PATTERN.matcher(part).find()) {
                         throw new FacesException("Invalid filename: " + filename);

--- a/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -252,4 +252,16 @@ public class FileUploadUtilsTest {
         assertEquals("", result);
     }
 
+    @Test
+    public void getValidFilename_GitHub8359() {
+        // Arrange
+        String filename = "~myfile.txt";
+
+        // Act
+        String result = FileUploadUtils.getValidFilename(filename);
+
+        // Assert
+        assertEquals(filename, result);
+    }
+
 }


### PR DESCRIPTION
Added unit test. It was definitely broken on Windows only.  Added fix