### PR TITLE
Remove "role"-attribute on tr and th elements (#9261)

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -660,7 +660,6 @@ public class DataTableRenderer extends DataRenderer {
         writer.startElement("th", component);
         writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("class", columnClass, null);
-        writer.writeAttribute("role", "columnheader", null);
         writer.writeAttribute(HTML.ARIA_LABEL, ariaHeaderLabel, null);
         writer.writeAttribute("scope", "col", null);
         if (component != null) {
@@ -1013,7 +1012,6 @@ public class DataTableRenderer extends DataRenderer {
                         String rowStyle = headerRow.getStyle();
 
                         writer.startElement("tr", null);
-                        writer.writeAttribute("role", "row", null);
                         if (rowClass != null) {
                             writer.writeAttribute("class", rowClass, null);
                         }
@@ -1051,7 +1049,6 @@ public class DataTableRenderer extends DataRenderer {
         }
         else {
             writer.startElement("tr", null);
-            writer.writeAttribute("role", "row", null);
 
             for (int i = columnStart; i < columnEnd; i++) {
                 UIColumn column = columns.get(i);
@@ -1256,7 +1253,6 @@ public class DataTableRenderer extends DataRenderer {
             writer.writeAttribute("data-rk", rowKey, null);
         }
         writer.writeAttribute("class", rowStyleClass, null);
-        writer.writeAttribute("role", "row", null);
         if (selectionEnabled) {
             writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(selected), null);
         }

--- a/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
@@ -153,7 +153,6 @@ public class PanelGridRenderer extends CoreRenderer {
 
                 writer.startElement("tr", null);
                 writer.writeAttribute("class", PanelGrid.TABLE_ROW_CLASS, null);
-                writer.writeAttribute("role", "row", null);
             }
 
             String columnClass = (colMod < columnClasses.length)
@@ -228,7 +227,6 @@ public class PanelGridRenderer extends CoreRenderer {
         }
 
         writer.writeAttribute("class", rowClass, null);
-        writer.writeAttribute("role", "row", null);
 
         for (UIComponent child : row.getChildren()) {
             if (child instanceof Column && child.isRendered()) {
@@ -419,7 +417,6 @@ public class PanelGridRenderer extends CoreRenderer {
             if (columns > 0) {
                 writer.startElement("tr", null);
                 writer.writeAttribute("class", "ui-widget-header", null);
-                writer.writeAttribute("role", "row", null);
 
                 writer.startElement("td", null);
                 writer.writeAttribute("colspan", columns, null);

--- a/primefaces/src/main/java/org/primefaces/component/row/renderer/PanelGridBodyRowRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/row/renderer/PanelGridBodyRowRenderer.java
@@ -40,7 +40,6 @@ public class PanelGridBodyRowRenderer extends CoreRenderer implements HelperRowR
 
         writer.startElement("tr", row);
         writer.writeAttribute("class", PanelGrid.TABLE_ROW_CLASS, null);
-        writer.writeAttribute("role", "row", null);
         renderDynamicPassThruAttributes(context, row);
         renderChildren(context, row);
         writer.endElement("tr");

--- a/primefaces/src/main/java/org/primefaces/component/row/renderer/PanelGridFacetRowRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/row/renderer/PanelGridFacetRowRenderer.java
@@ -39,7 +39,6 @@ public class PanelGridFacetRowRenderer extends CoreRenderer implements HelperRow
 
         writer.startElement("tr", row);
         writer.writeAttribute("class", "ui-widget-header", null);
-        writer.writeAttribute("role", "row", null);
         renderDynamicPassThruAttributes(context, row);
         renderChildren(context, row);
         writer.endElement("tr");

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -415,7 +415,6 @@ public class TreeTableRenderer extends DataRenderer {
                         String rowStyle = headerRow.getStyle();
 
                         writer.startElement("tr", null);
-                        writer.writeAttribute("role", "row", null);
                         if (rowClass != null) {
                             writer.writeAttribute("class", rowClass, null);
                         }
@@ -453,7 +452,6 @@ public class TreeTableRenderer extends DataRenderer {
         }
         else {
             writer.startElement("tr", null);
-            writer.writeAttribute("role", "row", null);
 
             List<UIColumn> columns = tt.getColumns();
             for (int i = 0; i < columns.size(); i++) {
@@ -560,7 +558,6 @@ public class TreeTableRenderer extends DataRenderer {
         writer.startElement("tr", null);
         writer.writeAttribute("id", tt.getClientId(context) + "_node_" + rowKey, null);
         writer.writeAttribute("class", rowStyleClass, null);
-        writer.writeAttribute("role", "row", null);
         writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(treeNode.isExpanded()), null);
         writer.writeAttribute("data-rk", rowKey, null);
 
@@ -720,7 +717,6 @@ public class TreeTableRenderer extends DataRenderer {
         writer.startElement("th", null);
         writer.writeAttribute("id", column.getContainerClientId(context), null);
         writer.writeAttribute("class", columnClass, null);
-        writer.writeAttribute("role", "columnheader", null);
         writer.writeAttribute(HTML.ARIA_LABEL, ariaHeaderLabel, null);
         if (style != null) {
             writer.writeAttribute("style", style, null);


### PR DESCRIPTION
Proposed Commit-Message:

```
Remove "role"-attribute on tr and th elements (#9261)

This commit removes the "role"-attribute on every element which are written as HTML table-row (tr) or table-header (tr) elements.

It's not removed on those where the header row is not rendered as such.

closes #9261
```