### PR TITLE
Fix #9682: Detect JDK8 and do not run Jakarta tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,19 @@
 
     <profiles>
         <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>8</jdk>
+            </activation>
+            <modules>
+                <module>primefaces</module>
+                <module>primefaces-showcase</module>
+                <module>primefaces-selenium</module>
+                <module>primefaces-integration-tests</module>
+                <module>primefaces-cli</module>
+            </modules>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Fix #9682: Detect JDK8 and do not run Jakarta tests