### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.inputtextarea.js
@@ -116,7 +116,7 @@ PrimeFaces.widget.InputTextarea = PrimeFaces.widget.DeferredWidget.extend({
             length = value.length;
 
             if(length > _self.cfg.maxlength) {
-                _self.jq.val(value.substr(0, _self.cfg.maxlength));
+                _self.jq.val(value.slice(0, _self.cfg.maxlength));
             }
         });
     },

--- a/primefaces/src/main/type-definitions/src/create-code-info-object.js
+++ b/primefaces/src/main/type-definitions/src/create-code-info-object.js
@@ -88,7 +88,7 @@ function createMethodCodeInfoFromTags(severitySettings, method, additionalTempla
                         name: tag.name,
                         required: !tag.optional,
                         rest: rest,
-                        typedef: rest ? type.substr(3) : type,
+                        typedef: rest ? type.slice(3) : type,
                     };
                 }
             }

--- a/primefaces/src/main/type-definitions/src/lang.js
+++ b/primefaces/src/main/type-definitions/src/lang.js
@@ -239,7 +239,7 @@ function newEmptyArray() {
  * @return {string} The given string, with the first character turned to upper case.
  */
 function capitalize(str) {
-    return str ? str.charAt(0).toUpperCase() + str.substr(1) : "";
+    return str ? str.charAt(0).toUpperCase() + str.slice(1) : "";
 }
 
 /**
@@ -248,10 +248,10 @@ function capitalize(str) {
  */
 function removeLineBreaksFromStartAndEnd(str) {
     while (str.startsWith("\n") || str.startsWith("\r")) {
-        str = str.substr(1);
+        str = str.slice(1);
     }
     while (str.endsWith("\n") || str.endsWith("\r")) {
-        str = str.substr(0, str.length - 1);
+        str = str.slice(0, -1);
     }
     return str;
 }

--- a/primefaces/src/main/type-definitions/src/ts-commenthandler.js
+++ b/primefaces/src/main/type-definitions/src/ts-commenthandler.js
@@ -115,8 +115,8 @@ function makeCommentHandler(docsByNode) {
  */
 function extractComment(fullText, commentRange, severitySettings) {
     const commentLength = commentRange.end - commentRange.pos;
-    const isTripleSlashComment = commentLength >= 3 && ts.SyntaxKind.SingleLineCommentTrivia === commentRange.kind && fullText.substr(commentRange.pos, 3) === "///";
-    const isDocComment = commentLength >= 3 && ts.SyntaxKind.MultiLineCommentTrivia === commentRange.kind && fullText.substr(commentRange.pos, 3) === "/**";
+    const isTripleSlashComment = commentLength >= 3 && ts.SyntaxKind.SingleLineCommentTrivia === commentRange.kind && fullText.slice(commentRange.pos, commentRange.pos + 3) === "///";
+    const isDocComment = commentLength >= 3 && ts.SyntaxKind.MultiLineCommentTrivia === commentRange.kind && fullText.slice(commentRange.pos, commentRange.pos + 3) === "/**";
     if (isTripleSlashComment) {
         return undefined;
     }

--- a/primefaces/src/main/type-definitions/src/ts-postprocess.js
+++ b/primefaces/src/main/type-definitions/src/ts-postprocess.js
@@ -116,8 +116,8 @@ function fixupInlineBlockComments(sourceCode) {
         if (indexSlashStarStar >= 0 && i < lines.length - 1) {
             const nextLine = lines[i + 1] ?? "";
             const indexStar = nextLine.indexOf("*");
-            const lineBeforeComment = trimmed.substr(0, indexSlashStarStar).trimRight();
-            if (indexStar >= 0 && lineBeforeComment.length > 0 && nextLine.substr(0, indexStar).trim().length === 0) {
+            const lineBeforeComment = trimmed.slice(0, indexSlashStarStar).trimRight();
+            if (indexStar >= 0 && lineBeforeComment.length > 0 && nextLine.slice(0, indexStar).trim().length === 0) {
                 const commentBeginLine = " ".repeat(indexStar - 1) + "/**";
                 result.push(lineBeforeComment);
                 result.push(commentBeginLine);

--- a/primefaces/src/main/type-definitions/src/ts-types.js
+++ b/primefaces/src/main/type-definitions/src/ts-types.js
@@ -113,7 +113,7 @@ function getReturnType({ async, generator, baseTypeNext, baseTypeReturn, baseTyp
  * @return {string} The type, without the rest "..." indicator if present.
  */
 function removeRestFromType(type) {
-    return hasRestSpecifier(type) ? type.substr(3) : type;
+    return hasRestSpecifier(type) ? type.slice(3) : type;
 }
 
 /**


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.