### PR TITLE
Fix #8950: DatePicker: year navigator input type number

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker011Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker011Test.java
@@ -293,7 +293,7 @@ public class DatePicker011Test extends AbstractDatePickerTest {
         }
 
         // Act - 7th next year via year drop down
-        datePicker.selectYearDropdown(LocalDate.now().getYear() + 1);
+        datePicker.navigateYear(LocalDate.now().getYear() + 1);
 
         // Assert
         PrimeSelenium.wait(SAFETY_WAIT_AFTER_DOUBLE_AJAX_CALL_MILLISECONDS);

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
@@ -287,7 +287,7 @@ public abstract class DatePicker extends AbstractInputComponent {
     }
 
     /**
-     * Select a month from the drodown.
+     * Select a month from the dropdown.
      *
      * @param month the month to select
      */
@@ -297,21 +297,16 @@ public abstract class DatePicker extends AbstractInputComponent {
     }
 
     /**
-     * Open the year select dropdown.
-     */
-    public void toggleYearDropdown() {
-        WebElement yearDropDown = showPanel().findElement(By.cssSelector("select.ui-datepicker-year"));
-        yearDropDown.click();
-    }
-
-    /**
-     * Select a year from the drodown.
+     * Navigate to a year.
      *
-     * @param year the year to select
+     * @param year the year to navigate to
      */
