### PR TITLE
Fixed #9733: Picklist accessibility updates

### DIFF
--- a/docs/13_0_0/components/picklist.md
+++ b/docs/13_0_0/components/picklist.md
@@ -55,6 +55,8 @@ label | null | String | A localized user presentable name.
 itemDisabled | false | Boolean | Specified if an item can be picked or not.
 showSourceFilter | false | Boolean | Displays and input filter for source list.
 showTargetFilter | false | Boolean | Displays and input filter for target list.
+sourceFilterPlaceholder | null | String | Placeholder for the source filter input element.
+targetFilterPlaceholder | null | String | Placeholder for the target filter input element.
 filterMatchMode | startsWith | String | Match mode for filtering, valid values are startsWith, contains, endsWith and custom.
 filterFunction | null | String | Name of the javascript function for custom filtering.
 filterNormalize | false | Boolean | Defines if filtering would be done using normalized values (accents will be removed from characters).

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -31,6 +31,7 @@ This page contains a list of big features. Please check the GitHub issues for al
     * Added attribute `flex` to support PrimeFlex CSS instead of legacy Grid CSS.
 * PickList
     * Added attribute `filterNormalize` to allow normalized filtering (without accents).
+    * Added attributes `sourceFilterPlaceholder` and `targetFilterPlaceholder` for accessibility.
 * TabView
     * Added `focusOnLastActiveTab` if you want to focus on the tab that the user last activated.
     * Added `footer` facet to add a footer to the whole TabView not per tab.

--- a/primefaces-showcase/src/main/webapp/ui/data/pickList.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/pickList.xhtml
@@ -38,8 +38,10 @@
                 <p:pickList id="pojoPickList" value="#{pickListView.countries}" var="country"
                             itemValue="#{country}" itemLabel="#{country.name}" showSourceControls="true"
                             showTargetControls="true" showCheckbox="true"
-                            showSourceFilter="true" showTargetFilter="true" filterMatchMode="contains"
-                            converter="#{countryConverter}" responsive="true">
+                            showSourceFilter="true" showTargetFilter="true" 
+                            sourceFilterPlaceholder="Filter available countries"
+                            targetFilterPlaceholder="Filter starting countries"
+                            filterMatchMode="contains" converter="#{countryConverter}" responsive="true">
 
                     <f:facet name="sourceCaption">Available</f:facet>
                     <f:facet name="targetCaption">Starting</f:facet>

--- a/primefaces/src/main/java/org/primefaces/component/picklist/PickListBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/picklist/PickListBase.java
@@ -73,6 +73,8 @@ public abstract class PickListBase extends UIInput implements Widget, ClientBeha
         itemDisabled,
         showSourceFilter,
         showTargetFilter,
+        sourceFilterPlaceholder,
+        targetFilterPlaceholder,
         filterMatchMode,
         filterFunction,
         showCheckbox,
