### PR TITLE
Fix #125: Support for footer facet in SelectCheckboxMenu

### DIFF
--- a/docs/13_0_0/components/selectcheckboxmenu.md
+++ b/docs/13_0_0/components/selectcheckboxmenu.md
@@ -92,7 +92,7 @@ function customFilter(itemLabel, filterValue) {
 
 ## Custom Content
 SelectCheckboxMenu can display custom content in overlay panel by using column component and the
-var option to refer to each item. Facets for column `header` may also be used.
+var option to refer to each item. Facets for column `header` and overall `footer` may also be used.
 
 ```java
 public class MenuBean {
@@ -119,6 +119,12 @@ public class MenuBean {
              <h:outputText value="Player"/>
          </f:facet>
     </p:column>
+
+    <f:facet name="footer">
+         <p:divider />
+         <h:outputText value="#{menuBean.players.size()} available players"
+                       style="font-weight: bold"/>
+    </f:facet>
 </p:selectCheckboxMenu>
 ```
 
@@ -164,6 +170,7 @@ the list of structural style classes;
 .ui-selectcheckboxmenu-trigger | Dropdown icon.
 .ui-selectcheckboxmenu-panel | Overlay panel.
 .ui-selectcheckboxmenu-header | Header in overlay panel.
+.ui-selectcheckboxmenu-footer | Footer in overlay panel.
 .ui-selectcheckboxmenu-filter-container | Container for filter in overlay panel header.
 .ui-selectcheckboxmenu-filter | Filter in overlay panel header.
 .ui-selectcheckboxmenu-close | Closer in overlay panel header.

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -32,6 +32,7 @@ This page contains a list of big features. Please check the GitHub issues for al
     * Added event `eventDblSelect` to allow an event to be double clicked.
 * SelectCheckboxMenu
     * Added attribute `var` to support custom content in overlay panel.
+    * Added support for facet `footer` in overlay panel.
 * SpeedDial
     * Added attribute `ariaLabel` to allow screen reader support on button and `title` for tooltip.
 * Menu

--- a/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
@@ -31,6 +31,12 @@
                                       style="width: 15rem" panelStyle="width: 15rem" scrollHeight="250"
                                       value="#{checkboxView.selectedCities}">
                     <f:selectItems value="#{checkboxView.cities}"/>
+
+                    <f:facet name="footer">
+                        <p:divider styleClass="mt-0" />
+                        <h:outputText value="#{checkboxView.cities.size()} cities"
+                                      styleClass="py-1 block font-bold"/>
+                    </f:facet>
                 </p:selectCheckboxMenu>
 
                 <h5>Multiple</h5>
@@ -74,6 +80,11 @@
                                 </f:facet>
                                 <h:outputText value="#{c.name}"/>
                             </p:column>
+
+                            <f:facet name="footer">
+                                <h:outputText value="#{checkboxView.countries2.size()} countries"
+                                              styleClass="py-1 block font-bold"/>
+                            </f:facet>
                         </p:selectCheckboxMenu>
                     </div>
 

--- a/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenu.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenu.java
@@ -57,6 +57,7 @@ public class SelectCheckboxMenu extends SelectCheckboxMenuBase {
     public static final String TRIGGER_CLASS = "ui-selectcheckboxmenu-trigger ui-state-default ui-corner-right";
     public static final String PANEL_CLASS = "ui-selectcheckboxmenu-panel ui-widget ui-widget-content ui-corner-all ui-helper-hidden ui-input-overlay";
     public static final String HEADER_CLASS = "ui-widget-header ui-corner-all ui-selectcheckboxmenu-header ui-helper-clearfix";
+    public static final String FOOTER_CLASS = "ui-selectcheckboxmenu-footer";
     public static final String FILTER_CONTAINER_CLASS = "ui-selectcheckboxmenu-filter-container";
     public static final String FILTER_CLASS = "ui-selectcheckboxmenu-filter ui-inputfield ui-inputtext ui-widget ui-state-default ui-corner-all";
     public static final String CLOSER_CLASS = "ui-selectcheckboxmenu-close ui-corner-all";

--- a/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -372,6 +372,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
 
         writer.endElement("div");
 
+        encodePanelFooter(context, menu);
         writer.endElement("div");
     }
 
@@ -486,6 +487,19 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         else {
             // Rendering was moved to the client - see renderPanelContentFromHiddenSelect as part of forms.selectcheckboxmenu.js
         }
+    }
+
+    protected void encodePanelFooter(FacesContext context, SelectCheckboxMenu menu) throws IOException {
+        UIComponent facet = menu.getFacet("footer");
+        if (!ComponentUtils.shouldRenderFacet(facet)) {
+            return;
+        }
+
+        ResponseWriter writer = context.getResponseWriter();
+        writer.startElement("div", null);
+        writer.writeAttribute("class", SelectCheckboxMenu.FOOTER_CLASS, null);
+        facet.encodeAll(context);
+        writer.endElement("div");
     }
 
     protected void encodeColumnsHeader(FacesContext context, SelectCheckboxMenu menu, List<Column> columns) throws IOException {


### PR DESCRIPTION
Fix #125: I used `SelectOneMenu` as template to add support for footer facet in `SelectCheckboxMenu`. Footers have been added to two demos in the showcase.

I will also add a few integration tests here.