### PR TITLE
Fix #8997: ToggleSwitch: Align icons (animation) with SpeedDial

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/toggleswitch/ToggleSwitchRenderer.java
@@ -24,7 +24,6 @@
 package org.primefaces.component.toggleswitch;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -33,6 +32,7 @@ import javax.faces.context.ResponseWriter;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 public class ToggleSwitchRenderer extends InputRenderer {
@@ -67,12 +67,13 @@ public class ToggleSwitchRenderer extends InputRenderer {
         boolean checked = Boolean.parseBoolean(ComponentUtils.getValueToRender(context, toggleSwitch));
         boolean disabled = toggleSwitch.isDisabled();
         String style = toggleSwitch.getStyle();
-        String styleClass = toggleSwitch.getStyleClass();
-        styleClass = (styleClass == null) ? ToggleSwitch.CONTAINER_CLASS : ToggleSwitch.CONTAINER_CLASS + " " + styleClass;
-        styleClass = (checked) ? styleClass + " " + ToggleSwitch.CHECKED_CLASS : styleClass;
-        if (disabled) {
-            styleClass = styleClass + " ui-state-disabled";
-        }
+        String styleClass = getStyleClassBuilder(context)
+                .add(ToggleSwitch.CONTAINER_CLASS)
+                .add(toggleSwitch.getStyleClass())
+                .add(checked, ToggleSwitch.CHECKED_CLASS)
+                .add(disabled, "ui-state-disabled")
+                .add(toggleSwitch.getOffIcon() != null, "ui-toggleswitch-dual-icon")
+                .build();
 
         writer.startElement("div", toggleSwitch);
         writer.writeAttribute("id", clientId, "id");
@@ -90,13 +91,27 @@ public class ToggleSwitchRenderer extends InputRenderer {
 
     protected void encodeSlider(FacesContext context, ToggleSwitch toggleSwitch, boolean checked) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
-        String icon = checked ? toggleSwitch.getOnIcon() : toggleSwitch.getOffIcon();
 
         writer.startElement("div", null);
         writer.writeAttribute("class", ToggleSwitch.SLIDER_CLASS, null);
 
         writer.startElement("span", null);
-        writer.writeAttribute("class", ToggleSwitch.HANDLER_CLASS + " " + Objects.toString(icon, ""), null);
+        writer.writeAttribute("class", ToggleSwitch.HANDLER_CLASS, null);
+
+        // on icon
+        if (LangUtils.isNotEmpty(toggleSwitch.getOnIcon())) {
+            writer.startElement("span", null);
+            writer.writeAttribute("class", toggleSwitch.getOnIcon(), null);
+            writer.endElement("span");
+        }
+
+        // off icon
+        if (LangUtils.isNotEmpty(toggleSwitch.getOffIcon())) {
+            writer.startElement("span", null);
+            writer.writeAttribute("class", toggleSwitch.getOffIcon(), null);
+            writer.endElement("span");
+        }
+
         writer.endElement("span");
 
         writer.endElement("div");
@@ -135,10 +150,7 @@ public class ToggleSwitchRenderer extends InputRenderer {
 
     protected void encodeScript(FacesContext context, ToggleSwitch toggleSwitch) throws IOException {
         WidgetBuilder wb = getWidgetBuilder(context);
-        wb.init("ToggleSwitch", toggleSwitch)
-          .attr("onIcon", toggleSwitch.getOnIcon(), null)
-          .attr("offIcon", toggleSwitch.getOffIcon(), null)
-            .finish();
+        wb.init("ToggleSwitch", toggleSwitch).finish();
     }
 
     protected boolean isChecked(String value) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.css
@@ -36,3 +36,29 @@
     -ms-transform: translateX(1.250em);
     transform: translateX(1.250em);
 }
+
+.ui-toggleswitch-dual-icon .ui-toggleswitch-handler {
+    position: relative;
+}
+
+.ui-toggleswitch-dual-icon .ui-toggleswitch-handler span {
+    position: absolute;
+    transition-duration: 250ms;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-property: opacity,transform;
+}
+
+.ui-toggleswitch-dual-icon .ui-toggleswitch-handler span + span {
+    opacity: 0;
+    transform: rotate(-90deg);
+}
+
+.ui-toggleswitch-dual-icon.ui-toggleswitch-checked .ui-toggleswitch-handler span {
+    opacity: 0;
+    transform: rotate(90deg);
+}
+
+.ui-toggleswitch-dual-icon.ui-toggleswitch-checked .ui-toggleswitch-handler span + span {
+    opacity: 1;
+    transform: rotate(0deg);
+}

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/toggleswitch/toggleswitch.js
@@ -13,8 +13,6 @@
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this
  * configuration is usually meant to be read-only and should not be modified.
  * @extends {PrimeFaces.widget.BaseWidgetCfg} cfg
- * @prop {string} cfg.onIcon Icon to display when button is selected.
- * @prop {string} cfg.offIcon Icon to display when button is unselected.
  */
 PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
 
@@ -107,9 +105,6 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
             this.input.trigger('change');
         }
         this.jq.addClass('ui-toggleswitch-checked');
-        if (this.cfg.onIcon) {
-            this.handler.removeClass(this.cfg.offIcon).addClass(this.cfg.onIcon);
-        }
     },
 
     /**
@@ -122,9 +117,6 @@ PrimeFaces.widget.ToggleSwitch = PrimeFaces.widget.BaseWidget.extend({
             this.input.trigger('change');
         }
         this.jq.removeClass('ui-toggleswitch-checked');
-        if (this.cfg.offIcon) {
-            this.handler.removeClass(this.cfg.onIcon).addClass(this.cfg.offIcon);
-        }
     },
 
     /**


### PR DESCRIPTION
Fix #8997

@mertsincan on order to align with speed dial I had to push down the icons to a child span (within `.ui-toggleswitch-handler`). So it might require a small change in the themes.
