### PR TITLE
Fix #8840: Selenium command components add clickUnguarded method

### DIFF
--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandButton.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandButton.java
@@ -52,4 +52,13 @@ public abstract class CommandButton extends AbstractComponent {
 
         button.click();
     }
+
+    /**
+     * #8840 Some scenario's with ajax="false" like in a download you may not want to guard the click.
+     */
+    public void clickUnguarded() {
+        WebElement button = getRoot();
+        PrimeSelenium.waitGui().until(ExpectedConditions.elementToBeClickable(button));
+        button.click();
+    }
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandLink.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandLink.java
@@ -52,4 +52,13 @@ public abstract class CommandLink extends Link {
 
         link.click();
     }
+
+    /**
+     * #8840 Some scenario's with ajax="false" like in a download you may not want to guard the click.
+     */
+    public void clickUnguarded() {
+        WebElement link = getRoot();
+        PrimeSelenium.waitGui().until(ExpectedConditions.elementToBeClickable(link));
+        link.click();
+    }
 }


### PR DESCRIPTION
For this scenario specifically allow the system to call the `click` method and guarantee its not guarded for AJAX or HTTP.