### PR TITLE
Schedule: Prevent NPE when end date is null

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -113,7 +113,9 @@ public class ScheduleRenderer extends CoreRenderer {
                 }
                 jsonObject.put("title", event.getTitle());
                 jsonObject.put("start", dateTimeFormatter.format(event.getStartDate().atZone(zoneId)));
-                jsonObject.put("end", dateTimeFormatter.format(event.getEndDate().atZone(zoneId)));
+                if (event.getEndDate() != null) {
+                    jsonObject.put("end", dateTimeFormatter.format(event.getEndDate().atZone(zoneId)));
+                }
                 jsonObject.put("allDay", event.isAllDay());
                 if (event.isDraggable() != null) {
                     jsonObject.put("startEditable", event.isDraggable());


### PR DESCRIPTION
The javascript schedule component supports null end dates but the Primefaces schedule renderer will throw a NPE when trying to encode the event to JSON. This will cause issues when using lazy loading. For example if you have 50 events in the month of august and one of them has no end date, none of them will show on the page.