### PR TITLE
Fix #8494: BlockUI do not automatically destroy widget

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -42,6 +42,9 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         if(this.cfg.blocked) {
             this.show();
         }
+
+        // GitHub #8494 do not remove BlockUI if its panel is removed from DOM
+        this.jq.off('remove');
     },
 
     /**
@@ -101,6 +104,10 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * milliseconds, respectively.
      */
     show: function(duration) {
+        if (!$.contains(document.documentElement, this.blocker.get(0))) {
+            // GitHub #8494 blocker is not longer in DOM so create another
+            this.refresh(this.cfg);
+        }
         this.blocker.css('z-index', PrimeFaces.nextZindex());
 
         //center position of content

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1289,10 +1289,10 @@ if (!PrimeFaces.ajax) {
                     var widget = PF(widgetVar);
                     if (widget) {
                         if (widget.isDetached() === true) {
-                            PrimeFaces.widgets[widgetVar] = null;
                             widget.destroy();
 
                             try {
+                                delete PrimeFaces.widgets[widgetVar];
                                 delete widget;
                             } catch (e) {}
                         }


### PR DESCRIPTION
Do not automatically destroy the block UI.  Also upon `show` we must check and see if the blocker has been already removed from the DOM we need to create it again.