### PR TITLE
Fix #8547: SelectOneMenu refactor escape

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1493,7 +1493,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
         }
 
-        var dataLabel = label.replace(/(<([^>]+)>)/gi, "").replaceAll('"', '&quot;');
+        var dataLabel = PrimeFaces.escapeHTML(label.replace(/(<([^>]+)>)/gi, ""));
         if ($item.data("noselection-option")) {
             cssClass += " ui-noselection-option";
         }


### PR DESCRIPTION
@tandraschko @jepsar @christophs78 isn't this the more appropriate code here as this is exactly what `escapeHtml` does?