### PR TITLE
Fix #8839: Schedule: Tooltips are transparent and lack padding

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/fullcalendar.min.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/fullcalendar.min.css
@@ -1457,3 +1457,9 @@ A VERTICAL event
 body .fc a {
     color: inherit;
 }
+
+.ui-tooltip:not([role]) {
+    background: var(--surface-a, '#fff');
+    padding: 5px;
+    font-size: .85em;
+}


### PR DESCRIPTION
Fix #8839

<img width="194" alt="Screenshot 2022-06-02 at 20 12 14" src="https://user-images.githubusercontent.com/7500178/171698384-8e12045e-dcb8-435c-8648-38458a655f3f.png">

<img width="184" alt="Screenshot 2022-06-02 at 20 12 24" src="https://user-images.githubusercontent.com/7500178/171698389-c93739f6-d7c8-4f24-9a6b-00a6cd1e2b71.png">

`p:tooltip`s are not affected, as they have a `role` attribute.

<img width="282" alt="Screenshot 2022-06-02 at 20 12 50" src="https://user-images.githubusercontent.com/7500178/171698391-1cf95ddd-86ea-4d11-87f1-8531453b12a0.png">

I've used the  theme's `--surface-a` variable as the background.

Our tooltips have a default padding of `5px`.

Schedule uses a font size of `.85em` on the events.