### PR TITLE
#9629 SelectOneMenu: filter does not work for lowercase i character

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1177,7 +1177,7 @@
          * @returns {string} to normalize.
          */
         normalize: function(string, lowercase) {
-            var result = string.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+            var result = string.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             return lowercase ? result.toLowerCase() : result;
         },
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1170,6 +1170,18 @@
         },
 
         /**
+         * Normalizes the provided string.
+         * 
+         * @param {string} string to normalize.
+         * @param {boolean} lowercase flag indicating whether the string should be lower cased.
+         * @returns {string} to normalize.
+         */
+        normalize: function(string, lowercase) {
+            var result = string.normalize('NFD').replace(/\p{Diacritic}/gu, '');
+            return lowercase ? result.toLowerCase() : result;
+        },
+
+        /**
          * Reset any state variables on update="@all".
          */
         resetState: function() {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1174,7 +1174,7 @@
          * 
          * @param {string} string to normalize.
          * @param {boolean} lowercase flag indicating whether the string should be lower cased.
-         * @returns {string} to normalize.
+         * @returns {string} normalized string.
          */
         normalize: function(string, lowercase) {
             var result = string.normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1177,6 +1177,7 @@
          * @returns {string} normalized string.
          */
         normalize: function(string, lowercase) {
+            if (!string) return string;
             var result = string.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
             return lowercase ? result.toLowerCase() : result;
         },

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1288,7 +1288,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
 
             for(var i = 0; i < this.options.length; i++) {
                 var option = this.options.eq(i),
-                itemLabel = PrimeFaces.normalize(option.text(), !this.cfg.caseSensitive)
+                itemLabel = PrimeFaces.normalize(option.text(), !this.cfg.caseSensitive);
                 item = this.items.eq(i);
 
                 if(item.hasClass('ui-noselection-option')) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1288,7 +1288,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
 
             for(var i = 0; i < this.options.length; i++) {
                 var option = this.options.eq(i),
-                itemLabel = PrimeFaces.normalize(option.text(), !this.cfg.caseSensitive);
+                itemLabel = PrimeFaces.normalize(option.text(), !this.cfg.caseSensitive),
                 item = this.items.eq(i);
 
                 if(item.hasClass('ui-noselection-option')) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1276,7 +1276,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
      */
     filter: function(value) {
         this.cfg.initialHeight = this.cfg.initialHeight||this.itemsWrapper.height();
-        var filterValue = this.cfg.caseSensitive ? PrimeFaces.trim(value) : PrimeFaces.trim(value).toLowerCase();
+        var filterValue = PrimeFaces.normalize(PrimeFaces.trim(value), !this.cfg.caseSensitive);
 
         if(filterValue === '') {
             this.items.filter(':hidden').show();
@@ -1288,7 +1288,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
 
             for(var i = 0; i < this.options.length; i++) {
                 var option = this.options.eq(i),
-                itemLabel = this.cfg.caseSensitive ? option.text() : option.text().toLowerCase(),
+                itemLabel = PrimeFaces.normalize(option.text(), !this.cfg.caseSensitive)
                 item = this.items.eq(i);
 
                 if(item.hasClass('ui-noselection-option')) {
@@ -1302,7 +1302,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
                         hide.push(item);
                     }
                     else {
-                        itemLabel = this.cfg.caseSensitive ? option.parent().attr('label') : option.parent().attr('label').toLowerCase();
+                        itemLabel = PrimeFaces.normalize(option.parent().attr('label'), !this.cfg.caseSensitive);
                         if (this.filterMatcher(itemLabel, filterValue)) {
                             show.push(item);
                         }


### PR DESCRIPTION
Fix #9629

If this is okay, we can add the normalize function to other components with search filters.

Can be tested at http://localhost:8080/showcase/ui/input/oneMenu.xhtml and search at "Advanced" on "curac" to find "Curaçao".