### PR TITLE
Fix #8389: Charts `beginAtZero` has moved from `CartesianLinearTicks`…

### DIFF
--- a/docs/migrationguide/12_0_0.md
+++ b/docs/migrationguide/12_0_0.md
@@ -4,5 +4,8 @@
 ## Captcha
   * Is now theme aware. The default value of `theme` is now `auto` so it will attempt to detect your current theme and set it to `light` or `dark`
   
+## Charts
+  * `beginAtZero` has moved from `CartesianLinearTicks` to `CartesianLinearAxes`
+  
 ## TextEditor
   * Is now theme aware. If you are using legacy theme or no theme you may need to add CSS variables to your stylesheet to support it (https://github.com/primefaces/primefaces/issues/8064)

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/chartjs/ChartJsView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/chartjs/ChartJsView.java
@@ -388,8 +388,8 @@ public class ChartJsView implements Serializable {
         CartesianScales cScales = new CartesianScales();
         CartesianLinearAxes linearAxes = new CartesianLinearAxes();
         linearAxes.setOffset(true);
+        linearAxes.setBeginAtZero(true);
         CartesianLinearTicks ticks = new CartesianLinearTicks();
-        ticks.setBeginAtZero(true);
         linearAxes.setTicks(ticks);
         cScales.addYAxesData(linearAxes);
         options.setScales(cScales);
@@ -470,8 +470,8 @@ public class ChartJsView implements Serializable {
         CartesianScales cScales = new CartesianScales();
         CartesianLinearAxes linearAxes = new CartesianLinearAxes();
         linearAxes.setOffset(true);
+        linearAxes.setBeginAtZero(true);
         CartesianLinearTicks ticks = new CartesianLinearTicks();
-        ticks.setBeginAtZero(true);
         linearAxes.setTicks(ticks);
         cScales.addYAxesData(linearAxes);
         options.setScales(cScales);
@@ -540,8 +540,8 @@ public class ChartJsView implements Serializable {
         CartesianScales cScales = new CartesianScales();
         CartesianLinearAxes linearAxes = new CartesianLinearAxes();
         linearAxes.setOffset(true);
+        linearAxes.setBeginAtZero(true);
         CartesianLinearTicks ticks = new CartesianLinearTicks();
-        ticks.setBeginAtZero(true);
         linearAxes.setTicks(ticks);
         cScales.addXAxesData(linearAxes);
         options.setScales(cScales);
@@ -926,8 +926,8 @@ public class ChartJsView implements Serializable {
         CartesianScales cScales = new CartesianScales();
         CartesianLinearAxes linearAxes = new CartesianLinearAxes();
         linearAxes.setOffset(true);
+        linearAxes.setBeginAtZero(true);
         CartesianLinearTicks ticks = new CartesianLinearTicks();
-        ticks.setBeginAtZero(true);
         linearAxes.setTicks(ticks);
 
         cScales.addYAxesData(linearAxes);

--- a/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/linear/CartesianLinearAxes.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/linear/CartesianLinearAxes.java
@@ -26,6 +26,7 @@ package org.primefaces.model.charts.axes.cartesian.linear;
 import java.io.IOException;
 
 import org.primefaces.model.charts.axes.cartesian.CartesianAxes;
+import org.primefaces.util.ChartUtils;
 import org.primefaces.util.FastStringWriter;
 
 /**
@@ -38,6 +39,7 @@ public class CartesianLinearAxes extends CartesianAxes {
     private static final long serialVersionUID = 1L;
 
     private String type;
+    private boolean beginAtZero;
     private CartesianLinearTicks ticks;
 
     /**
@@ -56,6 +58,24 @@ public class CartesianLinearAxes extends CartesianAxes {
      */
     public void setTicks(CartesianLinearTicks ticks) {
         this.ticks = ticks;
+    }
+
+    /**
+     * Gets the beginAtZero
+     *
+     * @return beginAtZero
+     */
+    public boolean isBeginAtZero() {
+        return beginAtZero;
+    }
+
+    /**
+     * Sets the beginAtZero
+     *
+     * @param beginAtZero if true, scale will include 0 if it is not already included.
+     */
+    public void setBeginAtZero(boolean beginAtZero) {
+        this.beginAtZero = beginAtZero;
     }
 
     /**
@@ -87,9 +107,8 @@ public class CartesianLinearAxes extends CartesianAxes {
         try (FastStringWriter fsw = new FastStringWriter()) {
             fsw.write(super.encode());
 
-            if (this.type != null) {
-                fsw.write(",\"type\":\"" + this.type + "\"");
-            }
+            ChartUtils.writeDataValue(fsw, "type", this.type, true);
+            ChartUtils.writeDataValue(fsw, "beginAtZero", this.beginAtZero, true);
 
             if (this.ticks != null) {
                 fsw.write(",\"ticks\":{");

--- a/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/linear/CartesianLinearTicks.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/linear/CartesianLinearTicks.java
@@ -36,7 +36,6 @@ public class CartesianLinearTicks extends CartesianTicks {
 
     private static final long serialVersionUID = 1L;
 
-    private boolean beginAtZero;
     private Number min;
     private Number max;
     private Number maxTicksLimit;
@@ -44,24 +43,6 @@ public class CartesianLinearTicks extends CartesianTicks {
     private Number stepSize;
     private Number suggestedMax;
     private Number suggestedMin;
-
-    /**
-     * Gets the beginAtZero
-     *
-     * @return beginAtZero
-     */
-    public boolean isBeginAtZero() {
-        return beginAtZero;
-    }
-
-    /**
-     * Sets the beginAtZero
-     *
-     * @param beginAtZero if true, scale will include 0 if it is not already included.
-     */
-    public void setBeginAtZero(boolean beginAtZero) {
-        this.beginAtZero = beginAtZero;
-    }
 
     /**
      * Gets the min
@@ -199,7 +180,6 @@ public class CartesianLinearTicks extends CartesianTicks {
     public String encode() throws IOException {
         try (FastStringWriter fsw = new FastStringWriter()) {
             fsw.write(super.encode());
-            ChartUtils.writeDataValue(fsw, "beginAtZero", this.beginAtZero, true);
             ChartUtils.writeDataValue(fsw, "min", this.min, true);
             ChartUtils.writeDataValue(fsw, "max", this.max, true);
             ChartUtils.writeDataValue(fsw, "maxTicksLimit", this.maxTicksLimit, true);


### PR DESCRIPTION
… to `CartesianLinearAxes`