### PR TITLE
Fix #8472: HTML5 do not render `text/javascript`

### DIFF
--- a/docs/13_0_0/gettingstarted/configuration.md
+++ b/docs/13_0_0/gettingstarted/configuration.md
@@ -13,8 +13,8 @@ pattern of JavaEE. Here is the list of all configuration options defined with a 
 
 | Name | Default | Description |
 | --- | --- | --- |
-| CLIENT_SIDE_VALIDATION | false | Enables/disables global client side validation . |
 | CLIENT_SIDE_LOCALISATION | false | Adds `"locales/locale-" + locale.getLanguage() + ".js"` automatically for your locale. |
+| CLIENT_SIDE_VALIDATION | false | Enables/disables global client side validation . |
 | COOKIES_SAME_SITE | Strict | Defines the SameSite value for all cookies, which will be added by PrimeFaces. Only supported in Faces 4.0 or higher. |
 | CSP | false | Enable Content Security Policy to prevent cross-site scripting (XSS), clickjacking and other code injection attacks. Values `true`, `false`, `reportOnly` and `policyProvided` |
 | CSP_POLICY | null | Custom CSP Policy that allows you to allowlist sites that you need JavaScript from such as `script-src 'self' https: *.googleapis.com` |
@@ -23,6 +23,8 @@ pattern of JavaEE. Here is the list of all configuration options defined with a 
 | EARLY_POST_PARAM_EVALUATION | false | Make p:ajax behave like f:ajax for queued AJAX requests. See: https://github.com/primefaces/primefaces/issues/109 |
 | EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING | null | Comma separated list of exceptions for PrimeExceptionHandler to ignore e.g. `javax.faces.application.ViewExpiredException,javax.persistence.RollbackException`. |
 | FLEX | false | Use PrimeFlex instead of Grid CSS in components with responsive-modes. (not implemented by all components yet) |
+| HIDE_RESOURCE_VERSION | false | Determines whether to hide version information in resource paths. |
+| HTML5_COMPLIANCE | false | Mark true if you know your site is HTML5 doctype so PF won't render certain non-HTML5 compliant values like `text/javascript` on scripts |
 | INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES | false | Whether to load messages for the client side validation (CSV) from server via the MessageInterpolator. |
 | LEGACY_WIDGET_NAMESPACE | false | Enables window scope so that widgets can be accessed using widgetVar.method() in addition to default PF namespace approach like PF('widgetVar').method(). |
 | MARK_INPUT_AS_INVALID_ON_ERROR_MSG | false | Marks a input as invalid, when a FacesMessage is added for a UIInput with 'SEVERITY_ERROR'. This will show the red border on the client side, when the input is updated. |
@@ -35,4 +37,3 @@ pattern of JavaEE. Here is the list of all configuration options defined with a 
 | TOUCHABLE | true | Globally enables/disables touch support on browsers that support touch. |
 | TRANSFORM_METADATA | false | Transforms bean validation metadata to HTML attributes. |
 | UPLOADER | auto | Defines uploader mode; 'auto', 'native' or 'commons'. 'auto' means 'native' on JSF2.2+, otherwise 'commons'. |
-| HIDE_RESOURCE_VERSION | false | Determines whether to hide version information in resource paths. |

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -6,6 +6,8 @@ This page contains a list of big features. Please check the GitHub issues for al
 
 ### PrimeFaces
 
+* Core
+    * Added attribute `primefaces.HTML5_COMPLIANCE` if you know your site is HTML5 doctype so PF won't render certain non-HTML5 compliant values like `text/javascript` on scripts.
 * BlockUI
     * Added attribute `delay` to delay displaying similar to AjaxStatus.
 * Captcha

--- a/primefaces/src/main/java/org/primefaces/application/factory/Html5FacesContextResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/factory/Html5FacesContextResponseWriter.java
@@ -29,6 +29,8 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.ResponseWriter;
 import javax.faces.context.ResponseWriterWrapper;
 
