### PR TITLE
Fix #9368: CSP call register handlers before executeScripts

### DIFF
--- a/primefaces/src/main/java/org/primefaces/csp/CspPartialResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspPartialResponseWriter.java
@@ -23,11 +23,14 @@
  */
 package org.primefaces.csp;
 
-import javax.faces.component.UIComponent;
-import javax.faces.context.PartialResponseWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
+
+import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
+import javax.faces.context.PartialResponseWriter;
+
 import org.primefaces.context.PartialResponseWriterWrapper;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.EscapeUtils;
@@ -196,7 +199,9 @@ public class CspPartialResponseWriter extends PartialResponseWriterWrapper {
             }
         }
 
-        requestContext.getScriptsToExecute().add(sb.toString());
+        // GitHub #9368 all register calls must be before ajax.executeScript calls
+        ArrayList<String> scripts = (ArrayList<String>) requestContext.getScriptsToExecute();
+        scripts.add(0, sb.toString());
 
         cspState.getEventHandlers().clear();
     }


### PR DESCRIPTION
Fix #9368: CSP call register handlers before executeScripts