### PR TITLE
#9642, remove dublicate definition of 'onblur' for autoComplete

### DIFF
--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -1179,14 +1179,6 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Client side callback to execute when input element loses focus.]]>
-            </description>
-            <name>onblur</name>
-            <required>false</required>
-            <type>java.lang.String</type>
-        </attribute>
-        <attribute>
-            <description>
                 <![CDATA[Client side callback to execute when input element loses focus and its value has been modified since gaining focus.]]>
             </description>
             <name>onchange</name>


### PR DESCRIPTION
Fix #9642, remove dublicate definition of 'onblur' for autoComplete