### PR TITLE
Fix #8548: BlockUI Refactor

### DIFF
--- a/docs/12_0_0/components/blockui.md
+++ b/docs/12_0_0/components/blockui.md
@@ -76,6 +76,7 @@ Widget: _PrimeFaces.widget.BlockUI_
 | --- | --- | --- | --- | 
 | show(duration) | duration: (optional) duration of the animation | void | Blocks the UI.
 | hide(duration) | duration: (optional) duration of the animation | void | Unblocks the UI
+| isBlocking()   | none | boolean | Is the widget currently blocking
 
 ## Skinning
 Following is the list of structural style classes;

--- a/primefaces-integration-tests/src/main/webapp/blockui/blockUI001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/blockui/blockUI001.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:panel id="panel1">Panel1</p:panel>
+            <br/>
+            <p:panel id="panel2">Panel2</p:panel>
+            <br/>
+
+            <p:commandButton id="btnRefresh" value="Refresh Panels" update="panel1 panel2" process="@this"/>
+
+            <p:blockUI id="blockui" block="panel1 panel2" widgetVar="blockui"/>
+           
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/blockui/BlockUI001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/blockui/BlockUI001Test.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.blockui;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.BlockUI;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Panel;
+
+public class BlockUI001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("BlockUI: Show the blocker")
+    public void testShow(Page page) {
+        // Arrange
+        BlockUI blockUI = page.blockUI;
+        assertClickable(page.panel1);
+        assertClickable(page.panel2);
+        Assertions.assertFalse(blockUI.isBlocking());
+
+        // Act
+        blockUI.show();
+
+        // Assert
+        Assertions.assertTrue(blockUI.isBlocking());
+        assertNotClickable(page.panel1);
+        assertNotClickable(page.panel2);
+        assertConfiguration(blockUI.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("BlockUI: Hide the blocker")
+    public void testHide(Page page) {
+        // Arrange
+        BlockUI blockUI = page.blockUI;
+        blockUI.show();
+        Assertions.assertTrue(blockUI.isBlocking());
+        assertNotClickable(page.panel1);
+        assertNotClickable(page.panel2);
+
+        // Act
+        blockUI.hide();
+
+        // Assert
+        assertClickable(page.panel1);
+        assertClickable(page.panel2);
+        Assertions.assertFalse(blockUI.isBlocking());
+        assertConfiguration(blockUI.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("BlockUI: Destroy the blocker and make sure DOM elements removed")
+    public void testDestroy(Page page) {
+        // Arrange
+        BlockUI blockUI = page.blockUI;
+        blockUI.show();
+        Assertions.assertTrue(blockUI.isBlocking());
+        Assertions.assertEquals(2, blockUI.getOverlays().size());
+        Assertions.assertEquals(1, blockUI.getContents().size());
+        assertNotClickable(page.panel1);
+        assertNotClickable(page.panel2);
+
+        // Act
+        blockUI.destroy();
+
+        // Assert
+        assertClickable(page.panel1);
+        assertClickable(page.panel2);
+        Assertions.assertEquals(0, blockUI.getOverlays().size());
+        Assertions.assertEquals(0, blockUI.getContents().size());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("BlockUI: #8548 Refresh the panel and make sure the blocker is not removed")
+    public void testRefresh(Page page) {
+        // Arrange
+        BlockUI blockUI = page.blockUI;
+        assertClickable(page.panel1);
+        assertClickable(page.panel2);
+
+        // Act
+        page.buttonRefresh.click();
+        blockUI.show();
+
+        // Assert
+        Assertions.assertTrue(blockUI.isBlocking());
+        assertNoJavascriptErrors();
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("BlockUI Config = " + cfg);
+        Assertions.assertEquals(cfg.get("block"), "form:panel1 form:panel2");
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:panel1")
+        Panel panel1;
+
+        @FindBy(id = "form:panel2")
+        Panel panel2;
+
+        @FindBy(id = "form:blockui")
+        BlockUI blockUI;
+
+        @FindBy(id = "form:btnRefresh")
+        CommandButton buttonRefresh;
+
+        @Override
+        public String getLocation() {
+            return "blockui/blockUI001.xhtml";
+        }
+    }
+
+}

--- a/primefaces-selenium/README.md
+++ b/primefaces-selenium/README.md
@@ -61,6 +61,7 @@ Currently, only the following components are implemented (partially):
 
 - AccordionPanel
 - AutoComplete
+- BlockUI
 - Calendar
 - CascadeSelect
 - Chips

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/BlockUI.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/BlockUI.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.selenium.component;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.base.AbstractComponent;
+
+/**
+ * Component wrapper for the PrimeFaces {@code p:blockUI}.
+ */
+public abstract class BlockUI extends AbstractComponent {
+
+    /**
+     * Finds all Block UI overlay elements by class name.
+     *
+     * @return a List<WebElement> containing at least one element
+     */
+    public List<WebElement> getOverlays() {
+        return getWebDriver().findElements(By.className("ui-blockui"));
+    }
+
+    /**
+     * Finds all Block UI content elements by class name.
+     *
+     * @return a List<WebElement> containing at least one element
+     */
+    public List<WebElement> getContents() {
+        return getWebDriver().findElements(By.className("ui-blockui-content"));
+    }
+
+    /**
+     * Is the blocker currently blocking.
+     *
+     * @return true if blocking false if not
+     */
+    public boolean isBlocking() {
+        return PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".isBlocking();");
+    }
+
+    /**
+     * Does the block have content.
+     *
+     * @return true if has content, false if not
+     */
+    public boolean hasContent() {
+        return PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".hasContent();");
+    }
+
+    /**
+     * Shows the blocker.
+     */
+    public void show() {
+        PrimeSelenium.executeScript(getWidgetByIdScript() + ".show();");
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.animationNotActive());
+    }
+
+    /**
+     * Hides the blocker.
+     */
+    public void hide() {
+        PrimeSelenium.executeScript(getWidgetByIdScript() + ".hide();");
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.animationNotActive());
+    }
+
+    /**
+     * Destroy the widget.
+     */
+    public void destroy() {
+        PrimeSelenium.executeScript(getWidgetByIdScript() + ".destroy();");
+    }
+
+}

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
@@ -23,20 +23,20 @@
  */
 package org.primefaces.selenium;
 
