### PR TITLE
Fix #8791: DataTable: row alignment issue with scrollable and frozen columns

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -184,13 +184,18 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
         });
 
         PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_align', $this.jq, function() {
-			$this.fixRowHeights();
-            if ($this.percentageScrollHeight) {
-                $this.adjustScrollHeight();
+			if ($this.resizeTimeout) {
+                clearTimeout($this.resizeTimeout);
             }
-            if ($this.percentageScrollWidth) {
-                $this.adjustScrollWidth();
-            }
+		    $this.resizeTimeout = setTimeout(function() {
+				$this.fixRowHeights();
+				if ($this.percentageScrollHeight) {
+                	$this.adjustScrollHeight();
+	            }
+	            if ($this.percentageScrollWidth) {
+	                $this.adjustScrollWidth();
+	            }
+			}, 150);
         });
     },
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -13,6 +13,7 @@
  * @prop {JQuery} frozenLayout The DOM element for the frozen layout container.
  * @prop {JQuery} frozenTbody The DOM element for the header TBODY.
  * @prop {JQuery} frozenTheadClone The DOM element for the clone of the frozen THEAD.
+ * @prop {JQuery} frozenTfoot The DOM element for the header TFOOT.
  * @prop {JQuery} scrollBodyTable The DOM element for the TABLE of the scrollable body.
  * @prop {JQuery} scrollContainer The DOM element for the container of the scrollable body.
  * @prop {undefined} scrollColgroup Always `undefined` and not used.
@@ -23,6 +24,7 @@
  * @prop {JQuery} scrollLayout The DOM element for the scrollable layout container.
  * @prop {JQuery} scrollThead The DOM element for the scrollable THEAD.
  * @prop {JQuery} scrollTheadClone The DOM element for the clone of the scrollable THEAD.
+ * @prop {JQuery} scrollTfoot The DOM element for the scrollable TFOOT.
  *
  * @interface {PrimeFaces.widget.FrozenDataTableCfg} cfg The configuration for the {@link  FrozenDataTable| FrozenDataTable widget}.
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -887,6 +887,8 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * Adjusts the height of the body and foot rows to fit the current settings.
      */
     fixRowHeights: function() {
+		// head rows
+		this._fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
 		// body rows
 		this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
 		// foot rows

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -893,50 +893,50 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * Adjusts the height of the body and foot rows to fit the current settings.
      */
     fixRowHeights: function() {
-		this._fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
-		this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
-		var frozenFootRows = this.frozenTfoot.children();
-		if (frozenFootRows.length > 0) {
-			this._fixRowHeights(this.scrollTfoot.children(), frozenFootRows);
-			var scrollBarHeight = this.scrollContainer.height() - this.frozenContainer.height();
-			if (scrollBarHeight > 0) {
-				var browser = PrimeFaces.env.browser;
-	            if (browser.webkit === true || browser.mozilla === true) {
-	                this.frozenBody.append('<div style="height:' + scrollBarHeight + 'px"></div>');
-	            } else {
-	                this.frozenBodyTable.css('margin-bottom', scrollBarHeight);
-	            }
-			}
-		}
-	},
+        this._fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
+        this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
+        var frozenFootRows = this.frozenTfoot.children();
+        if (frozenFootRows.length > 0) {
+            this._fixRowHeights(this.scrollTfoot.children(), frozenFootRows);
+            var scrollBarHeight = this.scrollContainer.height() - this.frozenContainer.height();
+            if (scrollBarHeight > 0) {
+                var browser = PrimeFaces.env.browser;
+                if (browser.webkit === true || browser.mozilla === true) {
+                    this.frozenBody.append('<div style="height:' + scrollBarHeight + 'px"></div>');
+                } else {
+                    this.frozenBodyTable.css('margin-bottom', scrollBarHeight);
+                }
+            }
+        }
+    },
 
-	/**
+    /**
      * Adjusts the height of the given rows to fit the current settings.
      * @protected
      * @param {JQuery} scrollRows The scrollable rows to adjust.
      * @param {JQuery} frozenRows The frozen rows to adjust.
      */
