### PR TITLE
DataTable: Do not warn when optional attribute lazy as well as datatable content are null #8436

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -90,12 +90,7 @@ public class UIData extends javax.faces.component.UIData {
             Class<?> type = ELUtils.getType(getFacesContext(),
                     getValueExpression("value"),
                     () -> getValue());
-            if (type == null) {
-                LOGGER.warning("Unable to automatically determine the `lazy` attribute, fallback to false. "
-                        + "Either define the `lazy` attribute on the component or make sure the `value` attribute doesn't resolve to `null`. "
-                        + "clientId: " + this.getClientId());
-            }
-            else {
+            if (type != null) {
                 lazy = LazyDataModel.class.isAssignableFrom(type);
             }
 


### PR DESCRIPTION
remove the warning since it pollutes the log for all legacy applications which rely on the default that the lazy attribute is false whenever not set explicitly