### PR TITLE
Fix #7767/#7763/#7765/#3781: AutoComplete/SelectOneMenu/RowExpansion/OrderList duplicate ids

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -550,19 +550,20 @@ public class AutoCompleteRenderer extends InputRenderer {
         writer.startElement("tbody", ac);
 
         if (items != null) {
+            int index = 0;
             if (ac.isClientQueryMode() || items instanceof Map) {
                 for (Map.Entry<String, List<String>> entry : ((Map<String, List<String>>) items).entrySet()) {
                     String key = entry.getKey();
                     List<String> list = entry.getValue();
 
                     for (Object item : list) {
-                        encodeSuggestionItemsAsTable(context, ac, item, converter, pojo, var, key);
+                        encodeSuggestionItemsAsTable(context, ac, item, converter, pojo, var, key, index++);
                     }
                 }
             }
             else {
                 for (Object item : (List) items) {
-                    encodeSuggestionItemsAsTable(context, ac, item, converter, pojo, var, null);
+                    encodeSuggestionItemsAsTable(context, ac, item, converter, pojo, var, null, index++);
                 }
 
                 if (ac.hasMoreSuggestions()) {
@@ -664,7 +665,7 @@ public class AutoCompleteRenderer extends InputRenderer {
     }
 
     protected void encodeSuggestionItemsAsTable(FacesContext context, AutoComplete ac, Object item, Converter converter,
-            boolean pojo, String var, String key) throws IOException {
+            boolean pojo, String var, String key, int index) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
         UIComponent itemtip = ac.getFacet("itemtip");
@@ -704,7 +705,7 @@ public class AutoCompleteRenderer extends InputRenderer {
                     writer.writeAttribute("class", column.getStyleClass(), null);
                 }
 
-                column.encodeAll(context);
+                encodeIndexedId(context, column, index);
 
                 writer.endElement("td");
             }
@@ -713,7 +714,7 @@ public class AutoCompleteRenderer extends InputRenderer {
         if (ComponentUtils.shouldRenderFacet(itemtip)) {
             writer.startElement("td", null);
             writer.writeAttribute("class", AutoComplete.ITEMTIP_CONTENT_CLASS, null);
-            itemtip.encodeAll(context);
+            encodeIndexedId(context, itemtip, index);
             writer.endElement("td");
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
@@ -35,6 +35,7 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.datatable.DataTableRenderer;
 import org.primefaces.component.datatable.DataTableState;
 import org.primefaces.component.rowexpansion.RowExpansion;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.LangUtils;
 
 public class RowExpandFeature implements DataTableFeature {
@@ -100,7 +101,7 @@ public class RowExpandFeature implements DataTableFeature {
             writer.startElement("td", null);
             writer.writeAttribute("colspan", table.getColumnsCount(), null);
 
-            table.getRowExpansion().encodeAll(context);
+            ComponentUtils.encodeIndexedId(context, table.getRowExpansion(), rowIndex);
 
             writer.endElement("td");
 

--- a/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListRenderer.java
@@ -160,6 +160,7 @@ public class OrderListRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String var = old.getVar();
         Converter converter = old.getConverter();
+        int index = 0;
 
         for (Object item : model) {
             context.getExternalContext().getRequestMap().put(var, item);
@@ -187,7 +188,7 @@ public class OrderListRenderer extends CoreRenderer {
                             writer.writeAttribute("class", column.getStyleClass(), null);
                         }
 
-                        renderChildren(context, column);
+                        encodeIndexedId(context, column, index++);
                         writer.endElement("td");
                     }
                 }

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -476,7 +476,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
                         writer.writeAttribute("class", styleClass, null);
                     }
 
-                    renderChildren(context, column);
+                    encodeIndexedId(context, column, i);
                     writer.endElement("td");
                 }
             }

--- a/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -836,6 +836,19 @@ public abstract class CoreRenderer extends Renderer {
         writer.endElement("div");
     }
 
+    /**
+     * GitHub #7763 Renders an in memory UIComponent and updates its ID with an index.
+     * For example id="form:test" becomes id="form:test:0".
+     *
+     * @param context the {@link FacesContext}.
+     * @param component the {@link UIComponent} to render.
+     * @param index the index number to append to the ID
+     * @throws IOException if any IO error occurs
+     */
+    protected void encodeIndexedId(FacesContext context, UIComponent component, int index) throws IOException {
+        ComponentUtils.encodeIndexedId(context, component, index);
+    }
+
     protected boolean endsWithLenghtUnit(String val) {
         return val.endsWith("px") || val.endsWith("%") // most common first
                 || val.endsWith("cm") || val.endsWith("mm") || val.endsWith("in")


### PR DESCRIPTION
This was the most elegant way to solve this without making a mess.  It basically captures the output in FastStringWriter and then appends the index on to each ID so `form:abc` becomes `form:abc:0` then `form:abc:1`

Tested against both reproducers and all is working properly.