### PR TITLE
Migrate setup-java action to use Temurin

### DIFF
--- a/.github/workflows/nightly-file.upload.yml
+++ b/.github/workflows/nightly-file.upload.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/.github/workflows/nightly-safari.yml
+++ b/.github/workflows/nightly-safari.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v3


### PR DESCRIPTION
AdoptOpenJDK has moved to the Eclipse Foundation and now distributes binaries under the new name "Eclipse Temurin"