@@ -287,6 +289,22 @@ public abstract class PickListBase extends UIInput implements Widget, ClientBeha
 
     public void setShowTargetFilter(boolean showTargetFilter) {
         getStateHelper().put(PropertyKeys.showTargetFilter, showTargetFilter);
+    }
+
+    public String getSourceFilterPlaceholder() {
+        return (String) getStateHelper().eval(PropertyKeys.sourceFilterPlaceholder, null);
+    }
+
+    public void setSourceFilterPlaceholder(String sourceFilterPlaceholder) {
+        getStateHelper().put(PropertyKeys.sourceFilterPlaceholder, sourceFilterPlaceholder);
+    }
+
+    public String getTargetFilterPlaceholder() {
+        return (String) getStateHelper().eval(PropertyKeys.targetFilterPlaceholder, null);
+    }
+
+    public void setTargetFilterPlaceholder(String targetFilterPlaceholder) {
+        getStateHelper().put(PropertyKeys.targetFilterPlaceholder, targetFilterPlaceholder);
     }
 
     public String getFilterMatchMode() {

--- a/primefaces/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
@@ -38,10 +38,7 @@ import org.primefaces.component.column.Column;
 import org.primefaces.model.DualListModel;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.renderkit.RendererUtils;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.HTML;
-import org.primefaces.util.MessageFactory;
-import org.primefaces.util.WidgetBuilder;
+import org.primefaces.util.*;
 
 public class PickListRenderer extends InputRenderer {
 
@@ -363,10 +360,12 @@ public class PickListRenderer extends InputRenderer {
         }
     }
 
-    protected void encodeFilter(FacesContext context, PickList pickList, String name, boolean isSource) throws IOException {
+    protected void encodeFilter(FacesContext context, PickList picklist, String name, boolean isSource) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
 
         String styleClass = PickList.FILTER_CLASS + (isSource ? " ui-source-filter-input" : " ui-target-filter-input");
+        String placeholder = isSource ? picklist.getSourceFilterPlaceholder() : picklist.getTargetFilterPlaceholder();
+        String ariaLabel = LangUtils.isNotBlank(placeholder) ? placeholder : MessageFactory.getMessage(InputRenderer.ARIA_FILTER);
 
         writer.startElement("div", null);
         writer.writeAttribute("class", PickList.FILTER_CONTAINER, null);
@@ -377,7 +376,10 @@ public class PickListRenderer extends InputRenderer {
         writer.writeAttribute("type", "text", null);
         writer.writeAttribute("autocomplete", "off", null);
         writer.writeAttribute("class", styleClass, null);
-        writer.writeAttribute(HTML.ARIA_LABEL, MessageFactory.getMessage(InputRenderer.ARIA_FILTER), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
+        if (LangUtils.isNotBlank(placeholder)) {
+            writer.writeAttribute("placeholder", placeholder, null);
+        }
         writer.endElement("input");
 
         writer.startElement("span", null);

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -20509,6 +20509,22 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Placeholder for the source filter input element.]]>
+            </description>
+            <name>sourceFilterPlaceholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Placeholder for the target filter input element.]]>
+            </description>
+            <name>targetFilterPlaceholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Match mode for filtering, valid values are startsWith (default), contains, endsWith and custom.]]>
             </description>
             <name>filterMatchMode</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/picklist/picklist.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/picklist/picklist.js
@@ -346,7 +346,7 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
                 if ($this.focusedItem) {
                     PrimeFaces.scrollInView(list, $this.focusedItem);
                     $this.focusedItem.addClass('ui-picklist-outline');
-                    $this.ariaRegion.text($this.focusedItem.data('item-label'));
+                    $this.updateAriaRegion();
                 }
             }, 100);
         })
@@ -380,7 +380,7 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
                             PrimeFaces.scrollInView(list, $this.focusedItem);
                         }
                     }
-                    $this.ariaRegion.text($this.focusedItem.data('item-label'));
+                    $this.updateAriaRegion();
                     e.preventDefault();
                 break;
 
@@ -400,7 +400,7 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
                             PrimeFaces.scrollInView(list, $this.focusedItem);
                         }
                     }
-                    $this.ariaRegion.text($this.focusedItem.data('item-label'));
+                    $this.updateAriaRegion();
                     e.preventDefault();
                 break;
 
@@ -424,7 +424,7 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
                             $this.selectItem(item);
                             $this.focusedItem = item;
                             PrimeFaces.scrollInView(list, $this.focusedItem);
-                            $this.ariaRegion.text($this.focusedItem.data('item-label'));
+                            $this.updateAriaRegion();
                             e.preventDefault();
                             return false;
                         }
@@ -1319,6 +1319,16 @@ PrimeFaces.widget.PickList = PrimeFaces.widget.BaseWidget.extend({
     updateListRole: function() {
         this.sourceList.children('li:visible').length > 0 ? this.sourceList.attr('role', 'menu') : this.sourceList.removeAttr('role');
         this.targetList.children('li:visible').length > 0 ? this.targetList.attr('role', 'menu') : this.targetList.removeAttr('role');
+    },
+    
+    /**
+     * Updates the `aria-grion` with the focused label text.
+     * @private
+     */
+    updateAriaRegion: function() {
+        var labelText = this.focusedItem.data('item-label');
+        this.ariaRegion.attr('aria-label', labelText)
+        this.ariaRegion.text(labelText);
     }
 
 });


### PR DESCRIPTION
Fixed #9733: Picklist accessibility updates

`aria-region` now gets `aria-label` when its updated.
'source' and 'target' filter placeholder which is exist replace the `aria-label`  if no placeholder then it defaults to what it is doing now with the message filter.