### PR TITLE
Fix #9518: JSF23 wrapped constructors

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/WEB-INF/web.xml
+++ b/primefaces-integration-tests/src/main/webapp/WEB-INF/web.xml
@@ -27,10 +27,6 @@
         <param-value>${primefaces.THEME}</param-value>
     </context-param>
     <context-param>
-        <param-name>primefaces.FONT_AWESOME</param-name>
-        <param-value>true</param-value>
-    </context-param>
-    <context-param>
         <param-name>primefaces.MOVE_SCRIPTS_TO_BOTTOM</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/primefaces/src/main/java/org/primefaces/application/DialogViewHandler.java
+++ b/primefaces/src/main/java/org/primefaces/application/DialogViewHandler.java
@@ -24,23 +24,17 @@
 package org.primefaces.application;
 
 import java.util.Map;
+
 import javax.faces.application.ViewHandler;
 import javax.faces.application.ViewHandlerWrapper;
 import javax.faces.context.FacesContext;
+
 import org.primefaces.util.Constants;
 
 public class DialogViewHandler extends ViewHandlerWrapper {
 
-    private ViewHandler wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public DialogViewHandler(ViewHandler wrapped) {
-        this.wrapped = wrapped;
-    }
-
-    @Override
-    public ViewHandler getWrapped() {
-        return this.wrapped;
+        super(wrapped);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
+++ b/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.el.ELException;
 import javax.faces.FacesException;
 import javax.faces.application.ProjectStage;
@@ -41,14 +42,11 @@ import javax.faces.application.ViewHandler;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
 import javax.faces.component.visit.VisitContext;
-import javax.faces.context.ExceptionHandler;
-import javax.faces.context.ExceptionHandlerWrapper;
-import javax.faces.context.ExternalContext;
-import javax.faces.context.FacesContext;
-import javax.faces.context.PartialResponseWriter;
+import javax.faces.context.*;
 import javax.faces.event.ExceptionQueuedEvent;
 import javax.faces.event.PhaseId;
 import javax.faces.view.ViewDeclarationLanguage;
+
 import org.primefaces.component.ajaxexceptionhandler.AjaxExceptionHandler;
 import org.primefaces.component.ajaxexceptionhandler.AjaxExceptionHandlerVisitCallback;
 import org.primefaces.config.PrimeConfiguration;
@@ -57,8 +55,8 @@ import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.csp.CspPhaseListener;
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.LangUtils;
 import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.Lazy;
 
 public class PrimeExceptionHandler extends ExceptionHandlerWrapper {
@@ -66,18 +64,11 @@ public class PrimeExceptionHandler extends ExceptionHandlerWrapper {
     private static final Logger LOGGER = Logger.getLogger(PrimeExceptionHandler.class.getName());
     private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
 
-    private final ExceptionHandler wrapped;
     private final Lazy<PrimeConfiguration> config;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeExceptionHandler(ExceptionHandler wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
         this.config = new Lazy(() -> PrimeApplicationContext.getCurrentInstance(FacesContext.getCurrentInstance()).getConfig());
-    }
-
-    @Override
-    public ExceptionHandler getWrapped() {
-        return wrapped;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandlerFactory.java
+++ b/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandlerFactory.java
@@ -28,20 +28,13 @@ import javax.faces.context.ExceptionHandlerFactory;
 
 public class PrimeExceptionHandlerFactory extends ExceptionHandlerFactory {
 
-    private final ExceptionHandlerFactory wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeExceptionHandlerFactory(final ExceptionHandlerFactory wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
     }
 
     @Override
     public ExceptionHandler getExceptionHandler() {
-        return new PrimeExceptionHandler(wrapped.getExceptionHandler());
+        return new PrimeExceptionHandler(getWrapped().getExceptionHandler());
     }
 
-    @Override
-    public ExceptionHandlerFactory getWrapped() {
-        return wrapped;
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/application/factory/Html5FacesContextFactory.java
+++ b/primefaces/src/main/java/org/primefaces/application/factory/Html5FacesContextFactory.java
@@ -48,28 +48,15 @@ import javax.faces.lifecycle.Lifecycle;
  */
 public class Html5FacesContextFactory extends FacesContextFactory {
 
-    private FacesContextFactory wrapped;
-
-    // #6212 - don't remove it
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
-    public Html5FacesContextFactory() {
-
-    }
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public Html5FacesContextFactory(FacesContextFactory wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
     }
 
     @Override
     public FacesContext getFacesContext(Object context, Object request, Object response, Lifecycle lifecycle)
                 throws FacesException {
-        FacesContext wrappedContext = wrapped.getFacesContext(context, request, response, lifecycle);
+        FacesContext wrappedContext = getWrapped().getFacesContext(context, request, response, lifecycle);
         return wrappedContext instanceof Html5FacesContext ? wrappedContext : new Html5FacesContext(wrappedContext);
     }
 
-    @Override
-    public FacesContextFactory getWrapped() {
-        return wrapped;
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -47,7 +47,6 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     private static final String SCRIPT_TYPE = "text/javascript";
     private static final String TYPE_ATTRIBUTE = "type";
 
-    private final ResponseWriter wrapped;
     private final MoveScriptsToBottomState state;
 
     private boolean inScript;
@@ -58,9 +57,8 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
 
     private boolean writeFouc;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public MoveScriptsToBottomResponseWriter(ResponseWriter wrapped, MoveScriptsToBottomState state) {
-        this.wrapped = wrapped;
+        super(wrapped);
         this.state = state;
 
         inScript = false;
@@ -69,11 +67,6 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
 
         includeAttributes = new LinkedHashMap<>(6);
         inline = new StringBuilder(75);
-    }
-
-    @Override
-    public ResponseWriter getWrapped() {
-        return wrapped;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/application/resource/PrimeResource.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/PrimeResource.java
@@ -26,6 +26,7 @@ package org.primefaces.application.resource;
 import javax.faces.application.Resource;
 import javax.faces.application.ResourceWrapper;
 import javax.faces.context.FacesContext;
+
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 
@@ -34,23 +35,15 @@ import org.primefaces.context.PrimeRequestContext;
  */
 public class PrimeResource extends ResourceWrapper {
 
-    private Resource wrapped;
-    private String version;
+    private final String version;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeResource(final Resource resource) {
-        super();
-        wrapped = resource;
+        super(resource);
 
         FacesContext context = FacesContext.getCurrentInstance();
         version = PrimeRequestContext.getCurrentInstance(context).isHideResourceVersion()
                 ? null
                 : "&v=" + PrimeApplicationContext.getCurrentInstance(context).getEnvironment().getBuildVersion();
-    }
-
-    @Override
-    public Resource getWrapped() {
-        return wrapped;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/application/resource/PrimeResourceHandler.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/PrimeResourceHandler.java
@@ -44,11 +44,8 @@ public class PrimeResourceHandler extends ResourceHandlerWrapper {
 
     private final Map<String, DynamicContentHandler> handlers;
 
-    private final ResourceHandler wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeResourceHandler(ResourceHandler wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
         handlers = new HashMap<>();
         handlers.put(DynamicContentType.STREAMED_CONTENT.toString(), new StreamedContentHandler());
 
@@ -59,11 +56,6 @@ public class PrimeResourceHandler extends ResourceHandlerWrapper {
         if (LangUtils.tryToLoadClassForName("io.nayuki.qrcodegen.QrCode") != null) {
             handlers.put(DynamicContentType.QR_CODE.toString(), new QRCodeHandler());
         }
-    }
-
-    @Override
-    public ResourceHandler getWrapped() {
-        return this.wrapped;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/clientwindow/PrimeClientWindowLifecycle.java
+++ b/primefaces/src/main/java/org/primefaces/clientwindow/PrimeClientWindowLifecycle.java
@@ -32,11 +32,8 @@ import javax.faces.lifecycle.LifecycleWrapper;
 // if we would add the client-window-factory entry, pre JSF2.3 would crash
 public class PrimeClientWindowLifecycle extends LifecycleWrapper {
 
-    private final Lifecycle wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeClientWindowLifecycle(Lifecycle wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
     }
 
     @Override
@@ -56,8 +53,4 @@ public class PrimeClientWindowLifecycle extends LifecycleWrapper {
         }
     }
 
-    @Override
-    public Lifecycle getWrapped() {
-        return wrapped;
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/clientwindow/PrimeClientWindowLifecycleFactory.java
+++ b/primefaces/src/main/java/org/primefaces/clientwindow/PrimeClientWindowLifecycleFactory.java
@@ -24,36 +24,30 @@
 package org.primefaces.clientwindow;
 
 import java.util.Iterator;
+
 import javax.faces.lifecycle.Lifecycle;
 import javax.faces.lifecycle.LifecycleFactory;
 
 public class PrimeClientWindowLifecycleFactory extends LifecycleFactory {
 
-    private final LifecycleFactory wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeClientWindowLifecycleFactory(LifecycleFactory wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
     }
 
     @Override
     public void addLifecycle(String lifecycleId, Lifecycle lifecycle) {
-        wrapped.addLifecycle(lifecycleId, lifecycle);
+        getWrapped().addLifecycle(lifecycleId, lifecycle);
     }
 
     @Override
     public Lifecycle getLifecycle(String lifecycleId) {
-        Lifecycle result = wrapped.getLifecycle(lifecycleId);
+        Lifecycle result = getWrapped().getLifecycle(lifecycleId);
         return new PrimeClientWindowLifecycle(result);
     }
 
     @Override
     public Iterator<String> getLifecycleIds() {
-        return wrapped.getLifecycleIds();
+        return getWrapped().getLifecycleIds();
     }
 
-    @Override
-    public LifecycleFactory getWrapped() {
-        return wrapped;
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
@@ -23,96 +23,17 @@
  */
 package org.primefaces.context;
 
-import java.io.IOException;
-import java.util.Map;
 import javax.faces.context.PartialResponseWriter;
 
+/**
+ * This partial response writer adds support for passing arguments to JavaScript context, executing
+ * oncomplete callback scripts, resetting the AJAX response (specifically for {@link FullAjaxExceptionHandler}) and
+ * fixing incomplete XML response in case of exceptions.
+ */
 public class PartialResponseWriterWrapper extends PartialResponseWriter {
-
-    private PartialResponseWriter wrapped;
 
     public PartialResponseWriterWrapper(PartialResponseWriter wrapped) {
         super(wrapped);
-        this.wrapped = wrapped;
     }
 
-    @Override
-    public void delete(String targetId) throws IOException {
-        wrapped.delete(targetId);
-    }
-
-    @Override
-    public void endDocument() throws IOException {
-        wrapped.endDocument();
-    }
-
-    @Override
-    public void endError() throws IOException {
-        wrapped.endError();
-    }
-
-    @Override
-    public void endEval() throws IOException {
-        wrapped.endEval();
-    }
-
-    @Override
-    public void endExtension() throws IOException {
-        wrapped.endExtension();
-    }
-
-    @Override
-    public void endInsert() throws IOException {
-        wrapped.endInsert();
-    }
-
-    @Override
-    public void endUpdate() throws IOException {
-        wrapped.endUpdate();
-    }
-
-    @Override
-    public void redirect(String url) throws IOException {
-        wrapped.redirect(url);
-    }
-
-    @Override
-    public void startDocument() throws IOException {
-        wrapped.startDocument();
-    }
-
-    @Override
-    public void startError(String errorName) throws IOException {
-        wrapped.startError(errorName);
-    }
-
-    @Override
-    public void startEval() throws IOException {
-        wrapped.startEval();
-    }
-
-    @Override
-    public void startExtension(Map<String, String> attributes) throws IOException {
-        wrapped.startExtension(attributes);
-    }
-
-    @Override
-    public void startInsertAfter(String targetId) throws IOException {
-        wrapped.startInsertAfter(targetId);
-    }
-
-    @Override
-    public void startInsertBefore(String targetId) throws IOException {
-        wrapped.startInsertBefore(targetId);
-    }
-
-    @Override
-    public void startUpdate(String targetId) throws IOException {
-        wrapped.startUpdate(targetId);
-    }
-
-    @Override
-    public void updateAttributes(String targetId, Map<String, String> attributes) throws IOException {
-        wrapped.updateAttributes(targetId, attributes);
-    }
 }

--- a/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
@@ -23,17 +23,361 @@
  */
 package org.primefaces.context;
 
+import java.io.IOException;
+import java.util.Map;
+
+import javax.faces.component.NamingContainer;
+import javax.faces.component.UIViewRoot;
+import javax.faces.context.FacesContext;
 import javax.faces.context.PartialResponseWriter;
+import javax.faces.context.ResponseWriter;
+import javax.faces.context.ResponseWriterWrapper;
+import javax.faces.render.ResponseStateManager;
+
 
 /**
  * This partial response writer adds support for passing arguments to JavaScript context, executing
  * oncomplete callback scripts, resetting the AJAX response (specifically for {@link FullAjaxExceptionHandler}) and
  * fixing incomplete XML response in case of exceptions.
  */
-public class PartialResponseWriterWrapper extends PartialResponseWriter {
+public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
 
-    public PartialResponseWriterWrapper(PartialResponseWriter wrapped) {
-        super(wrapped);
+    /**
+     * <p class="changed_added_2_0">Reserved ID value to indicate
+     * entire ViewRoot.</p>
+     *
+     * @since 2.0
+     */
+    public static final String RENDER_ALL_MARKER = "javax.faces.ViewRoot";
+
+    /**
+     * <p class="changed_added_2_0">Reserved ID value to indicate
+     * serialized ViewState.</p>
+     *
+     * @since 2.0
+     */
+    public static final String VIEW_STATE_MARKER = ResponseStateManager.VIEW_STATE_PARAM;
+
+    // True when we need to close a changes tag
+    //
+    private boolean inChanges = false;
+
+    // True when we need to close a before insert tag
+    //
+    private boolean inInsertBefore = false;
+
+    // True when we need to close afer insert tag
+    //
+    private boolean inInsertAfter = false;
+
+    // True when we need to close an update tag
+    //
+    private boolean inUpdate = false;
+
+    /**
+     * <p class="changed_added_2_0">Create a <code>PartialResponseWriter</code>.</p>
+     *
+     * @param writer The writer to wrap.
+     * @since 2.0
+     */
+    public PartialResponseWriterWrapper(ResponseWriter writer) {
+        super(writer);
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of a partial response.</p>
+     * <p class="changed_added_2_3">If {@link UIViewRoot} is an instance of
+     * {@link NamingContainer}, then write
+     * {@link UIViewRoot#getContainerClientId(FacesContext)} as value of the
+     * <code>id</code> attribute of the root element.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    @Override
+    public void startDocument() throws IOException {
+        ResponseWriter writer = getWrapped();
+        String encoding = writer.getCharacterEncoding( );
+        if ( encoding == null ) {
+            encoding = "utf-8";
+        }
+        writer.writePreamble("<?xml version='1.0' encoding='" + encoding + "'?>\n");
+        writer.startElement("partial-response", null);
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (null != ctx && ctx.getViewRoot() instanceof NamingContainer) {
+            String id = ctx.getViewRoot().getContainerClientId(ctx);
+            writer.writeAttribute("id", id, "id");
+        }
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of a partial response.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    @Override
+    public void endDocument() throws IOException {
+        endChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        /*
+         * Because during a <script> writing an exception can occur we need to
+         * make sure the wrapped response only writes one partial-response, but
+         * also calls to end the document (so we can properly cleanup in the
+         * wrapped HtmlResponseWriter). See issue #3473.
+         */
+        if (!(writer instanceof PartialResponseWriter)) {
+            writer.endElement("partial-response");
+        }
+        writer.endDocument();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an insert operation
+     * where the contents will be inserted before the specified target node.</p>
+     *
+     * @param targetId ID of the node insertion should occur before
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startInsertBefore(String targetId)
+            throws IOException {
+        startChangesIfNecessary();
+        inInsertBefore = true;
+        ResponseWriter writer = getWrapped();
+        writer.startElement("insert", null);
+        writer.startElement("before", null);
+        writer.writeAttribute("id", targetId, null);
+        writer.startCDATA();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an insert operation
+     * where the contents will be inserted after the specified target node.</p>
+     *
+     * @param targetId ID of the node insertion should occur after
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startInsertAfter(String targetId)
+            throws IOException {
+        startChangesIfNecessary();
+        inInsertAfter = true;
+        ResponseWriter writer = getWrapped();
+        writer.startElement("insert", null);
+        writer.startElement("after", null);
+        writer.writeAttribute("id", targetId, null);
+        writer.startCDATA();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of an insert operation.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void endInsert() throws IOException {
+        ResponseWriter writer = getWrapped();
+        writer.endCDATA();
+        if (inInsertBefore) {
+            writer.endElement("before");
+            inInsertBefore = false;
+        }
+        else if (inInsertAfter) {
+            writer.endElement("after");
+            inInsertAfter = false;
+        }
+        writer.endElement("insert");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an update operation.</p>
+     *
+     * @param targetId ID of the node to be updated
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startUpdate(String targetId) throws IOException {
+        startChangesIfNecessary();
+        inUpdate = true;
+        ResponseWriter writer = getWrapped();
+        writer.startElement("update", null);
+        writer.writeAttribute("id", targetId, null);
+        writer.startCDATA();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of an update operation.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void endUpdate() throws IOException {
+        ResponseWriter writer = getWrapped();
+        writer.endCDATA();
+        writer.endElement("update");
+        inUpdate = false;
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write an attribute update operation.</p>
+     *
+     * @param targetId   ID of the node to be updated
+     * @param attributes Map of attribute name/value pairs to be updated
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void updateAttributes(String targetId, Map<String, String> attributes)
+            throws IOException {
+        startChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("attributes", null);
+        writer.writeAttribute("id", targetId, null);
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            writer.startElement("attribute", null);
+            writer.writeAttribute("name", entry.getKey(), null);
+            writer.writeAttribute("value", entry.getValue(), null);
+            writer.endElement("attribute");
+        }
+        writer.endElement("attributes");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write a delete operation.</p>
+     *
+     * @param targetId ID of the node to be deleted
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void delete(String targetId) throws IOException {
+        startChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("delete", null);
+        writer.writeAttribute("id", targetId, null);
+        writer.endElement("delete");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write a redirect operation.</p>
+     *
+     * @param url URL to redirect to
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void redirect(String url) throws IOException {
+        endChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("redirect", null);
+        writer.writeAttribute("url", url, null);
+        writer.endElement("redirect");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an eval operation.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startEval() throws IOException {
+        startChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("eval", null);
+        writer.startCDATA();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of an eval operation.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void endEval() throws IOException {
+        ResponseWriter writer = getWrapped();
+        writer.endCDATA();
+        writer.endElement("eval");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an extension operation.</p>
+     *
+     * @param attributes String name/value pairs for extension element attributes
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startExtension(Map<String, String> attributes) throws IOException {
+        startChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("extension", null);
+        if (attributes != null && !attributes.isEmpty()) {
+            for (Map.Entry<String, String> entry : attributes.entrySet()) {
+                writer.writeAttribute(entry.getKey(), entry.getValue(), null);
+            }
+        }
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of an extension operation.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void endExtension() throws IOException {
+        ResponseWriter writer = getWrapped();
+        writer.endElement("extension");
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the start of an error.</p>
+     *
+     * @param errorName Descriptive string for the error
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void startError(String errorName) throws IOException {
+        endUpdateIfNecessary();
+        endChangesIfNecessary();
+        ResponseWriter writer = getWrapped();
+        writer.startElement("error", null);
+        writer.startElement("error-name", null);
+        writer.write(errorName);
+        writer.endElement("error-name");
+        writer.startElement("error-message", null);
+        writer.startCDATA();
+    }
+
+    /**
+     * <p class="changed_added_2_0">Write the end of an error.</p>
+     *
+     * @throws IOException if an input/output error occurs
+     * @since 2.0
+     */
+    public void endError() throws IOException {
+        ResponseWriter writer = getWrapped();
+        writer.endCDATA();
+        writer.endElement("error-message");
+        writer.endElement("error");
+    }
+
+    private void startChangesIfNecessary() throws IOException {
+        if (!inChanges) {
+            ResponseWriter writer = getWrapped();
+            writer.startElement("changes", null);
+            inChanges = true;
+        }
+    }
+
+    private void endUpdateIfNecessary() throws IOException {
+        if (inUpdate) {
+            endUpdate();
+        }
+    }
+
+    private void endChangesIfNecessary() throws IOException {
+        if (inChanges) {
+            ResponseWriter writer = getWrapped();
+            writer.endElement("changes");
+            inChanges = false;
+        }
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/context/PartialResponseWriterWrapper.java
@@ -31,7 +31,6 @@ import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.faces.context.PartialResponseWriter;
 import javax.faces.context.ResponseWriter;
-import javax.faces.context.ResponseWriterWrapper;
 import javax.faces.render.ResponseStateManager;
 
 
@@ -40,7 +39,7 @@ import javax.faces.render.ResponseStateManager;
  * oncomplete callback scripts, resetting the AJAX response (specifically for {@link FullAjaxExceptionHandler}) and
  * fixing incomplete XML response in case of exceptions.
  */
-public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
+public class PartialResponseWriterWrapper extends PartialResponseWriter {
 
     /**
      * <p class="changed_added_2_0">Reserved ID value to indicate
@@ -140,6 +139,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startInsertBefore(String targetId)
             throws IOException {
         startChangesIfNecessary();
@@ -159,6 +159,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startInsertAfter(String targetId)
             throws IOException {
         startChangesIfNecessary();
@@ -176,6 +177,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void endInsert() throws IOException {
         ResponseWriter writer = getWrapped();
         writer.endCDATA();
@@ -197,6 +199,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startUpdate(String targetId) throws IOException {
         startChangesIfNecessary();
         inUpdate = true;
@@ -212,6 +215,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void endUpdate() throws IOException {
         ResponseWriter writer = getWrapped();
         writer.endCDATA();
@@ -227,6 +231,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void updateAttributes(String targetId, Map<String, String> attributes)
             throws IOException {
         startChangesIfNecessary();
@@ -249,6 +254,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void delete(String targetId) throws IOException {
         startChangesIfNecessary();
         ResponseWriter writer = getWrapped();
@@ -264,6 +270,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void redirect(String url) throws IOException {
         endChangesIfNecessary();
         ResponseWriter writer = getWrapped();
@@ -278,6 +285,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startEval() throws IOException {
         startChangesIfNecessary();
         ResponseWriter writer = getWrapped();
@@ -291,6 +299,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void endEval() throws IOException {
         ResponseWriter writer = getWrapped();
         writer.endCDATA();
@@ -304,6 +313,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startExtension(Map<String, String> attributes) throws IOException {
         startChangesIfNecessary();
         ResponseWriter writer = getWrapped();
@@ -321,6 +331,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void endExtension() throws IOException {
         ResponseWriter writer = getWrapped();
         writer.endElement("extension");
@@ -333,6 +344,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void startError(String errorName) throws IOException {
         endUpdateIfNecessary();
         endChangesIfNecessary();
@@ -351,6 +363,7 @@ public class PartialResponseWriterWrapper extends ResponseWriterWrapper {
      * @throws IOException if an input/output error occurs
      * @since 2.0
      */
+    @Override
     public void endError() throws IOException {
         ResponseWriter writer = getWrapped();
         writer.endCDATA();

--- a/primefaces/src/main/java/org/primefaces/context/PrimeExternalContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeExternalContext.java
@@ -29,16 +29,8 @@ import javax.faces.context.FacesContext;
 
 public class PrimeExternalContext extends ExternalContextWrapper {
 
-    private ExternalContext wrapped;
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeExternalContext(ExternalContext wrapped) {
-        this.wrapped = wrapped;
-    }
-
-    @Override
-    public ExternalContext getWrapped() {
-        return wrapped;
+        super(wrapped);
     }
 
     public static PrimeExternalContext getCurrentInstance(FacesContext facesContext) {

--- a/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
@@ -25,11 +25,8 @@ package org.primefaces.context;
 
 import javax.faces.application.FacesMessage;
 import javax.faces.component.UIInput;
-import javax.faces.context.ExternalContext;
-import javax.faces.context.FacesContext;
-import javax.faces.context.FacesContextWrapper;
-import javax.faces.context.ResponseWriter;
-import javax.faces.context.ResponseWriterWrapper;
+import javax.faces.context.*;
+
 import org.primefaces.application.resource.MoveScriptsToBottomResponseWriter;
 import org.primefaces.application.resource.MoveScriptsToBottomState;
 import org.primefaces.config.PrimeConfiguration;
@@ -41,7 +38,6 @@ import org.primefaces.csp.CspState;
  */
 public class PrimeFacesContext extends FacesContextWrapper {
 
-    private final FacesContext wrapped;
     private final boolean moveScriptsToBottom;
     private final boolean csp;
     private final boolean markInputAsInvalidOnErrorMsg;
@@ -50,9 +46,8 @@ public class PrimeFacesContext extends FacesContextWrapper {
     private CspState cspState;
     private PrimeExternalContext externalContext;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeFacesContext(FacesContext wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
 
         PrimeRequestContext requestContext = new PrimeRequestContext(wrapped);
         PrimeRequestContext.setCurrentInstance(requestContext, wrapped);
@@ -77,7 +72,7 @@ public class PrimeFacesContext extends FacesContextWrapper {
     @Override
     public ExternalContext getExternalContext() {
         if (externalContext == null) {
-            externalContext = new PrimeExternalContext(wrapped.getExternalContext());
+            externalContext = new PrimeExternalContext(getWrapped().getExternalContext());
         }
         return externalContext;
     }
@@ -116,13 +111,8 @@ public class PrimeFacesContext extends FacesContextWrapper {
     }
 
     @Override
-    public FacesContext getWrapped() {
-        return wrapped;
-    }
-
-    @Override
     public void release() {
-        PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(wrapped);
+        PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(getWrapped());
         if (requestContext != null) {
             requestContext.release();
         }

--- a/primefaces/src/main/java/org/primefaces/context/PrimeFacesContextFactory.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeFacesContextFactory.java
@@ -35,22 +35,16 @@ public class PrimeFacesContextFactory extends FacesContextFactory {
 
     private FacesContextFactory wrapped;
 
-    // #6212 - don't remove it
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
-    public PrimeFacesContextFactory() {
-
-    }
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimeFacesContextFactory(FacesContextFactory wrapped) {
-        this.wrapped = wrapped;
+        super(wrapped);
+        this.wrapped = wrapped; // We can't rely on getWrapped() due to MyFaces bug
     }
 
     @Override
     public FacesContext getFacesContext(Object context, Object request, Object response, Lifecycle lifecycle)
             throws FacesException {
 
-        FacesContext wrappedContext = wrapped.getFacesContext(context, request, response, lifecycle);
+        FacesContext wrappedContext = getWrapped().getFacesContext(context, request, response, lifecycle);
 
         if (wrappedContext instanceof PrimeFacesContext) {
             return wrappedContext;
@@ -63,4 +57,5 @@ public class PrimeFacesContextFactory extends FacesContextFactory {
     public FacesContextFactory getWrapped() {
         return wrapped;
     }
+
 }

--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
@@ -42,7 +42,7 @@ import org.primefaces.util.EscapeUtils;
 import org.primefaces.util.LangUtils;
 import org.primefaces.util.ResourceUtils;
 
-public class PrimePartialResponseWriter extends PartialResponseWriter {
+public class PrimePartialResponseWriter extends PartialResponseWriterWrapper {
 
     private static final Map<String, String> CALLBACK_EXTENSION_PARAMS;
 

--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
@@ -23,14 +23,8 @@
  */
 package org.primefaces.context;
 
-import org.primefaces.application.resource.DynamicResourcesPhaseListener;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.primefaces.util.BeanUtils;
-import org.primefaces.util.EscapeUtils;
-import org.primefaces.util.LangUtils;
-import org.primefaces.util.ResourceUtils;
+import java.io.IOException;
+import java.util.*;
 
 import javax.faces.component.NamingContainer;
 import javax.faces.component.UINamingContainer;
@@ -38,15 +32,17 @@ import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.faces.context.PartialResponseWriter;
 import javax.faces.event.AbortProcessingException;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
-public class PrimePartialResponseWriter extends PartialResponseWriterWrapper {
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.primefaces.application.resource.DynamicResourcesPhaseListener;
+import org.primefaces.util.BeanUtils;
+import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
+import org.primefaces.util.ResourceUtils;
+
+public class PrimePartialResponseWriter extends PartialResponseWriter {
 
     private static final Map<String, String> CALLBACK_EXTENSION_PARAMS;
 

--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContext.java
@@ -30,10 +30,10 @@ import javax.faces.context.PartialResponseWriter;
 import javax.faces.context.PartialViewContext;
 import javax.faces.context.PartialViewContextWrapper;
 import javax.faces.event.PhaseId;
+
 import org.primefaces.config.PrimeConfiguration;
 import org.primefaces.csp.CspPartialResponseWriter;
 import org.primefaces.expression.SearchExpressionConstants;
-
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
@@ -42,17 +42,10 @@ import org.primefaces.visit.ResetInputVisitCallback;
 
 public class PrimePartialViewContext extends PartialViewContextWrapper {
 
-    private PartialViewContext wrapped;
     private PartialResponseWriter writer;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimePartialViewContext(PartialViewContext wrapped) {
-        this.wrapped = wrapped;
-    }
-
-    @Override
-    public PartialViewContext getWrapped() {
-        return this.wrapped;
+        super(wrapped);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContextFactory.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContextFactory.java
@@ -29,22 +29,8 @@ import javax.faces.context.PartialViewContextFactory;
 
 public class PrimePartialViewContextFactory extends PartialViewContextFactory {
 
-    private PartialViewContextFactory parent;
-
-    // #6212 - don't remove it
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
-    public PrimePartialViewContextFactory() {
-
-    }
-
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public PrimePartialViewContextFactory(PartialViewContextFactory parent) {
-        this.parent = parent;
-    }
-
-    @Override
-    public PartialViewContextFactory getWrapped() {
-        return this.parent;
+        super(parent);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/csp/CspResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspResponseWriter.java
@@ -25,12 +25,8 @@ package org.primefaces.csp;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
@@ -58,8 +54,6 @@ public class CspResponseWriter extends ResponseWriterWrapper {
                     "onselect", "onshow", "onstalled", "onstorage", "onsubmit", "onsuspend", "ontimeupdate", "ontoggle", "ontouchcancel",
                     "ontouchend", "ontouchmove", "ontouchstart", "ontransitionend", "onunload", "onvolumechange", "onwaiting", "onwheel"));
 
-    private ResponseWriter wrapped;
-
     private CspState cspState;
 
     private String lastElement;
@@ -69,9 +63,8 @@ public class CspResponseWriter extends ResponseWriterWrapper {
 
     private Lazy<Boolean> policyProvided;
 
-    @SuppressWarnings("deprecation") // the default constructor is deprecated in JSF 2.3
     public CspResponseWriter(ResponseWriter wrapped, CspState cspState) {
-        this.wrapped = wrapped;
+        super(wrapped);
         this.cspState = cspState;
 
         policyProvided = new Lazy<>(() ->
@@ -262,8 +255,4 @@ public class CspResponseWriter extends ResponseWriterWrapper {
         return getWrapped().cloneWithWriter(writer);
     }
 
-    @Override
-    public ResponseWriter getWrapped() {
-        return wrapped;
-    }
 }


### PR DESCRIPTION
Fix #9518: JSF23 wrapped constructors

The note `// #6212 - don't remove it` is in reference to this old Google Code ticket: https://code.google.com/archive/p/primefaces/issues/6212

From 2013: "GlassFish 4/Weld logs a warning about it" so I think its safe to remove now in 2023.