### PR TITLE
Fix #3132: SelectItem(s) passthrough attributes

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/WrapperSelectItem.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/WrapperSelectItem.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2023 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.api;
+
+import javax.faces.component.UIComponent;
+import javax.faces.component.UISelectItem;
+import javax.faces.model.SelectItem;
+
+/**
+ * Wraps a SelectItem so its `<f:selectitem>` passthrough attributes can be used.
+ */
+public class WrapperSelectItem extends SelectItem {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Owning component like `<f:selectitem>` or `<f:selectitems>`
+     */
+    private transient UIComponent component;
+
+    public WrapperSelectItem() {
+        super();
+    }
+
+    public WrapperSelectItem(UISelectItem component) {
+        super(component.getItemValue(),
+                component.getItemLabel(),
+                component.getItemDescription(),
+                component.isItemDisabled(),
+                component.isItemEscaped(),
+                component.isNoSelectionOption());
+        setComponent(component);
+    }
+
+    public WrapperSelectItem(Object value, String label, String description, boolean disabled, boolean escape,
+            boolean noSelectionOption) {
+        super(value, label, description, disabled, escape, noSelectionOption);
+    }
+
+
+    public UIComponent getComponent() {
+        return component;
+    }
+
+    public void setComponent(UIComponent component) {
+        this.component = component;
+    }
+
+}

--- a/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -46,11 +46,7 @@ import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.expression.SearchExpressionUtils;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.renderkit.SelectManyRenderer;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.Constants;
-import org.primefaces.util.HTML;
-import org.primefaces.util.MessageFactory;
-import org.primefaces.util.WidgetBuilder;
+import org.primefaces.util.*;
 
 public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
 
@@ -181,7 +177,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         }
 
         //input
-        writer.startElement("input", null);
+        writer.startElement("input", getSelectItemComponent(option));
         writer.writeAttribute("id", id, null);
         writer.writeAttribute("name", name, null);
         writer.writeAttribute("type", "checkbox", null);
@@ -623,7 +619,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         }
 
         //item as row
