### PR TITLE
Fix #8205: ExportTag and ExportRowTag attributes

### DIFF
--- a/docs/13_0_0/components/column.md
+++ b/docs/13_0_0/components/column.md
@@ -32,6 +32,7 @@ treetable and more.
 | exportValue | null | String | Defines the value of the cell to be exported if you want something other than the cell contents or exportFunction.
 | exportRowspan | 0 | Integer | Defines the number of rows the column spans to be exported.
 | exportColspan | 0 | Integer | Defines the number of columns the column spans to be exported.
+| exportTag | null | String | If XML data exporter in use, this allows customization of the column tag in the XML.
 | field | null | String | Name of the field associated to bean "var". If not specified, filterBy-sortBy values are used to identify the field name.
 | filterable | true | Boolean | Boolean value to mark column as filterable.
 | filterBy | null | ValueExpr | ValueExpression to be used for filtering.

--- a/docs/13_0_0/components/columns.md
+++ b/docs/13_0_0/components/columns.md
@@ -30,6 +30,7 @@ Columns is used by datatable to create columns dynamically.
 | exportHeaderValue | null | String | Defines if the header value of column to be exported.
 | exportRowspan | 0 | Integer | Defines the number of rows the column spans to be exported.
 | exportValue | null | String | Defines the value of the cell to be exported if something other than the cell contents or exportFunction.
+| exportTag | null | String | If XML data exporter in use, this allows customization of the column tag in the XML.
 | exportable | true | Boolean | Defines if the column should be exported by dataexporter.
 | field | null | String | Name of the field associated to bean "var". If not specified, filterBy-sortBy values are used to identify the field name.
 | filterBy | null | ValueExpr | ValueExpression to be used for filtering.

--- a/docs/13_0_0/components/datatable.md
+++ b/docs/13_0_0/components/datatable.md
@@ -41,6 +41,7 @@ DataTable displays data in tabular format.
 | emptyMessage              | No records found.  | String           | Text to display when there is no data to display. Alternative is emptyMessage facet.
 | escapeText                | true               | Boolean          | Defines if headerText and footerText values on columns are escaped or not. Default is true.
 | expandedRow               | false              | Boolean          | Defines if row should be rendered as expanded by default.
+| exportRowTag              | null               | String           | If XML data exporter in use, this allows customization of the row tag in the XML.
 | filterBy                  | null               | FilterMeta / Collection<FilterMeta> | Property to be used for default filtering. Expects a single or a collection of FilterMeta.
 | filterDelay               | 300                | Integer          | Delay in milliseconds before sending an ajax filter query.
 | filterEvent               | keyup              | String           | Event triggering filter for input filters.

--- a/docs/13_0_0/components/treetable.md
+++ b/docs/13_0_0/components/treetable.md
@@ -33,6 +33,7 @@ editInitEvent | null | String | Defines a client side event to open cell on edit
 editMode | row | String | Defines edit mode, valid values are "row" (default) and "cell".
 emptyMessage | No records found | String | Text to display when there is no data to display.
 expandMode | children | String | Updates children only when set to “children” or the node itself with children when set to “self” on node expand.
+exportRowTag | null | String | If XML data exporter in use, this allows customization of the row tag in the XML.
 filterBy | null | SortMeta / Collection<SortMeta> | Property to be used for default sorting. Expects a single or a collection of SortMeta.
 filterDelay | 300 | Integer | Delay in milliseconds before sending an ajax filter query.
 filterEvent | keyup | String | Event triggering filter for input filters.

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -10,11 +10,14 @@ This page contains a list of big features. Please check the GitHub issues for al
     * Added attribute `delay` to delay displaying similar to AjaxStatus.
 * Captcha
     * Added attribute `sourceUrl` to override the Google JS location for countries that do not have access to Google.
+* Column/Columns
+    * Added attribute `exportTag` to allow finer grain control over XML export.
 * DataGrid
     * Added attribute `rowTitle` to support row-specific titles.
 * DataTable
     * Added attribute `rowTitle` to support row-specific titles.
     * Added attribute `title` column/columns to support cell specific titles.
+    * Added attribute `exportRowTag` to allow finer grain control over XML export.
 * DataView
     * Added attribute `gridRowTitle` to support row-specific titles.
 * OverlayPanel
@@ -24,6 +27,7 @@ This page contains a list of big features. Please check the GitHub issues for al
 * TreeTable
     * Added attribute `rowTitle` to support row-specific titles.
     * Added attribute `title` column/columns to support cell specific titles.
