### PR TITLE
Fix #127: Schedule add range selection

### DIFF
--- a/docs/12_0_0/components/schedule.md
+++ b/docs/12_0_0/components/schedule.md
@@ -20,34 +20,33 @@ Renderer Class | org.primefaces.component.schedule.ScheduleRenderer
 | Name | Default | Type | Description | 
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
-rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
-binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
-widgetVar | null | String | Name of the client side widget.
-value | null | Object | An org.primefaces.model.ScheduleModel instance representing the backed model
-locale | null | Object | Locale for localization, can be String or a java.util.Locale instance
-dir | ltr | String | Defines direction of schedule. Valid values are "ltr" (default) and "rtl".
 allDaySlot | true | Boolean | Determines if all-day slot will be displayed in timeGridWeek or timeGridDay views
 aspectRatio | null | Float | Ratio of calendar width to height, higher the value shorter the height is
+binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 centerHeaderTemplate | title | String | Content of center of header.
 clientTimeZone | local | String | Defines how to interpret the dates at browser. Valid values are "local", "UTC" and ids like "America/Chicago". (see https://fullcalendar.io/docs/timeZone)
 columnFormat | null | String | Deprecated, use columnHeaderFormat instead. Format for column headers.
 columnHeaderFormat | null | String | Format for column headers. (eg `timeGridWeek: {weekday: 'narrow'}` or `timeGridWeek: {weekday: 'short'}, timeGridDay: {day: 'numeric'}`) see: https://fullcalendar.io/docs/v4/columnHeaderFormat
+dir | ltr | String | Defines direction of schedule. Valid values are "ltr" (default) and "rtl".
 displayEventEnd | null | String | Whether or not to display an event's end time text when it is rendered on the calendar. Value can be a boolean to globally configure for all views or a comma separated list such as "month:false,basicWeek:true" to configure per view.
 draggable | true | Boolean | When true, events are draggable.
 extender | null | String | Name of JavaScript function to extend the options of the underlying FullCalendar plugin.
 height | null | String | Sets the height of the entire calendar, including header and footer. By default, this option is unset and the calendar’s height is calculated by aspectRatio. If "auto" is specified, the view’s contents will assume a natural height and no scrollbars will be used.
 initialDate | null | java.time.LocalDate | The initial date that is used when schedule loads. If ommitted, the schedule starts on the current date
 leftHeaderTemplate | prev, next, today | String | Content of left side of header.
+locale | null | Object | Locale for localization, can be String or a java.util.Locale instance
 maxTime | null | String | Maximum time to display in a day view.
 minTime | null | String | Minimum time to display in a day view.
 nextDayThreshold | 09:00:00 | String | When an event's end time spans into another day, the minimum time it must be in order for it to render as if it were on that day. Default is `09:00:00`.
 noOpener | true | Boolean | Whether for URL events access to the opener window from the target site should be prevented (phishing protection), default value is true.
+rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
 resizable | true | Boolean | When true, events are resizable.
 rightHeaderTemplate | dayGridMonth, timeGridWeek, timeGridDay | String | Content of right side of header.
 scrollTime | 06:00:00 | String | Determines how far down the scroll pane is initially scrolled down.
+selectable | false | Boolean | Enables selection of time ranges by clicking and dragging on the schedule, see https://fullcalendar.io/docs/select-callback. Uses the ajax-event "rangeSelect" instead of "dateSelect".
 showHeader | true | Boolean | Specifies visibility of header content.
-showWeekends | true | Boolean | Specifies inclusion Saturday/Sunday columns in any of the views
 showWeekNumbers | false | Boolean | Display week numbers in schedule.
+showWeekends | true | Boolean | Specifies inclusion Saturday/Sunday columns in any of the views
 slotDuration | 00:30:00 | String | The frequency for displaying time slots.
 slotEventOverlap | true | Boolean | If true contemporary events will be rendered one overlapping the other, else they will be rendered side by side.
 slotLabelFormat | null | String | Determines the text that will be displayed within a time slot. The default English value will produce times that look like 5pm and 5:30pm. (see https://momentjs.com/docs/#/displaying/)
@@ -58,9 +57,11 @@ timeFormat | null | String | Determines the time-text that will be displayed on 
 timeZone | null | Object | String or a java.time.ZoneId instance to specify the timezone used for date conversion, defaults to ZoneId.systemDefault().
 tooltip | false | Boolean | Displays description of events on a tooltip.
 urlTarget | _blank | String | Target for events with urls. Clicking on such events in the schedule will not trigger the selectEvent but open the url using this target instead. Default is "_blank".
+value | null | Object | An org.primefaces.model.ScheduleModel instance representing the backed model
 view | dayGridMonth | String | The view type to use, possible values are 'dayGridMonth', 'dayGridWeek', 'dayGridDay', 'timeGridWeek', 'timeGridDay', 'listYear' , 'listMonth', 'listWeek', 'listDay'.
 weekNumberCalculation | local | String | The method for calculating week numbers that are displayed. Valid values are "local"(default), "ISO" and "custom".
-weekNumberCalculator | null | String | Client side function to use in custom `weekNumberCalculation`. This must be a JavaScript expression that results in an integer week number. You can use the local variable `date`, which points to the `Date` object for which the week number is to be determined. To illustrate, if you were to specify `date.getFullYear()`, the year would be shown instead of the actual week number.  
+weekNumberCalculator | null | String | Client side function to use in custom `weekNumberCalculation`. This must be a JavaScript expression that results in an integer week number. You can use the local variable `date`, which points to the `Date` object for which the week number is to be determined. To illustrate, if you were to specify `date.getFullYear()`, the year would be shown instead of the actual week number. 
+widgetVar | null | String | Name of the client side widget. 
 
 ## Getting started with Schedule
 Schedule needs to be backed by an _org.primefaces.model.ScheduleModel_ instance, a schedule
@@ -123,8 +124,9 @@ Schedule provides various ajax behavior events to respond user actions.
 dateSelect | org.primefaces.event.SelectEvent<LocalDateTime> | When a date is selected.
 dateDblSelect | org.primefaces.event.SelectEvent<LocalDateTime> | When a date is double click selected.
 eventSelect | org.primefaces.event.SelectEvent<ScheduleEvent> | When an event is selected.
-eventMove | org.primefaces.event.ScheduleEntryMoveEvent | When an event is moved.
-eventResize | org.primefaces.event.ScheduleEntryResizeEvent | When an event is resized.
+eventMove | org.primefaces.event.schedule.ScheduleEntryMoveEvent | When an event is moved.
+eventResize | org.primefaces.event.schedule.ScheduleEntryResizeEvent | When an event is resized.
+rangeSelect | org.primefaces.event.schedule.ScheduleRangeEvent  | When a date range is selected when selectable=true.
 viewChange | org.primefaces.event.SelectEvent<String> | When a view is changed.
 
 ## Ajax Updates

--- a/docs/12_0_0/gettingstarted/whatsnew.md
+++ b/docs/12_0_0/gettingstarted/whatsnew.md
@@ -26,6 +26,7 @@ This page contains a list of big features. Please check the GitHub issues for al
   * Now can be enabled and disabled by its widget.
   * Added `disableOnAjax` attribute to disable the button during Ajax requests triggered by its menu items.
 * Printer: added `configuration` attribute for passing custom JSON options to PrintJS.
+* Schedule: added `selectable` property and `rangeSelect` AJAX event
 * SelectOneRadio: improved accessibility of custom layout via `custom` facet.
 * Spinner: added `modifyValueOnWheel` to increment or decrement the element value with the mouse wheel.
 * SplitButton

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/schedule/Schedule001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/schedule/Schedule001.java
@@ -32,9 +32,9 @@ import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
-import org.primefaces.event.ScheduleEntryMoveEvent;
-import org.primefaces.event.ScheduleEntryResizeEvent;
 import org.primefaces.event.SelectEvent;
+import org.primefaces.event.schedule.ScheduleEntryMoveEvent;
+import org.primefaces.event.schedule.ScheduleEntryResizeEvent;
 import org.primefaces.model.DefaultScheduleEvent;
 import org.primefaces.model.DefaultScheduleModel;
 import org.primefaces.model.ScheduleEvent;

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/ScheduleJava8View.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/ScheduleJava8View.java
@@ -23,13 +23,9 @@
  */
 package org.primefaces.showcase.view.data;
 
-import org.primefaces.event.ScheduleEntryMoveEvent;
-import org.primefaces.event.ScheduleEntryResizeEvent;
-import org.primefaces.event.SelectEvent;
-import org.primefaces.model.*;
-import org.primefaces.showcase.service.ExtenderService;
-import org.primefaces.showcase.service.ExtenderService.ExtenderExample;
-
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
@@ -44,9 +40,14 @@ import javax.faces.model.SelectItem;
 import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.io.Serializable;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+
+import org.primefaces.event.SelectEvent;
+import org.primefaces.event.schedule.ScheduleEntryMoveEvent;
+import org.primefaces.event.schedule.ScheduleEntryResizeEvent;
+import org.primefaces.event.schedule.ScheduleRangeEvent;
+import org.primefaces.model.*;
+import org.primefaces.showcase.service.ExtenderService;
+import org.primefaces.showcase.service.ExtenderService.ExtenderExample;
 
 @Named
 @ViewScoped
@@ -66,6 +67,7 @@ public class ScheduleJava8View implements Serializable {
     private boolean showHeader = true;
     private boolean draggable = true;
     private boolean resizable = true;
+    private boolean selectable = false;
     private boolean showWeekends = true;
     private boolean tooltip = true;
     private boolean allDaySlot = true;
@@ -311,6 +313,13 @@ public class ScheduleJava8View implements Serializable {
         addMessage(message);
     }
 
+    public void onRangeSelect(ScheduleRangeEvent event) {
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, "Range selected",
+                "Start-Date:" + event.getStartDate() + ", End-Date: " + event.getEndDate());
+
+        addMessage(message);
+    }
+
     public void onEventDelete() {
         String eventId = FacesContext.getCurrentInstance().getExternalContext().getRequestParameterMap().get("eventId");
         if (event != null) {
@@ -380,6 +389,14 @@ public class ScheduleJava8View implements Serializable {
 
     public void setResizable(boolean resizable) {
         this.resizable = resizable;
+    }
+
+    public boolean isSelectable() {
+        return selectable;
+    }
+
+    public void setSelectable(boolean selectable) {
+        this.selectable = selectable;
     }
 
     public boolean isTooltip() {

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/configuration.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/configuration.xhtml
@@ -32,6 +32,9 @@
                         <p:selectBooleanCheckbox value="#{scheduleJava8View.draggable}" itemLabel="draggable events">
                             <p:ajax update="schedule"/>
                         </p:selectBooleanCheckbox>
+                        <p:selectBooleanCheckbox value="#{scheduleJava8View.selectable}" itemLabel="range selection">
+                            <p:ajax update="schedule"/>
+                        </p:selectBooleanCheckbox>
                         <p:selectBooleanCheckbox value="#{scheduleJava8View.showWeekends}" itemLabel="show weekends">
                             <p:ajax update="schedule"/>
                         </p:selectBooleanCheckbox>
@@ -229,6 +232,7 @@
                             initialDate="#{scheduleJava8View.initialDate}"
                             aspectRatio="#{scheduleJava8View.aspectRatio}"
                             resizable="#{scheduleJava8View.resizable}"
+                            selectable="#{scheduleJava8View.selectable}"
                             draggable="#{scheduleJava8View.draggable}" showHeader="#{scheduleJava8View.showHeader}"
                             slotLabelFormat="#{scheduleJava8View.slotLabelFormat}"
                             showWeekNumbers="#{scheduleJava8View.showWeekNumbers}"
@@ -248,6 +252,7 @@
                             oncomplete="PF('eventDialog').show();"/>
                     <p:ajax event="eventMove" listener="#{scheduleJava8View.onEventMove}" update="messages"/>
                     <p:ajax event="eventResize" listener="#{scheduleJava8View.onEventResize}" update="messages"/>
+                    <p:ajax event="rangeSelect" listener="#{scheduleJava8View.onRangeSelect}" update="messages"/>
                     <p:ajax event="viewChange" listener="#{scheduleJava8View.onViewChange}" update="view"/>
 
                 </p:schedule>

--- a/primefaces/src/main/java/org/primefaces/component/schedule/Schedule.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/Schedule.java
@@ -39,9 +39,10 @@ import javax.faces.event.BehaviorEvent;
 import javax.faces.event.FacesEvent;
 
 import org.primefaces.el.ValueExpressionAnalyzer;
-import org.primefaces.event.ScheduleEntryMoveEvent;
-import org.primefaces.event.ScheduleEntryResizeEvent;
 import org.primefaces.event.SelectEvent;
+import org.primefaces.event.schedule.ScheduleEntryMoveEvent;
+import org.primefaces.event.schedule.ScheduleEntryResizeEvent;
+import org.primefaces.event.schedule.ScheduleRangeEvent;
 import org.primefaces.model.ScheduleEvent;
 import org.primefaces.util.*;
 
@@ -65,6 +66,7 @@ public class Schedule extends ScheduleBase {
             .put("eventMove", ScheduleEntryMoveEvent.class)
             .put("eventResize", ScheduleEntryResizeEvent.class)
             .put("viewChange", SelectEvent.class)
+            .put("rangeSelect", ScheduleRangeEvent.class)
             .build();
     private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
 
@@ -105,6 +107,16 @@ public class Schedule extends ScheduleBase {
                 SelectEvent<?> selectEvent = new SelectEvent(this, behaviorEvent.getBehavior(), selectedDate);
                 selectEvent.setPhaseId(behaviorEvent.getPhaseId());
 
+                wrapperEvent = selectEvent;
+            }
+            if ("rangeSelect".equals(eventName)) {
+                String startDateStr = params.get(clientId + "_startDate");
+                String endDateStr = params.get(clientId + "_endDate");
+                ZoneId zoneId = CalendarUtils.calculateZoneId(this.getTimeZone());
+                LocalDateTime startDate =  CalendarUtils.toLocalDateTime(zoneId, startDateStr);
+                LocalDateTime endDate =  CalendarUtils.toLocalDateTime(zoneId, endDateStr);
+                ScheduleRangeEvent selectEvent = new ScheduleRangeEvent(this, behaviorEvent.getBehavior(), startDate, endDate);
+                selectEvent.setPhaseId(behaviorEvent.getPhaseId());
                 wrapperEvent = selectEvent;
             }
             else if ("eventSelect".equals(eventName)) {

--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
@@ -49,6 +49,7 @@ public abstract class ScheduleBase extends UIComponentBase implements Widget, RT
         styleClass,
         draggable,
         resizable,
+        selectable,
         showHeader,
         leftHeaderTemplate,
         centerHeaderTemplate,
@@ -174,6 +175,14 @@ public abstract class ScheduleBase extends UIComponentBase implements Widget, RT
 
     public void setResizable(boolean resizable) {
         getStateHelper().put(PropertyKeys.resizable, resizable);
+    }
+
+    public boolean isSelectable() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.selectable, false);
+    }
+
+    public void setSelectable(boolean selectable) {
+        getStateHelper().put(PropertyKeys.selectable, selectable);
     }
 
     public boolean isShowHeader() {

--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -228,6 +228,7 @@ public class ScheduleRenderer extends CoreRenderer {
                 .attr("weekends", schedule.isShowWeekends(), true)
                 .attr("eventStartEditable", schedule.isDraggable())
                 .attr("eventDurationEditable", schedule.isResizable())
+                .attr("selectable", schedule.isSelectable(), false)
                 .attr("slotLabelInterval", schedule.getSlotLabelInterval(), null)
                 .attr("eventTimeFormat", schedule.getTimeFormat(), null) //https://momentjs.com/docs/#/displaying/
                 .attr("weekNumbers", isShowWeekNumbers, false)

--- a/primefaces/src/main/java/org/primefaces/event/DateRangeEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/DateRangeEvent.java
@@ -21,21 +21,32 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.event.timeline;
+package org.primefaces.event;
 
 import java.time.LocalDateTime;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
 
-import org.primefaces.event.DateRangeEvent;
-
-public class TimelineRangeEvent extends DateRangeEvent {
+public class DateRangeEvent extends AbstractAjaxBehaviorEvent {
 
     private static final long serialVersionUID = 1L;
 
-    public TimelineRangeEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate) {
-        super(component, behavior, startDate, endDate);
+    private final LocalDateTime startDate;
+
+    private final LocalDateTime endDate;
+
+    public DateRangeEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate) {
+        super(component, behavior);
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
 
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleEntryMoveEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleEntryMoveEvent.java
@@ -21,11 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.event;
+package org.primefaces.event.schedule;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
 
+import org.primefaces.event.AbstractAjaxBehaviorEvent;
 import org.primefaces.model.ScheduleEvent;
 
 import java.time.Duration;

--- a/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleEntryResizeEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleEntryResizeEvent.java
@@ -21,11 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.event;
+package org.primefaces.event.schedule;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.Behavior;
 
+import org.primefaces.event.AbstractAjaxBehaviorEvent;
 import org.primefaces.model.ScheduleEvent;
 
 import java.time.Duration;

--- a/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleRangeEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/schedule/ScheduleRangeEvent.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.event.timeline;
+package org.primefaces.event.schedule;
 
 import java.time.LocalDateTime;
 
@@ -30,11 +30,11 @@ import javax.faces.component.behavior.Behavior;
 
 import org.primefaces.event.DateRangeEvent;
 
-public class TimelineRangeEvent extends DateRangeEvent {
+public class ScheduleRangeEvent extends DateRangeEvent {
 
     private static final long serialVersionUID = 1L;
 
-    public TimelineRangeEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate) {
+    public ScheduleRangeEvent(UIComponent component, Behavior behavior, LocalDateTime startDate, LocalDateTime endDate) {
         super(component, behavior, startDate, endDate);
     }
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -22256,6 +22256,12 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <name>selectable</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+            <description>Enables selection of time ranges by clicking and dragging on the schedule, see https://fullcalendar.io/docs/select-callback. Uses the ajax-event "rangeSelect" instead of "dateSelect".</description>
+        </attribute>
+        <attribute>
             <description>
                 <![CDATA[Specifies visibility of header content. Default is true.]]>
             </description>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -223,6 +223,21 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
             }
         };
 
+        if (this.cfg.options.selectable) {
+            this.cfg.options.select = function(selectionInfo) {
+                if ($this.hasBehavior('rangeSelect')) {
+                    var ext = {
+                        params: [
+                            { name: $this.id + '_startDate', value: selectionInfo.start.toISOString() },
+                            { name: $this.id + '_endDate', value: selectionInfo.end.toISOString() }
+                        ]
+                    };
+
+                    $this.callBehavior('rangeSelect', ext);
+                }
+            };
+        };
+
         if(this.cfg.tooltip) {
             this.cfg.options.eventMouseEnter = function(mouseEnterInfo) {
                 if(mouseEnterInfo.event.extendedProps.description) {


### PR DESCRIPTION
Reviving this really old PR.  It was closed because of concerns about Date translation but now we know everything is UTC etc.

https://github.com/primefaces/primefaces/pull/159/files

Also refactored to have a common DateRangeSelect event that can be reusted for `TimelineRangeEvent` and `ScheduleRangeEvent`.

https://github.com/primefaces/primefaces/issues/127