### PR TITLE
Fix #8503: Timeline bind to contextMenu

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/timeline/1-timeline.js
@@ -4,6 +4,8 @@
  * Timeline is an interactive graph to visualize events in time. Currently uses
  * [vis-timeline](https://github.com/visjs/vis-timeline).
  *
+ * @implements {PrimeFaces.widget.ContextMenu.ContextMenuProvider<PrimeFaces.widget.Timeline>}
+ *
  * @typedef PrimeFaces.widget.Timeline.AddCallbackCallback Callback that is invoked when an event was added to this
  * timeline. See also {@link Timeline.addCallback}.
  * @param {import("vis-timeline").TimelineItem} PrimeFaces.widget.Timeline.AddCallbackCallback.item The timeline item
@@ -484,6 +486,22 @@ PrimeFaces.widget.Timeline = PrimeFaces.widget.DeferredWidget.extend({
             // make the timeline droppable
             $(el).droppable(droppableOpts);
         }
+    },
+
+   /**
+     * @override
+     * @inheritdoc
+     * @param {PrimeFaces.widget.ContextMenu} menuWidget
+     * @param {PrimeFaces.widget.Timeline} targetWidget
+     * @param {string} targetId
+     * @param {PrimeFaces.widget.ContextMenuCfg} cfg 
+     */
+    bindContextMenu : function(menuWidget, targetWidget, targetId, cfg) {
+        // block default context menu
+        targetWidget.instance.on('contextmenu', function (properties) {
+           menuWidget.show(properties.event);
+           properties.event.preventDefault();
+        });
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/timeline/timeline.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/timeline/timeline.css
@@ -1207,8 +1207,3 @@ div.timeline-menu-rtl {
 	left: 0px;
 	right: inherit;
 }
-/** GitHub #8503 */
-div.vis-item .vis-drag-center {
-   z-index: -1;
-   /*allows context menus to work*/
-}


### PR DESCRIPTION
The real fix here is how we do it for DataTable and other components.  We need to disable the default Timeline context menu and attach to that event.