### PR TITLE
Fix #76: TabMenu: Add orientation

### DIFF
--- a/docs/12_0_0/components/tabmenu.md
+++ b/docs/12_0_0/components/tabmenu.md
@@ -27,6 +27,7 @@ style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 activeIndex | 0 | Integer | Index of the active tab.
 widgetVar | null | String | Name of the client side widget.
+orientation | top | String | Orientation of the tab items relative to where you want to put the content, valid values are "top" (default), "left", "right" and "bottom".
 
 ## Getting started with TabMenu
 TabMenu requires menuitems as children components, each menuitem is rendered as a tab. Just like

--- a/docs/12_0_0/gettingstarted/whatsnew.md
+++ b/docs/12_0_0/gettingstarted/whatsnew.md
@@ -36,6 +36,7 @@ This page contains a list of big features. Please check the GitHub issues for al
   * Now can be enabled and disabled by its widget.
   * Added `disableOnAjax` attribute to disable the button during Ajax requests triggered by it or its menu items.
   * Added Ajax load indicator (spinner) within the button during Ajax requests triggered by it.
+* TabMenu: added `orientation` (of the tab items relative to where you want to put the content) attribute.
 * TabView: added `ui-state-error` class to tabs that contain invalid inputs.
 * Tree: added `filterFunction` attribute for custom filtering.
 * ToggleSwitch: added `onIcon` and `offIcon` attributes

--- a/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
@@ -39,23 +39,8 @@
         </div>
 
         <div class="card">
-            <h5 class="mt-0">Vertical</h5>
-            <style>
-                body .ui-tabmenu.vertical .ui-tabmenu-nav {
-                    flex-direction: column;
-                }
-                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem {
-                    border-bottom: 0;
-                    border-right: 2px solid var(--surface-d);
-                }
-                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover {
-                    border-right-color: var(--text-color-secondary);
-                }
-                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active {
-                    border-right-color: var(--primary-color);
-                }
-            </style>
-            <p:tabMenu activeIndex="#{param.i}" style="width:15rem" styleClass="vertical">
+            <h5 class="mt-0">Orientation Left</h5>
+            <p:tabMenu activeIndex="#{param.i}" style="width:15rem" orientation="left">
                 <p:menuitem value="Home" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-home">
                     <f:param name="i" value="0"/>
                 </p:menuitem>

--- a/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
@@ -57,6 +57,35 @@
                     <f:param name="i" value="4"/>
                 </p:menuitem>
             </p:tabMenu>
+            <style>
+                body .ui-tabmenu:is(.ui-tabs-left, .ui-tabs-right) .ui-tabmenu-nav {
+                    flex-direction: column;
+                }
+                body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-width: 0;
+                    border-style: solid;
+                    border-color: var(--surface-d);
+                    border-bottom-width: 2px;
+                }
+                body .ui-tabmenu:not(.ui-tabs-top) .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-bottom-width: 0;
+                }
+                body .ui-tabmenu.ui-tabs-left .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-right-width: 2px;
+                }
+                body .ui-tabmenu.ui-tabs-right .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-left-width: 2px;
+                }
+                body .ui-tabmenu.ui-tabs-bottom .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-top-width: 2px;
+                }
+                body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover {
+                    border-color: var(--text-color-secondary);
+                }
+                body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active {
+                    border-color: var(--primary-color);
+                }
+            </style>
         </div>
     </ui:define>
 

--- a/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
@@ -18,7 +18,44 @@
 
     <ui:define name="implementation">
         <div class="card">
+            <h5 class="mt-0">Basic</h5>
             <p:tabMenu activeIndex="#{param.i}">
