### PR TITLE
Fix #7580: Tooltip 'autoHide' attribute

### DIFF
--- a/docs/12_0_0/components/tooltip.md
+++ b/docs/12_0_0/components/tooltip.md
@@ -44,6 +44,7 @@ onShow | null | String | Client side callback to execute after tooltip is shown.
 position | right | String | Position of the tooltip, valid values are right, left, top and bottom.
 my | null | String | Position of tooltip with respect to target. If set overrides the 'position' attribute. Example "left center".
 at | null | String | Position of tooltip with respect to target. If set overrides the 'position' attribute. Example "right center".
+autoHide | true | boolean | Whether to hide tooltip when hovering over tooltip content.
 
 ## Getting started with the Tooltip
 Tooltip can be used by attaching it to a target component. Tooltip value can also be retrieved from

--- a/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
@@ -50,6 +50,16 @@
             <p:graphicImage id="track" name="/images/primefaces-logo.svg" library="showcase"/>
             <p:tooltip for="track" value="Enter your username" trackMouse="true"/>
 
+            <h5>Auto Hide</h5>
+            <p:commandButton type="button" id="autoHideTrue" value="Auto Hide (true)" class="p-mr-2" />
+            <p:tooltip for="autoHideTrue" autoHide="true">
+                <p:graphicImage name="/images/primefaces-logo.svg" library="showcase"/>
+            </p:tooltip>
+            <p:commandButton type="button" id="autoHideFalse" value="Auto Hide (false)" />
+            <p:tooltip for="autoHideFalse" autoHide="false">
+                <p:graphicImage name="/images/primefaces-logo.svg" library="showcase"/>
+            </p:tooltip>
+
             <h5>Animation</h5>
             <p:commandButton type="button" id="animate" icon="pi pi-cog"/>
             <p:tooltip for="animate" value="Customization options" showEffect="clip" hideEffect="fold" />

--- a/primefaces/src/main/java/org/primefaces/component/tooltip/TooltipBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tooltip/TooltipBase.java
@@ -54,7 +54,8 @@ public abstract class TooltipBase extends UIOutput implements Widget {
         position,
         delegate,
         my,
-        at;
+        at,
+        autoHide;
 
         private String toString;
 
@@ -238,5 +239,13 @@ public abstract class TooltipBase extends UIOutput implements Widget {
 
     public void setAt(String at) {
         getStateHelper().put(PropertyKeys.at, at);
+    }
+
+    public boolean isAutoHide() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.autoHide, true);
+    }
+
+    public void setAutoHide(boolean autoHide) {
+        getStateHelper().put(PropertyKeys.autoHide, autoHide);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/tooltip/TooltipRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tooltip/TooltipRenderer.java
@@ -109,6 +109,7 @@ public class TooltipRenderer extends CoreRenderer {
                 .attr("atPos", tooltip.getAt(), null)
                 .attr("delegate", tooltip.isDelegate(), false)
                 .attr("styleClass", tooltip.getStyleClass(), null)
+                .attr("autoHide", tooltip.isAutoHide(), true)
                 .returnCallback("beforeShow", "function()", tooltip.getBeforeShow())
                 .callback("onShow", "function()", tooltip.getOnShow())
                 .callback("onHide", "function()", tooltip.getOnHide());

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -29200,6 +29200,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Whether to hide tooltip when hovering over tooltip content, default is true.]]>
+            </description>
+            <name>autoHide</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Tooltip position follows pointer on mousemove, default is false]]>
             </description>
             <name>trackMouse</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.css
@@ -1,7 +1,6 @@
 .ui-tooltip {
     position:absolute;
     display:none;
-    pointer-events: none;
 }
 
 .ui-tooltip.ui-tooltip-right,

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -25,6 +25,7 @@
  * @prop {JQuery.TriggeredEvent} mouseEvent The mouse event that occurred for this tooltip.
  * @prop {JQuery} target The DOM element for the target component.
  * @prop {number} timeout The set-timeout timer ID of the time for the tooltip delay.
