### PR TITLE
Fix #9068: BlockUI: fix incorrect position of an overlay

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -227,12 +227,12 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             // set the size and position to match the target
             var height = currentTarget.height(),
                 width = currentTarget.width(),
-                position = currentTarget.position();
+                offset = currentTarget.offset();
             var sizeAndPosition = {
                 'height': height + 'px',
                 'width': width + 'px',
-                'left': position.left + 'px',
-                'top': position.top + 'px'
+                'left': offset.left + 'px',
+                'top': offset.top + 'px'
             };
             currentBlocker.css(sizeAndPosition);
 


### PR DESCRIPTION
Affected version: 12-RC2

It seems it's a mistake to use `.position()` which returns the position of en element relative to its parent.

But instead it should be relative to a page, because the overlay element is no more created next to `block` element, but instead attached to `@(body)`.