### PR TITLE
Fix #8597: Excel Exporter respect cell font

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/dataexporter/CustomizedDocumentsView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/dataexporter/CustomizedDocumentsView.java
@@ -23,7 +23,18 @@
  */
 package org.primefaces.showcase.view.data.dataexporter;
 
-import com.lowagie.text.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.apache.poi.hssf.usermodel.*;
 import org.apache.poi.hssf.util.HSSFColor;
 import org.apache.poi.ss.usermodel.FillPatternType;
@@ -33,16 +44,7 @@ import org.primefaces.component.export.PDFOrientationType;
 import org.primefaces.showcase.domain.Product;
 import org.primefaces.showcase.service.ProductService;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.RequestScoped;
-import javax.faces.context.ExternalContext;
-import javax.faces.context.FacesContext;
-import javax.inject.Inject;
-import javax.inject.Named;
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.List;
+import com.lowagie.text.*;
 
 @Named
 @RequestScoped
@@ -73,7 +75,7 @@ public class CustomizedDocumentsView implements Serializable {
         excelOpt.setFacetFontSize("10");
         excelOpt.setFacetFontColor("#0000ff");
         excelOpt.setFacetFontStyle("BOLD");
-        excelOpt.setCellFontColor("#00ff00");
+        excelOpt.setCellFontColor("#145c14");
         excelOpt.setCellFontSize("8");
         excelOpt.setFontName("Verdana");
 

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
@@ -20,7 +20,7 @@
             <h:form>
                 <h5>Processors</h5>
                 <p:commandButton value="XLS" styleClass="p-mr-2 p-mb-2">
-                    <p:dataExporter type="xls" target="tbl" fileName="products"
+                    <p:dataExporter type="xlsxstream" target="tbl" fileName="products"
                                     postProcessor="#{customizedDocumentsView.postProcessXLS}"/>
                 </p:commandButton>
 
@@ -62,7 +62,7 @@
 
                 <h5>Options</h5>
                 <p:commandButton value="XLS" styleClass="p-mr-2 p-mb-2">
-                    <p:dataExporter type="xls" target="tbl2" fileName="products"
+                    <p:dataExporter type="xlsxstream" target="tbl2" fileName="products"
                                     options="#{customizedDocumentsView.excelOpt}"/>
                 </p:commandButton>
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExcelExporter.java
@@ -533,10 +533,6 @@ public class DataTableExcelExporter extends DataTableExporter {
     }
 
     protected Cell applyColumnAlignments(UIColumn column, Cell cell) {
-        if (cell.getCellStyle() != null) {
-            // don't apply style if cell already has one
-            return cell;
-        }
         String[] styles = new String[] {column.getStyle(), column.getStyleClass()};
         if (LangUtils.containsIgnoreCase(styles, "right")) {
             cell.setCellStyle(cellStyleRightAlign);


### PR DESCRIPTION
Looks like POI changed this used to return NULL now it returns the default cell style.

```java
        if (cell.getCellStyle() != null) {
            // don't apply style if cell already has one
            return cell;
        }
```