### PR TITLE
Fix #9559/#8365: DatePicker AM/PM localization

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker015.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker015.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2022 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import javax.annotation.PostConstruct;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DatePicker015 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private LocalDateTime german;
+    private LocalDateTime spanish;
+    private LocalDateTime english;
+
+    @PostConstruct
+    public void init() {
+        german = LocalDateTime.of(2020, 2, 10, 1, 16, 04);
+        spanish = LocalDateTime.of(2021, 4, 13, 5, 21, 19);
+        english = LocalDateTime.of(2022, 5, 30, 17, 07, 12);
+    }
+
+    public void submit() {
+        TestUtils.addMessage("German", german.format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withLocale(Locale.GERMAN)));
+        TestUtils.addMessage("Spanish", spanish.format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withLocale(new Locale("es"))));
+        TestUtils.addMessage("English", english.format(DateTimeFormatter.ofPattern("MM/dd/yyyy hh:mm a").withLocale(Locale.ENGLISH)));
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker015.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker015.xhtml
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<h:form id="form">
+			<p:messages id="msgs" showDetail="true" />
+
+			<div class="ui-fluid grid formgrid">
+				<div class="field">
+					<p:outputLabel value="Spanish a. m. / p. m." />
+					<p:datePicker id="spanish" value="#{datePicker015.spanish}"
+						pattern="MM/dd/yyyy hh:mm a" showIcon="true" monthNavigator="true"
+						yearNavigator="true" showTime="true" readonlyInput="true"
+						timeInput="true" showOnFocus="false" hourFormat="12"
+						touchUI="false" showButtonBar="true" resolverStyle="strict"
+						locale="es" />
+				</div>
+				<div class="field">
+					<p:outputLabel value="German vorm. / nachm." />
+					<p:datePicker id="german" value="#{datePicker015.german}"
+						pattern="MM/dd/yyyy hh:mm a" showIcon="true" monthNavigator="true"
+						yearNavigator="true" showTime="true" readonlyInput="true"
+						timeInput="true" showOnFocus="false" hourFormat="12"
+						touchUI="true" showButtonBar="true" resolverStyle="strict"
+						locale="de" />
+				</div>
+				<div class="field">
+					<p:outputLabel value="English AM / PM" />
+					<p:datePicker id="english" value="#{datePicker015.english}"
+						pattern="MM/dd/yyyy hh:mm a" showIcon="true" monthNavigator="true"
+						yearNavigator="true" showTime="true" readonlyInput="true"
+						timeInput="true" showOnFocus="false" hourFormat="12"
+						touchUI="true" showButtonBar="true" resolverStyle="strict"
+						locale="en" />
+				</div>
+			</div>
+
+			<p:commandButton id="button" value="Submit" update="@form"
+				action="#{datePicker015.submit()}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
@@ -1,0 +1,177 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2022 PrimeTek
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+
+import java.text.DateFormatSymbols;
+import java.time.LocalDateTime;
+import java.util.Locale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DatePicker;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.util.Constants;
+
+public class DatePicker015Test extends AbstractDatePickerTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DatePicker: German AM / PM")
+    public void testGermanAmPm(Page page) {
+        // Arrange
+        DatePicker datePicker = page.german;
+        LocalDateTime expected = LocalDateTime.of(2020, 2, 10, 1, 16, 0);
+        String expectedString = "02/10/2020 01:16 ";
+        DateFormatSymbols symbols = new DateFormatSymbols(Locale.GERMANY);
+        String[] ampm = symbols.getAmPmStrings();
+        String am = ampm[0];
+        String pm = ampm[1];
+
+        // Assert
+        Assertions.assertEquals(expected, datePicker.getValue());
+        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+
+        // Act
+        WebElement panel = datePicker.showPanel();
+        assertAmPm(panel, am);
+        toggleAmPm(panel);
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+        Assertions.assertEquals(expectedString + pm, page.messages.getMessage(0).getDetail());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DatePicker: Spanish AM / PM")
+    public void testSpanishAmPm(Page page) {
+        // Arrange
+        DatePicker datePicker = page.spanish;
+        LocalDateTime expected = LocalDateTime.of(2021, 4, 13, 5, 21, 0);
+        String expectedString = "04/13/2021 05:21 ";
+        DateFormatSymbols symbols = new DateFormatSymbols(new Locale("es"));
+        String[] ampm = symbols.getAmPmStrings();
+        String am = ampm[0];
+        String pm = ampm[1];
+
+        // Assert
+        Assertions.assertEquals(expected, datePicker.getValue());
+        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+
+        // Act
+        WebElement panel = datePicker.showPanel();
+        assertAmPm(panel, am);
+        toggleAmPm(panel);
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+        Assertions.assertEquals(expectedString + pm, page.messages.getMessage(1).getDetail());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("DatePicker: English AM / PM Defaults")
+    public void testEnglishAmPm(Page page) {
+        // Arrange
+        DatePicker datePicker = page.english;
+        LocalDateTime expected = LocalDateTime.of(2022, 5, 30, 17, 07, 0);
+        String expectedString = "05/30/2022 05:07 ";
+        DateFormatSymbols symbols = new DateFormatSymbols(Locale.ENGLISH);
+        String[] ampm = symbols.getAmPmStrings();
+        String am = ampm[0];
+        String pm = ampm[1];
+
+        // Assert
+        Assertions.assertEquals(expected, datePicker.getValue());
+        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+
+        // Act
+        WebElement panel = datePicker.showPanel();
+        assertAmPm(panel, pm);
+        toggleAmPm(panel);
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+        Assertions.assertEquals(expectedString + am, page.messages.getMessage(2).getDetail());
+    }
+
+    protected void assertAmPm(WebElement panel, String ampm) {
+        Assertions.assertNotNull(panel);
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
+        WebElement timePicker = panel.findElement(By.className("ui-timepicker"));
+        
+        // between JDK8 and 11 some space characters became non breaking space '\u00A0'
+        ampm = ampm.replaceAll(Constants.SPACE, Constants.NON_BREAKING_SPACE_STR);
+        Assertions.assertEquals(ampm,
+                timePicker.findElement(By.cssSelector("div.ui-ampm-picker > span")).getText());
+    }
+
+    protected void toggleAmPm(WebElement panel) {
+        Assertions.assertNotNull(panel);
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
+        WebElement amPmPicker = panel.findElement(By.className("ui-ampm-picker"));
+        amPmPicker.findElement(By.className("ui-picker-down")).click();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:german")
+        DatePicker german;
+
+        @FindBy(id = "form:spanish")
+        DatePicker spanish;
+
+        @FindBy(id = "form:english")
+        DatePicker english;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker015.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
@@ -60,7 +60,7 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         Assertions.assertEquals(expected, datePicker.getValue());
-        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
 
         // Act
         WebElement panel = datePicker.showPanel();
@@ -71,8 +71,8 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         assertNoJavascriptErrors();
-        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
-        Assertions.assertEquals(expectedString + pm, page.messages.getMessage(0).getDetail());
+        assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + pm, page.messages.getMessage(0).getDetail());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         Assertions.assertEquals(expected, datePicker.getValue());
-        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
 
         // Act
         WebElement panel = datePicker.showPanel();
@@ -101,8 +101,8 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         assertNoJavascriptErrors();
-        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
-        Assertions.assertEquals(expectedString + pm, page.messages.getMessage(1).getDetail());
+        assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + pm, page.messages.getMessage(1).getDetail());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         Assertions.assertEquals(expected, datePicker.getValue());
-        Assertions.assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + pm, datePicker.getInput().getAttribute("value"));
 
         // Act
         WebElement panel = datePicker.showPanel();