+                <p:menuitem value="Home" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-home">
+                    <f:param name="i" value="0"/>
+                </p:menuitem>
+                <p:menuitem value="Calendar" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-calendar">
+                    <f:param name="i" value="1"/>
+                </p:menuitem>
+                <p:menuitem value="Edit" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-pencil">
+                    <f:param name="i" value="2"/>
+                </p:menuitem>
+                <p:menuitem value="Documentation" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-file">
+                    <f:param name="i" value="3"/>
+                </p:menuitem>
+                <p:menuitem value="Settings" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-cog">
+                    <f:param name="i" value="4"/>
+                </p:menuitem>
+            </p:tabMenu>
+        </div>
+
+        <div class="card">
+            <h5 class="mt-0">Vertical</h5>
+            <style>
+                body .ui-tabmenu.vertical .ui-tabmenu-nav {
+                    flex-direction: column;
+                }
+                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem {
+                    border-bottom: 0;
+                    border-right: 2px solid var(--surface-d);
+                }
+                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover {
+                    border-right-color: var(--text-color-secondary);
+                }
+                body .ui-tabmenu.vertical .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active {
+                    border-right-color: var(--primary-color);
+                }
+            </style>
+            <p:tabMenu activeIndex="#{param.i}" style="width:15rem" styleClass="vertical">
                 <p:menuitem value="Home" outcome="/ui/menu/tabMenu" icon="pi pi-fw pi-home">
                     <f:param name="i" value="0"/>
                 </p:menuitem>

--- a/primefaces/src/main/java/org/primefaces/component/tabmenu/TabMenuBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabmenu/TabMenuBase.java
@@ -38,7 +38,8 @@ public abstract class TabMenuBase extends AbstractMenu implements Widget {
         model,
         style,
         styleClass,
-        activeIndex
+        activeIndex,
+        orientation
     }
 
     public TabMenuBase() {
@@ -89,5 +90,13 @@ public abstract class TabMenuBase extends AbstractMenu implements Widget {
 
     public void setActiveIndex(int activeIndex) {
         getStateHelper().put(PropertyKeys.activeIndex, activeIndex);
+    }
+
+    public String getOrientation() {
+        return (String) getStateHelper().eval(PropertyKeys.orientation, "top");
+    }
+
+    public void setOrientation(String orientation) {
+        getStateHelper().put(PropertyKeys.orientation, orientation);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/tabmenu/TabMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabmenu/TabMenuRenderer.java
@@ -52,8 +52,11 @@ public class TabMenuRenderer extends BaseMenuRenderer {
         ResponseWriter writer = context.getResponseWriter();
         TabMenu menu = (TabMenu) component;
         String clientId = menu.getClientId(context);
-        String styleClass = menu.getStyleClass();
-        styleClass = styleClass == null ? TabMenu.CONTAINER_CLASS : TabMenu.CONTAINER_CLASS + " " + styleClass;
+        String styleClass = getStyleClassBuilder(context)
+                .add(TabMenu.CONTAINER_CLASS)
+                .add("ui-tabs-" + menu.getOrientation())
+                .add(menu.getStyleClass())
+                .build();
         int activeIndex = menu.getActiveIndex();
         List<?> elements = menu.getElements();
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -27576,6 +27576,14 @@
             <required>false</required>
             <type>java.lang.Integer</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Orientation of the tab items relative to where you want to put the content, valid values are "top" (default), "left", "right" and "bottom".]]>
+            </description>
+            <name>orientation</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>
@@ -27718,7 +27726,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Orientation of the tab headers, valid values are "top" and "bottom".]]>
+                <![CDATA[Orientation of the tab headers, valid values are "top" (default), "left", "right" and "bottom".]]>
             </description>
             <name>orientation</name>
             <required>false</required>


### PR DESCRIPTION
Fix #76 

However, this will require a (simple) fix to the themes to add styling. The example CSS in the issue overrides theme CSS, so it could not be added to a PR.

Reference CSS for @mertsincan (also put in the showcase.. should be removed from there when added to the themes)
```css
body .ui-tabmenu:is(.ui-tabs-left, .ui-tabs-right) .ui-tabmenu-nav {
    flex-direction: column;
}
body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem {
    border-width: 0;
    border-style: solid;
    border-color: var(--surface-d);
    border-bottom-width: 2px;
}
body .ui-tabmenu:not(.ui-tabs-top) .ui-tabmenu-nav .ui-tabmenuitem {
    border-bottom-width: 0;
}
body .ui-tabmenu.ui-tabs-left .ui-tabmenu-nav .ui-tabmenuitem {
    border-right-width: 2px;
}
body .ui-tabmenu.ui-tabs-right .ui-tabmenu-nav .ui-tabmenuitem {
    border-left-width: 2px;
}
body .ui-tabmenu.ui-tabs-bottom .ui-tabmenu-nav .ui-tabmenuitem {
    border-top-width: 2px;
}
body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-hover {
    border-color: var(--text-color-secondary);
}
body .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-active {
    border-color: var(--primary-color);
}
```