### PR TITLE
Fix #9324: DataTable: Implement IN MatchMode for JpaLazyDataModel

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -163,7 +163,8 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                 Field filterField = LangUtils.getFieldRecursive(entityClass, filter.getField());
                 Object filterValue = filter.getFilterValue();
                 Object convertedFilterValue;
-                if (filterValue.getClass().isArray() || filterValue instanceof Collection) {
+                Class<?> filterClass = filterValue.getClass();
+                if (filterClass.isArray() || Collection.class.isAssignableFrom(filterClass)) {
                     convertedFilterValue = filterValue;
                 }
                 else {

--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -227,7 +227,9 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                         ? cb.equal(fieldExpression, filterValueAsCollection.get().iterator().next())
                         : fieldExpression.in(filterValueAsCollection.get());
             case NOT_IN:
-                throw new UnsupportedOperationException("MatchMode.NOT_IN currently not supported!");
+                return filterValueAsCollection.get().size() == 1
+                        ? cb.notEqual(fieldExpression, filterValueAsCollection.get().iterator().next())
+                        : fieldExpression.in(filterValueAsCollection.get()).not();
             case BETWEEN:
                 throw new UnsupportedOperationException("MatchMode.BETWEEN currently not supported!");
             case NOT_BETWEEN:


### PR DESCRIPTION
I had to push the cast to `Comparable` further into `createPredicate` since IN needs either an array or `Collection`, neither of which are `Comparable`.

Testing this change with the [new primefaces-test jpa branch](https://github.com/primefaces/primefaces-test/tree/jpa) by replacing `stringCol` with:

```xml
<p:column field="stringCol" filterMatchMode="in">
  <f:facet name="filter">
    <p:selectCheckboxMenu onchange="PF('jpaTable').filter()">
      <f:selectItem itemLabel="New York" itemValue="New York" />
      <f:selectItem itemLabel="Philadelphia" itemValue="Philadelphia" />
      <f:selectItem itemLabel="Detroit" itemValue="Detroit" />
    </p:selectCheckboxMenu>
  </f:facet>
</p:column>
```