@@ -131,19 +131,15 @@ public class DatePicker015Test extends AbstractDatePickerTest {
 
         // Assert
         assertNoJavascriptErrors();
-        Assertions.assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
-        Assertions.assertEquals(expectedString + am, page.messages.getMessage(2).getDetail());
+        assertEquals(expectedString + am, datePicker.getInput().getAttribute("value"));
+        assertEquals(expectedString + am, page.messages.getMessage(2).getDetail());
     }
 
     protected void assertAmPm(WebElement panel, String ampm) {
         Assertions.assertNotNull(panel);
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
         WebElement timePicker = panel.findElement(By.className("ui-timepicker"));
-
-        // between JDK8 and 11 some space characters became non breaking space '\u00A0'
-        ampm = ampm.replaceAll(Constants.SPACE, Constants.NON_BREAKING_SPACE_STR);
-        Assertions.assertEquals(ampm,
-                timePicker.findElement(By.cssSelector("div.ui-ampm-picker > span")).getText());
+        assertEquals(ampm, timePicker.findElement(By.cssSelector("div.ui-ampm-picker > span")).getText());
     }
 
     protected void toggleAmPm(WebElement panel) {
@@ -151,6 +147,13 @@ public class DatePicker015Test extends AbstractDatePickerTest {
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
         WebElement amPmPicker = panel.findElement(By.className("ui-ampm-picker"));
         amPmPicker.findElement(By.className("ui-picker-down")).click();
+    }
+
+    protected void assertEquals(String expected, String actual) {
+        // between JDK8 and 11 some space characters became non breaking space '\u00A0'
+        expected = expected.replaceAll("\\p{Z}", Constants.SPACE);
+        actual = actual.replaceAll("\\p{Z}", Constants.SPACE);
+        Assertions.assertEquals(expected, actual);
     }
 
     public static class Page extends AbstractPrimePage {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker015Test.java
@@ -139,7 +139,7 @@ public class DatePicker015Test extends AbstractDatePickerTest {
         Assertions.assertNotNull(panel);
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
         WebElement timePicker = panel.findElement(By.className("ui-timepicker"));
-        
+
         // between JDK8 and 11 some space characters became non breaking space '\u00A0'
         ampm = ampm.replaceAll(Constants.SPACE, Constants.NON_BREAKING_SPACE_STR);
         Assertions.assertEquals(ampm,

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -24,6 +24,7 @@
 package org.primefaces.component.datepicker;
 
 import java.io.IOException;
+import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -170,9 +171,15 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             defaultDate = value;
         }
 
+        // #9559 java locale must match UI local for AM/PM
+        DateFormatSymbols symbols = new DateFormatSymbols(locale);
+        String[] ampm = symbols.getAmPmStrings();
+
         wb.attr("defaultDate", defaultDate, null)
             .attr("inline", datePicker.isInline())
             .attr("userLocale", locale.toString())
+            .attr("localeAm", ampm[0], "AM")
+            .attr("localePm", ampm[1], "PM")
             .attr("dateFormat", CalendarUtils.convertPattern(pattern))
             .attr("showIcon", datePicker.isShowIcon(), false)
             .attr("buttonTabindex", datePicker.getButtonTabindex())

--- a/primefaces/src/main/java/org/primefaces/util/Constants.java
+++ b/primefaces/src/main/java/org/primefaces/util/Constants.java
@@ -127,6 +127,10 @@ public class Constants {
 
     public static final String MULTI_VIEW_STATES = "primefaces.MULTI_VIEW_STATES";
 
+    /** Space hack to fix Brazilian Real and other locale issues */
+    public static final char NON_BREAKING_SPACE = '\u00A0';
+    public static final String NON_BREAKING_SPACE_STR = Character.toString(NON_BREAKING_SPACE);
+
     private Constants() {
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
+++ b/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
@@ -48,10 +48,6 @@ public class CurrencyValidator extends BigDecimalValidator {
 
     private static final CurrencyValidator VALIDATOR = new CurrencyValidator();
 
-    /** Space hack to fix Brazilian Real and maybe others */
-    private static final char NON_BREAKING_SPACE = '\u00A0';
-    private static final String NON_BREAKING_SPACE_STR = Character.toString(NON_BREAKING_SPACE);
-
     /**
      * Return a singleton instance of this validator.
      *
@@ -82,8 +78,8 @@ public class CurrencyValidator extends BigDecimalValidator {
         }
 
         // between JDK8 and 11 some space characters became non breaking space '\u00A0'
-        if (formatter.getPositivePrefix().indexOf(NON_BREAKING_SPACE) >= 0) {
-            value = value.replaceAll(Constants.SPACE, NON_BREAKING_SPACE_STR);
+        if (formatter.getPositivePrefix().indexOf(Constants.NON_BREAKING_SPACE) >= 0) {
+            value = value.replaceAll(Constants.SPACE, Constants.NON_BREAKING_SPACE_STR);
         }
 
         // Initial parse of the value

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -76,7 +76,9 @@
                 year: 'Year',
                 month: 'Month',
                 week: 'Week',
-                day: 'Day'
+                day: 'Day',
+                am: 'AM',
+                pm: 'PM'
             },
             dateFormat: 'mm/dd/yy',
             yearRange: null,
@@ -751,7 +753,7 @@
             }
 
             if (this.options.hourFormat === '12') {
-                output += date.getHours() > 11 ? ' PM' : ' AM';
+                output += date.getHours() > 11 ? ' ' + this.options.locale.pm : ' ' + this.options.locale.am;
             }
 
             return output;
@@ -776,9 +778,9 @@
                 throw "Invalid time";
             }
             else {
-                if (this.options.hourFormat === '12' && h !== 12 && ampm === 'PM') {
+                if (this.options.hourFormat === '12' && h !== 12 && ampm === this.options.locale.pm) {
                     h += 12;
-                } else if (this.options.hourFormat === '12' && h === 12 && ampm === 'AM') {
+                } else if (this.options.hourFormat === '12' && h === 12 && ampm === this.options.locale.am) {
                     h -= 12;
                 }
 
@@ -996,6 +998,12 @@
                 if (this.options.showTime) {
                     var ampm = this.options.hourFormat === '12' ? parts.pop() : null;
                     var timeString = parts.pop();
+                    
+                    // #9559 some locales are "a. m." with a space 
+                    if (/\d/.test(timeString) === false) {
+                        ampm = timeString + ' ' +  ampm;
+                        timeString = parts.pop();
+                    }
 
                     date = this.parseDate(parts.join(' '), this.options.dateFormat);
                     this.populateTime(date, timeString, ampm);
@@ -1009,7 +1017,7 @@
         },
 
         populateTime: function (value, timeString, ampm) {
-            if (this.options.hourFormat === '12' && (ampm !== 'PM' && ampm !== 'AM')) {
+            if (this.options.hourFormat === '12' && (ampm !== this.options.locale.pm && ampm !== this.options.locale.am)) {
                 throw new Error('Invalid Time');
             }
 
@@ -1626,7 +1634,7 @@
         renderAmPmPicker: function () {
             if (this.options.hourFormat === '12') {
                 var hour = this.isDate(this.value) ? this.value.getHours() : this.viewDate.getHours(),
-                    display = hour > 11 ? 'PM' : 'AM';
+                    display = hour > 11 ? this.options.locale.pm : this.options.locale.am;
 
                 return this.renderTimeElements("ui-ampm-picker", '<span>' + display + '</span>', 4);
             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -224,6 +224,12 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
 
         if(localeSettings) {
             var locale = {};
+            if (this.cfg.localeAm) {
+                locale["am"] = this.cfg.localeAm;
+            }
+            if (this.cfg.localePm) {
+                locale["pm"] = this.cfg.localePm;
+            }
             for(var setting in localeSettings) {
                 locale[setting] = localeSettings[setting];
             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/datepicker.css
@@ -39,7 +39,8 @@
 
 .p-datepicker-panel .ui-timepicker > .ui-minute-picker, 
 .p-datepicker-panel .ui-timepicker > .ui-second-picker,
-.p-datepicker-panel .ui-timepicker > .ui-millisecond-picker {
+.p-datepicker-panel .ui-timepicker > .ui-millisecond-picker,
+.p-datepicker-panel .ui-timepicker > .ui-ampm-picker {
     margin-left: 0;
 }
 
@@ -71,6 +72,10 @@
 
 .p-datepicker-panel .ui-timepicker.ui-timepicker-timeinput .ui-ampm-picker .ui-picker-down {
     padding-top: .1em;
+}
+
+.p-datepicker-panel .ui-timepicker.ui-timepicker-timeinput .ui-ampm-picker > span {
+    padding: .5rem;
 }
 
 .ui-datepicker-multiple-month .ui-datepicker-group {


### PR DESCRIPTION
Fix #9559: DatePicker AM/PM localization
Fix #8365: DatePicker AM/PM localization

1. Reads the Java locale values for AM PM string.
2. Pass those to widget defaulting to AM / PM
3. Widget updates to use local values everywhere
4. Bug fix because Spanish has a space in its "a. m." not "a.m.".
5. Integration Tests for Spanish, German and English

The reason to default to the Java locale values is because the client and server MUST be in sync with the values submitted.
