### PR TITLE
BlockUI Refactor

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -3,7 +3,7 @@
  *
  * BlockUI is used to block interactivity of JSF components with optional AJAX integration.
  *
- * @prop {JQuery} block The DOM element for the overlay that blocks the UI.
+ * @prop {JQuery} target The DOM element for the overlay that blocks the UI.
  * @prop {JQuery} content The DOM element for the content of the blocker.
  * @prop {JQuery} blocker The DOM element for the content of the blocking overlay.
  *
@@ -28,18 +28,18 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     init: function(cfg) {
         this._super(cfg);
 
-        this.block = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.block);
+        this.target = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.block);
         this.content = this.jq;
         this.cfg.animate = (this.cfg.animate === false) ? false : true;
         this.cfg.blocked = (this.cfg.blocked === true) ? true : false;
 
         this.render();
 
-        if(this.cfg.triggers) {
+        if (this.cfg.triggers) {
             this.bindTriggers();
         }
 
-        if(this.cfg.blocked) {
+        if (this.cfg.blocked) {
             this.show();
         }
     },
@@ -50,11 +50,29 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
      */
     refresh: function(cfg) {
-        this.blocker.remove();
-        this.block.children('.ui-blockui-content').remove();
-        $(document).off('pfAjaxSend.' + this.id + ' pfAjaxComplete.' + this.id);
+        this._cleanup();
 
         this._super(cfg);
+    },
+
+    /**
+     * @override
+     * @inheritdoc
+     */
+    destroy: function() {
+        this._super();
+
+        this._cleanup();
+    },
+
+    /**
+     * Clean up this widget and remove elements from DOM.
+     * @private
+     */
+    _cleanup: function() {
+        this.blocker.remove();
+        this.target.children('.ui-blockui-content').remove();
+        $(document).off('pfAjaxSend.' + this.id + ' pfAjaxComplete.' + this.id);
     },
 
     /**
@@ -66,11 +84,11 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
 
         //listen global ajax send and complete callbacks
         $(document).on('pfAjaxSend.' + this.id, function(e, xhr, settings) {
-            if(!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
+            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
                 $this.show();
             }
         }).on('pfAjaxComplete.' + this.id, function(e, xhr, settings) {
-            if(!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
+            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
                 $this.hide();
             }
         });
@@ -82,7 +100,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * @param {JQuery.AjaxSettings} settings containing source ID.
      * @returns {boolean} `true` if if one of component's triggers equals the source ID from the provided settings.
      */
-    isXhrSourceATrigger: function (settings) {
+    isXhrSourceATrigger: function(settings) {
         var sourceId = PrimeFaces.ajax.Utils.getSourceId(settings);
         if (!sourceId) {
             return false;
@@ -104,31 +122,31 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         this.blocker.css('z-index', PrimeFaces.nextZindex());
 
         //center position of content
-        for(var i = 0; i < this.block.length; i++) {
+        for (var i = 0; i < this.target.length; i++) {
             var blocker = $(this.blocker[i]),
                 content = $(this.content[i]);
 
             content.css({
                 'left': ((blocker.width() - content.outerWidth()) / 2) + 'px',
-                'top': ((blocker.height() - content.outerHeight()) / 2)+ 'px',
+                'top': ((blocker.height() - content.outerHeight()) / 2) + 'px',
                 'z-index': PrimeFaces.nextZindex()
             });
         }
 
         var animated = this.cfg.animate;
-        if(animated)
+        if (animated)
             this.blocker.fadeIn(duration);
         else
             this.blocker.show(duration);
 
-        if(this.hasContent()) {
-            if(animated)
+        if (this.hasContent()) {
+            if (animated)
                 this.content.fadeIn(duration);
             else
                 this.content.show(duration);
         }
 
-        this.block.attr('aria-busy', true);
+        this.target.attr('aria-busy', true);
     },
 
     /**
@@ -141,19 +159,19 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     hide: function(duration) {
         var animated = this.cfg.animate;
 
-        if(animated)
+        if (animated)
             this.blocker.fadeOut(duration);
         else
             this.blocker.hide(duration);
 
-        if(this.hasContent()) {
-            if(animated)
+        if (this.hasContent()) {
+            if (animated)
                 this.content.fadeOut(duration);
             else
                 this.content.hide(duration);
         }
 
-        this.block.attr('aria-busy', false);
+        this.target.attr('aria-busy', false);
     },
 
     /**
@@ -163,27 +181,27 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     render: function() {
         this.blocker = $('<div id="' + this.id + '_blocker" class="ui-blockui ui-widget-overlay ui-helper-hidden"></div>');
 
-        if(this.cfg.styleClass) {
+        if (this.cfg.styleClass) {
             this.blocker.addClass(this.cfg.styleClass);
         }
 
-        if(this.block.hasClass('ui-corner-all')) {
+        if (this.target.hasClass('ui-corner-all')) {
             this.blocker.addClass('ui-corner-all');
         }
 
-        if(this.block.length > 1) {
+        if (this.target.length > 1) {
             this.content = this.content.clone();
         }
 
-        var position = this.block.css("position");
-        if (position !== "fixed" && position  !== "absolute") {
-            this.block.css('position', 'relative');
+        var position = this.target.css("position");
+        if (position !== "fixed" && position !== "absolute") {
+            this.target.css('position', 'relative');
         }
-        this.block.attr('aria-busy', this.cfg.blocked).append(this.blocker).append(this.content);
+        this.target.attr('aria-busy', this.cfg.blocked).append(this.blocker).append(this.content);
 
-        if(this.block.length > 1) {
+        if (this.target.length > 1) {
             this.blocker = $(PrimeFaces.escapeClientId(this.id + '_blocker'));
-            this.content = this.block.children('.ui-blockui-content');
+            this.content = this.target.children('.ui-blockui-content');
         }
     },
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1287,15 +1287,13 @@ if (!PrimeFaces.ajax) {
                     var widgetVar = PrimeFaces.detachedWidgets[i];
 
                     var widget = PF(widgetVar);
-                    if (widget) {
-                        if (widget.isDetached() === true) {
-                            PrimeFaces.widgets[widgetVar] = null;
-                            widget.destroy();
+                    if (widget && widget.isDetached() === true) {
+                        widget.destroy();
 
-                            try {
-                                delete widget;
-                            } catch (e) {}
-                        }
+                        try {
+                            delete PrimeFaces.widgets[widgetVar];
+                            delete widget;
+                        } catch (e) { }
                     }
                 }
 


### PR DESCRIPTION
@tandraschko this component is subtly complex. The more I changed the more scenarios broke.  So this PR is just to...

1. change `block` to `target` as that is a more consistent name we use and it makes the code more readable
2. Added a `destroy` method because I realized if you manually called `widget.destroy()` it was never cleaning up its DOM elements it created.  Followed pattern we use on other components.
3. Slight refactor of `detached` widgets destroy

I wanted to do this first to get the code in better readability before trying to tackle the real issue.   I tested this with the Showcase and everything is still working as expected.