### PR TITLE
Fix #8443/#8867: Menu model integration tests

### DIFF
--- a/docs/migrationguide/12_0_0.md
+++ b/docs/migrationguide/12_0_0.md
@@ -1,7 +1,7 @@
 # Migration guide 11.0.0 -> 12.0.0
 
 ## Core
-  * PrimeFlex 3.x is now the standard version of PrimeFlex that should be used. Use CLI migration tool to migrate from 2 to 3 (https://github.com/primefaces/primefaces/tree/master/primefaces-cli) 
+  * PrimeFlex 3.x is now the standard version of PrimeFlex that should be used. Use CLI migration tool to migrate from 2 to 3 (https://github.com/primefaces/primefaces/tree/master/primefaces-cli)
 
 ## DataTable
   * Row select mode `checkbox` is now `none`.

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/menubar/MenuBar002.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/menubar/MenuBar002.java
@@ -21,29 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.showcase.view.menu;
+package org.primefaces.integrationtests.menubar;
 
-import java.io.IOException;
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
-import javax.faces.application.FacesMessage;
-import javax.faces.context.ExternalContext;
-import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
 
+import org.primefaces.integrationtests.general.utilities.TestUtils;
 import org.primefaces.model.menu.DefaultMenuItem;
 import org.primefaces.model.menu.DefaultMenuModel;
 import org.primefaces.model.menu.DefaultSubMenu;
 import org.primefaces.model.menu.MenuModel;
 
+import lombok.Data;
+
 @Named
 @ViewScoped
-public class MenuView implements Serializable {
+@Data
+public class MenuBar002 implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5366641524856531279L;
 
     private MenuModel model;
 
@@ -60,23 +59,24 @@ public class MenuView implements Serializable {
                 .value("Save (Non-Ajax)")
                 .icon("pi pi-save")
                 .ajax(false)
-                .command("#{menuView.save}")
-                .update("messages")
+                .command("#{menuBar002.save}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
         item = DefaultMenuItem.builder()
                 .value("Update")
                 .icon("pi pi-refresh")
-                .command("#{menuView.update}")
-                .update("messages")
+                .command("#{menuBar002.update}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
         item = DefaultMenuItem.builder()
                 .value("Delete")
                 .icon("pi pi-times")
-                .command("#{menuView.delete}")
+                .command("#{menuBar002.delete}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
@@ -97,52 +97,23 @@ public class MenuView implements Serializable {
         item = DefaultMenuItem.builder()
                 .value("Internal")
                 .icon("pi pi-upload")
-                .command("#{menuView.redirect}")
+                .command("#{menuBar002.redirect}")
                 .build();
         secondSubmenu.getElements().add(item);
 
         model.getElements().add(secondSubmenu);
     }
 
-    public MenuModel getModel() {
-        return model;
-    }
-
-    public void redirect() throws IOException {
-        ExternalContext ec = FacesContext.getCurrentInstance().getExternalContext();
-        ec.redirect(ec.getRequestContextPath());
-    }
-
     public void save() {
-        addMessage("Save", "Data saved");
+        TestUtils.addMessage("Save", "Data saved");
     }
 
     public void update() {
-        addMessage("Update", "Data updated");
+        TestUtils.addMessage("Update", "Data updated");
     }
 
     public void delete() {
-        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_WARN, "Delete", "Data deleted");
-        FacesContext.getCurrentInstance().addMessage(null, message);
+        TestUtils.addMessage("Delete", "Data deleted");
     }
 
-    public void sleepAndSave() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        save();
-    }
-
-    public void sleepAndUpdate() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        update();
-    }
-
-    public void sleepAndDelete() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        delete();
-    }
-
-    public void addMessage(String summary, String detail) {
-        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, detail);
-        FacesContext.getCurrentInstance().addMessage(null, message);
-    }
 }

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/menubar/MenuBar003.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/menubar/MenuBar003.java
@@ -21,29 +21,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.showcase.view.menu;
+package org.primefaces.integrationtests.menubar;
 
-import java.io.IOException;
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
-import javax.faces.application.FacesMessage;
-import javax.faces.context.ExternalContext;
-import javax.faces.context.FacesContext;
-import javax.faces.view.ViewScoped;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Named;
 
+import org.primefaces.integrationtests.general.utilities.TestUtils;
 import org.primefaces.model.menu.DefaultMenuItem;
 import org.primefaces.model.menu.DefaultMenuModel;
 import org.primefaces.model.menu.DefaultSubMenu;
 import org.primefaces.model.menu.MenuModel;
 
-@Named
-@ViewScoped
-public class MenuView implements Serializable {
+import lombok.Data;
 
-    private static final long serialVersionUID = 1L;
+@Named
+@RequestScoped
+@Data
+public class MenuBar003 implements Serializable {
+
+    private static final long serialVersionUID = 5366641524856531279L;
 
     private MenuModel model;
 
@@ -60,23 +59,24 @@ public class MenuView implements Serializable {
                 .value("Save (Non-Ajax)")
                 .icon("pi pi-save")
                 .ajax(false)
-                .command("#{menuView.save}")
-                .update("messages")
+                .command("#{menuBar002.save}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
         item = DefaultMenuItem.builder()
                 .value("Update")
                 .icon("pi pi-refresh")
-                .command("#{menuView.update}")
-                .update("messages")
+                .command("#{menuBar002.update}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
         item = DefaultMenuItem.builder()
                 .value("Delete")
                 .icon("pi pi-times")
-                .command("#{menuView.delete}")
+                .command("#{menuBar002.delete}")
+                .update("msgs")
                 .build();
         firstSubmenu.getElements().add(item);
 
@@ -97,52 +97,23 @@ public class MenuView implements Serializable {
         item = DefaultMenuItem.builder()
                 .value("Internal")
                 .icon("pi pi-upload")
-                .command("#{menuView.redirect}")
+                .command("#{menuBar002.redirect}")
                 .build();
         secondSubmenu.getElements().add(item);
 
         model.getElements().add(secondSubmenu);
     }
 
-    public MenuModel getModel() {
-        return model;
-    }
-
-    public void redirect() throws IOException {
-        ExternalContext ec = FacesContext.getCurrentInstance().getExternalContext();
-        ec.redirect(ec.getRequestContextPath());
-    }
-
     public void save() {
-        addMessage("Save", "Data saved");
+        TestUtils.addMessage("Save", "Data saved");
     }
 
     public void update() {
-        addMessage("Update", "Data updated");
+        TestUtils.addMessage("Update", "Data updated");
     }
 
     public void delete() {
-        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_WARN, "Delete", "Data deleted");
-        FacesContext.getCurrentInstance().addMessage(null, message);
+        TestUtils.addMessage("Delete", "Data deleted");
     }
 
-    public void sleepAndSave() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        save();
-    }
-
-    public void sleepAndUpdate() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        update();
-    }
-
-    public void sleepAndDelete() throws InterruptedException {
-        TimeUnit.SECONDS.sleep(1);
-        delete();
-    }
-
-    public void addMessage(String summary, String detail) {
-        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, detail);
-        FacesContext.getCurrentInstance().addMessage(null, message);
-    }
 }

--- a/primefaces-integration-tests/src/main/webapp/menubar/menuBar002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/menubar/menuBar002.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true" skipDetailIfEqualsSummary="true" />
+
+            <p:menubar id="menubar" model="#{menuBar002.model}" />
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/menubar/menuBar003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/menubar/menuBar003.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true" skipDetailIfEqualsSummary="true" />
+
+            <p:menubar id="menubar" model="#{menuBar003.model}" />
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menubar/MenuBar002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menubar/MenuBar002Test.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.menubar;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.Menubar;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.model.Msg;
+
+public class MenuBar002Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("MenuBar: ViewScoped model executing AJAX menu item using MenuItem ID")
+    public void testModelAjaxMenuItem(Page page) {
+        // Arrange
+        Menubar menubar = page.menubar;
+
+        // Act
+        menubar.selectMenuitemByValue("Options");
+        menubar.selectMenuitemByValue("Update");
+
+        // Assert
+        assertMessage(page, "Data updated");
+        assertConfiguration(menubar.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("MenuBar: ViewScoped model executing non-AJAX menu item using MenuItem ID")
+    public void testModelNonAjaxMenuItem(Page page) {
+        // Arrange
+        Menubar menubar = page.menubar;
+
+        // Act
+        menubar.selectMenuitemByValue("Options");
+        menubar.selectMenuitemByValue("Save (Non-Ajax)");
+
+        // Assert
+        assertMessage(page, "Data saved");
+        assertConfiguration(menubar.getWidgetConfiguration());
+    }
+
+    private void assertMessage(Page page, String message) {
+        Messages messages = page.messages;
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(messages));
+        Msg msg = messages.getMessage(0);
+        Assertions.assertEquals(message, msg.getDetail());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("MenuBar Config = " + cfg);
+        Assertions.assertTrue(cfg.has("toggleEvent"));
+        Assertions.assertTrue(cfg.has("autoDisplay"));
+        Assertions.assertEquals("hover", cfg.getString("toggleEvent"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:menubar")
+        Menubar menubar;
+
+        @Override
+        public String getLocation() {
+            return "menubar/menuBar002.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menubar/MenuBar003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menubar/MenuBar003Test.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.menubar;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.Menubar;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.model.Msg;
+
+public class MenuBar003Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("MenuBar: RequestScoped model executing AJAX menu item using MenuItem Coordinates")
+    public void testModelAjaxMenuItem(Page page) {
+        // Arrange
+        Menubar menubar = page.menubar;
+
+        // Act
+        menubar.selectMenuitemByValue("Options");
+        menubar.selectMenuitemByValue("Update");
+
+        // Assert
+        assertMessage(page, "Data updated");
+        assertConfiguration(menubar.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("MenuBar: RequestScoped model executing non-AJAX menu item using MenuItem Coordinates")
+    public void testModelNonAjaxMenuItem(Page page) {
+        // Arrange
+        Menubar menubar = page.menubar;
+
+        // Act
+        menubar.selectMenuitemByValue("Options");
+        menubar.selectMenuitemByValue("Save (Non-Ajax)");
+
+        // Assert
+        assertMessage(page, "Data saved");
+        assertConfiguration(menubar.getWidgetConfiguration());
+    }
+
+    private void assertMessage(Page page, String message) {
+        Messages messages = page.messages;
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(messages));
+        Msg msg = messages.getMessage(0);
+        Assertions.assertEquals(message, msg.getDetail());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("MenuBar Config = " + cfg);
+        Assertions.assertTrue(cfg.has("toggleEvent"));
+        Assertions.assertTrue(cfg.has("autoDisplay"));
+        Assertions.assertEquals("hover", cfg.getString("toggleEvent"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:menubar")
+        Menubar menubar;
+
+        @Override
+        public String getLocation() {
+            return "menubar/menuBar003.xhtml";
+        }
+    }
+}


### PR DESCRIPTION
When using the MenuModel now that ticket #8443 has been implemented this Model must have a longer lived state than `RequestScoped`.

This is due to that fact that the old Menu had positional based lookup so "1_2" meant the first submenu and the 2nd menu item down. But now that we are uniquely identifying menu items so they can be looked up again the ID must remain so when the call is made from the UI it has to be able to find that `ID` again and not "assume its position".