+ * @prop {boolean} allowHide Variable used to control whether the tooltip is being hovered in autoHide mode
  * 
  * @interface {PrimeFaces.widget.TooltipCfg} cfg The configuration for the {@link  Tooltip| Tooltip widget}.
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this
@@ -33,6 +34,7 @@
  * 
  * @prop {PrimeFaces.widget.Tooltip.BeforeShowCallback} cfg.beforeShow Client side callback to execute before tooltip is
  * shown. Returning false will prevent display.
+ * @prop {string} cfg.autoHide Whether to hide tooltip when hovering over tooltip content.
  * @prop {string} cfg.delegate Search expression for overriding the {@link target}.
  * @prop {boolean} cfg.escape Defines whether HTML would be escaped or not.
  * @prop {string} cfg.globalSelector A jQuery selector for global tooltip, defaults to `a,:input,:button`.
@@ -69,10 +71,12 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         this.cfg.showDelay = PrimeFaces.utils.defaultNumeric(this.cfg.showDelay, 150);
         this.cfg.hideDelay = PrimeFaces.utils.defaultNumeric(this.cfg.hideDelay, 0);
         this.cfg.hideEffectDuration = this.cfg.target ? 250 : 1;
-        this.cfg.position = this.cfg.position||'right';
+        this.cfg.position = this.cfg.position || 'right';
         this.cfg.escape = (this.cfg.escape === undefined) ? true : this.cfg.escape;
+        this.cfg.autoHide = (this.cfg.autoHide === undefined) ? true : this.cfg.autoHide;
+        this.allowHide = true;
 
-        if(this.cfg.target)
+        if (this.cfg.target)
             this.bindTarget();
         else
             this.bindGlobal();