+import org.primefaces.renderkit.RendererUtils;
+
 /**
  * JSF generates all script tags with 'type="text/javascript"' which throws HTML5 validation warnings.
  * NOTE: Not necessary for Faces 4.0+.
@@ -38,7 +40,6 @@ import javax.faces.context.ResponseWriterWrapper;
 public class Html5FacesContextResponseWriter extends ResponseWriterWrapper {
 
     private static final String SCRIPT = "script";
-    private static final String TYPE = "text/javascript";
     private boolean inScriptStartTag;
 
     public Html5FacesContextResponseWriter(ResponseWriter wrapped) {
@@ -61,7 +62,7 @@ public class Html5FacesContextResponseWriter extends ResponseWriterWrapper {
 
     @Override
     public void writeAttribute(String name, Object value, String property) throws IOException {
-        if (inScriptStartTag && TYPE.equals(value)) {
+        if (inScriptStartTag && RendererUtils.SCRIPT_TYPE.equals(value)) {
             return;
         }
         super.writeAttribute(name, value, property);

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -36,6 +36,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.context.ResponseWriterWrapper;
 
+import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.util.AgentUtils;
 import org.primefaces.util.LangUtils;
 
@@ -44,7 +45,6 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     private static final String SCRIPT_TAG = "script";
     private static final String BODY_TAG = "body";
     private static final String HTML_TAG = "html";
-    private static final String SCRIPT_TYPE = "text/javascript";
     private static final String TYPE_ATTRIBUTE = "type";
 
     private final ResponseWriter wrapped;
@@ -170,7 +170,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     public void startElement(String name, UIComponent component) throws IOException {
         if (SCRIPT_TAG.equalsIgnoreCase(name)) {
             inScript = true;
-            scriptType = SCRIPT_TYPE;
+            scriptType = RendererUtils.SCRIPT_TYPE;
         }
         else {
             writeFouc();
@@ -266,7 +266,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
         String minimized = script.toString();
 
         if (LangUtils.isNotBlank(minimized)) {
-            if (SCRIPT_TYPE.equalsIgnoreCase(type)) {
+            if (RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type)) {
                 minimized = minimized.replace(";;", ";");
 
                 if (minimized.contains("PrimeFaces")) {

--- a/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
@@ -59,7 +59,7 @@ public class FocusRenderer extends CoreRenderer {
         writer.endElement("span");
 
         writer.startElement("script", focus);
-        RendererUtils.encodeScript(context);
+        RendererUtils.encodeScriptIfNecessary(context);
 
         if (isValueBlank(focus.getFor())) {
             encodeImplicitFocus(context, focus);

--- a/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
@@ -35,6 +35,7 @@ import javax.faces.context.ResponseWriter;
 
 import org.primefaces.expression.SearchExpressionFacade;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.renderkit.RendererUtils;
 
 public class FocusRenderer extends CoreRenderer {
 
@@ -58,7 +59,7 @@ public class FocusRenderer extends CoreRenderer {
         writer.endElement("span");
 
         writer.startElement("script", focus);
-        writer.writeAttribute("type", "text/javascript", null);
+        RendererUtils.encodeScript(context);
 
         if (isValueBlank(focus.getFor())) {
             encodeImplicitFocus(context, focus);

--- a/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/focus/FocusRenderer.java
@@ -59,7 +59,7 @@ public class FocusRenderer extends CoreRenderer {
         writer.endElement("span");
 
         writer.startElement("script", focus);
-        RendererUtils.encodeScriptIfNecessary(context);
+        RendererUtils.encodeScriptTypeIfNecessary(context);
 
         if (isValueBlank(focus.getFor())) {
             encodeImplicitFocus(context, focus);

--- a/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
@@ -54,7 +54,7 @@ public class HotkeyRenderer extends CoreRenderer {
         String clientId = hotkey.getClientId(context);
 
         writer.startElement("script", null);
-        RendererUtils.encodeScript(context);
+        RendererUtils.encodeScriptIfNecessary(context);
 
         String event = "keydown." + clientId;
         writer.write("$(function(){");

--- a/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
@@ -54,7 +54,7 @@ public class HotkeyRenderer extends CoreRenderer {
         String clientId = hotkey.getClientId(context);
 
         writer.startElement("script", null);
-        RendererUtils.encodeScriptIfNecessary(context);
+        RendererUtils.encodeScriptTypeIfNecessary(context);
 
         String event = "keydown." + clientId;
         writer.write("$(function(){");

--- a/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/hotkey/HotkeyRenderer.java
@@ -32,6 +32,7 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.event.ActionEvent;
 
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.util.AgentUtils;
 
 public class HotkeyRenderer extends CoreRenderer {
@@ -53,7 +54,7 @@ public class HotkeyRenderer extends CoreRenderer {
         String clientId = hotkey.getClientId(context);
 
         writer.startElement("script", null);
-        writer.writeAttribute("type", "text/javascript", null);
+        RendererUtils.encodeScript(context);
 
         String event = "keydown." + clientId;
         writer.write("$(function(){");

--- a/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
@@ -86,7 +86,7 @@ public class RemoteCommandRenderer extends CoreRenderer {
         //script
         writer.startElement("script", command);
         writer.writeAttribute("id", clientId, null);
-        RendererUtils.encodeScript(context);
+        RendererUtils.encodeScriptIfNecessary(context);
 
         writer.write(name + " = function() {");
         writer.write(request);

--- a/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
@@ -23,6 +23,8 @@
  */
 package org.primefaces.component.remotecommand;
 
