### PR TITLE
Docs: replace apostrophe with singlequote

### DIFF
--- a/docs/10_0_0/core/elFunctions.md
+++ b/docs/10_0_0/core/elFunctions.md
@@ -33,7 +33,7 @@ NOTE: this example passes "cc" as component to start the search. To start from r
     <p:dialog id="dlg" widgetVar="dlg">
         //contents
     </p:dialog>
-    <p:commandButton type="button" value="Show" onclick="PF('#{p:resolveWidgetVar(‘dlg’, cc)}').show()" />
+    <p:commandButton type="button" value="Show" onclick="PF(`#{p:resolveWidgetVar('dlg', cc)}`).show()" />
 </cc:implementation>
 ```
 

--- a/docs/11_0_0/core/elFunctions.md
+++ b/docs/11_0_0/core/elFunctions.md
@@ -33,7 +33,7 @@ NOTE: this example passes "cc" as component to start the search. To start from r
     <p:dialog id="dlg" widgetVar="dlg">
         //contents
     </p:dialog>
-    <p:commandButton type="button" value="Show" onclick="PF('#{p:resolveWidgetVar(‘dlg’, cc)}').show()" />
+    <p:commandButton type="button" value="Show" onclick="PF(`#{p:resolveWidgetVar('dlg', cc)}`).show()" />
 </cc:implementation>
 ```
 

--- a/docs/12_0_0/core/elFunctions.md
+++ b/docs/12_0_0/core/elFunctions.md
@@ -35,7 +35,7 @@ NOTE: this example passes "cc" as component to start the search. To start from r
     <p:dialog id="dlg" widgetVar="dlg">
         //contents
     </p:dialog>
-    <p:commandButton type="button" value="Show" onclick="PF('#{p:resolveWidgetVar(‘dlg’, cc)}').show()" />
+    <p:commandButton type="button" value="Show" onclick="PF(`#{p:resolveWidgetVar('dlg', cc)}`).show()" />
 </cc:implementation>
 ```
 

--- a/docs/8_0/core/elFunctions.md
+++ b/docs/8_0/core/elFunctions.md
@@ -31,7 +31,7 @@ NOTE: this example passes "cc" as component to start the search. To start from r
     <p:dialog id="dlg" widgetVar="dlg">
         //contents
     </p:dialog>
-    <p:commandButton type="button" value="Show" onclick="PF('#{p:resolveWidgetVar(‘dlg’, cc)}').show()" />
+    <p:commandButton type="button" value="Show" onclick="PF(`#{p:resolveWidgetVar('dlg', cc)}`).show()" />
 </cc:implementation>
 ```
 


### PR DESCRIPTION
Inside the docs for `resolveWidgetVar` is an apostrophe used which throws an error in the application server.
The solution was to replace the outer single quotes with back ticks and use single quotes instead the apostrophe.