### PR TITLE
doc: added renamed chart fields to the 12.0 migration guide

### DIFF
--- a/docs/migrationguide/12_0_0.md
+++ b/docs/migrationguide/12_0_0.md
@@ -23,6 +23,8 @@
   * `scales.axes.gridLines` was renamed to `scales.axes.grid`
   * `scales.axes.gridLines.offsetGridLines` was renamed to `scales.axes.grid.offset`
   * `scales.axes.gridLines.tickMarkLength` was renamed to `scales.axes.grid.tickLength`
+  * `charts.line.lineTension` was renamed to `charts.line.tension`
+  * `charts.line.steppedLine` was renamed to `charts.line.stepped`
   
 ## GMap
   * Marker `icon` type is now `Object` instead of `String` (to support `Symbol`).


### PR DESCRIPTION
In #6812 (https://github.com/primefaces/primefaces/commit/06fa539d970977a85f19f658cc3d9509f080c719#diff-d42b438705de9522ab25d4230c912e5469e298fdd5c08a774b2f6efc73119571) `org.primefaces.model.charts.line.LineChartDataSet` attributes `lineTension` and `lineStepped` were renamed to `tension `and `stepped` respectively.
This requires client code to be updated when migrating to primefaces 12