+import java.io.IOException;
+
 import javax.faces.component.UIComponent;
 import javax.faces.component.UINamingContainer;
 import javax.faces.context.FacesContext;
@@ -30,10 +32,9 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.PhaseId;
 
-import java.io.IOException;
-
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.renderkit.CoreRenderer;
+import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.util.CSVBuilder;
 
 public class RemoteCommandRenderer extends CoreRenderer {
@@ -85,7 +86,7 @@ public class RemoteCommandRenderer extends CoreRenderer {
         //script
         writer.startElement("script", command);
         writer.writeAttribute("id", clientId, null);
-        writer.writeAttribute("type", "text/javascript", null);
+        RendererUtils.encodeScript(context);
 
         writer.write(name + " = function() {");
         writer.write(request);

--- a/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/remotecommand/RemoteCommandRenderer.java
@@ -86,7 +86,7 @@ public class RemoteCommandRenderer extends CoreRenderer {
         //script
         writer.startElement("script", command);
         writer.writeAttribute("id", clientId, null);
-        RendererUtils.encodeScriptIfNecessary(context);
+        RendererUtils.encodeScriptTypeIfNecessary(context);
 
         writer.write(name + " = function() {");
         writer.write(request);

--- a/primefaces/src/main/java/org/primefaces/config/PrimeConfiguration.java
+++ b/primefaces/src/main/java/org/primefaces/config/PrimeConfiguration.java
@@ -54,6 +54,7 @@ public class PrimeConfiguration {
     private final boolean interpolateClientSideValidationMessages;
     private final boolean earlyPostParamEvaluation;
     private final boolean moveScriptsToBottom;
+    private final boolean html5Compliance;
     private boolean csp;
     private boolean policyProvided;
     private String cspPolicy;
@@ -124,6 +125,9 @@ public class PrimeConfiguration {
 
         value = externalContext.getInitParameter(Constants.ContextParams.MOVE_SCRIPTS_TO_BOTTOM);
         moveScriptsToBottom = Boolean.parseBoolean(value);
+
+        value = externalContext.getInitParameter(Constants.ContextParams.HTML5_COMPLIANCE);
+        html5Compliance = Boolean.parseBoolean(value);
 
         value = Objects.toString(externalContext.getInitParameter(Constants.ContextParams.CSP));
         switch (value) {
@@ -252,6 +256,10 @@ public class PrimeConfiguration {
 
     public boolean isMoveScriptsToBottom() {
         return moveScriptsToBottom;
+    }
+
+    public boolean isHtml5Compliant() {
+        return html5Compliance;
     }
 
     public boolean isStringConverterAvailable() {

--- a/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
@@ -73,7 +73,7 @@ public class BodyRenderer extends CoreRenderer {
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            RendererUtils.encodeScriptIfNecessary(context);
+            RendererUtils.encodeScriptTypeIfNecessary(context);
 
             writer.write("$(function(){");
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
@@ -26,10 +26,12 @@ package org.primefaces.renderkit;
 import java.io.IOException;
 import java.util.List;
 import java.util.ListIterator;
+
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
+
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.HTML;
 
@@ -60,18 +62,18 @@ public class BodyRenderer extends CoreRenderer {
         encodeResources(context);
 
         if (!context.getPartialViewContext().isAjaxRequest()) {
-            encodeOnloadScripts(writer);
+            encodeOnloadScripts(context, writer);
         }
 
         writer.endElement("body");
     }
 
-    protected void encodeOnloadScripts(ResponseWriter writer) throws IOException {
+    protected void encodeOnloadScripts(FacesContext context, ResponseWriter writer) throws IOException {
         List<String> scripts = PrimeRequestContext.getCurrentInstance().getScriptsToExecute();
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            writer.writeAttribute("type", "text/javascript", null);
+            RendererUtils.encodeScript(context);
 
             writer.write("$(function(){");
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/BodyRenderer.java
@@ -73,7 +73,7 @@ public class BodyRenderer extends CoreRenderer {
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            RendererUtils.encodeScript(context);
+            RendererUtils.encodeScriptIfNecessary(context);
 
             writer.write("$(function(){");
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -195,7 +195,7 @@ public class HeadRenderer extends Renderer {
         ProjectStage projectStage = context.getApplication().getProjectStage();
 
         writer.startElement("script", null);
-        RendererUtils.encodeScriptIfNecessary(context);
+        RendererUtils.encodeScriptTypeIfNecessary(context);
         writer.write("if(window.PrimeFaces){");
 
         writer.write("PrimeFaces.settings.locale='" + LocaleUtils.getCurrentLocale(context) + "';");
@@ -261,7 +261,7 @@ public class HeadRenderer extends Renderer {
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            RendererUtils.encodeScriptIfNecessary(context);
+            RendererUtils.encodeScriptTypeIfNecessary(context);
 
             boolean moveScriptsToBottom = PrimeRequestContext.getCurrentInstance().getApplicationContext().getConfig().isMoveScriptsToBottom();
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -33,7 +33,6 @@ import javax.el.ValueExpression;
 import javax.faces.FacesException;
 import javax.faces.application.ProjectStage;
 import javax.faces.application.Resource;
-
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.ExternalContext;
@@ -43,8 +42,9 @@ import javax.faces.lifecycle.ClientWindow;
 import javax.faces.render.Renderer;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
-import org.primefaces.clientwindow.PrimeClientWindowUtils;
+
 import org.primefaces.clientwindow.PrimeClientWindow;
+import org.primefaces.clientwindow.PrimeClientWindowUtils;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.ComponentUtils;
@@ -133,7 +133,7 @@ public class HeadRenderer extends Renderer {
         encodeSettingScripts(context, applicationContext, requestContext, writer, csvEnabled);
 
         // encode initialization scripts
-        encodeInitScripts(writer);
+        encodeInitScripts(context, writer);
     }
 
     @Override
@@ -195,7 +195,7 @@ public class HeadRenderer extends Renderer {
         ProjectStage projectStage = context.getApplication().getProjectStage();
 
         writer.startElement("script", null);
-        writer.writeAttribute("type", "text/javascript", null);
+        RendererUtils.encodeScript(context);
         writer.write("if(window.PrimeFaces){");
 
         writer.write("PrimeFaces.settings.locale='" + LocaleUtils.getCurrentLocale(context) + "';");
@@ -256,12 +256,12 @@ public class HeadRenderer extends Renderer {
         writer.endElement("script");
     }
 
-    protected void encodeInitScripts(ResponseWriter writer) throws IOException {
+    protected void encodeInitScripts(FacesContext context, ResponseWriter writer) throws IOException {
         List<String> scripts = PrimeRequestContext.getCurrentInstance().getInitScriptsToExecute();
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            writer.writeAttribute("type", "text/javascript", null);
+            RendererUtils.encodeScript(context);
 
             boolean moveScriptsToBottom = PrimeRequestContext.getCurrentInstance().getApplicationContext().getConfig().isMoveScriptsToBottom();
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -195,7 +195,7 @@ public class HeadRenderer extends Renderer {
         ProjectStage projectStage = context.getApplication().getProjectStage();
 
         writer.startElement("script", null);
-        RendererUtils.encodeScript(context);
+        RendererUtils.encodeScriptIfNecessary(context);
         writer.write("if(window.PrimeFaces){");
 
         writer.write("PrimeFaces.settings.locale='" + LocaleUtils.getCurrentLocale(context) + "';");
@@ -261,7 +261,7 @@ public class HeadRenderer extends Renderer {
 
         if (!scripts.isEmpty()) {
             writer.startElement("script", null);
-            RendererUtils.encodeScript(context);
+            RendererUtils.encodeScriptIfNecessary(context);
 
             boolean moveScriptsToBottom = PrimeRequestContext.getCurrentInstance().getApplicationContext().getConfig().isMoveScriptsToBottom();
 

--- a/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
@@ -130,7 +130,7 @@ public class RendererUtils {
      * @param context the FacesContext
      * @throws IOException if any error occurs
      */
-    public static void encodeScript(FacesContext context) throws IOException {
+    public static void encodeScriptIfNecessary(FacesContext context) throws IOException {
         PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(context);
         PrimeApplicationContext applicationContext = requestContext.getApplicationContext();
         if (applicationContext.getConfig().isHtml5Compliant()) {

--- a/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
@@ -24,6 +24,7 @@
 package org.primefaces.renderkit;
 
 import java.io.IOException;
+
 import javax.faces.FactoryFinder;
 import javax.faces.application.Application;
 import javax.faces.application.ViewHandler;
@@ -33,9 +34,13 @@ import javax.faces.context.ResponseWriter;
 import javax.faces.render.RenderKit;
 import javax.faces.render.RenderKitFactory;
 
+import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.HTML;
 
 public class RendererUtils {
+
+    public static final String SCRIPT_TYPE = "text/javascript";
 
     private RendererUtils() {
         // Hide constructor
@@ -117,6 +122,22 @@ public class RendererUtils {
         }
 
         return ((RenderKitFactory) FactoryFinder.getFactory(FactoryFinder.RENDER_KIT_FACTORY)).getRenderKit(context, renderKitId);
+    }
+
+    /**
+     * HTML5 Doctype does not require the script type on JavaScript files.
+     *
+     * @param context the FacesContext
+     * @throws IOException if any error occurs
+     */
+    public static void encodeScript(FacesContext context) throws IOException {
+        PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(context);
+        PrimeApplicationContext applicationContext = requestContext.getApplicationContext();
+        if (applicationContext.getConfig().isHtml5Compliant()) {
+            return;
+        }
+        ResponseWriter writer = context.getResponseWriter();
+        writer.writeAttribute("type", SCRIPT_TYPE, null);
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/RendererUtils.java
@@ -130,7 +130,7 @@ public class RendererUtils {
      * @param context the FacesContext
      * @throws IOException if any error occurs
      */
-    public static void encodeScriptIfNecessary(FacesContext context) throws IOException {
+    public static void encodeScriptTypeIfNecessary(FacesContext context) throws IOException {
         PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(context);
         PrimeApplicationContext applicationContext = requestContext.getApplicationContext();
         if (applicationContext.getConfig().isHtml5Compliant()) {

--- a/primefaces/src/main/java/org/primefaces/util/Constants.java
+++ b/primefaces/src/main/java/org/primefaces/util/Constants.java
@@ -31,31 +31,32 @@ public class Constants {
         public static final String INTERPRET_EMPTY_STRING_AS_NULL = "javax.faces.INTERPRET_EMPTY_STRING_SUBMITTED_VALUES_AS_NULL";
 
         // PF context params
-        public static final String THEME = "primefaces.THEME";
-        public static final String SUBMIT = "primefaces.SUBMIT";
-        public static final String DIRECTION = "primefaces.DIR";
-        public static final String TOUCHABLE = "primefaces.TOUCHABLE";
-        public static final String RESET_VALUES = "primefaces.RESET_VALUES";
-        public static final String CSV = "primefaces.CLIENT_SIDE_VALIDATION";
-        public static final String UPLOADER = "primefaces.UPLOADER";
-        public static final String CACHE_PROVIDER = "primefaces.CACHE_PROVIDER";
-        public static final String TRANSFORM_METADATA = "primefaces.TRANSFORM_METADATA";
-        public static final String LEGACY_WIDGET_NAMESPACE = "primefaces.LEGACY_WIDGET_NAMESPACE";
         public static final String BEAN_VALIDATION_DISABLED = "javax.faces.validator.DISABLE_DEFAULT_BEAN_VALIDATOR";
-        public static final String INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES = "primefaces.INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES";
-        public static final String EARLY_POST_PARAM_EVALUATION = "primefaces.EARLY_POST_PARAM_EVALUATION";
-        public static final String MOVE_SCRIPTS_TO_BOTTOM = "primefaces.MOVE_SCRIPTS_TO_BOTTOM";
+        public static final String CACHE_PROVIDER = "primefaces.CACHE_PROVIDER";
+        public static final String CLIENT_SIDE_LOCALISATION = "primefaces.CLIENT_SIDE_LOCALISATION";
+        public static final String COOKIES_SAME_SITE = "primefaces.COOKIES_SAME_SITE";
         public static final String CSP = "primefaces.CSP";
         public static final String CSP_POLICY = "primefaces.CSP_POLICY";
         public static final String CSP_REPORT_ONLY_POLICY = "primefaces.CSP_REPORT_ONLY_POLICY";
+        public static final String CSV = "primefaces.CLIENT_SIDE_VALIDATION";
+        public static final String DIRECTION = "primefaces.DIR";
+        public static final String EARLY_POST_PARAM_EVALUATION = "primefaces.EARLY_POST_PARAM_EVALUATION";
         public static final String EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING = "primefaces.EXCEPTION_TYPES_TO_IGNORE_IN_LOGGING";
-        public static final String MULTI_VIEW_STATE_STORE = "primefaces.MULTI_VIEW_STATE_STORE";
-        public static final String MARK_INPUT_AS_INVALID_ON_ERROR_MSG = "primefaces.MARK_INPUT_AS_INVALID_ON_ERROR_MSG";
-        public static final String COOKIES_SAME_SITE = "primefaces.COOKIES_SAME_SITE";
         public static final String FLEX = "primefaces.FLEX";
-        public static final String PRIME_ICONS = "primefaces.PRIME_ICONS";
-        public static final String CLIENT_SIDE_LOCALISATION = "primefaces.CLIENT_SIDE_LOCALISATION";
         public static final String HIDE_RESOURCE_VERSION = "primefaces.HIDE_RESOURCE_VERSION";
+        public static final String HTML5_COMPLIANCE = "primefaces.HTML5_COMPLIANCE";
+        public static final String INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES = "primefaces.INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES";
+        public static final String LEGACY_WIDGET_NAMESPACE = "primefaces.LEGACY_WIDGET_NAMESPACE";
+        public static final String MARK_INPUT_AS_INVALID_ON_ERROR_MSG = "primefaces.MARK_INPUT_AS_INVALID_ON_ERROR_MSG";
+        public static final String MOVE_SCRIPTS_TO_BOTTOM = "primefaces.MOVE_SCRIPTS_TO_BOTTOM";
+        public static final String MULTI_VIEW_STATE_STORE = "primefaces.MULTI_VIEW_STATE_STORE";
+        public static final String PRIME_ICONS = "primefaces.PRIME_ICONS";
+        public static final String RESET_VALUES = "primefaces.RESET_VALUES";
+        public static final String SUBMIT = "primefaces.SUBMIT";
+        public static final String THEME = "primefaces.THEME";
+        public static final String TOUCHABLE = "primefaces.TOUCHABLE";
+        public static final String TRANSFORM_METADATA = "primefaces.TRANSFORM_METADATA";
+        public static final String UPLOADER = "primefaces.UPLOADER";
 
         private ContextParams() {
 

--- a/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
+++ b/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
@@ -23,14 +23,16 @@
  */
 package org.primefaces.util;
 
-import org.primefaces.config.PrimeConfiguration;
-
-import javax.faces.context.FacesContext;
-import javax.faces.context.ResponseWriter;
 import java.io.IOException;
 import java.util.Map;
+
 import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.context.ResponseWriter;
+
 import org.primefaces.component.api.Widget;
+import org.primefaces.config.PrimeConfiguration;
+import org.primefaces.renderkit.RendererUtils;
 
 /**
  * Helper to generate scripts for widgets.
@@ -137,7 +139,7 @@ public class WidgetBuilder {
         ResponseWriter rw = context.getResponseWriter();
         rw.startElement("script", null);
         rw.writeAttribute("id", id + "_s", null);
-        rw.writeAttribute("type", "text/javascript", null);
+        RendererUtils.encodeScript(context);
     }
 
     protected WidgetBuilder renderLifecycleCallbacks(UIComponent component) throws IOException {

--- a/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
+++ b/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
@@ -139,7 +139,7 @@ public class WidgetBuilder {
         ResponseWriter rw = context.getResponseWriter();
         rw.startElement("script", null);
         rw.writeAttribute("id", id + "_s", null);
-        RendererUtils.encodeScriptIfNecessary(context);
+        RendererUtils.encodeScriptTypeIfNecessary(context);
     }
 
     protected WidgetBuilder renderLifecycleCallbacks(UIComponent component) throws IOException {

--- a/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
+++ b/primefaces/src/main/java/org/primefaces/util/WidgetBuilder.java
@@ -139,7 +139,7 @@ public class WidgetBuilder {
         ResponseWriter rw = context.getResponseWriter();
         rw.startElement("script", null);
         rw.writeAttribute("id", id + "_s", null);
-        RendererUtils.encodeScript(context);
+        RendererUtils.encodeScriptIfNecessary(context);
     }
 
     protected WidgetBuilder renderLifecycleCallbacks(UIComponent component) throws IOException {


### PR DESCRIPTION
Fix #8472: JSF40 do not render `text\javascript`

Added new web.xml param since we cann't detect DocType easily.

```xml
<context-param>
    <param-name>primefaces.HTML5_COMPLIANCE</param-name>
    <param-value>true</param-value>
</context-param>
```