-	_fixRowHeights: function(scrollRows, frozenRows) {
-		frozenRows.each(function(index) {
-			var frozenRow = $(this);
-			var scrollRow = scrollRows.eq(index);
-            
+    _fixRowHeights: function(scrollRows, frozenRows) {
+        frozenRows.each(function(index) {
+            var frozenRow = $(this);
+            var scrollRow = scrollRows.eq(index);
+
             frozenRow.css('height', '');
             scrollRow.css('height', '');
-            
+
             var scrollRowHeight = scrollRow.innerHeight();
             var frozenRowHeight = frozenRow.innerHeight();
-            
+
             if (scrollRowHeight == frozenRowHeight) {
-				return;
-			}
-			var height = scrollRowHeight > frozenRowHeight ? scrollRowHeight : frozenRowHeight;
-			// compensation for decimal fractions
-			height += 1;
-			
+                return;
+            }
+            var height = scrollRowHeight > frozenRowHeight ? scrollRowHeight : frozenRowHeight;
+            // compensation for decimal fractions
+            height += 1;
+
             frozenRow.innerHeight(height);
             scrollRow.innerHeight(height);
-		});
-	}
+        });
+    }
 	
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -109,7 +109,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
         }
 
         this.cloneHead();
-        this.fixRowHeights();
+        this.fixRowHeightsAll();
 
         if(this.cfg.liveScroll) {
             this.clearScrollState();
@@ -188,7 +188,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
                 clearTimeout($this.resizeTimeout);
             }
             $this.resizeTimeout = setTimeout(function() {
-                $this.fixRowHeights();
+                $this.fixRowHeightsAll();
                 if ($this.percentageScrollHeight) {
                     $this.adjustScrollHeight();
                 }
@@ -375,7 +375,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
         }
 
         this.postUpdateData();
-        this.fixRowHeights();
+        this.fixRowHeightsAll();
     },
     
     /**
@@ -890,14 +890,14 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
     },
 
     /**
-     * Adjusts the height of the body and foot rows to fit the current settings.
+     * Adjusts the height of all rows to fit the current settings.
      */
