### PR TITLE
disable Password002Test and Password003Test for Firefox

### DIFF
--- a/primefaces-integration-tests/pom.xml
+++ b/primefaces-integration-tests/pom.xml
@@ -426,16 +426,13 @@
             <id>firefox</id>
             <properties>
                 <webdriver.browser>firefox</webdriver.browser>
+                <excludedGroups>FirefoxExclude</excludedGroups>
             </properties>
         </profile>
         <profile>
             <id>safari</id>
             <properties>
                 <webdriver.browser>safari</webdriver.browser>
-                <!-- optionally only run tests with specific @Tag -->
-                <!--
-                <groups>SafariBasic</groups>
-                -->
                 <excludedGroups>SafariExclude</excludedGroups>
                 <junit.jupiter.execution.parallel.enabled>false</junit.jupiter.execution.parallel.enabled>
             </properties>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/password/Password002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/password/Password002Test.java
@@ -24,16 +24,14 @@
 package org.primefaces.integrationtests.password;
 
 import org.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.Password;
 
+@Tag("FirefoxExclude") // stability-issues for Firefox (96, 97) together with Selenium 4 and password.showFeedback
 public class Password002Test extends AbstractPrimePageTest {
 
     @Test

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/password/Password003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/password/Password003Test.java
@@ -24,16 +24,14 @@
 package org.primefaces.integrationtests.password;
 
 import org.json.JSONObject;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.Password;
 
+@Tag("FirefoxExclude") // stability-issues for Firefox (96, 97) together with Selenium 4 and password.showFeedback
 public class Password003Test extends AbstractPrimePageTest {
 
     @Test


### PR DESCRIPTION
... so our daily IT does not fail anymore.

I had not been able to figure out how to get `org.primefaces.selenium.component.Password#showFeedback` running stable with Firefox on Selenium 4. Even after putting hour´s into this issue.