### PR TITLE
Fix #9757: TreeTable default sort/filter align with datatable

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -128,10 +128,10 @@ public class TreeTableRenderer extends DataRenderer {
             encodeNodeChildren(context, tt, root, root, tt.getFirst(), tt.getRows());
         }
         else {
-            if (tt.isDefaultFilter()) {
+            if (tt.isFilteringCurrentlyActive()) {
                 FilterFeature.getInstance().filter(context, tt, root);
             }
-            if (tt.isDefaultSort()) {
+            if (tt.isSortingCurrentlyActive()) {
                 SortFeature.getInstance().sort(context, tt);
             }
 


### PR DESCRIPTION
Fix #9757: TreeTable default sort/filter align with datatable