-    fixRowHeights: function() {
-        this._fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
-        this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
+    fixRowHeightsAll: function() {
+        this.fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
+        this.fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
         var frozenFootRows = this.frozenTfoot.children();
         if (frozenFootRows.length > 0) {
-            this._fixRowHeights(this.scrollTfoot.children(), frozenFootRows);
+            this.fixRowHeights(this.scrollTfoot.children(), frozenFootRows);
             var scrollBarHeight = this.scrollContainer.height() - this.frozenContainer.height();
             if (scrollBarHeight > 0) {
                 var browser = PrimeFaces.env.browser;
@@ -916,7 +916,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * @param {JQuery} scrollRows The scrollable rows to adjust.
      * @param {JQuery} frozenRows The frozen rows to adjust.
      */
-    _fixRowHeights: function(scrollRows, frozenRows) {
+    fixRowHeights: function(scrollRows, frozenRows) {
         frozenRows.each(function(index) {
             var frozenRow = $(this);
             var scrollRow = scrollRows.eq(index);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -884,7 +884,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
     /**
      * Adjusts the height of the body and foot rows to fit the current settings.
      */
-    fixRowHeights = function() {
+    fixRowHeights: function() {
 		// body rows
 		this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
 		// foot rows
@@ -909,7 +909,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * @param {JQuery} scrollRows The scrollable rows to adjust.
      * @param {JQuery} frozenRows The frozen rows to adjust.
      */
-	_fixRowHeights = function(scrollRows, frozenRows) {
+	_fixRowHeights: function(scrollRows, frozenRows) {
         for (i = 0; i < frozenRows.length; i++) {
             var scrollableRow = scrollRows.eq(i);
             var frozenRow = frozenRows.eq(i);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -927,7 +927,7 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
             var scrollRowHeight = scrollRow.innerHeight();
             var frozenRowHeight = frozenRow.innerHeight();
 
-            if (scrollRowHeight == frozenRowHeight) {
+            if (scrollRowHeight === frozenRowHeight) {
                 return;
             }
             var height = scrollRowHeight > frozenRowHeight ? scrollRowHeight : frozenRowHeight;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -370,8 +370,9 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
         }
 
         this.postUpdateData();
+        this.fixRowHeights();
     },
-
+    
     /**
      * Clones the given row and returns it
      * @param {JQuery} original DOM element of the original row.
@@ -887,11 +888,8 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * Adjusts the height of the body and foot rows to fit the current settings.
      */
     fixRowHeights: function() {
-		// head rows
 		this._fixRowHeights(this.scrollThead.children(), this.frozenThead.children());
-		// body rows
 		this._fixRowHeights(this.scrollTbody.children(), this.frozenTbody.children());
-		// foot rows
 		var frozenFootRows = this.frozenTfoot.children();
 		if (frozenFootRows.length > 0) {
 			this._fixRowHeights(this.scrollTfoot.children(), frozenFootRows);
@@ -914,24 +912,26 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
      * @param {JQuery} frozenRows The frozen rows to adjust.
      */
 	_fixRowHeights: function(scrollRows, frozenRows) {
-        for (i = 0; i < frozenRows.length; i++) {
-            var scrollableRow = scrollRows.eq(i);
-            var frozenRow = frozenRows.eq(i);
+		frozenRows.each(function(index) {
+			var frozenRow = $(this);
+			var scrollRow = scrollRows.eq(index);
             
-            scrollableRow.css("height", "");
-            frozenRow.css("height", "");
+            frozenRow.css('height', '');
+            scrollRow.css('height', '');
             
-            var scrollableRowHeight = scrollableRow.height();
-            var frozenRowHeight = frozenRow.height();
+            var scrollRowHeight = scrollRow.innerHeight();
+            var frozenRowHeight = frozenRow.innerHeight();
             
-            if (scrollableRowHeight == frozenRowHeight) {
-				continue;
+            if (scrollRowHeight == frozenRowHeight) {
+				return;
 			}
-			if (scrollableRowHeight > frozenRowHeight) {
-				frozenRow.css("height", scrollableRowHeight);
-			} else {
-				scrollableRow.css("height", frozenRowHeight);
-			}
-        }
+			var height = scrollRowHeight > frozenRowHeight ? scrollRowHeight : frozenRowHeight;
+			// compensation for decimal fractions
+			height += 1;
+			
+            frozenRow.innerHeight(height);
+            scrollRow.innerHeight(height);
+		});
 	}
+	
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.frozen.js
@@ -184,18 +184,18 @@ PrimeFaces.widget.FrozenDataTable = PrimeFaces.widget.DataTable.extend({
         });
 
         PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_align', $this.jq, function() {
-			if ($this.resizeTimeout) {
+            if ($this.resizeTimeout) {
                 clearTimeout($this.resizeTimeout);
             }
-		    $this.resizeTimeout = setTimeout(function() {
-				$this.fixRowHeights();
-				if ($this.percentageScrollHeight) {
-                	$this.adjustScrollHeight();
-	            }
-	            if ($this.percentageScrollWidth) {
-	                $this.adjustScrollWidth();
-	            }
-			}, 150);
+            $this.resizeTimeout = setTimeout(function() {
+                $this.fixRowHeights();
+                if ($this.percentageScrollHeight) {
+                    $this.adjustScrollHeight();
+                }
+                if ($this.percentageScrollWidth) {
+                    $this.adjustScrollWidth();
+                }
+            }, 150);
         });
     },
 


### PR DESCRIPTION
So to summarize

- Rows in thead, tbody and tfoot get now aligned as follows
  - on page load
  - after an AJAX request
  - when resizing (with timeout, so the rows are not constantly updated)
- When there is a footer with a horizontal scrollbar, then a gap is added in the frozen part for alignment of the footer row