### PR TITLE
Fix #9486: DatePicker year/month navigator ARIA labels

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -72,7 +72,12 @@
                 monthNames: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
                 monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
                 today: 'Today',
-                clear: 'Clear'
+                clear: 'Clear',
+                select: 'Select',
+                year: 'Year',
+                month: 'Month',
+                week: 'Week',
+                day: 'Day'
             },
             dateFormat: 'mm/dd/yy',
             yearRange: null,
@@ -1344,7 +1349,7 @@
 
         renderTitleMonthElement: function (month, index) {
             if (this.options.monthNavigator && this.options.view !== 'month' && index === 0) {
-                return '<select class="ui-datepicker-month">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
+                return '<select class="ui-datepicker-month" aria-label="'+this.options.locale.select+' '+this.options.locale.month+'">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-month">' + this.escapeHTML(this.options.locale.monthNames[month]) + '</span>' + '&#xa0;';
@@ -1363,7 +1368,7 @@
                     yearOptions.push(i);
                 }
 
-                return '<select class="ui-datepicker-year">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
+                return '<select class="ui-datepicker-year" aria-label="'+this.options.locale.select+' '+this.options.locale.year+'">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-year">' + year + '</span>';

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -73,7 +73,6 @@
                 monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
                 today: 'Today',
                 clear: 'Clear',
-                select: 'Select',
                 year: 'Year',
                 month: 'Month',
                 week: 'Week',
@@ -1349,7 +1348,7 @@
 
         renderTitleMonthElement: function (month, index) {
             if (this.options.monthNavigator && this.options.view !== 'month' && index === 0) {
-                return '<select class="ui-datepicker-month" aria-label="'+this.options.locale.select+' '+this.options.locale.month+'">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
+                return '<select class="ui-datepicker-month" aria-label="'+this.options.locale.month+'">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-month">' + this.escapeHTML(this.options.locale.monthNames[month]) + '</span>' + '&#xa0;';
@@ -1368,7 +1367,7 @@
                     yearOptions.push(i);
                 }
 
-                return '<select class="ui-datepicker-year" aria-label="'+this.options.locale.select+' '+this.options.locale.year+'">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
+                return '<select class="ui-datepicker-year" aria-label="'+this.options.locale.year+'">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-year">' + year + '</span>';

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
@@ -32,7 +32,6 @@
      noEventsText: 'No Events',
      today: 'Today',
      clear: 'Clear',
-     select: 'Select',
      aria: {
          'paginator.PAGE': 'Page {0}',
          'calendar.BUTTON': 'Show Calendar',

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/locales/locale-en.js
@@ -32,6 +32,7 @@
      noEventsText: 'No Events',
      today: 'Today',
      clear: 'Clear',
+     select: 'Select',
      aria: {
          'paginator.PAGE': 'Page {0}',
          'calendar.BUTTON': 'Show Calendar',


### PR DESCRIPTION
Fix #9486: DatePicker year/month navigator ARIA labels

![image](https://user-images.githubusercontent.com/4399574/207460539-79a4daa9-9ba4-40b8-8e66-6d55396f7f74.png)

@jepsar @Rapster @tandraschko if you send me your language translation for the word "Select" like "Select Year" I can add it to the locales of this PR.