### PR TITLE
Fix #8958: Spinner allow non printable characters F12 etc

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -147,16 +147,15 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
                     $this.format();
                 break;
 
-                case keyCode.BACKSPACE:
-                case keyCode.DELETE:
-                case keyCode.LEFT:
-                case keyCode.RIGHT:
-                case keyCode.TAB:
-                    return;
-
                 default:
                     //do nothing
                 break;
+            }
+
+            // #8958 allow TAB, F1, F12 etc
+            var isPrintableKey = e.key.length === 1 || e.key === 'Unidentified';
+            if (!isPrintableKey) {
+                return;
             }
 
             /* Github #1964 do not allow minus */


### PR DESCRIPTION
Found on Stack overflow: 

`let isPrintableKey = event.key.length === 1 || event.key === 'Unidentified';`
If you do not include: `|| event.key === 'Unidentified'` your code will not work on mobile browsers.

https://stackoverflow.com/a/70866532