### PR TITLE
disable logging-capability for FF when headless is enabled

### DIFF
--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/internal/DefaultWebDriverAdapter.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/internal/DefaultWebDriverAdapter.java
@@ -83,7 +83,9 @@ public class DefaultWebDriverAdapter implements WebDriverAdapter {
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
                 firefoxOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
                 firefoxOptions.setHeadless(config.isWebdriverHeadless());
-                firefoxOptions.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
+                if (!config.isWebdriverHeadless()) {
+                    firefoxOptions.setCapability(CapabilityType.LOGGING_PREFS, logPrefs);
+                }
                 return new FirefoxDriver(firefoxOptions);
             case "chrome":
                 ChromeOptions chromeOptions = new ChromeOptions();


### PR DESCRIPTION
... because with logging-capability added headless is ignored. Causing failure on Github Actions.