### PR TITLE
temporary disable Chips004Test#testClipboardPaste for Chrome 98

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/chips/Chips004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/chips/Chips004Test.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.Chips;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.InputText;
@@ -46,6 +47,15 @@ public class Chips004Test extends AbstractPrimePageTest {
     @DisplayName("Chips: GitHub #1895/#6691: Chips allow pasting of delimited list")
     @Tag("SafariExclude") // can't get copy and paste working on Safari
     public void testClipboardPaste(Page page) {
+        if (PrimeSelenium.isChrome()) {
+            /*
+             * Chrome 98 - bug
+             * https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999
+             * Re-enable with Chrome 99!
+             */
+            return;
+        }
+
         // Arrange
         Chips chips = page.chips;
         InputText clipboard = page.clipboard;


### PR DESCRIPTION
due to https://bugs.chromium.org/p/chromedriver/issues/detail?id=3999
Re-enable with Chrome 99!