+    * Added attribute `exportRowTag` to allow finer grain control over XML export.
 * Schedule
     * Added event `eventDblSelect` to allow an event to be double clicked.
 * SpeedDial

--- a/primefaces/src/main/java/org/primefaces/component/api/DynamicColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/DynamicColumn.java
@@ -314,6 +314,11 @@ public class DynamicColumn implements UIColumn {
     }
 
     @Override
+    public String getExportTag() {
+        return columns.getExportTag();
+    }
+
+    @Override
     public String getSortOrder() {
         return columns.getSortOrder();
     }

--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -228,6 +228,8 @@ public interface UIColumn {
 
     String getExportFooterValue();
 
+    String getExportTag();
+
     String getSortOrder();
 
     int getSortPriority();

--- a/primefaces/src/main/java/org/primefaces/component/column/ColumnBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/column/ColumnBase.java
@@ -50,6 +50,7 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
         exportColspan,
         exportRowspan,
         exportable,
+        exportTag,
         field,
         filterBy,
         filterFunction,
@@ -485,5 +486,14 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
 
     public void setTitle(String title) {
         getStateHelper().put(PropertyKeys.title, title);
+    }
+
+    @Override
+    public String getExportTag() {
+        return (String) getStateHelper().eval(PropertyKeys.exportTag, null);
+    }
+
+    public void setExportTag(String exportTag) {
+        getStateHelper().put(PropertyKeys.exportTag, exportTag);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/columns/ColumnsBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/columns/ColumnsBase.java
@@ -46,6 +46,7 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
         exportColspan,
         exportRowspan,
         exportable,
+        exportTag,
         field,
         filterBy,
         filterFunction,
@@ -373,6 +374,15 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
 
     public void setExportValue(String exportValue) {
         getStateHelper().put(PropertyKeys.exportValue, exportValue);
+    }
+
+    @Override
+    public String getExportTag() {
+        return (String) getStateHelper().eval(PropertyKeys.exportTag, null);
+    }
+
+    public void setExportTag(String exportTag) {
+        getStateHelper().put(PropertyKeys.exportTag, exportTag);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -57,6 +57,7 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
         editingRow,
         escapeText,
         expandedRow,
+        exportRowTag,
         filterBy,
         filterDelay,
         filterEvent,
@@ -717,5 +718,13 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
 
     public void setShowSelectAll(boolean showSelectAll) {
         getStateHelper().put(PropertyKeys.showSelectAll, showSelectAll);
+    }
+
+    public String getExportRowTag() {
+        return (String) getStateHelper().eval(PropertyKeys.exportRowTag, null);
+    }
+
+    public void setExportRowTag(String exportRowTag) {
+        getStateHelper().put(PropertyKeys.exportRowTag, exportRowTag);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableXMLExporter.java
@@ -38,6 +38,7 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.export.ExportConfiguration;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
 
 public class DataTableXMLExporter extends DataTableExporter {
 
@@ -90,12 +91,14 @@ public class DataTableXMLExporter extends DataTableExporter {
 
     @Override
     protected void preRowExport(DataTable table, Object document) {
-        ((PrintWriter) document).append("\t<" + table.getVar() + ">\n");
+        String rowtag = table.getExportRowTag() != null ? table.getExportRowTag() : table.getVar();
+        ((PrintWriter) document).append("\t<" + rowtag + ">\n");
     }
 
     @Override
     protected void postRowExport(DataTable table, Object document) {
-        ((PrintWriter) document).append("\t</" + table.getVar() + ">\n");
+        String rowtag = table.getExportRowTag() != null ? table.getExportRowTag() : table.getVar();
+        ((PrintWriter) document).append("\t</" + rowtag + ">\n");
     }
 
     @Override
@@ -117,7 +120,10 @@ public class DataTableXMLExporter extends DataTableExporter {
     }
 
     protected String getColumnTag(UIColumn column) {
-        String headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        String headerText = column.getExportTag();
+        if (LangUtils.isBlank(headerText)) {
+            headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        }
         UIComponent facet = column.getFacet("header");
         String columnTag;
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -87,7 +87,8 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
         cloneOnFilter,
         saveOnCellBlur,
         showGridlines,
-        size
+        size,
+        exportRowTag
     }
 
     protected enum InternalPropertyKeys {
@@ -519,5 +520,13 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
 
     public void setSize(String size) {
         getStateHelper().put(PropertyKeys.size, size);
+    }
+
+    public String getExportRowTag() {
+        return (String) getStateHelper().eval(PropertyKeys.exportRowTag, null);
+    }
+
+    public void setExportRowTag(String exportRowTag) {
+        getStateHelper().put(PropertyKeys.exportRowTag, exportRowTag);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableXMLExporter.java
@@ -40,6 +40,7 @@ import org.primefaces.component.treetable.TreeTable;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
 
 public class TreeTableXMLExporter extends TreeTableExporter {
 
@@ -90,12 +91,14 @@ public class TreeTableXMLExporter extends TreeTableExporter {
 
     @Override
     protected void preRowExport(TreeTable table, Object document) {
-        ((PrintWriter) document).append("\t<" + table.getVar() + ">\n");
+        String rowtag = table.getExportRowTag() != null ? table.getExportRowTag() : table.getVar();
+        ((PrintWriter) document).append("\t<" + rowtag + ">\n");
     }
 
     @Override
     protected void postRowExport(TreeTable table, Object document) {
-        ((PrintWriter) document).append("\t</" + table.getVar() + ">\n");
+        String rowtag = table.getExportRowTag() != null ? table.getExportRowTag() : table.getVar();
+        ((PrintWriter) document).append("\t</" + rowtag + ">\n");
     }
 
     @Override
@@ -117,7 +120,10 @@ public class TreeTableXMLExporter extends TreeTableExporter {
     }
 
     protected String getColumnTag(UIColumn column) {
-        String headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        String headerText = column.getExportTag();
+        if (LangUtils.isBlank(headerText)) {
+            headerText = (column.getExportHeaderValue() != null) ? column.getExportHeaderValue() : column.getHeaderText();
+        }
         UIComponent facet = column.getFacet("header");
         String columnTag;
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -5264,6 +5264,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[If XML data exporter in use, this allows customization of the column tag in the XML.]]>
+            </description>
+            <name>exportTag</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines the display priority, in which order the columns should be displayed.]]>
             </description>
             <name>displayPriority</name>
@@ -5704,6 +5712,14 @@
                 <![CDATA[Defines if the footer value of column to be exported.]]>
             </description>
             <name>exportFooterValue</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[If XML data exporter in use, this allows customization of the column tag in the XML.]]>
+            </description>
+            <name>exportTag</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
@@ -8078,6 +8094,14 @@
             <name>editingRow</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[If XML data exporter in use, this allows customization of the row tag in the XML.]]>
+            </description>
+            <name>exportRowTag</name>
+            <required>false</required>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>
@@ -29725,6 +29749,14 @@
                 <![CDATA[Updates children only when set to "children" or the node itself with children when set to "self" on node expand.]]>
             </description>
             <name>expandMode</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[If XML data exporter in use, this allows customization of the row tag in the XML.]]>
+            </description>
+            <name>exportRowTag</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>


### PR DESCRIPTION
Fix #8205: ExportTag and ExportRowTag attributes

For TreeTable and Datatable allowing you to do this..

```xml
                
<p:dataTable id="tbl" var="product" value="#{dataExporterView.products}" exportRowTag="rowval">
	<p:column headerText="Code" exportTag="code-tag" >
		<h:outputText value="#{product.code}"/>
	</p:column>
	<p:column headerText="Name" exportTag="name-tag" >
		<h:outputText value="#{product.name}"/>
	</p:column>
	<p:column headerText="Category" exportTag="cat-tag">
		<h:outputText value="#{product.category}"/>
	</p:column>
	<p:column headerText="Quantity" exportTag="quantity-tag">
		<h:outputText value="#{product.quantity}"/>
	</p:column>
	<p:column headerText="Price" exportTag="price-tag">
		<h:outputText value="#{product.price}">
			<f:convertNumber type="currency" />
		</h:outputText>
	</p:column>
</p:dataTable>
```

And output will look like this...

```xml
<?xml version="1.0"?>
<tbl>
	<rowval>
		<code-tag>mbvjkgip5</code-tag>
		<name-tag>Galaxy Earrings</name-tag>
		<cat-tag>Accessories</cat-tag>
		<quantity-tag>23</quantity-tag>
		<price-tag>$34.00</price-tag>
	</rowval>
	<rowval>
		<code-tag>250vm23cc</code-tag>
		<name-tag>Green T-Shirt</name-tag>
		<cat-tag>Clothing</cat-tag>
		<quantity-tag>74</quantity-tag>
		<price-tag>$49.00</price-tag>
	</rowval>
```