### PR TITLE
Fix #9546: CSV bean validation must unproxy class

### DIFF
--- a/primefaces/src/main/java/org/primefaces/metadata/BeanValidationMetadataExtractor.java
+++ b/primefaces/src/main/java/org/primefaces/metadata/BeanValidationMetadataExtractor.java
@@ -25,6 +25,7 @@ package org.primefaces.metadata;
 
 import java.util.Collections;
 import java.util.Set;
+
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.el.ValueReference;
@@ -34,8 +35,10 @@ import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstraintDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
+
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.el.ValueExpressionAnalyzer;
+import org.primefaces.util.LangUtils;
 
 public class BeanValidationMetadataExtractor {
 
@@ -84,7 +87,8 @@ public class BeanValidationMetadataExtractor {
                 Object property = vr.getProperty();
 
                 if (base != null && property != null) {
-                    BeanDescriptor beanDescriptor = validator.getConstraintsForClass(base.getClass());
+                    Class<?> unproxied = LangUtils.getUnproxiedClass(base.getClass());
+                    BeanDescriptor beanDescriptor = validator.getConstraintsForClass(unproxied);
 
                     if (beanDescriptor != null) {
                         return beanDescriptor.getConstraintsForProperty(property.toString());


### PR DESCRIPTION
Fix #9546: CSV bean validation must unproxy class

Quarkus proxies the classes so it has to be unwrapped.