### PR TITLE
Fix #8673/#8674: Filters use interface for non-ee environments

### DIFF
--- a/primefaces/src/main/java/org/primefaces/webapp/filter/CharacterEncodingFilter.java
+++ b/primefaces/src/main/java/org/primefaces/webapp/filter/CharacterEncodingFilter.java
@@ -26,28 +26,31 @@ package org.primefaces.webapp.filter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpFilter;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-public class CharacterEncodingFilter extends HttpFilter {
+import javax.servlet.*;
+
+public class CharacterEncodingFilter implements Filter {
 
     private Charset encoding = StandardCharsets.UTF_8;
 
     @Override
-    public void init() throws ServletException {
-        String encodingParam = getInitParameter("encoding");
+    public void init(FilterConfig filterConfig) throws ServletException {
+        String encodingParam = filterConfig.getInitParameter("encoding");
         if (encodingParam != null) {
             encoding = Charset.forName(encodingParam);
         }
     }
 
     @Override
-    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         request.setCharacterEncoding(encoding.name());
 
         chain.doFilter(request, response);
     }
+
+    @Override
+    public void destroy() {
+       // do nothing
+    }
+
 }

--- a/primefaces/src/main/java/org/primefaces/webapp/filter/NoCacheFilter.java
+++ b/primefaces/src/main/java/org/primefaces/webapp/filter/NoCacheFilter.java
@@ -34,8 +34,8 @@ public class NoCacheFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        final HttpServletRequest httpRequest = (HttpServletRequest) request;
-        final HttpServletResponse httpResponse = (HttpServletResponse) response;
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
         if (!httpRequest.getRequestURI().contains(ResourceHandler.RESOURCE_IDENTIFIER)) { // Skip JSF resources (CSS/JS/Images/etc)
             httpResponse.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
             httpResponse.setHeader("Pragma", "no-cache"); // HTTP 1.0.

--- a/primefaces/src/main/java/org/primefaces/webapp/filter/NoCacheFilter.java
+++ b/primefaces/src/main/java/org/primefaces/webapp/filter/NoCacheFilter.java
@@ -24,24 +24,35 @@
 package org.primefaces.webapp.filter;
 
 import java.io.IOException;
+
 import javax.faces.application.ResourceHandler;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpFilter;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-public class NoCacheFilter extends HttpFilter {
+public class NoCacheFilter implements Filter {
 
     @Override
-    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-        if (!request.getRequestURI().contains(ResourceHandler.RESOURCE_IDENTIFIER)) { // Skip JSF resources (CSS/JS/Images/etc)
-            response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
-            response.setHeader("Pragma", "no-cache"); // HTTP 1.0.
-            response.setDateHeader("Expires", 0); // Proxies.
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        final HttpServletRequest httpRequest = (HttpServletRequest) request;
+        final HttpServletResponse httpResponse = (HttpServletResponse) response;
+        if (!httpRequest.getRequestURI().contains(ResourceHandler.RESOURCE_IDENTIFIER)) { // Skip JSF resources (CSS/JS/Images/etc)
+            httpResponse.setHeader("Cache-Control", "no-cache, no-store, must-revalidate"); // HTTP 1.1.
+            httpResponse.setHeader("Pragma", "no-cache"); // HTTP 1.0.
+            httpResponse.setDateHeader("Expires", 0); // Proxies.
         }
 
         chain.doFilter(request, response);
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // do nothing
+    }
+
+    @Override
+    public void destroy() {
+       // do nothing
     }
 }
 


### PR DESCRIPTION
@tandraschko @FlipWarthog @jepsar had to switch to use `Filter` interface instead of `HttpFilter` for Jetty and possibly other non-ee environments.