@@ -84,16 +88,32 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
      */
     refresh: function(cfg) {
-        if(cfg.target) {
+        this._cleanup();
+        this._super(cfg);
+    },
+
+    /**
+     * @override
+     * @inheritdoc
+     */
+    destroy: function() {
+        this._super();
+        this._cleanup();
+    },
+
+    /**
+     * Clean up this widget and remove elements from DOM.
+     * @private
+     */
+    _cleanup: function() {
+        if (cfg.target) {
             var targetTooltip = $(document.body).children(PrimeFaces.escapeClientId(cfg.id));
-            if(targetTooltip.length)
+            if (targetTooltip.length)
                 targetTooltip.remove();
         }
         else {
             $(document.body).children('.ui-tooltip-global').remove();
         }
-
-        this._super(cfg);
     },
 
     /**
@@ -106,56 +126,56 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         this.jq.append('<div class="ui-tooltip-arrow"></div><div class="ui-tooltip-text ui-shadow ui-corner-all"></div>');
 
         this.jq.addClass(this.cfg.styleClass);
-        
-        this.cfg.globalSelector = this.cfg.globalSelector||'a,:input,:button';
+
+        this.cfg.globalSelector = this.cfg.globalSelector || 'a,:input,:button';
         var $this = this;
 
         $(document).off(this.cfg.showEvent + ' ' + this.cfg.hideEvent, this.cfg.globalSelector)
-                    .on(this.cfg.showEvent, this.cfg.globalSelector, function(e) {
-                        var element = $(this);
-                        if(element.prop('disabled')) {
-                            return;
-                        }
+            .on(this.cfg.showEvent, this.cfg.globalSelector, function(e) {
+                var element = $(this);
+                if (element.prop('disabled')) {
+                    return;
+                }
 
-                        if($this.cfg.trackMouse) {
-                            $this.mouseEvent = e;
-                        }
+                if ($this.cfg.trackMouse) {
+                    $this.mouseEvent = e;
+                }
 
-                        var title = element.attr('title');
-                        if(title) {
-                            element.data('tooltip', title).removeAttr('title');
-                        }
+                var title = element.attr('title');
+                if (title) {
+                    element.data('tooltip', title).removeAttr('title');
+                }
 
-                        var arrow = $this.jq.children('.ui-tooltip-arrow');
+                var arrow = $this.jq.children('.ui-tooltip-arrow');
 
-                        if(element.hasClass('ui-state-error')) {
-                            $this.jq.children('.ui-tooltip-text').addClass('ui-state-error');
-                            arrow.addClass('ui-state-error');
-                        }
-                        else {
-                            arrow.removeClass('ui-state-error');
-                        }
+                if (element.hasClass('ui-state-error')) {
+                    $this.jq.children('.ui-tooltip-text').addClass('ui-state-error');
+                    arrow.addClass('ui-state-error');
+                }
+                else {
+                    arrow.removeClass('ui-state-error');
+                }
 
-                        var text = element.data('tooltip');
-                        if(text) {
-                            if($this.cfg.escape)
-                                $this.jq.children('.ui-tooltip-text').text(text);
-                            else
-                                $this.jq.children('.ui-tooltip-text').html(text);
+                var text = element.data('tooltip');
+                if (text) {
+                    if ($this.cfg.escape)
+                        $this.jq.children('.ui-tooltip-text').text(text);
+                    else
+                        $this.jq.children('.ui-tooltip-text').html(text);
 
-                            $this.globalTitle = text;
-                            $this.target = element;
-                            $this.show();
-                        }
-                    })
-                    .on(this.cfg.hideEvent + '.tooltip', this.cfg.globalSelector, function() {
-                        if($this.globalTitle) {
-                            $this.hide();
-                            $this.globalTitle = null;
-                            $this.target = null;
-                            $this.jq.children('.ui-tooltip-text').removeClass('ui-state-error');
-                        }
-                    });
+                    $this.globalTitle = text;
+                    $this.target = element;
+                    $this.show();
+                }
+            })
+            .on(this.cfg.hideEvent + '.tooltip', this.cfg.globalSelector, function() {
+                if ($this.globalTitle) {
+                    $this.hide();
+                    $this.globalTitle = null;
+                    $this.target = null;
+                    $this.jq.children('.ui-tooltip-text').removeClass('ui-state-error');
+                }
+            });
 
         PrimeFaces.utils.registerResizeHandler(this, 'resize.tooltip' + '_align', $this.jq, function() {
             $this.align();
@@ -182,44 +202,46 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         this.target.attr("aria-describedby", describedBy);
 
         var $this = this;
-        if(this.cfg.delegate) {
+        if (this.cfg.delegate) {
             var targetSelector = "*[id='" + this.target.attr('id') + "']";
 
             $(document).off(this.cfg.showEvent + ' ' + this.cfg.hideEvent, targetSelector)
-                        .on(this.cfg.showEvent, targetSelector, function(e) {
-                            if($this.cfg.trackMouse) {
-                                $this.mouseEvent = e;
-                            }
+                .on(this.cfg.showEvent, targetSelector, function(e) {
+                    if ($this.cfg.trackMouse) {
+                        $this.mouseEvent = e;
+                    }
 
-                            if(PrimeFaces.trim($this.jq.children('.ui-tooltip-text').html()) !== '') {
-                                $this.show();
-                            }
-                        })
-                        .on(this.cfg.hideEvent + '.tooltip', function() {
-                            $this.hide();
-                        });
+                    if (PrimeFaces.trim($this.jq.children('.ui-tooltip-text').html()) !== '') {
+                        $this.show();
+                    }
+                })
+                .on(this.cfg.hideEvent + '.tooltip', function() {
+                    $this.hide();
+                });
         }
         else {
             this.target.off(this.cfg.showEvent + ' ' + this.cfg.hideEvent)
-                        .on(this.cfg.showEvent, function(e) {
-                            if($this.cfg.trackMouse) {
-                                $this.mouseEvent = e;
-                            }
+                .on(this.cfg.showEvent, function(e) {
+                    if ($this.cfg.trackMouse) {
+                        $this.mouseEvent = e;
+                    }
 
-                            if(PrimeFaces.trim($this.jq.children('.ui-tooltip-text').html()) !== '') {
-                                $this.show();
-                            }
-                        })
-                        .on(this.cfg.hideEvent + '.tooltip', function() {
-                            $this.hide();
-                        });
+                    if (PrimeFaces.trim($this.jq.children('.ui-tooltip-text').html()) !== '') {
+                        $this.show();
+                    }
+                })
+                .on(this.cfg.hideEvent + '.tooltip', function() {
+                    $this.hide();
+                });
+
+            this.bindAutoHide();
         }
 
         this.jq.appendTo(document.body);
 
-        if(PrimeFaces.trim(this.jq.children('.ui-tooltip-text').html()) === '') {
+        if (PrimeFaces.trim(this.jq.children('.ui-tooltip-text').html()) === '') {
             var text = this.target.attr('title');
-            if(this.cfg.escape)
+            if (this.cfg.escape)
                 this.jq.children('.ui-tooltip-text').text(text);
             else
                 this.jq.children('.ui-tooltip-text').html(text);
@@ -234,25 +256,44 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
+      * Sets up mouse listeners if autoHide is disabled to keep the toolip open if tooltip has focus.
+      * @private
+      */
+    bindAutoHide: function() {
+        if (this.isAutoHide()) {
+            return;
+        }
+        var $this = this;
+        this.jq.off("mouseenter.tooltip mouseleave.tooltip")
+            .on("mouseenter.tooltip", function(e) {
+                $this.allowHide = false;
+            })
+            .on("mouseleave.tooltip", function(e) {
+                $this.allowHide = true;
+                $this.hide(e);
+            });
+    },
+
+    /**
      * Aligns the position of this tooltip via the given options.
      * @private
      * @param {PrimeFaces.widget.Tooltip.TooltipPosition} position Position where the tooltip should be shown.
      * @param {Record<string, string>} feedback Feedback about the position and dimensions of both elements, as well as
      * calculations to their relative position.
      */
-    alignUsing: function(position,feedback) {
+    alignUsing: function(position, feedback) {
         this.jq.removeClass('ui-tooltip-left ui-tooltip-right ui-tooltip-top ui-tooltip-bottom');
         switch (this.cfg.position) {
-        case "right":
-        case "left":
-            this.jq.addClass('ui-tooltip-'+
-                    (feedback['horizontal']=='left'?'right':'left'));
-            break;
-        case "top":
-        case "bottom":
-            this.jq.addClass('ui-tooltip-'+
-                    (feedback['vertical']=='top'?'bottom':'top'));
-            break;
+            case "right":
+            case "left":
+                this.jq.addClass('ui-tooltip-' +
+                    (feedback['horizontal'] == 'left' ? 'right' : 'left'));
+                break;
+            case "top":
+            case "bottom":
+                this.jq.addClass('ui-tooltip-' +
+                    (feedback['vertical'] == 'top' ? 'bottom' : 'top'));
+                break;
         }
         this.jq.css({
             left: position['left'] + 'px',
@@ -265,49 +306,49 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      */
     align: function() {
         var $this = this;
-         this.jq.css({
-            left:'',
-            top:'',
+        this.jq.css({
+            left: '',
+            top: '',
             'z-index': PrimeFaces.nextZindex()
         });
 
-        if(this.cfg.trackMouse && this.mouseEvent) {
+        if (this.cfg.trackMouse && this.mouseEvent) {
             this.jq.position({
                 my: 'left+3 top',
                 of: this.mouseEvent,
                 collision: 'flipfit',
-                using: function(p,f) {
-                    $this.alignUsing.call($this,p,f);
+                using: function(p, f) {
+                    $this.alignUsing.call($this, p, f);
                 }
             });
 
             this.mouseEvent = null;
         }
         else {
-            var _my = this.cfg.myPos, 
-            _at = this.cfg.atPos;
+            var _my = this.cfg.myPos,
+                _at = this.cfg.atPos;
 
             if (!_my || !_at) {
-                switch(this.cfg.position) {
-                case 'right':
-                    _my = 'left center';
-                    _at = 'right center';
-                break;
+                switch (this.cfg.position) {
+                    case 'right':
+                        _my = 'left center';
+                        _at = 'right center';
+                        break;
 
-                case 'left':
-                    _my = 'right center';
-                    _at = 'left center';
-                break;
+                    case 'left':
+                        _my = 'right center';
+                        _at = 'left center';
+                        break;
 
-                case 'top':
-                    _my = 'center bottom';
-                    _at = 'center top';
-                break;
+                    case 'top':
+                        _my = 'center bottom';
+                        _at = 'center top';
+                        break;
 
-                case 'bottom':
-                    _my = 'center top';
-                    _at = 'center bottom';
-                break;
+                    case 'bottom':
+                        _my = 'center top';
+                        _at = 'center bottom';
+                        break;
                 }
             }
 
@@ -316,8 +357,8 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
                 at: _at,
                 of: this.getTarget(),
                 collision: 'flipfit',
-                using: function(p,f) {
-                    $this.alignUsing.call($this,p,f);
+                using: function(p, f) {
+                    $this.alignUsing.call($this, p, f);
                 }
             });
         }
@@ -327,7 +368,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      * Brings up this tooltip and displays it next to the target component.
      */
     show: function() {
-        if(this.getTarget()) {
+        if (this.getTarget()) {
             var $this = this;
             this.clearTimeout();
 
@@ -344,24 +385,24 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
     _show: function() {
         var $this = this;
 
-        if(this.cfg.beforeShow) {
+        if (this.cfg.beforeShow) {
             var retVal = this.cfg.beforeShow.call(this);
-            if(retVal === false) {
+            if (retVal === false) {
                 return;
             }
         }
 
-        this.jq.css({'display':'block', 'opacity':'0', 'pointer-events': 'none'});
-    
+        this.jq.css({ 'display': 'block', 'opacity': '0', 'pointer-events': 'none' });
+
         this.align();
 
-        this.jq.css({'display':'none', 'opacity':'', 'pointer-events': ''});
-        
-        if(this.cfg.trackMouse) {
+        this.jq.css({ 'display': 'none', 'opacity': '', 'pointer-events': '' });
+
+        if (this.cfg.trackMouse) {
             this.followMouse();
         }
         this.jq.show(this.cfg.showEffect, {}, 250, function() {
-            if($this.cfg.onShow) {
+            if ($this.cfg.onShow) {
                 $this.cfg.onShow.call();
             }
         });
@@ -374,14 +415,9 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
         this.clearTimeout();
 
-        if(this.cfg.hideDelay) {
-            this.timeout = setTimeout(function() {
-                $this._hide();
-            }, this.cfg.hideDelay);
-        }
-        else {
-            this._hide();
-        }
+        this.timeout = setTimeout(function() {
+            $this._hide();
+        }, this.cfg.hideDelay);
     },
 
     /**
@@ -391,14 +427,18 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
     _hide: function() {
         var $this = this;
 
-        if(this.isVisible()) {
+        if (this.isVisible()) {
+            if (!this.isAutoHide() && this.allowHide === false) {
+                return;
+            }
+
             this.jq.hide(this.cfg.hideEffect, {}, this.cfg.hideEffectDuration, function() {
                 $(this).css('z-index', '');
-                if($this.cfg.trackMouse) {
+                if ($this.cfg.trackMouse) {
                     $this.unfollowMouse();
                 }
 
-                if($this.cfg.onHide) {
+                if ($this.cfg.onHide) {
                     $this.cfg.onHide.call();
                 }
             });
@@ -410,7 +450,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     clearTimeout: function() {
-        if(this.timeout) {
+        if (this.timeout) {
             clearTimeout(this.timeout);
         }
     },
@@ -439,7 +479,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      */
     unfollowMouse: function() {
         var target = this.getTarget();
-        if(target) {
+        if (target) {
             target.off('mousemove.tooltip-track');
         }
     },
@@ -453,12 +493,20 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
+     * Checks if the target has the autoHide property enabled or disabled to keep the tooltip open.
+     * @return {boolean} Whether this tooltip should be left showing or closed.
+     */
+    isAutoHide: function() {
+        return this.jq.data('autohide') || this.cfg.autoHide;
+    },
+
+    /**
      * Finds the component for which this tooltip is shown.
      * @private
      * @return {JQuery} The target component for this tooltip.
      */
     getTarget: function() {
-        if(this.cfg.delegate)
+        if (this.cfg.delegate)
             return PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.target);
         else
             return this.target;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -106,8 +106,8 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     _cleanup: function() {
-        if (cfg.target) {
-            var targetTooltip = $(document.body).children(PrimeFaces.escapeClientId(cfg.id));
+        if (this.cfg.target) {
+            var targetTooltip = $(document.body).children(PrimeFaces.escapeClientId(this.cfg.id));
             if (targetTooltip.length)
                 targetTooltip.remove();
         }


### PR DESCRIPTION
Adds the `autoHide` attribute and makes it work exactly like PrimeReact does: https://primefaces.org/primereact/tooltip/