### PR TITLE
Fix #8205: DataExporter useLocale attribute

### DIFF
--- a/docs/11_0_0/components/dataexporter.md
+++ b/docs/11_0_0/components/dataexporter.md
@@ -19,6 +19,9 @@ type | null | String | Export type: "xls", "xlsx", "xlsxstream", "pdf", "csv", "
 target | null | String | Search expression to resolve one or multiple datatables.
 fileName | null | String | Filename of the generated export file, defaults to datatable id.
 pageOnly | false | Boolean | Exports only current page instead of whole dataset
+visibleOnly | false | Boolean | Exports only visible columns instead of whole dataset.
+exportHeader | true | Boolean | When enabled, the header will be exported.
+exportFooter | true | Boolean | When enabled, the footer will be exported.
 preProcessor | null | MethodExpr | PreProcessor for the exported document.
 postProcessor | null | MethodExpr | PostProcessor for the exported document.
 encoding | UTF-8 | String | Character encoding to use

--- a/docs/12_0_0/components/dataexporter.md
+++ b/docs/12_0_0/components/dataexporter.md
@@ -19,6 +19,9 @@ type | null | String | Export type: "xls", "xlsx", "xlsxstream", "pdf", "csv", "
 target | null | String | Search expression to resolve one or multiple target components.
 fileName | null | String | Filename of the generated export file, defaults to target component id.
 pageOnly | false | Boolean | Exports only current page instead of whole dataset.
+visibleOnly | false | Boolean | Exports only visible columns instead of whole dataset.
+exportHeader | true | Boolean | When enabled, the header will be exported.
+exportFooter | true | Boolean | When enabled, the footer will be exported.
 preProcessor | null | MethodExpr | PreProcessor for the exported document.
 postProcessor | null | MethodExpr | PostProcessor for the exported document.
 encoding | UTF-8 | String | Character encoding to use

--- a/docs/13_0_0/components/dataexporter.md
+++ b/docs/13_0_0/components/dataexporter.md
@@ -19,6 +19,11 @@ type | null | String | Export type: "xls", "xlsx", "xlsxstream", "pdf", "csv", "
 target | null | String | Search expression to resolve one or multiple target components.
 fileName | null | String | Filename of the generated export file, defaults to target component id.
 pageOnly | false | Boolean | Exports only current page instead of whole dataset.
+pageOnly | false | Boolean | Exports only current page instead of whole dataset.
+visibleOnly | false | Boolean | Exports only visible columns instead of whole dataset.
+exportHeader | true | Boolean | When enabled, the header will be exported.
+exportFooter | true | Boolean | When enabled, the footer will be exported.
+useLocale | true | Boolean | When enabled, the column headers are use as XML tags or CSV/Excel headers. If disabled then it will use the column id.
 preProcessor | null | MethodExpr | PreProcessor for the exported document.
 postProcessor | null | MethodExpr | PostProcessor for the exported document.
 encoding | UTF-8 | String | Character encoding to use

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -10,6 +10,8 @@ This page contains a list of big features. Please check the GitHub issues for al
     * Added attribute `delay` to delay displaying similar to AjaxStatus.
 * Captcha
     * Added attribute `sourceUrl` to override the Google JS location for countries that do not have access to Google.
