### PR TITLE
Fix #9155: BlockUI dynamically adjust after DOM updates

### DIFF
--- a/docs/12_0_0/core/ajaxJavascriptApi.md
+++ b/docs/12_0_0/core/ajaxJavascriptApi.md
@@ -110,6 +110,8 @@ before sending the XHR.
 | [pfAjaxError](../jsdocs/interfaces/src_PrimeFaces.JQuery.TypeToTriggeredEventMap.html#pfAjaxError) | xhr, settings, error | Executed when sending the request or receiving the response failed.
 | [pfAjaxSuccess](../jsdocs/interfaces/src_PrimeFaces.JQuery.TypeToTriggeredEventMap.html#pfAjaxSuccess) | xhr, settings | Executed
 after the response was received but before processing the response / replace DOM elements.
+| [pfAjaxUpdated](../jsdocs/interfaces/src_PrimeFaces.JQuery.TypeToTriggeredEventMap.html#pfAjaxUpdated) | xhr, settings | Executed
+after the response was received but after the DOM elements have been updated.
 | [pfAjaxComplete](../jsdocs/interfaces/src_PrimeFaces.JQuery.TypeToTriggeredEventMap.html#pfAjaxComplete) | xhr, settings | Executed
 after the AJAX lifecycle has been completed, independent of success or error.
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -85,12 +85,13 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     bindResizer: function() {
         var $this = this;
         this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_resize', this.target, function() {
-            var isVisible = $this.isBlocking();
-            $this.content.remove();
-            $this.blocker.remove();
-            $this.render();
-            if (isVisible) {
-                $this.show();
+            $this.alignOverlay();
+        });
+
+        // subscribe to all DOM update events so we can resize even if another DOM element changed
+        $(document).on('pfAjaxUpdated', function(e, xhr, settings) {
+            if (!$this.cfg.blocked) {
+                $this.alignOverlay();
             }
         });
     },
@@ -106,10 +107,6 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         $(document).on('pfAjaxSend.' + this.id, function(e, xhr, settings) {
             if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
                 $this.show();
-            }
-        }).on('pfAjaxUpdated.' + this.id, function(e, xhr, settings) {
-            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
-                $this.alignOverlay();
             }
         }).on('pfAjaxComplete.' + this.id, function(e, xhr, settings) {
             if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -83,8 +83,8 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     bindResizer: function() {
-       var $this = this;
-       this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_resize', this.target, function() {
+        var $this = this;
+        this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_resize', this.target, function() {
             var isVisible = $this.isBlocking();
             $this.content.remove();
             $this.blocker.remove();
@@ -92,13 +92,13 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             if (isVisible) {
                 $this.show();
             }
-       });
+        });
     },
 
-   /**
-     * Sets up the global event listeners on the document.
-     * @private
-     */
+    /**
+      * Sets up the global event listeners on the document.
+      * @private
+      */
     bindTriggers: function() {
         var $this = this;
 
@@ -106,6 +106,10 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         $(document).on('pfAjaxSend.' + this.id, function(e, xhr, settings) {
             if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
                 $this.show();
+            }
+        }).on('pfAjaxUpdated.' + this.id, function(e, xhr, settings) {
+            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
+                $this.alignOverlay();
             }
         }).on('pfAjaxComplete.' + this.id, function(e, xhr, settings) {
             if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings)) {
@@ -143,26 +147,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         if (this.isBlocking()) {
             return;
         }
-        this.blocker.css('z-index', PrimeFaces.nextZindex());
-
-        //center position of content
-        for (var i = 0; i < this.target.length; i++) {
-            var currentTarget = $(this.target[i]),
-                blocker = $(this.blocker[i]),
-                content = $(this.content[i]);
-        
-            // configure the target positioning
-            var position = currentTarget.css("position");
-            if (position !== "fixed" && position !== "absolute") {
-                currentTarget.css('position', 'relative');
-            }
-
-            content.css({
-                'left': ((blocker.width() - content.outerWidth()) / 2) + 'px',
-                'top': ((blocker.height() - content.outerHeight()) / 2) + 'px',
-                'z-index': PrimeFaces.nextZindex()
-            });
-        }
+        this.alignOverlay();
 
         var animated = this.cfg.animate;
         if (animated)
@@ -249,7 +234,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
                 currentContent = currentContent.clone();
                 currentContent.attr('id', currentTargetId + '_blockcontent');
             }
-            
+
             // assign data ids to this widget
             currentBlocker.attr('data-bui-overlay', widgetId);
             currentContent.attr('data-bui-content', widgetId);
@@ -257,6 +242,41 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
 
             // ARIA 
             currentTarget.attr('aria-busy', this.cfg.blocked);
+
+            // append the blocker to the document 
+            $(document.body).append(currentBlocker);
+            currentBlocker.append(currentContent);
+        }
+
+        // assign all matching blockers to widget
+        this.blocker = $('[data-bui-overlay~="' + widgetId + '"]');
+        this.content = $('[data-bui-content~="' + widgetId + '"]');
+
+        // set the size and position to match the target
+        this.alignOverlay();
+    },
+
+    /**
+    * Align the overlay so it covers its target component.
+    * @private
+    */
+    alignOverlay: function() {
+        this.target = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.cfg.block);
+        if (this.blocker) {
+            this.blocker.css('z-index', PrimeFaces.nextZindex());
+        }
+
+        //center position of content
+        for (var i = 0; i < this.target.length; i++) {
+            var currentTarget = $(this.target[i]),
+                blocker = $(this.blocker[i]),
+                content = $(this.content[i]);
+
+            // configure the target positioning
+            var position = currentTarget.css("position");
+            if (position !== "fixed" && position !== "absolute") {
+                currentTarget.css('position', 'relative');
+            }
 
             // set the size and position to match the target
             var height = currentTarget.height(),
@@ -268,16 +288,14 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
                 'left': offset.left + 'px',
                 'top': offset.top + 'px'
             };
-            currentBlocker.css(sizeAndPosition);
+            blocker.css(sizeAndPosition);
 
-            // append the blocker to the document 
-            $(document.body).append(currentBlocker);
-            currentBlocker.append(currentContent);
+            content.css({
+                'left': ((blocker.width() - content.outerWidth()) / 2) + 'px',
+                'top': ((blocker.height() - content.outerHeight()) / 2) + 'px',
+                'z-index': PrimeFaces.nextZindex()
+            });
         }
-
-        // assign all matching blockers to widget
-        this.blocker = $('[data-bui-overlay~="' + widgetId + '"]');
-        this.content = $('[data-bui-content~="' + widgetId + '"]');
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -892,6 +892,10 @@ if (!PrimeFaces.ajax) {
                             PrimeFaces.error(err);
                         }
 
+                        if(global) {
+                            $(document).trigger('pfAjaxUpdated', [xhr, this]);
+                        }
+
                         PrimeFaces.debug('DOM is updated.');
                     })
                     .always(function(data, status, xhr) {


### PR DESCRIPTION
Fix #9155: BlockUI dynamically adjust after DOM updates

@tandraschko please review I had to add a new `pfAjaxUpdated` because I needed an event AFTER the DOM has been updated and `pfAjaxSuccess` fires before the DOM may be updated.