### PR TITLE
Tree: fix dragdrop on server side model

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/TreeNodeChildren.java
+++ b/primefaces/src/main/java/org/primefaces/model/TreeNodeChildren.java
@@ -67,6 +67,16 @@ public class TreeNodeChildren<T> extends TreeNodeList<T> {
             throw new IndexOutOfBoundsException();
         }
 
+        // check if the movement is on the same list
+        if (node.getParent() != null && node.getParent().getChildren() == this) {
+
+            // check if the movement is downwards then correct the index
+            int removedIndex = super.indexOf(node);
+            if (removedIndex > -1 && index > removedIndex) {
+                index--;
+            }
+        }
+
         eraseParent(node);
         super.add(index, node);
         node.setParent(parent);

--- a/primefaces/src/test/java/org/primefaces/model/TreeNodeChildrenTest.java
+++ b/primefaces/src/test/java/org/primefaces/model/TreeNodeChildrenTest.java
@@ -59,4 +59,185 @@ public class TreeNodeChildrenTest {
         assertEquals(root, values.get(1).getParent());
     }
 
+    @Test
+    public void moveNodeSameListDown() {
+        // Arrange
+        TreeNode<String> root = new DefaultTreeNode<>("Node R", null);
+        TreeNode<String> node1 = new DefaultTreeNode<>("Node 1", root);
+        TreeNode<String> node2 = new DefaultTreeNode<>("Node 2", root);
+        TreeNode<String> node3 = new DefaultTreeNode<>("Node 3", root);
+        TreeNode<String> node4 = new DefaultTreeNode<>("Node 4", root);
+        TreeNode<String> node5 = new DefaultTreeNode<>("Node 5", root);
+
+        // Pre-assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node4, root.getChildren().get(3));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+
+        // Act (simulate Drag&Drop)
+        root.getChildren().add(2, root.getChildren().get(0));
+
+        // Assert
+        assertEquals(node2, root.getChildren().get(0));
+        assertEquals(root, node2.getParent());
+        assertEquals(node1, root.getChildren().get(1));
+        assertEquals(root, node1.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node4, root.getChildren().get(3));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+    }
+
+    @Test
+    public void moveNodeSameListUp() {
+        // Arrange
+        TreeNode<String> root = new DefaultTreeNode<>("Node R", null);
+        TreeNode<String> node1 = new DefaultTreeNode<>("Node 1", root);
+        TreeNode<String> node2 = new DefaultTreeNode<>("Node 2", root);
+        TreeNode<String> node3 = new DefaultTreeNode<>("Node 3", root);
+        TreeNode<String> node4 = new DefaultTreeNode<>("Node 4", root);
+        TreeNode<String> node5 = new DefaultTreeNode<>("Node 5", root);
+
+        // Pre-assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node4, root.getChildren().get(3));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+
+        // Act (simulate Drag&Drop)
+        root.getChildren().add(2, root.getChildren().get(3));
+
+        // Assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node4, root.getChildren().get(2));
+        assertEquals(root, node4.getParent());
+        assertEquals(node3, root.getChildren().get(3));
+        assertEquals(root, node3.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+    }
+
+    @Test
+    public void moveNodeToChild() {
+        // Arrange
+        TreeNode<String> root = new DefaultTreeNode<>("Node R", null);
+        TreeNode<String> node1 = new DefaultTreeNode<>("Node 1", root);
+        TreeNode<String> node2 = new DefaultTreeNode<>("Node 2", root);
+        TreeNode<String> node3 = new DefaultTreeNode<>("Node 3", root);
+        TreeNode<String> node31 = new DefaultTreeNode<>("Node 3.1", node3);
+        TreeNode<String> node32 = new DefaultTreeNode<>("Node 3.2", node3);
+        TreeNode<String> node33 = new DefaultTreeNode<>("Node 3.3", node3);
+        TreeNode<String> node4 = new DefaultTreeNode<>("Node 4", root);
+        TreeNode<String> node5 = new DefaultTreeNode<>("Node 5", root);
+
+        // Pre-assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node31, root.getChildren().get(2).getChildren().get(0));
+        assertEquals(node3, node31.getParent());
+        assertEquals(node32, root.getChildren().get(2).getChildren().get(1));
+        assertEquals(node3, node32.getParent());
+        assertEquals(node33, root.getChildren().get(2).getChildren().get(2));
+        assertEquals(node3, node33.getParent());
+        assertEquals(node4, root.getChildren().get(3));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+
+        // Act (simulate Drag&Drop)
+        root.getChildren().get(2).getChildren().add(1, root.getChildren().get(3));
+
+        // Assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node31, root.getChildren().get(2).getChildren().get(0));
+        assertEquals(node3, node31.getParent());
+        assertEquals(node4, root.getChildren().get(2).getChildren().get(1));
+        assertEquals(node3, node4.getParent());
+        assertEquals(node32, root.getChildren().get(2).getChildren().get(2));
+        assertEquals(node3, node32.getParent());
+        assertEquals(node33, root.getChildren().get(2).getChildren().get(3));
+        assertEquals(node3, node33.getParent());
+        assertEquals(node5, root.getChildren().get(3));
+        assertEquals(root, node5.getParent());
+    }
+
+    @Test
+    public void moveNodeToParent() {
+        // Arrange
+        TreeNode<String> root = new DefaultTreeNode<>("Node R", null);
+        TreeNode<String> node1 = new DefaultTreeNode<>("Node 1", root);
+        TreeNode<String> node2 = new DefaultTreeNode<>("Node 2", root);
+        TreeNode<String> node3 = new DefaultTreeNode<>("Node 3", root);
+        TreeNode<String> node31 = new DefaultTreeNode<>("Node 3.1", node3);
+        TreeNode<String> node32 = new DefaultTreeNode<>("Node 3.2", node3);
+        TreeNode<String> node33 = new DefaultTreeNode<>("Node 3.3", node3);
+        TreeNode<String> node4 = new DefaultTreeNode<>("Node 4", root);
+        TreeNode<String> node5 = new DefaultTreeNode<>("Node 5", root);
+
+        // Pre-assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node3, root.getChildren().get(2));
+        assertEquals(root, node3.getParent());
+        assertEquals(node31, root.getChildren().get(2).getChildren().get(0));
+        assertEquals(node3, node31.getParent());
+        assertEquals(node32, root.getChildren().get(2).getChildren().get(1));
+        assertEquals(node3, node32.getParent());
+        assertEquals(node33, root.getChildren().get(2).getChildren().get(2));
+        assertEquals(node3, node33.getParent());
+        assertEquals(node4, root.getChildren().get(3));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(4));
+        assertEquals(root, node5.getParent());
+
+        // Act (simulate Drag&Drop)
+        root.getChildren().add(2, root.getChildren().get(2).getChildren().get(1));
+
+        // Assert
+        assertEquals(node1, root.getChildren().get(0));
+        assertEquals(root, node1.getParent());
+        assertEquals(node2, root.getChildren().get(1));
+        assertEquals(root, node2.getParent());
+        assertEquals(node32, root.getChildren().get(2));
+        assertEquals(root, node32.getParent());
+        assertEquals(node3, root.getChildren().get(3));
+        assertEquals(root, node3.getParent());
+        assertEquals(node31, root.getChildren().get(3).getChildren().get(0));
+        assertEquals(node3, node31.getParent());
+        assertEquals(node33, root.getChildren().get(3).getChildren().get(1));
+        assertEquals(node3, node33.getParent());
+        assertEquals(node4, root.getChildren().get(4));
+        assertEquals(root, node4.getParent());
+        assertEquals(node5, root.getChildren().get(5));
+        assertEquals(root, node5.getParent());
+    }
 }


### PR DESCRIPTION
If you move an item in tree downwards, then the frontend shows it correctly but the model at server side has wrong order.

Initial order
```
Node 1
Node 2
Node 3
Node 4
```
move an item
```
Node 2
<-- Node 1
Node 3
Node 4
```
order at server side (vs client side)
```
Node 2 (Node 2)
Node 3 (Node 1)
Node 1 (Node 3)
Node 4 (Node 4)
```