### PR TITLE
Fix #8333: Check parent for zIndex value as well

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -157,7 +157,8 @@ if (!PrimeFaces.utils) {
             //Disable tabbing out of modal and stop events from targets outside of the overlay element
             var $document = $(document);
             $document.on('focus.' + id + ' mousedown.' + id + ' mouseup.' + id, function(event) {
-                if ($(event.target).zIndex() < zIndex) {
+                var target = $(event.target);
+                if (!target.is(document.body) && (target.zIndex() < zIndex && target.parent().zIndex() < zIndex)) {
                     event.preventDefault();
                 }
             });
@@ -198,7 +199,7 @@ if (!PrimeFaces.utils) {
                         }
                     }
                 }
-                else if(!target.is(document.body) && (target.zIndex() < zIndex)) {
+                else if (!target.is(document.body) && (target.zIndex() < zIndex && target.parent().zIndex() < zIndex)) {
                     event.preventDefault();
                 }
             });


### PR DESCRIPTION
Because the input group puts a new SPAN in there and the button is `position:relative` it causes the zIndex of the button to be 1.  I think I safe thing to check is the target zindex or its immediate parent zIndex.