### PR TITLE
Fix #8883 Own DateTimeConverter should be considered

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker014.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker014.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.DateTimeConverter;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DatePicker014 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private OwnDateTime dateTime;
+
+    // Use own DateTimeConverter here and bind it to f:dateTimeConverter.
+    // Instead of a binding the converter can be set globally in faces-config.xml
+    private final transient DateTimeConverter converter = new OnwDateTimeConverter();
+
+    @PostConstruct
+    public void init() {
+        dateTime = new OwnDateTime(2021, 1, 10, 1, 16, 04);
+    }
+
+    public static final class OwnDateTime implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+        private final int year;
+        private final int month;
+        private final int day;
+        private final int hour;
+        private final int minute;
+        private final int second;
+
+        public OwnDateTime(int year, int month, int day, int hour, int minute, int second) {
+            this.year = year;
+            this.month = month;
+            this.day = day;
+            this.hour = hour;
+            this.minute = minute;
+            this.second = second;
+        }
+
+        @Override
+        public String toString() {
+            return year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second;
+        }
+    }
+
+    public static final class OnwDateTimeConverter extends DateTimeConverter {
+        @Override
+        public String getAsString(FacesContext facesContext, UIComponent uiComponent, Object value) {
+            return value.toString();
+        }
+
+        @Override
+        public Object getAsObject(FacesContext facesContext, UIComponent uiComponent, String value) {
+            int start = 0;
+            int end = value.indexOf("-");
+            int year = Integer.parseInt(value.substring(0, end));
+            start = end + 1;
+            end = value.indexOf("-", start);
+            int month = Integer.parseInt(value.substring(start, end));
+            start = end + 1;
+            end = value.indexOf(" ", start);
+            int day = Integer.parseInt(value.substring(start, end));
+            start = end + 1;
+            end = value.indexOf(":", start);
+            int hour = Integer.parseInt(value.substring(start, end));
+            start = end + 1;
+            end = value.indexOf(":", start);
+            int minute = Integer.parseInt(value.substring(start, end));
+            start = end + 1;
+            int second = Integer.parseInt(value.substring(start, value.length()));
+            return new OwnDateTime(year, month, day, hour, minute, second);
+        }
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker014.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker014.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages/>
+
+            <p:datePicker id="datepicker" value="#{datePicker014.dateTime}"
+                          pattern="yyyy-MM-dd HH:mm:ss" showTime="true">
+                <f:convertDateTime type="both" pattern="yyyy-MM-dd HH:mm:ss" binding="#{datePicker014.converter}"/>
+            </p:datePicker>
+
+            <p:commandButton id="button" value="Submit" update="@form"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker014Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker014Test.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DatePicker;
+
+public class DatePicker014Test extends AbstractDatePickerTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DatePicker: f:convertDateTime with own converter")
+    public void testFConvertDateTimeVsInternal(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+        LocalDateTime expected = LocalDateTime.of(2021, 1, 10, 1, 16, 04);
+
+        // Assert
+        Assertions.assertEquals(expected, datePicker.getValue());
+
+        // Act
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        Assertions.assertEquals(expected, datePicker.getValue());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datepicker")
+        DatePicker datePicker;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker014.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -306,7 +306,8 @@ public class CalendarUtils {
             if (isGoodConverter(converter, value)) {
                 try {
                     return converter.getAsString(context, calendar, value);
-                } catch (ConverterException ex) {
+                }
+                catch (ConverterException ex) {
                     addBadConverter(converter, value);
                 }
             }
@@ -356,16 +357,16 @@ public class CalendarUtils {
     }
 
     private static void addBadConverter(Converter converter, Object value) {
-      Set<Class<? extends Converter>> converters = BAD_CONVERTERS.computeIfAbsent(value.getClass(), cl -> new HashSet<Class<? extends Converter>>());
-      converters.add(converter.getClass());
+        Set<Class<? extends Converter>> converters = BAD_CONVERTERS.computeIfAbsent(value.getClass(), cl -> new HashSet<Class<? extends Converter>>());
+        converters.add(converter.getClass());
     }
 
     private static boolean isGoodConverter(Converter converter, Object value) {
-      Set<Class<? extends Converter>> converters = BAD_CONVERTERS.get(value.getClass());
-      if (converters == null) {
-        return true;
-      }
-      return ! converters.contains(converter.getClass());
+        Set<Class<? extends Converter>> converters = BAD_CONVERTERS.get(value.getClass());
+        if (converters == null) {
+            return true;
+        }
+        return !converters.contains(converter.getClass());
     }
 
     /**

--- a/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -25,14 +25,25 @@ package org.primefaces.util;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import javax.faces.FacesException;
@@ -51,6 +62,8 @@ public class CalendarUtils {
     private static final String[] TIME_CHARS = {"H", "K", "h", "k", "m", "s"};
 
     private static final PatternConverter PATTERN_CONVERTER = new DateTimePatternConverter();
+
+    private static final Map<Class<?>, Set<Class<? extends Converter>>> BAD_CONVERTERS = new HashMap<>();
 
     private CalendarUtils() {
     }
@@ -290,16 +303,12 @@ public class CalendarUtils {
         //first ask the converter
         Converter converter = calendar.getConverter();
         if (converter != null) {
-            if (converter instanceof javax.faces.convert.DateTimeConverter) {
-                javax.faces.convert.DateTimeConverter nativeConverter = (javax.faces.convert.DateTimeConverter) converter;
-                String dateType = nativeConverter.getType();
-                // only run converter if type for dates match
-                if (value.getClass().getSimpleName().equalsIgnoreCase(dateType)) {
+            if (isGoodConverter(converter, value)) {
+                try {
                     return converter.getAsString(context, calendar, value);
+                } catch (ConverterException ex) {
+                    addBadConverter(converter, value);
                 }
-            }
-            else {
-                return converter.getAsString(context, calendar, value);
             }
         }
 
@@ -344,6 +353,19 @@ public class CalendarUtils {
 
             throw new FacesException("Value could be either String, LocalDate, LocalDateTime, LocalTime, YearMonth or java.util.Date (deprecated)");
         }
+    }
+
+    private static void addBadConverter(Converter converter, Object value) {
+      Set<Class<? extends Converter>> converters = BAD_CONVERTERS.computeIfAbsent(value.getClass(), cl -> new HashSet<Class<? extends Converter>>());
+      converters.add(converter.getClass());
+    }
+
+    private static boolean isGoodConverter(Converter converter, Object value) {
+      Set<Class<? extends Converter>> converters = BAD_CONVERTERS.get(value.getClass());
+      if (converters == null) {
+        return true;
+      }
+      return ! converters.contains(converter.getClass());
     }
 
     /**


### PR DESCRIPTION
Converter.getType() has nothing to do with the type of the value that
the converter can handle. Possible values are for type are 'date',
'time' and 'both'.

Instead, I try to use the converter and if it is not able to convert a
value I put it on a blacklist, so that the next time the Primefaces
codes is used. This is important since the standard DateTimeConverter
does not handle java.time.* classes correct. On the other hand our own
converter should be used for our own date time data types.