### PR TITLE
Fixed nightly builds

### DIFF
--- a/.github/workflows/nightly-file.upload.yml
+++ b/.github/workflows/nightly-file.upload.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [11, 17]
         profile: [
           'headless,firefox,myfaces-2.3,uploader-native', 'headless,firefox,mojarra-2.3,uploader-native',
           'headless,firefox,myfaces-2.3,uploader-commons', 'headless,firefox,mojarra-2.3,uploader-commons',

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17, 19]
+        java: [11, 17, 19]
         profile: [ 'chrome-jsf22,csp,theme-saga,myfaces-2.2', 'firefox,theme-saga,myfaces-2.3', 'firefox,csp,theme-saga,myfaces-2.3', 'chrome,theme-saga,myfaces-2.3', 'chrome,theme-saga,myfaces-next-2.3','chrome,csp,theme-nova,myfaces-2.3', 'chrome,csp,theme-nova,mojarra-2.3', 'chrome,client-state-saving,theme-nova,mojarra-2.3' ]
 
     steps:


### PR DESCRIPTION
Remove Java8 for now since we test Java 8 on every PR rather than making a huge script for this nightly builds