+* DataExporter
+    * Added attribute `useLocale` to ignore column headers and use column id for titles. Useful for XML export.
 * DataGrid
     * Added attribute `rowTitle` to support row-specific titles.
 * DataTable

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -26,8 +26,11 @@ package org.primefaces.component.datatable.export;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
 import javax.el.MethodExpression;
 import javax.faces.FacesException;
 import javax.faces.component.UIComponent;

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
@@ -117,9 +117,16 @@ public class DataTableXMLExporter extends DataTableExporter {
     }
 
     protected String getColumnTag(UIColumn column) {
-        String headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        String headerText = null;
         UIComponent facet = column.getFacet("header");
         String columnTag;
+        if (!getExportConfiguration().iseUseLocale()) {
+            String id = column.getClientId();
+            headerText = id.substring(id.lastIndexOf(":") + 1);
+        }
+        else {
+            headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        }
 
         if (headerText != null) {
             columnTag = headerText.toLowerCase();

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
@@ -61,6 +61,7 @@ public class DataExporter implements ActionListener, StateHolder {
     private ValueExpression visibleOnly;
     private ValueExpression exportHeader;
     private ValueExpression exportFooter;
+    private ValueExpression useLocale;
     private MethodExpression preProcessor;
     private MethodExpression postProcessor;
     private ValueExpression options;
@@ -120,6 +121,13 @@ public class DataExporter implements ActionListener, StateHolder {
                         : (Boolean) exportFooter.getValue(context.getELContext());
         }
 
+        boolean isUseLocale = true;
+        if (useLocale != null) {
+            isUseLocale = useLocale.isLiteralText()
+                        ? Boolean.parseBoolean(useLocale.getValue(context.getELContext()).toString())
+                        : (Boolean) useLocale.getValue(context.getELContext());
+        }
+
         ExporterOptions exporterOptions = null;
         if (options != null) {
             exporterOptions = (ExporterOptions) options.getValue(elContext);
@@ -141,6 +149,7 @@ public class DataExporter implements ActionListener, StateHolder {
                         .selectionOnly(isSelectionOnly)
                         .visibleOnly(isVisibleOnly)
                         .exportHeader(isExportHeader)
+                        .useLocale(isUseLocale)
                         .exportFooter(isExportFooter)
                         .options(exporterOptions)
                         .preProcessor(preProcessor)
@@ -257,17 +266,18 @@ public class DataExporter implements ActionListener, StateHolder {
         visibleOnly = (ValueExpression) values[5];
         exportHeader = (ValueExpression) values[6];
         exportFooter = (ValueExpression) values[7];
-        preProcessor = (MethodExpression) values[8];
-        postProcessor = (MethodExpression) values[9];
-        encoding = (ValueExpression) values[10];
-        options = (ValueExpression) values[11];
-        onTableRender = (MethodExpression) values[12];
-        exporter = (ValueExpression) values[13];
+        useLocale = (ValueExpression) values[8];
+        preProcessor = (MethodExpression) values[9];
+        postProcessor = (MethodExpression) values[10];
+        encoding = (ValueExpression) values[11];
+        options = (ValueExpression) values[12];
+        onTableRender = (MethodExpression) values[13];
+        exporter = (ValueExpression) values[14];
     }
 
     @Override
     public Object saveState(FacesContext context) {
-        Object[] values = new Object[14];
+        Object[] values = new Object[15];
 
         values[0] = target;
         values[1] = type;
@@ -277,12 +287,13 @@ public class DataExporter implements ActionListener, StateHolder {
         values[5] = visibleOnly;
         values[6] = exportHeader;
         values[7] = exportFooter;
-        values[8] = preProcessor;
-        values[9] = postProcessor;
-        values[10] = encoding;
-        values[11] = options;
-        values[12] = onTableRender;
-        values[13] = exporter;
+        values[8] = useLocale;
+        values[9] = preProcessor;
+        values[10] = postProcessor;
+        values[11] = encoding;
+        values[12] = options;
+        values[13] = onTableRender;
+        values[14] = exporter;
 
         return (values);
     }
@@ -302,6 +313,7 @@ public class DataExporter implements ActionListener, StateHolder {
         private ValueExpression visibleOnly;
         private ValueExpression exportHeader;
         private ValueExpression exportFooter;
+        private ValueExpression useLocale;
         private MethodExpression preProcessor;
         private MethodExpression postProcessor;
         private ValueExpression options;
@@ -356,6 +368,11 @@ public class DataExporter implements ActionListener, StateHolder {
             return this;
         }
 
+        public Builder useLocale(ValueExpression useLocale) {
+            this.useLocale = useLocale;
+            return this;
+        }
+
         public Builder preProcessor(MethodExpression preProcessor) {
             this.preProcessor = preProcessor;
             return this;
@@ -392,6 +409,7 @@ public class DataExporter implements ActionListener, StateHolder {
             exporter.visibleOnly = this.visibleOnly;
             exporter.exportHeader = this.exportHeader;
             exporter.exportFooter = this.exportFooter;
+            exporter.useLocale = this.useLocale;
             exporter.preProcessor = this.preProcessor;
             exporter.postProcessor = this.postProcessor;
             exporter.options = this.options;

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporterTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporterTagHandler.java
@@ -40,6 +40,7 @@ public class DataExporterTagHandler extends TagHandler {
     private final TagAttribute visibleOnly;
     private final TagAttribute exportHeader;
     private final TagAttribute exportFooter;
+    private final TagAttribute useLocale;
     private final TagAttribute preProcessor;
     private final TagAttribute postProcessor;
     private final TagAttribute encoding;
@@ -57,6 +58,7 @@ public class DataExporterTagHandler extends TagHandler {
         visibleOnly = getAttribute("visibleOnly");
         exportHeader = getAttribute("exportHeader");
         exportFooter = getAttribute("exportFooter");
+        useLocale = getAttribute("useLocale");
         encoding = getAttribute("encoding");
         preProcessor = getAttribute("preProcessor");
         postProcessor = getAttribute("postProcessor");
@@ -79,6 +81,7 @@ public class DataExporterTagHandler extends TagHandler {
         ValueExpression visibleOnlyVE = null;
         ValueExpression exportHeaderVE = null;
         ValueExpression exportFooterVE = null;
+        ValueExpression useLocaleVE = null;
         ValueExpression encodingVE = null;
         MethodExpression preProcessorME = null;
         MethodExpression postProcessorME = null;
@@ -104,6 +107,9 @@ public class DataExporterTagHandler extends TagHandler {
         if (exportFooter != null) {
             exportFooterVE = exportFooter.getValueExpression(faceletContext, Object.class);
         }
+        if (useLocale != null) {
+            useLocaleVE = useLocale.getValueExpression(faceletContext, Object.class);
+        }
         if (preProcessor != null) {
             preProcessorME = preProcessor.getMethodExpression(faceletContext, null, new Class[]{Object.class});
         }
@@ -128,6 +134,7 @@ public class DataExporterTagHandler extends TagHandler {
                     .exporter(exporterVE)
                     .exportFooter(exportFooterVE)
                     .exportHeader(exportHeaderVE)
+                    .useLocale(useLocaleVE)
                     .onTableRender(onTableRenderME)
                     .options(optionsVE)
                     .pageOnly(pageOnlyVE)

--- a/primefaces/src/main/java/org/primefaces/component/export/ExportConfiguration.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/ExportConfiguration.java
@@ -33,6 +33,7 @@ public class ExportConfiguration {
     private boolean visibleOnly;
     private boolean exportHeader;
     private boolean exportFooter;
+    private boolean useLocale;
     private String encodingType;
     private MethodExpression preProcessor;
     private MethodExpression postProcessor;
@@ -55,6 +56,7 @@ public class ExportConfiguration {
         private boolean visibleOnly;
         private boolean exportHeader;
         private boolean exportFooter;
+        private boolean useLocale;
         private String encodingType;
         private MethodExpression preProcessor;
         private MethodExpression postProcessor;
@@ -94,6 +96,11 @@ public class ExportConfiguration {
             return this;
         }
 
+        public Builder useLocale(boolean useLocale) {
+            this.useLocale = useLocale;
+            return this;
+        }
+
         public Builder encodingType(String encodingType) {
             this.encodingType = encodingType;
             return this;
@@ -127,6 +134,7 @@ public class ExportConfiguration {
             config.visibleOnly = this.visibleOnly;
             config.exportHeader = this.exportHeader;
             config.exportFooter = this.exportFooter;
+            config.useLocale = this.useLocale;
             config.encodingType = this.encodingType;
             config.preProcessor = this.preProcessor;
             config.postProcessor = this.postProcessor;
@@ -174,6 +182,10 @@ public class ExportConfiguration {
 
     public boolean isExportFooter() {
         return exportFooter;
+    }
+
+    public boolean iseUseLocale() {
+        return useLocale;
     }
 
     public String getEncodingType() {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
@@ -117,9 +117,16 @@ public class TreeTableXMLExporter extends TreeTableExporter {
     }
 
     protected String getColumnTag(UIColumn column) {
-        String headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        String headerText = null;
         UIComponent facet = column.getFacet("header");
         String columnTag;
+        if (!getExportConfiguration().iseUseLocale()) {
+            String id = column.getClientId();
+            headerText = id.substring(id.lastIndexOf(":") + 1);
+        }
+        else {
+            headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        }
 
         if (headerText != null) {
             columnTag = headerText.toLowerCase();

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -203,6 +203,12 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <description>When enabled, the column headers are use as XML tags or CSV/Excel headers. If disabled then it will use the column id.</description>
+            <name>useLocale</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
             <description>Options object to customize document.</description>
             <name>options</name>
             <required>false</required>


### PR DESCRIPTION
Fix #8205: DataExporter useLocale attribute

usage:
```xml
 <p:dataExporter type="xml" target="tbl" fileName="products" useLocale="false"/>
```

TRUE (default):
```xml
<tbl>
	<product>
		<code>nvklal433</code>
		<name>Black Watch</name>
		<category>Accessories</category>
		<quantity>61</quantity>
		<price>$72.00</price>
	</product>
```

FALSE:
```xml
<?xml version="1.0"?>
<tbl>
	<product>
		<j_id_9h>waas1x2as</j_id_9h>
		<j_id_9k>Headphones</j_id_9k>
		<j_id_9n>Electronics</j_id_9n>
		<j_id_9q>8</j_id_9q>
		<j_id_9t>$175.00</j_id_9t>
	</product>
```