-        writer.startElement("tr", null);
+        writer.startElement("tr", getSelectItemComponent(selectItem));
         writer.writeAttribute("class", rowStyleClass, null);
         writer.writeAttribute("data-label", itemLabel, null);
         if ((itemValueAsString != null) && menu.isMultiple()) {

--- a/primefaces/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectmanybutton/SelectManyButtonRenderer.java
@@ -135,7 +135,7 @@ public class SelectManyButtonRenderer extends SelectManyRenderer {
         buttonStyle = disabled ? buttonStyle + " ui-state-disabled" : buttonStyle;
 
         //button
-        writer.startElement("div", null);
+        writer.startElement("div", getSelectItemComponent(option));
         writer.writeAttribute("class", buttonStyle, null);
         if (option.getDescription() != null) {
             writer.writeAttribute("title", option.getDescription(), null);

--- a/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxRenderer.java
@@ -484,7 +484,7 @@ public class SelectManyCheckboxRenderer extends SelectManyRenderer {
             return;
         }
 
-        writer.startElement("div", null);
+        writer.startElement("div", getSelectItemComponent(option));
         writer.writeAttribute("class", HTML.CHECKBOX_CLASS, null);
 
         encodeOptionInput(context, checkbox, id, name, selected, disabled, itemValueAsString);

--- a/primefaces/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectmanymenu/SelectManyMenuRenderer.java
@@ -199,7 +199,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
             String var = menu.getVar();
             context.getExternalContext().getRequestMap().put(var, option.getValue());
 
-            writer.startElement("tr", null);
+            writer.startElement("tr", getSelectItemComponent(option));
             writer.writeAttribute("class", itemClass, null);
             if (option.getDescription() != null) {
                 writer.writeAttribute("title", option.getDescription(), null);
@@ -233,7 +233,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
             writer.endElement("tr");
         }
         else {
-            writer.startElement("li", null);
+            writer.startElement("li", getSelectItemComponent(option));
             writer.writeAttribute("class", itemClass, null);
 
             if (showCheckbox) {
@@ -286,7 +286,7 @@ public class SelectManyMenuRenderer extends SelectManyRenderer {
             return;
         }
 
-        writer.startElement("option", null);
+        writer.startElement("option", getSelectItemComponent(option));
         writer.writeAttribute("value", itemValueAsString, null);
         if (disabled) {
             writer.writeAttribute("disabled", "disabled", null);

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -449,7 +449,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
 
             context.getExternalContext().getRequestMap().put(var, itemValue);
 
-            writer.startElement("tr", null);
+            writer.startElement("tr", getSelectItemComponent(selectItem));
             writer.writeAttribute("class", itemStyleClass, null);
             writer.writeAttribute("data-label", itemLabel, null);
             writer.writeAttribute("role", "option", null);
@@ -581,7 +581,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             boolean selected = isSelected(context, menu, itemValue, valuesArray, converter);
 
             if (!menu.isDynamic() || (menu.isDynamic() && (selected || menu.isDynamicLoadRequest(context) || itemIndex == 0))) {
-                writer.startElement("option", null);
+                writer.startElement("option", getSelectItemComponent(option));
                 writer.writeAttribute("value", itemValueAsString, null);
                 if (disabled) {
                     writer.writeAttribute("disabled", "disabled", null);

--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -23,29 +23,21 @@
  */
 package org.primefaces.renderkit;
 
+import java.lang.reflect.Array;
+import java.util.*;
+
 import javax.el.ELException;
 import javax.el.ExpressionFactory;
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
-import javax.faces.component.UIComponent;
-import javax.faces.component.UIInput;
-import javax.faces.component.UISelectItem;
-import javax.faces.component.UISelectItems;
-import javax.faces.component.ValueHolder;
+import javax.faces.component.*;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 import javax.faces.model.SelectItem;
 import javax.faces.model.SelectItemGroup;
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.RandomAccess;
 
+import org.primefaces.component.api.WrapperSelectItem;
 import org.primefaces.util.LangUtils;
 
 public abstract class SelectRenderer extends InputRenderer {
@@ -74,12 +66,7 @@ public abstract class SelectRenderer extends InputRenderer {
                 Object selectItemValue = uiSelectItem.getValue();
 
                 if (selectItemValue == null) {
-                    selectItem = new SelectItem(uiSelectItem.getItemValue(),
-                            uiSelectItem.getItemLabel(),
-                            uiSelectItem.getItemDescription(),
-                            uiSelectItem.isItemDisabled(),
-                            uiSelectItem.isItemEscaped(),
-                            uiSelectItem.isNoSelectionOption());
+                    selectItem = new WrapperSelectItem(uiSelectItem);
                 }
                 else {
                     selectItem = (SelectItem) selectItemValue;
@@ -182,7 +169,9 @@ public abstract class SelectRenderer extends InputRenderer {
             requestMap.remove(var);
         }
 
-        return new SelectItem(itemValue, itemLabel, description, disabled, escaped, noSelectionOption);
+        WrapperSelectItem wrapper = new WrapperSelectItem(itemValue, itemLabel, description, disabled, escaped, noSelectionOption);
+        wrapper.setComponent(uiSelectItems);
+        return wrapper;
     }
 
     protected String getOptionAsString(FacesContext context, UIComponent component, Converter converter, Object value) throws ConverterException {
@@ -397,5 +386,19 @@ public abstract class SelectRenderer extends InputRenderer {
         }
 
         return validSubmittedValues;
+    }
+
+    /**
+     * Helper method to find the defining component of a SelectItem so passthrough attributes can be rendered.
+     * @param item the SelectItem to check
+     * @return either NULL or a component the SelectItem was defined by
+     */
+    public UIComponent getSelectItemComponent(SelectItem item) {
+        if (item instanceof WrapperSelectItem) {
+            WrapperSelectItem wrapper = (WrapperSelectItem) item;
+            return wrapper.getComponent();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Fix #3132: SelectItem(s) passthrough attributes

allows passthrough attributes now on all item or items like...

```xml
<f:selectItem itemLabel="Option2" itemValue="Option2" pt:data-name="Test2" />
```
or
```xml
<f:selectItems value="#{selectOneMenuView.cities}" pt:data-name="Test2"/>
```