### PR TITLE
Fix #9769: Splitbutton rendering multiple onClick scripts

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/splitbutton/SplitButtonRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/splitbutton/SplitButtonRenderer.java
@@ -136,7 +136,7 @@ public class SplitButtonRenderer extends MenuItemAwareRenderer {
         }
 
         // GitHub #9381 ignore style as its applied to parent div
-        List<String> attrs = new ArrayList<>(HTML.BUTTON_WITH_CLICK_ATTRS);
+        List<String> attrs = new ArrayList<>(HTML.BUTTON_WITHOUT_CLICK_ATTRS);
         attrs.remove("style");
         renderPassThruAttributes(context, button, attrs);
 


### PR DESCRIPTION
Fix #9769: Splitbutton rendering multiple onClick scripts