### PR TITLE
Fix #8885: GMap Marker icon symbol

### DIFF
--- a/docs/12_0_0/gettingstarted/whatsnew.md
+++ b/docs/12_0_0/gettingstarted/whatsnew.md
@@ -22,6 +22,7 @@ This page contains a list of big features. Please check the GitHub issues for al
   * Added `disableOnAjax` attribute to disable the link during Ajax requests triggered by it.
 * Exporter: added new options for `visibleOnly`, `exportHeader` and `exportFooter` to give better control over output.
 * FileUpload: added `clear()` widget method in SkinSimple mode to clear out selected file.
+* GMap: added `Symbol` which can be used as marker icon.
 * InputMask: added new options for `showMaskOnFocus` and `showMaskOnHover` to give better control over mask.
 * MenuButton
   * Now can be enabled and disabled by its widget.

--- a/docs/migrationguide/12_0_0.md
+++ b/docs/migrationguide/12_0_0.md
@@ -21,6 +21,9 @@
   
 ## Lightbox
   * **Lighbox** is deprecated in favor of **Galleria**. It will be removed in 13.0.0
+
+## GMap
+  * Marker `icon` type is now `Object` instead of `String` (to support `Symbol`).
   
 ## Printer
   * `title` has been removed and you can set the title with the `configuration` property like `configuration="title: 'Nature Image Header', timeout: 1000"`

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/gmap/MarkersView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/gmap/MarkersView.java
@@ -47,9 +47,12 @@ public class MarkersView implements Serializable {
 
         simpleModel.addOverlay(new Marker(new LatLng(36.879466, 30.667648), "Konyaalti"));
         simpleModel.addOverlay(new Marker(new LatLng(36.883707, 30.689216), "Ataturk Parki"));
-        simpleModel.addOverlay(new Marker(new LatLng(36.879703, 30.706707), "Karaalioglu Parki"));
 
-        Marker marker = new Marker(new LatLng(36.885233, 30.702323), "Kaleici");
+        Marker marker3 = new Marker(new LatLng(36.879703, 30.706707), "Karaalioglu Parki");
+        marker3.setIcon("https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png");
+        simpleModel.addOverlay(marker3);
+
+        Marker marker4 = new Marker(new LatLng(36.885233, 30.702323), "Kaleici");
         Symbol symbol = new Symbol(
                 "M10.453 14.016l6.563-6.609-1.406-1.406-5.156 5.203-2.063-2.109-1.406 1.406zM12 2.016q2.906 0 4.945"
               + " 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75"
@@ -59,8 +62,8 @@ public class MarkersView implements Serializable {
         symbol.setFillOpacity(.7);
         symbol.setScale(2.0);
         symbol.setAnchor(new Point(15.0, 30.0));
-        marker.setIcon(symbol);
-        simpleModel.addOverlay(marker);
+        marker4.setIcon(symbol);
+        simpleModel.addOverlay(marker4);
     }
 
     public MapModel getSimpleModel() {

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/gmap/MarkersView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/gmap/MarkersView.java
@@ -32,6 +32,8 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Named;
 import java.io.Serializable;
+import org.primefaces.model.map.Point;
+import org.primefaces.model.map.Symbol;
 
 @Named
 @RequestScoped
@@ -43,17 +45,22 @@ public class MarkersView implements Serializable {
     public void init() {
         simpleModel = new DefaultMapModel();
 
-        //Shared coordinates
-        LatLng coord1 = new LatLng(36.879466, 30.667648);
-        LatLng coord2 = new LatLng(36.883707, 30.689216);
-        LatLng coord3 = new LatLng(36.879703, 30.706707);
-        LatLng coord4 = new LatLng(36.885233, 30.702323);
+        simpleModel.addOverlay(new Marker(new LatLng(36.879466, 30.667648), "Konyaalti"));
+        simpleModel.addOverlay(new Marker(new LatLng(36.883707, 30.689216), "Ataturk Parki"));
+        simpleModel.addOverlay(new Marker(new LatLng(36.879703, 30.706707), "Karaalioglu Parki"));
 
-        //Basic marker
-        simpleModel.addOverlay(new Marker(coord1, "Konyaalti"));
-        simpleModel.addOverlay(new Marker(coord2, "Ataturk Parki"));
-        simpleModel.addOverlay(new Marker(coord3, "Karaalioglu Parki"));
-        simpleModel.addOverlay(new Marker(coord4, "Kaleici"));
+        Marker marker = new Marker(new LatLng(36.885233, 30.702323), "Kaleici");
+        Symbol symbol = new Symbol(
+                "M10.453 14.016l6.563-6.609-1.406-1.406-5.156 5.203-2.063-2.109-1.406 1.406zM12 2.016q2.906 0 4.945"
+              + " 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75"
+              + " 0.797q-0.281-0.328-0.75-0.867t-1.688-2.156-2.133-3.141-1.664-3.445-0.75-3.375q0-2.906"
+              + " 2.039-4.945t4.945-2.039z");
+        symbol.setFillColor("#fff");
+        symbol.setFillOpacity(.7);
+        symbol.setScale(2.0);
+        symbol.setAnchor(new Point(15.0, 30.0));
+        marker.setIcon(symbol);
+        simpleModel.addOverlay(marker);
     }
 
     public MapModel getSimpleModel() {

--- a/primefaces/src/main/java/org/primefaces/component/gmap/GMapRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/gmap/GMapRenderer.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.faces.FacesException;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.behavior.ClientBehavior;
@@ -206,7 +207,8 @@ public class GMapRenderer extends CoreRenderer {
             writer.write(",title:\"" + EscapeUtils.forJavaScript(marker.getTitle()) + "\"");
         }
         if (marker.getIcon() != null) {
-            writer.write(",icon:'" + marker.getIcon() + "'");
+            writer.write(",icon:");
+            encodeIcon(context, marker.getIcon());
         }
         if (marker.getShadow() != null) {
             writer.write(",shadow:'" + marker.getShadow() + "'");
@@ -231,6 +233,46 @@ public class GMapRenderer extends CoreRenderer {
         }
 
         writer.write("})");
+    }
+
+    protected void encodeIcon(FacesContext context, Object icon) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
+        if (icon instanceof String) {
+            writer.write("'" + icon + "'");
+            return;
+        }
+        if (!(icon instanceof Symbol)) {
+            throw new FacesException("Icon must be String or Symbol");
+        }
+        Symbol symbol = (Symbol) icon;
+
+        writer.write("{path:'" + symbol.getPath() + "'");
+        if (symbol.getAnchor() != null) {
+            writer.write(",anchor:new google.maps.Point(" + symbol.getAnchor().getX()
+                    + "," + symbol.getAnchor().getY() + ")");
+        }
+        if (symbol.getFillColor() != null) {
+            writer.write(",fillColor:'" + symbol.getFillColor() + "'");
+        }
+        if (symbol.getFillOpacity() != null) {
+            writer.write(",fillOpacity:" + symbol.getFillOpacity());
+        }
+        if (symbol.getRotation() != null) {
+            writer.write(",rotation:" + symbol.getRotation());
+        }
+        if (symbol.getScale() != null) {
+            writer.write(",scale:" + symbol.getScale());
+        }
+        if (symbol.getStrokeColor() != null) {
+            writer.write(",strokeColor:" + symbol.getStrokeColor());
+        }
+        if (symbol.getStrokeOpacity() != null) {
+            writer.write(",strokeOpacity:" + symbol.getStrokeOpacity());
+        }
+        if (symbol.getStrokeWeight() != null) {
+            writer.write(",strokeWeight:" + symbol.getStrokeWeight());
+        }
+        writer.write("}");
     }
 
     protected void encodePolylines(FacesContext context, GMap map) throws IOException {

--- a/primefaces/src/main/java/org/primefaces/component/gmap/GMapRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/gmap/GMapRenderer.java
@@ -239,13 +239,17 @@ public class GMapRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         if (icon instanceof String) {
             writer.write("'" + icon + "'");
-            return;
         }
-        if (!(icon instanceof Symbol)) {
-            throw new FacesException("Icon must be String or Symbol");
+        else if (icon instanceof Symbol) {
+            encodeIcon(context, (Symbol) icon);
         }
-        Symbol symbol = (Symbol) icon;
+        else {
+            throw new FacesException("GMap marker icon must be String or Symbol");
+        }
+    }
 
+    protected void encodeIcon(FacesContext context, Symbol symbol) throws IOException {
+        ResponseWriter writer = context.getResponseWriter();
         writer.write("{path:'" + symbol.getPath() + "'");
         if (symbol.getAnchor() != null) {
             writer.write(",anchor:new google.maps.Point(" + symbol.getAnchor().getX()
@@ -264,7 +268,7 @@ public class GMapRenderer extends CoreRenderer {
             writer.write(",scale:" + symbol.getScale());
         }
         if (symbol.getStrokeColor() != null) {
-            writer.write(",strokeColor:" + symbol.getStrokeColor());
+            writer.write(",strokeColor:'" + symbol.getStrokeColor() + "'");
         }
         if (symbol.getStrokeOpacity() != null) {
             writer.write(",strokeOpacity:" + symbol.getStrokeOpacity());

--- a/primefaces/src/main/java/org/primefaces/model/map/Marker.java
+++ b/primefaces/src/main/java/org/primefaces/model/map/Marker.java
@@ -35,6 +35,10 @@ public class Marker extends Overlay {
 
     private boolean flat;
 
+    /**
+     * Either a URL (as {@link String}) pointing to an image file or {@link Symbol} to display instead of the default
+     * Google Maps pushpin icon.
+     */
     private Object icon;
 
     private LatLng latlng;

--- a/primefaces/src/main/java/org/primefaces/model/map/Marker.java
+++ b/primefaces/src/main/java/org/primefaces/model/map/Marker.java
@@ -35,7 +35,7 @@ public class Marker extends Overlay {
 
     private boolean flat;
 
-    private String icon;
+    private Object icon;
 
     private LatLng latlng;
 
@@ -119,11 +119,11 @@ public class Marker extends Overlay {
         this.flat = flat;
     }
 
-    public String getIcon() {
+    public Object getIcon() {
         return icon;
     }
 
-    public void setIcon(String icon) {
+    public void setIcon(Object icon) {
         this.icon = icon;
     }
 

--- a/primefaces/src/main/java/org/primefaces/model/map/Point.java
+++ b/primefaces/src/main/java/org/primefaces/model/map/Point.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.model.map;
+
+import java.io.Serializable;
+
+public class Point implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private double x;
+
+    private double y;
+
+    public Point() {
+        // NOOP
+    }
+
+    public Point(double x, double y) {
+        this();
+        this.x = x;
+        this.y = y;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getY() {
+        return y;
+    }
+
+    public void setY(double y) {
+        this.y = y;
+    }
+
+    @Override
+    public String toString() {
+        return "Point{" + "x=" + x + ", y=" + y + '}';
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 79 * hash + (int) (Double.doubleToLongBits(this.x) ^ (Double.doubleToLongBits(this.x) >>> 32));
+        hash = 79 * hash + (int) (Double.doubleToLongBits(this.y) ^ (Double.doubleToLongBits(this.y) >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Point other = (Point) obj;
+        if (Double.doubleToLongBits(this.x) != Double.doubleToLongBits(other.x)) {
+            return false;
+        }
+        return Double.doubleToLongBits(this.y) == Double.doubleToLongBits(other.y);
+    }
+
+}

--- a/primefaces/src/main/java/org/primefaces/model/map/Symbol.java
+++ b/primefaces/src/main/java/org/primefaces/model/map/Symbol.java
@@ -1,0 +1,237 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2021 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.model.map;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class Symbol implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Path defining the shape of the symbol. You can define a custom path using SVG path notation. Note: Vector paths
+     * on a polyline must fit within a 22x22px square. If your path includes points outside this square, then you must
+     * adjust the symbol's scale property to a fractional value, such as 0.2, so that the resulting scaled points fit
+     * within the square.
+     */
+    private String path;
+
+    /**
+     * Position of the symbol relative to the marker or polyline. The coordinates of the symbol's path are translated
+     * left and up by the anchor's x and y coordinates respectively. By default, a symbol is anchored at (0, 0). The
+     * position is expressed in the same coordinate system as the symbol's path.
+     */
+    private Point anchor;
+
+    /**
+     * Color of the symbol's fill (that is, the region bordered by the stroke). All CSS3 colors are supported except for
+     * extended named colors. For symbols on markers, the default is 'black'. For symbols on polylines, the default is
+     * the stroke color of the corresponding polyline.
+     */
+    private String fillColor;
+
+    /**
+     * Relative opacity (that is, lack of transparency) of the symbol's fill. The values range from 0.0 (fully
+     * transparent) to 1.0 (fully opaque). The default is 0.0.
+     */
+    private Double fillOpacity;
+
+    /**
+     * Angle by which to rotate the symbol, expressed clockwise in degrees. By default, a symbol marker has a rotation
+     * of 0, and a symbol on a polyline is rotated by the angle of the edge on which it lies. Setting the rotation of a
+     * symbol on a polyline will fix the rotation of the symbol such that it will no longer follow the curve of the
+     * line.
+     */
+    private Double rotation;
+
+    /**
+     * Amount by which the symbol is scaled in size. For symbol markers, the default scale is 1. After scaling the
+     * symbol may be of any size. For symbols on a polyline, the default scale is the stroke weight of the polyline.
+     * After scaling, the symbol must lie inside a 22x22px square, centered at the symbol's anchor.
+     */
+    private Double scale;
+
+    /**
+     * Color of the symbol's outline. All CSS3 colors are supported except for extended named colors. For symbols on
+     * markers, the default is 'black'. For symbols on a polyline, the default color is the stroke color of the
+     * polyline.
+     */
+    private String strokeColor;
+
+    /**
+     * Relative opacity (that is, lack of transparency) of the symbol's stroke. The values range from 0.0 (fully
+     * transparent) to 1.0 (fully opaque). For symbol markers, the default is 1.0. For symbols on polylines, the default
+     * is the stroke opacity of the polyline.
+     */
+    private Double strokeOpacity;
+
+    /**
+     * Weight of the symbol's outline. The default is the scale of the symbol.
+     */
+    private Double strokeWeight;
+
+    public Symbol() {
+        // NOOP
+    }
+
+    public Symbol(String path) {
+        this();
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Point getAnchor() {
+        return anchor;
+    }
+
+    public void setAnchor(Point anchor) {
+        this.anchor = anchor;
+    }
+
+    public String getFillColor() {
+        return fillColor;
+    }
+
+    public void setFillColor(String fillColor) {
+        this.fillColor = fillColor;
+    }
+
+    public Double getFillOpacity() {
+        return fillOpacity;
+    }
+
+    public void setFillOpacity(Double fillOpacity) {
+        this.fillOpacity = fillOpacity;
+    }
+
+    public Double getRotation() {
+        return rotation;
+    }
+
+    public void setRotation(Double rotation) {
+        this.rotation = rotation;
+    }
+
+    public Double getScale() {
+        return scale;
+    }
+
+    public void setScale(Double scale) {
+        this.scale = scale;
+    }
+
+    public String getStrokeColor() {
+        return strokeColor;
+    }
+
+    public void setStrokeColor(String strokeColor) {
+        this.strokeColor = strokeColor;
+    }
+
+    public Double getStrokeOpacity() {
+        return strokeOpacity;
+    }
+
+    public void setStrokeOpacity(Double strokeOpacity) {
+        this.strokeOpacity = strokeOpacity;
+    }
+
+    public Double getStrokeWeight() {
+        return strokeWeight;
+    }
+
+    public void setStrokeWeight(Double strokeWeight) {
+        this.strokeWeight = strokeWeight;
+    }
+
+    @Override
+    public String toString() {
+        return "Symbol{" + "path=" + path + ", anchor=" + anchor + ", fillColor=" + fillColor + ", fillOpacity="
+                + fillOpacity + ", rotation=" + rotation + ", scale=" + scale + ", strokeColor=" + strokeColor
+                + ", strokeOpacity=" + strokeOpacity + ", strokeWeight=" + strokeWeight + '}';
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 97 * hash + Objects.hashCode(this.path);
+        hash = 97 * hash + Objects.hashCode(this.anchor);
+        hash = 97 * hash + Objects.hashCode(this.fillColor);
+        hash = 97 * hash + Objects.hashCode(this.fillOpacity);
+        hash = 97 * hash + Objects.hashCode(this.rotation);
+        hash = 97 * hash + Objects.hashCode(this.scale);
+        hash = 97 * hash + Objects.hashCode(this.strokeColor);
+        hash = 97 * hash + Objects.hashCode(this.strokeOpacity);
+        hash = 97 * hash + Objects.hashCode(this.strokeWeight);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Symbol other = (Symbol) obj;
+        if (!Objects.equals(this.path, other.path)) {
+            return false;
+        }
+        if (!Objects.equals(this.fillColor, other.fillColor)) {
+            return false;
+        }
+        if (!Objects.equals(this.strokeColor, other.strokeColor)) {
+            return false;
+        }
+        if (!Objects.equals(this.anchor, other.anchor)) {
+            return false;
+        }
+        if (!Objects.equals(this.fillOpacity, other.fillOpacity)) {
+            return false;
+        }
+        if (!Objects.equals(this.rotation, other.rotation)) {
+            return false;
+        }
+        if (!Objects.equals(this.scale, other.scale)) {
+            return false;
+        }
+        if (!Objects.equals(this.strokeOpacity, other.strokeOpacity)) {
+            return false;
+        }
+        return Objects.equals(this.strokeWeight, other.strokeWeight);
+    }
+
+}


### PR DESCRIPTION
Fix #8885

```java
simpleModel = new DefaultMapModel();

simpleModel.addOverlay(new Marker(new LatLng(36.879466, 30.667648), "Konyaalti"));
simpleModel.addOverlay(new Marker(new LatLng(36.883707, 30.689216), "Ataturk Parki"));

Marker marker3 = new Marker(new LatLng(36.879703, 30.706707), "Karaalioglu Parki");
marker3.setIcon("https://developers.google.com/maps/documentation/javascript/examples/full/images/beachflag.png");
simpleModel.addOverlay(marker3);

Marker marker4 = new Marker(new LatLng(36.885233, 30.702323), "Kaleici");
Symbol symbol = new Symbol(
        "M10.453 14.016l6.563-6.609-1.406-1.406-5.156 5.203-2.063-2.109-1.406 1.406zM12 2.016q2.906 0 4.945"
      + " 2.039t2.039 4.945q0 1.453-0.727 3.328t-1.758 3.516-2.039 3.070-1.711 2.273l-0.75"
      + " 0.797q-0.281-0.328-0.75-0.867t-1.688-2.156-2.133-3.141-1.664-3.445-0.75-3.375q0-2.906"
      + " 2.039-4.945t4.945-2.039z");
symbol.setFillColor("#fff");
symbol.setFillOpacity(.7);
symbol.setScale(2.0);
symbol.setAnchor(new Point(15.0, 30.0));
marker4.setIcon(symbol);
simpleModel.addOverlay(marker4);
```

<img width="309" alt="Screenshot 2022-06-17 at 08 39 11" src="https://user-images.githubusercontent.com/7500178/174240302-8f69464c-bbfe-4567-93f6-c3452b790731.png">
