### PR TITLE
Fixes #8941: allow absolute path in native mode

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/file/NativeUploadedFile.java
+++ b/primefaces/src/main/java/org/primefaces/model/file/NativeUploadedFile.java
@@ -23,7 +23,6 @@
  */
 package org.primefaces.model.file;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.primefaces.shaded.owasp.SafeFile;
 import org.primefaces.util.FileUploadUtils;
@@ -101,7 +100,7 @@ public class NativeUploadedFile implements UploadedFile, Serializable {
     @Override
     public void write(String filePath) throws Exception {
         SafeFile file = new SafeFile(filePath);
-        String validFileName = FileUploadUtils.getValidFilename(FilenameUtils.getName(file.getPath()));
+        String validFileName = FileUploadUtils.getValidFilePath(file.getCanonicalPath());
         part.write(validFileName);
     }
 


### PR DESCRIPTION
javax.servlet.http.Part supports passing an absolute path on write method, so NativeUploadedFile should also support it.