### PR TITLE
Fix #9021: Datatable cell editor not closing

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3250,7 +3250,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                             if(target.is(ignoredOverlay) || target.closest(ignoredOverlay).length)
                                 return;
 
-                            if($.datepicker._datepickerShowing || $('.p-datepicker-panel:visible').length)
+                            if($.datepicker && ($.datepicker._datepickerShowing || $('.p-datepicker-panel:visible').length))
                                 return;
 
                             if($this.cfg.saveOnCellBlur)

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -775,7 +775,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
                     if(target.is(ignoredOverlay) || target.closest(ignoredOverlay).length)
                         return;
 
-                    if($.datepicker._datepickerShowing || $('.p-datepicker-panel:visible').length)
+                    if($.datepicker && ($.datepicker._datepickerShowing || $('.p-datepicker-panel:visible').length))
                         return;
 
                     if($this.cfg.saveOnCellBlur)


### PR DESCRIPTION
Fix #9021: Datatable cell editor not closing

This was introduced when we moved the calendar to its own JS file from `components.js` since it is deprecated and now we need to detect if there is a calendar/datepicker on the page.