### PR TITLE
Fix #9663: Jakarta fix jakarta.el

### DIFF
--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -1087,11 +1087,6 @@
                                     <shadedPattern>jakarta.faces</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>/javax.faces</pattern>
-                                    <shadedPattern>/jakarta.faces</shadedPattern>
-                                    <rawString>true</rawString>
-                                </relocation>
-                                <relocation>
                                     <pattern>javax.el</pattern>
                                     <shadedPattern>jakarta.el</shadedPattern>
                                 </relocation>
@@ -1154,6 +1149,11 @@
                                 <relocation>
                                     <pattern>jsf.ajax</pattern>
                                     <shadedPattern>faces.ajax</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>/javax.faces</pattern>
+                                    <shadedPattern>/jakarta.faces</shadedPattern>
+                                    <rawString>true</rawString>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
@@ -23,25 +23,6 @@
  */
 package org.primefaces.context;
 
-import org.primefaces.cache.CacheProvider;
-import org.primefaces.cache.DefaultCacheProvider;
-import org.primefaces.component.fileupload.FileUploadDecoder;
-import org.primefaces.config.PrimeConfiguration;
-import org.primefaces.config.PrimeEnvironment;
-import org.primefaces.util.Constants;
-import org.primefaces.util.LangUtils;
-import org.primefaces.util.Lazy;
-import org.primefaces.virusscan.VirusScannerService;
-import org.primefaces.webapp.FileUploadChunksServlet;
-
-import javax.faces.FacesException;
-import javax.faces.context.FacesContext;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletRegistration;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -54,6 +35,26 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import javax.faces.FacesException;
+import javax.faces.context.FacesContext;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.primefaces.cache.CacheProvider;
+import org.primefaces.cache.DefaultCacheProvider;
+import org.primefaces.component.fileupload.FileUploadDecoder;
+import org.primefaces.config.PrimeConfiguration;
+import org.primefaces.config.PrimeEnvironment;
+import org.primefaces.util.Constants;
+import org.primefaces.util.LangUtils;
+import org.primefaces.util.Lazy;
+import org.primefaces.virusscan.VirusScannerService;
+import org.primefaces.webapp.FileUploadChunksServlet;
 
 /**
  * A {@link PrimeApplicationContext} is a contextual store for the current application.

--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -23,38 +23,26 @@
  */
 package org.primefaces.model;
 
-import org.primefaces.util.LangUtils;
-
-import javax.faces.context.FacesContext;
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Order;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.*;
+
 import org.primefaces.util.BeanUtils;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.Lazy;
 import org.primefaces.util.SerializableSupplier;
 


### PR DESCRIPTION
I don't know why but moving this rawString one down to the bottom fixes jakarta.el.

Now I only see two left not being converted its `javax.persistence` in JpaLazyModel