### PR TITLE
Fix #8480: role="button" not necessary on <button> element

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -349,13 +349,6 @@
                 $(this).removeClass('ui-state-active');
             });
 
-            //aria
-            var role = button.attr('role');
-            if(!role) {
-                button.attr('role', 'button');
-            }
-            button.attr('aria-disabled', button.prop('disabled'));
-
             return this;
         },
 


### PR DESCRIPTION
The `button` role is unnecessary for element `button`.

Attribute `aria-disabled` is unnecessary for elements that have attribute `disabled`.