### PR TITLE
Fix #8743: Targeted reset after update=@all

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -260,7 +260,7 @@ if (!PrimeFaces.ajax) {
                     var ajaxUtils = PrimeFaces.ajax.Utils;
 
                     // reset PrimeFaces JS state because the view is completely replaced with a new one
-                    window.PrimeFaces = null;
+                    window.PrimeFaces.resetState();
 
                     ajaxUtils.updateHead(content);
                     ajaxUtils.updateBody(content);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1134,6 +1134,15 @@
         },
 
         /**
+         * Reset any state variables on update="@all".
+         */
+        resetState: function() {
+            PrimeFaces.zindex = 1000;
+            PrimeFaces.detachedWidgets = [];
+            PrimeFaces.widgets = {};
+        },
+
+        /**
          * Logs the current PrimeFaces and jQuery version to console.
          */
         version: function() {


### PR DESCRIPTION
Trying to make the reset on ALL more targeted than blowing away the whole `windows.PrimeFaces = null;` namepsace.