+import java.time.Duration;
 import java.util.List;
+
 import org.openqa.selenium.*;
+import org.openqa.selenium.html5.WebStorage;
+import org.openqa.selenium.support.decorators.WebDriverDecorator;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.primefaces.selenium.internal.ConfigProvider;
 import org.primefaces.selenium.internal.Guard;
+import org.primefaces.selenium.spi.DeploymentAdapter;
 import org.primefaces.selenium.spi.PrimePageFactory;
 import org.primefaces.selenium.spi.PrimePageFragmentFactory;
 import org.primefaces.selenium.spi.WebDriverProvider;
-import org.primefaces.selenium.spi.DeploymentAdapter;
-
-import java.time.Duration;
-import org.openqa.selenium.html5.WebStorage;
-import org.openqa.selenium.support.decorators.WebDriverDecorator;
 
 public final class PrimeSelenium {
 
@@ -313,7 +313,10 @@ public final class PrimeSelenium {
      * @return true if clickable false if not
      */
     public static boolean isElementClickable(WebElement element) {
-        return isElementDisplayed(element) && isElementEnabled(element) && !hasCssClass(element, "ui-state-disabled");
+        return isElementDisplayed(element) &&
+                    isElementEnabled(element) &&
+                    !hasCssClass(element, "ui-state-disabled") &&
+                    !Boolean.parseBoolean(element.getAttribute("aria-busy"));
     }
 
     /**

--- a/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
@@ -36,7 +36,7 @@
                     <p:commandButton id="saveBtn" value="Save" icon="pi pi-check" action="#{blockUIView.save}" update="growl" styleClass="p-mt-3" />
                 </p:panel>
 
-                <p:blockUI block="pnl" trigger="saveBtn"/>
+                <p:blockUI block="pnl" trigger="saveBtn" widgetVar="buiBasic"/>
 
                 <h5>Custom Content</h5>
                 <p:dataTable id="dataTable" var="customer" value="#{blockUIView.customers}"
@@ -74,7 +74,7 @@
                     </p:column>
                 </p:dataTable>
 
-                <p:blockUI block="dataTable" trigger="dataTable">
+                <p:blockUI block="dataTable" trigger="dataTable" widgetVar="buiDatatable">
                     <i class="pi pi-spin pi-spinner" style="font-size: 3rem"></i>
                 </p:blockUI>
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -179,30 +179,46 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     render: function() {
-        this.blocker = $('<div id="' + this.id + '_blocker" class="ui-blockui ui-widget-overlay ui-helper-hidden"></div>');
+        var isMultiple = this.target.length > 1;
+        // there can be 1 to N targets
+        for (var i = 0; i < this.target.length; i++) {
+            var currentTarget = $(this.target[i]),
+                currentTargetId = currentTarget.attr('id') || this.id,
+                currentContent = this.jq;
 
-        if (this.cfg.styleClass) {
-            this.blocker.addClass(this.cfg.styleClass);
+            // create a specific blocker for this target
+            var currentBlocker = $('<div id="' + currentTargetId + '_blocker" class="ui-blockui ui-widget-overlay ui-helper-hidden"></div>');
+
+            // style the blocker
+            if (this.cfg.styleClass) {
+                currentBlocker.addClass(this.cfg.styleClass);
+            }
+            if (currentTarget.hasClass('ui-corner-all')) {
+                currentBlocker.addClass('ui-corner-all');
+            }
+
+            // when more than 1 target need to clone the blocker for each target
+            if (isMultiple) {
+                currentContent = currentContent.clone();
+                currentContent.attr('id', currentTargetId + '_blockcontent');
+            }
+
+            // configure the target positioning
+            var position = currentTarget.css("position");
+            if (position !== "fixed" && position !== "absolute") {
+                currentTarget.css('position', 'relative');
+            }
+
+            // ARIA 
+            currentTarget.attr('aria-busy', this.cfg.blocked);
+
+            // append the blocker to the target 
+            currentTarget.append(currentBlocker).append(currentContent);
         }
 
-        if (this.target.hasClass('ui-corner-all')) {
-            this.blocker.addClass('ui-corner-all');
-        }
-
-        if (this.target.length > 1) {
-            this.content = this.content.clone();
-        }
-
-        var position = this.target.css("position");
-        if (position !== "fixed" && position !== "absolute") {
-            this.target.css('position', 'relative');
-        }
-        this.target.attr('aria-busy', this.cfg.blocked).append(this.blocker).append(this.content);
-
-        if (this.target.length > 1) {
-            this.blocker = $(PrimeFaces.escapeClientId(this.id + '_blocker'));
-            this.content = this.target.children('.ui-blockui-content');
-        }
+        // assign all matching blockers to widget
+        this.blocker = $(this.target.find('.ui-blockui.ui-widget-overlay'));
+        this.content = $(this.target.find('.ui-blockui-content'));
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -179,7 +179,8 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     render: function() {
-        var isMultiple = this.target.length > 1;
+        var isMultiple = this.target.length > 1,
+            widgetId = this.id;
         // there can be 1 to N targets
         for (var i = 0; i < this.target.length; i++) {
             var currentTarget = $(this.target[i]),
@@ -200,8 +201,12 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             // when more than 1 target need to clone the blocker for each target
             if (isMultiple) {
                 currentContent = currentContent.clone();
-                currentContent.attr('id', currentTargetId + '_blockcontent');
             }
+            currentContent.attr('id', currentTargetId + '_blockcontent');
+
+            // assign data ids to this widget
+            currentBlocker.attr('data-bui-overlay', widgetId);
+            currentContent.attr('data-bui-content', widgetId);
 
             // configure the target positioning
             var position = currentTarget.css("position");
@@ -212,13 +217,30 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             // ARIA 
             currentTarget.attr('aria-busy', this.cfg.blocked);
 
-            // append the blocker to the target 
-            currentTarget.append(currentBlocker).append(currentContent);
+            // set the size and position to match the target
+            var height = currentTarget.height(),
+                width = currentTarget.width(),
+                position = currentTarget.position();
+            currentBlocker.css({
+                'height': height + 'px',
+                'width': width + 'px',
+                'left': position.left + 'px',
+                'top': position.top + 'px'
+            });
+            currentContent.css({
+                'height': height + 'px',
+                'width': width + 'px',
+                'left': position.left + 'px',
+                'top': position.top + 'px'
+            });
+
+            // append the blocker to the document 
+            $(document.body).append(currentBlocker).append(currentContent);
         }
 
         // assign all matching blockers to widget
-        this.blocker = $(this.target.find('.ui-blockui.ui-widget-overlay'));
-        this.content = $(this.target.find('.ui-blockui-content'));
+        this.blocker = $('[data-bui-overlay~="' + widgetId + '"]');
+        this.content = $('[data-bui-content~="' + widgetId + '"]');
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -71,7 +71,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      */
     _cleanup: function() {
         this.blocker.remove();
-        this.target.children('.ui-blockui-content').remove();
+        this.content.remove();
         $(document).off('pfAjaxSend.' + this.id + ' pfAjaxComplete.' + this.id);
     },
 
@@ -221,18 +221,14 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             var height = currentTarget.height(),
                 width = currentTarget.width(),
                 position = currentTarget.position();
-            currentBlocker.css({
+            var sizeAndPosition = {
                 'height': height + 'px',
                 'width': width + 'px',
                 'left': position.left + 'px',
                 'top': position.top + 'px'
-            });
-            currentContent.css({
-                'height': height + 'px',
-                'width': width + 'px',
-                'left': position.left + 'px',
-                'top': position.top + 'px'
-            });
+            };
+            currentBlocker.css(sizeAndPosition);
+            currentContent.css(sizeAndPosition);
 
             // append the blocker to the document 
             $(document.body).append(currentBlocker).append(currentContent);


### PR DESCRIPTION
@tandraschko this is part of my incremental refactoring just trying to untangle this component.  This PR documents the current process and fixes the issue of duplicate ID's when using multiple targets.

![image](https://user-images.githubusercontent.com/4399574/157737676-a3744d13-da22-4240-adf9-ad8e4125636a.png)

This now gives it unique `_block` and `_blockcontent` ids using the target id and not the BLockUI's id.