### PR TITLE
Fix #4068: MenuItem allow action and link on same item

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/menu/MenuView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/menu/MenuView.java
@@ -77,6 +77,7 @@ public class MenuView implements Serializable {
                 .value("Delete")
                 .icon("pi pi-times")
                 .command("#{menuView.delete}")
+                .update("messages")
                 .build();
         firstSubmenu.getElements().add(item);
 

--- a/primefaces-showcase/src/main/webapp/ui/menu/menu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menu.xhtml
@@ -33,6 +33,7 @@
                     <p:submenu label="Navigations">
                         <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link"/>
                         <p:menuitem value="Internal" outcome="/ui/menu/menubar" icon="pi pi-upload"/>
+                        <p:menuitem value="Update (right click open in new tab)" action="#{menuView.update}" update="messages" url="http://www.primefaces.org" icon="pi pi-thumbs-up"/>
                     </p:submenu>
                 </p:menu>
             </div>
@@ -50,6 +51,7 @@
                     <p:submenu label="Navigations">
                         <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link"/>
                         <p:menuitem value="Internal" outcome="/ui/menu/menubar" icon="pi pi-upload"/>
+                        <p:menuitem value="Update (right click open in new tab)" action="#{menuView.update}" update="messages" url="http://www.primefaces.org" icon="pi pi-thumbs-up"/>
                     </p:submenu>
                 </p:menu>
             </div>
@@ -71,6 +73,7 @@
                     <p:submenu label="Navigations">
                         <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link"/>
                         <p:menuitem value="Internal" outcome="/ui/menu/menubar" icon="pi pi-upload"/>
+                        <p:menuitem value="Update (right click open in new tab)" action="#{menuView.update}" update="messages" url="http://www.primefaces.org" icon="pi pi-thumbs-up"/>
                     </p:submenu>
                 </p:menu>
             </div>

--- a/primefaces/src/main/java/org/primefaces/renderkit/MenuItemAwareRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/MenuItemAwareRenderer.java
@@ -41,11 +41,13 @@ import javax.faces.event.PhaseId;
 import org.primefaces.behavior.confirm.ConfirmBehavior;
 import org.primefaces.component.api.*;
 import org.primefaces.component.divider.Divider;
+import org.primefaces.component.menuitem.UIMenuItem;
 import org.primefaces.event.MenuActionEvent;
 import org.primefaces.model.menu.*;
 import org.primefaces.util.ComponentTraversalUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 
 public class MenuItemAwareRenderer extends OutcomeTargetRenderer {
 
@@ -61,9 +63,15 @@ public class MenuItemAwareRenderer extends OutcomeTargetRenderer {
         setConfirmationScript(context, menuitem);
 
         String onclick = menuitem.getOnclick();
+        boolean isLink = LangUtils.isNotBlank(menuitem.getUrl()) || LangUtils.isNotBlank(menuitem.getOutcome());
+        boolean isCommand = LangUtils.isNotBlank(menuitem.getCommand());
+        if (!isCommand && menuitem instanceof UIMenuItem) {
+            UIMenuItem uim = (UIMenuItem) menuitem;
+            isCommand = uim.getActionExpression() != null || uim.getActionListeners().length > 0;
+        }
 
         //GET
-        if (menuitem.getUrl() != null || menuitem.getOutcome() != null) {
+        if (isLink) {
             String targetURL = getTargetURL(context, (UIOutcomeTarget) menuitem);
             writer.writeAttribute("href", targetURL, null);
 
@@ -73,9 +81,11 @@ public class MenuItemAwareRenderer extends OutcomeTargetRenderer {
         }
         //POST
         else {
-            writer.writeAttribute("href", "#", null);
-            String menuClientId = source.getClientId(context);
+            writer.writeAttribute("href", "javascript:void(0)", null);
+        }
 
+        if (isCommand) {
+            String menuClientId = source.getClientId(context);
             UIForm form = ComponentTraversalUtils.closestForm(context, source);
             if (form == null) {
                 LOGGER.log(Level.FINE, "Menu '" + menuClientId


### PR DESCRIPTION
Fix #4068: MenuItem allow action and link on same item

this allows a MenuItem like this...

```xml
<p:menuitem 
value="Create" 
url="http://jira.apache.org/create" 
actionListener="#{view.create}" 
update="dialog" 
oncomplete="PF('dlg').show();"/>
```

IF single clicking the link will cause an AJAX request to `view.create` and open a new dialog.  If you right-click and do "Open In New Tab" it opens the URL ` url="http://jira.apache.org/create"`