### PR TITLE
Fix #9179: Exporter support dynamic column groups

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -31,14 +31,17 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
 import javax.faces.component.visit.VisitContext;
 import javax.faces.component.visit.VisitResult;
 import javax.faces.context.FacesContext;
+
 import org.primefaces.component.column.Column;
 import org.primefaces.component.columngroup.ColumnGroup;
 import org.primefaces.component.columns.Columns;
+import org.primefaces.component.row.Row;
 import org.primefaces.model.ColumnMeta;
 import org.primefaces.util.ComponentUtils;
 
@@ -147,6 +150,34 @@ public interface ColumnAware {
             }
         }
 
+        return true;
+    }
+
+    /**
+     * Return each {@link Row} in a Column Group.
+     * @param context  the {@link FacesContext}
+     * @param cg the {@link ColumnGroup} to get
+     * @param skipUnrendered If unrendered components should be skipped
+     * @param callback The callback, which will be invoked for each row. If it returns false, the algorithm will be cancelled
+     * @return false when the algorithm was cancelled
+     */
+    default boolean forEachColumnGroupRow(FacesContext context, ColumnGroup cg, boolean skipUnrendered, Predicate<Row> callback) {
+        if (cg == null || cg.getChildCount() == 0) {
+            return false;
+        }
+        for (UIComponent component : cg.getChildren()) {
+            if (!(component instanceof Row)) {
+                continue;
+            }
+            Row row = (Row) component;
+            if (skipUnrendered && !row.isRendered()) {
+                continue;
+            }
+
+            if (!callback.test(row)) {
+                return false;
+            }
+        }
         return true;
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -261,20 +261,9 @@ public class DataTablePDFExporter extends DataTableExporter {
 
     protected boolean addColumnGroup(DataTable table, PdfPTable pdfTable,  ColumnType columnType) {
         ColumnGroup cg = table.getColumnGroup(columnType.facet());
-        if (cg == null || cg.getChildCount() == 0) {
-            return false;
-        }
-        for (UIComponent component : cg.getChildren()) {
-            if (!(component instanceof org.primefaces.component.row.Row)) {
-                continue;
-            }
-            org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
-            for (UIComponent rowComponent : row.getChildren()) {
-                if (!(rowComponent instanceof UIColumn)) {
-                    // most likely a ui:repeat which won't work here
-                    continue;
-                }
-                UIColumn column = (UIColumn) rowComponent;
+        FacesContext context = FacesContext.getCurrentInstance();
+        table.forEachColumnGroupRow(context, cg, true, row -> {
+            table.forEachColumn(context, row, true, true, false, column -> {
                 if (column.isRendered() && column.isExportable()) {
                     String textValue;
                     switch (columnType) {
@@ -295,9 +284,12 @@ public class DataTablePDFExporter extends DataTableExporter {
                     int colSpan = column.getColspan();
                     addColumnValue(pdfTable, textValue, rowSpan, colSpan);
                 }
-            }
+                return true;
+            });
+
             pdfTable.completeRow();
-        }
+            return true;
+        });
         return true;
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExcelExporter.java
@@ -26,6 +26,7 @@ package org.primefaces.component.treetable.export;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIPanel;
@@ -42,8 +43,10 @@ import org.primefaces.component.export.ExcelOptions;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.component.treetable.TreeTable;
-import org.primefaces.util.*;
+import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.ExcelStylesManager;
+import org.primefaces.util.LocaleUtils;
 
 
 public class TreeTableExcelExporter extends TreeTableExporter {
@@ -214,27 +217,13 @@ public class TreeTableExcelExporter extends TreeTableExporter {
 
     protected boolean addColumnGroup(TreeTable table, Sheet sheet, TreeTableExporter.ColumnType columnType) {
         ColumnGroup cg = table.getColumnGroup(columnType.facet());
-        if (cg == null || cg.getChildCount() == 0) {
-            return false;
-        }
-        for (UIComponent component : cg.getChildren()) {
-            if (!(component instanceof org.primefaces.component.row.Row)) {
-                continue;
-            }
-            org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
+        FacesContext context = FacesContext.getCurrentInstance();
+        table.forEachColumnGroupRow(context, cg, true, row -> {
+            final AtomicInteger colIndex = new AtomicInteger(0);
             int rowIndex = sheet.getLastRowNum() + 1;
             Row xlRow = sheet.createRow(rowIndex);
-            int colIndex = 0;
-            for (UIComponent rowComponent : row.getChildren()) {
-                if (!(rowComponent instanceof UIColumn)) {
-                    // most likely a ui:repeat which won't work here
-                    continue;
-                }
-                UIColumn column = (UIColumn) rowComponent;
-                if (!column.isRendered() || !column.isExportable()) {
-                    continue;
-                }
 
+            table.forEachColumn(context, row, true, true, false, column -> {
                 String text = null;
                 switch (columnType) {
                     case HEADER:
@@ -255,43 +244,45 @@ public class TreeTableExcelExporter extends TreeTableExporter {
                 int colSpan = column.getColspan() - 1;
 
                 if (rowSpan > 0 && colSpan > 0) {
-                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
+                    colIndex.set(calculateColumnOffset(sheet, rowIndex, colIndex.get()));
                     sheet.addMergedRegion(new CellRangeAddress(
                                 rowIndex, // first row (0-based)
                                 rowIndex + rowSpan, // last row (0-based)
-                                colIndex, // first column (0-based)
-                                colIndex + colSpan // last column (0-based)
+                                colIndex.get(), // first column (0-based)
+                                colIndex.get() + colSpan // last column (0-based)
                     ));
-                    addColumnValue(xlRow, (short) colIndex, text);
-                    colIndex = colIndex + colSpan;
+                    addColumnValue(xlRow, (short) colIndex.get(), text);
+                    colIndex.set(colIndex.get() + colSpan);
                 }
                 else if (rowSpan > 0) {
                     sheet.addMergedRegion(new CellRangeAddress(
                                 rowIndex, // first row (0-based)
                                 rowIndex + rowSpan, // last row (0-based)
-                                colIndex, // first column (0-based)
-                                colIndex // last column (0-based)
+                                colIndex.get(), // first column (0-based)
+                                colIndex.get() // last column (0-based)
                     ));
-                    addColumnValue(xlRow, (short) colIndex, text);
+                    addColumnValue(xlRow, (short) colIndex.get(), text);
                 }
                 else if (colSpan > 0) {
-                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
+                    colIndex.set(calculateColumnOffset(sheet, rowIndex, colIndex.get()));
                     sheet.addMergedRegion(new CellRangeAddress(
                                 rowIndex, // first row (0-based)
                                 rowIndex, // last row (0-based)
-                                colIndex, // first column (0-based)
-                                colIndex + colSpan // last column (0-based)
+                                colIndex.get(), // first column (0-based)
+                                colIndex.get() + colSpan // last column (0-based)
                     ));
-                    addColumnValue(xlRow, (short) colIndex, text);
-                    colIndex = colIndex + colSpan;
+                    addColumnValue(xlRow, (short) colIndex.get(), text);
+                    colIndex.set(colIndex.get() + colSpan);
                 }
                 else {
-                    colIndex = calculateColumnOffset(sheet, rowIndex, colIndex);
-                    addColumnValue(xlRow, (short) colIndex, text);
+                    colIndex.set(calculateColumnOffset(sheet, rowIndex, colIndex.get()));
+                    addColumnValue(xlRow, (short) colIndex.get(), text);
                 }
-                colIndex++;
-            }
-        }
+                colIndex.incrementAndGet();
+                return true;
+            });
+            return true;
+        });
         return true;
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
@@ -258,20 +258,9 @@ public class TreeTablePDFExporter extends TreeTableExporter {
 
     protected boolean addColumnGroup(TreeTable table, PdfPTable pdfTable,  ColumnType columnType) {
         ColumnGroup cg = table.getColumnGroup(columnType.facet());
-        if (cg == null || cg.getChildCount() == 0) {
-            return false;
-        }
-        for (UIComponent component : cg.getChildren()) {
-            if (!(component instanceof org.primefaces.component.row.Row)) {
-                continue;
-            }
-            org.primefaces.component.row.Row row = (org.primefaces.component.row.Row) component;
-            for (UIComponent rowComponent : row.getChildren()) {
-                if (!(rowComponent instanceof UIColumn)) {
-                    // most likely a ui:repeat which won't work here
-                    continue;
-                }
-                UIColumn column = (UIColumn) rowComponent;
+        FacesContext context = FacesContext.getCurrentInstance();
+        table.forEachColumnGroupRow(context, cg, true, row -> {
+            table.forEachColumn(context, row, true, true, false, column -> {
                 if (column.isRendered() && column.isExportable()) {
                     String textValue;
                     switch (columnType) {
@@ -292,9 +281,12 @@ public class TreeTablePDFExporter extends TreeTableExporter {
                     int colSpan = column.getColspan();
                     addColumnValue(pdfTable, textValue, rowSpan, colSpan);
                 }
-            }
+                return true;
+            });
+
             pdfTable.completeRow();
-        }
+            return true;
+        });
         return true;
     }
 


### PR DESCRIPTION
Fix #9179: Exporter support dynamic column groups

@tandraschko you were right had to use `forEachColumn` and now it works!