### PR TITLE
Fix Javadoc. Ignore shaded classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
                 <configuration>
                     <sourcepath>${basedir}/src/main/java;</sourcepath>
                     <doclint>none</doclint>
+                    <excludePackageNames>org.primefaces.shaded.*</excludePackageNames>
                 </configuration>
                 <executions>
                     <execution>

--- a/primefaces/src/main/java/org/primefaces/model/charts/axes/AxesGridLines.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/axes/AxesGridLines.java
@@ -289,18 +289,18 @@ public class AxesGridLines implements Serializable {
     }
 
     /**
-     * Gets the offsetGridLines
+     * Gets the offset
      *
-     * @return offsetGridLines
+     * @return offset
      */
     public boolean isOffset() {
         return offset;
     }
 
     /**
-     * Sets the offsetGridLines
+     * Sets the offset
      *
-     * @param offsetGridLines If true, grid lines will be shifted to be between labels.
+     * @param offset If true, grid lines will be shifted to be between labels.
      * This is set to true in the bar chart by default.
      */
     public void setOffset(boolean offset) {

--- a/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/CartesianAxes.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/CartesianAxes.java
@@ -115,9 +115,9 @@ public abstract class CartesianAxes implements Serializable {
     }
 
     /**
-     * Sets the gridLines
+     * Sets the grid
      *
-     * @param gridLines the {@link AxesGridLines} object
+     * @param grid the {@link AxesGridLines} object
      */
     public void setGrid(AxesGridLines grid) {
         this.grid = grid;


### PR DESCRIPTION
Trying to fix the JDK17 and 18 build issues with Javadoc

https://bugs.openjdk.java.net/browse/JDK-8281944?jql=project%20%3D%20JDK%20AND%20fixVersion%20%3D%20%2217%22