-    public void selectYearDropdown(int year) {
-        Select yearDropDown = new Select(showPanel().findElement(By.cssSelector("select.ui-datepicker-year")));
-        yearDropDown.selectByValue(Integer.toString(year));
+    public void navigateYear(int year) {
+        PrimeSelenium.replaceInput(
+                showPanel().findElement(By.cssSelector("input.ui-datepicker-year")),
+                String.valueOf(year),
+                true,
+                100);
     }
 
 }

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
@@ -465,31 +465,53 @@ public final class PrimeSelenium {
      * @see <a href="https://stackoverflow.com/a/64067604/502366">Safari Hack</a>
      */
     public static void clearInput(WebElement input, boolean isAjaxified) {
+        replaceInput(input, "", isAjaxified);
+    }
+
+    /**
+     * Replaces the input field of text.
+     *
+     * @param input the WebElement input to replace the input of
+     * @param value the value to replace the input value with
+     * @param isAjaxified true if using AJAX
+     */
+    public static void replaceInput(WebElement input, String value, boolean isAjaxified) {
+        replaceInput(input, value, isAjaxified, 0);
+    }
+
+    /**
+     * Replaces the input field of text.
+     *
+     * @param input the WebElement input to replace the input of
+     * @param value the value to replace the input value with
+     * @param isAjaxified true if using AJAX
+     * @param delayInMilliseconds how long to delay before expecting an AJAX event
+     */
+    public static void replaceInput(WebElement input, String value, boolean isAjaxified, int delayInMilliseconds) {
         if (PrimeSelenium.isSafari()) {
             // Safari hack https://stackoverflow.com/a/64067604/502366
             String inputText = input.getAttribute("value");
             if (inputText != null && inputText.length() > 0) {
-                CharSequence[] clearText = new CharSequence[inputText.length()];
-                for (int i = 0; i < inputText.length(); i++) {
-                    clearText[i] = Keys.BACK_SPACE;
-                }
+                StringBuilder keys = new StringBuilder();
+                keys.append(Keys.BACK_SPACE, 0, inputText.length() - 1);
+                keys.append(value);
                 if (isAjaxified) {
-                    guardAjax(input).sendKeys(clearText);
+                    guardAjax(input, delayInMilliseconds).sendKeys(keys);
                 }
                 else {
-                    input.sendKeys(clearText);
+                    input.sendKeys(keys);
                 }
             }
         }
         else {
-            // CTRL+A then BACKSPACE
+            // CTRL+A then value
             Keys command = PrimeSelenium.isMacOs() ? Keys.COMMAND : Keys.CONTROL;
             input.sendKeys(Keys.chord(command, "a"));
             if (isAjaxified) {
-                guardAjax(input).sendKeys(Keys.BACK_SPACE);
+                guardAjax(input, delayInMilliseconds).sendKeys(value);
             }
             else {
-                input.sendKeys(Keys.BACK_SPACE);
+                input.sendKeys(value);
             }
         }
     }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -1341,7 +1341,7 @@
 
         renderTitleMonthElement: function (month, index) {
             if (this.options.monthNavigator && this.options.view !== 'month' && index === 0) {
-                return '<select class="ui-datepicker-month">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
+                return '<select class="ui-datepicker-month">' + this.renderTitleOptions(this.options.locale.monthNamesShort, month) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-month">' + this.escapeHTML(this.options.locale.monthNames[month]) + '</span>' + '&#xa0;';
@@ -1351,40 +1351,26 @@
         renderTitleYearElement: function (year, index) {
             if (this.options.yearNavigator && index === 0) {
                 this.updateYearNavigator();
-                var yearOptions = [],
-                    years = this.options.yearRange.split(':'),
+                var years = this.options.yearRange.split(':'),
                     yearStart = parseInt(years[0], 10),
                     yearEnd = parseInt(years[1], 10);
 
-                for (var i = yearStart; i <= yearEnd; i++) {
-                    yearOptions.push(i);
-                }
-
-                return '<select class="ui-datepicker-year">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
+                return '<input class="ui-datepicker-year" type="number" min="' + yearStart +
+                        '" max="' + yearEnd + '" step="1" value="' + year + '"/>';
             }
             else {
                 return '<span class="ui-datepicker-year">' + year + '</span>';
             }
         },
 
-        renderTitleOptions: function (name, options, current) {
+        renderTitleOptions: function (options, current) {
             var _options = '',
                 minDate = this.options.minDate,
                 maxDate = this.options.maxDate;
 
             for (var i = 0; i < options.length; i++) {
-                switch(name) {
-                    case 'month':
-                        if ((!this.isInMinYear() || i >= minDate.getMonth()) && (!this.isInMaxYear() || i <= maxDate.getMonth())) {
-                            _options += '<option value="' + i + '"' + (i === current ? ' selected' : '') + '>' + this.escapeHTML(options[i]) + '</option>';
-                        }
-                        break;
-                    case 'year':
-                        var option = options[i];
-                        if (!(minDate && minDate.getFullYear() > option) && !(maxDate && maxDate.getFullYear() < option)) {
-                            _options += '<option value="' +  option + '"' + (option === current ? ' selected' : '') + '>' +  option + '</option>';
-                        }
-                        break;
+                if ((!this.isInMinYear() || i >= minDate.getMonth()) && (!this.isInMaxYear() || i <= maxDate.getMonth())) {
+                    _options += '<option value="' + i + '"' + (i === current ? ' selected' : '') + '>' + this.escapeHTML(options[i]) + '</option>';
                 }
             }
 
@@ -1701,9 +1687,9 @@
             this.panel.off('click.datePicker-navForward', navForwardSelector).on('click.datePicker-navForward', navForwardSelector, null, this.navForward.bind($this));
 
             var monthNavigatorSelector = '.ui-datepicker-header > .ui-datepicker-title > .ui-datepicker-month',
-                yearNavigatorSelector = '.ui-datepicker-header > .ui-datepicker-title > .ui-datepicker-year';
+                yearNavigator = '.ui-datepicker-header > .ui-datepicker-title > .ui-datepicker-year';
             this.panel.off('change.datePicker-monthNav', monthNavigatorSelector).on('change.datePicker-monthNav', monthNavigatorSelector, null, this.onMonthDropdownChange.bind($this));
-            this.panel.off('change.datePicker-yearNav', yearNavigatorSelector).on('change.datePicker-yearNav', yearNavigatorSelector, null, this.onYearDropdownChange.bind($this));
+            this.panel.off('change.datePicker-yearNav', yearNavigator).on('change.datePicker-yearNav', yearNavigator, null, this.onYearChange.bind($this));
 
             var monthViewMonthSelector = '.ui-monthpicker > .ui-monthpicker-month';
             this.panel.off('change.datePicker-monthViewMonth', monthViewMonthSelector).on('click.datePicker-monthViewMonth', monthViewMonthSelector, null, function (e) {
@@ -1878,7 +1864,7 @@
             this.updateViewDate(event, newViewDate);
         },
 
-        onYearDropdownChange: function (event) {
+        onYearChange: function (event) {
             var newViewDate = new Date(this.viewDate.getTime());
             newViewDate.setFullYear(parseInt(event.target.value, 10));
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
@@ -113,3 +113,12 @@
 .p-datepicker-panel .ui-datepicker-buttonbar .ui-g-6 {
     text-align: center;
 }
+
+input.ui-datepicker-year {
+    -moz-appearance: auto !important;
+}
+
+input.ui-datepicker-year::-webkit-outer-spin-button,
+input.ui-datepicker-year::-webkit-inner-spin-button {
+    -webkit-appearance: auto !important;
+}


### PR DESCRIPTION
Fix #8950

This is working. However, somehow the spinner buttons are not showing on the input number. I don't get why. After some research it looks like they could be disabled by CSS, but I cannot find where. They are not inspectable using the DOM inspector (at least I didn't find a way), so it's hard to debug.