### PR TITLE
#9384 CommandLink: Invalid HTML when disabled

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -100,7 +100,6 @@ public class CommandLinkRenderer extends CoreRenderer {
         writer.writeAttribute(HTML.ARIA_LABEL, link.getAriaLabel(), null);
         if (link.isDisabled()) {
             writer.writeAttribute("tabindex", "-1", null);
-            writer.writeAttribute("aria-disabled", "true", null);
         }
 
         if (ajax) {

--- a/primefaces/src/main/java/org/primefaces/util/HTML.java
+++ b/primefaces/src/main/java/org/primefaces/util/HTML.java
@@ -109,7 +109,6 @@ public class HTML {
         "charset",
         "coords",
         "dir",
-        "disabled",
         "hreflang",
         "rel",
         "rev",

--- a/primefaces/src/main/java/org/primefaces/util/HTML.java
+++ b/primefaces/src/main/java/org/primefaces/util/HTML.java
@@ -93,7 +93,6 @@ public class HTML {
         "charset",
         "coords",
         "dir",
-        "disabled",
         "hreflang",
         "rel",
         "rev",

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandlink.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandlink.js
@@ -79,8 +79,7 @@ PrimeFaces.widget.CommandLink = PrimeFaces.widget.BaseWidget.extend({
     disable: function() {
         this.jq.removeClass('ui-state-hover ui-state-focus ui-state-active')
                 .addClass('ui-state-disabled')
-                .attr('tabindex', '-1')
-                .attr('aria-disabled', 'true');
+                .attr('tabindex', '-1');
     },
 
     /**
@@ -88,7 +87,7 @@ PrimeFaces.widget.CommandLink = PrimeFaces.widget.BaseWidget.extend({
      */
     enable: function() {
         this.jq.removeClass('ui-state-disabled')
-                .removeAttr('tabindex aria-disabled');
+                .removeAttr('tabindex');
     }
 
 });


### PR DESCRIPTION
Fix #9384

No CSS change was needed as we already have

https://github.com/primefaces/primefaces/blob/2e79cbc628fa98885cad4688813fc7e82f6f3a97/primefaces/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.css#L66-L69

