### PR TITLE
Fix #8396: Spinner: role

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -73,8 +73,6 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
 
         this.format();
 
-        this.addARIA();
-
         if(this.input.prop('disabled')||this.input.prop('readonly')) {
             return;
         }
@@ -84,6 +82,7 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
         this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
 
         PrimeFaces.skinInput(this.input);
+        this.addARIA();
     },
 
     /**


### PR DESCRIPTION
Fix #8396

`PrimeFaces.skinInput(this.input);` also sets role, so the ARIA code must be execute later.
