### PR TITLE
Fix #8912: DatePicker default view date inside min-max range

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker010.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker010.xhtml
@@ -14,6 +14,12 @@
         <h:form id="form">
             <p:datePicker id="datepicker" value="02.06.2021"
                           mindate="27.05.2021" maxdate="10.06.2021" pattern="dd.MM.yyyy"/>
+                          
+            <!-- GitHub #8912 default view date with no value should be October 2021 not NOW -->
+            <p:datePicker id="maxdate" maxdate="17.10.2021" pattern="dd.MM.yyyy"/>
+            
+            <!-- GitHub #8912 default view date with no value should be August 2034 not NOW -->
+            <p:datePicker id="mindate" mindate="08.08.2034" pattern="dd.MM.yyyy"/>
         </h:form>
 
     </h:body>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker010Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker010Test.java
@@ -24,9 +24,11 @@
 package org.primefaces.integrationtests.datepicker;
 
 import java.time.LocalDate;
+
 import org.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -38,6 +40,7 @@ public class DatePicker010Test extends AbstractDatePickerTest {
 
     @Test
     @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    @Order(1)
     public void testMinMax(Page page) {
         // Arrange
         DatePicker datePicker = page.datePicker;
@@ -63,6 +66,7 @@ public class DatePicker010Test extends AbstractDatePickerTest {
 
     @Test
     @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    @Order(1)
     public void testMinMaxValueInside(Page page) {
         // Arrange
         DatePicker datePicker = page.datePicker;
@@ -86,6 +90,7 @@ public class DatePicker010Test extends AbstractDatePickerTest {
 
     @Test
     @DisplayName("DatePicker: minDate and maxDate; See GitHub #7576")
+    @Order(1)
     public void testMinMaxValueOutside(Page page) {
         // Arrange
         DatePicker datePicker = page.datePicker;
@@ -107,6 +112,36 @@ public class DatePicker010Test extends AbstractDatePickerTest {
         assertConfiguration(datePicker.getWidgetConfiguration());
     }
 
+    @Test
+    @DisplayName("DatePicker: maxDate after now default view to max date; See GitHub #8912")
+    @Order(2)
+    public void testViewDateisMaxDate(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePickerMaxDate;
+
+        // Act
+        datePicker.click(); // focus to bring up panel
+
+        // Assert
+        assertDate(datePicker.showPanel(), "October", "2021");
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @DisplayName("DatePicker: minDate after now default view to min date; See GitHub #8912")
+    @Order(3)
+    public void testViewDateisMinDate(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePickerMinDate;
+
+        // Act
+        datePicker.click(); // focus to bring up panel
+
+        // Assert
+        assertDate(datePicker.showPanel(), "August", "2034");
+        assertNoJavascriptErrors();
+    }
+
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
         System.out.println("DatePicker Config = " + cfg);
@@ -120,6 +155,12 @@ public class DatePicker010Test extends AbstractDatePickerTest {
     public static class Page extends AbstractPrimePage {
         @FindBy(id = "form:datepicker")
         DatePicker datePicker;
+
+        @FindBy(id = "form:maxdate")
+        DatePicker datePickerMaxDate;
+
+        @FindBy(id = "form:mindate")
+        DatePicker datePickerMinDate;
 
         @Override
         public String getLocation() {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -186,7 +186,7 @@
             this.options.maxDate = this.parseMinMaxValue(this.options.maxDate);
             this.ticksTo1970 = (((1970 - 1) * 365 + Math.floor(1970 / 4) - Math.floor(1970 / 100) + Math.floor(1970 / 400)) * 24 * 60 * 60 * 10000000);
 
-            if (this.options.timeOnly && viewDateDefaultsToNow) {
+            if (viewDateDefaultsToNow) {
                 if (this.options.minDate) {
                     if (this.viewDate < this.options.minDate) {
                         this.viewDate = new Date(this.options.minDate.getTime());


### PR DESCRIPTION
This ticket from @christophs78 already had this code in there but was only doing it for Time Only mode.  It now does it for both modes so the default view date is not `new Date()` if it does not fit inside the min max range.

Original Ticket: https://github.com/primefaces/primefaces/issues/5334