### PR TITLE
Fix #9794; bugfix in showcase

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/panel/tabView.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/tabView.xhtml
@@ -200,7 +200,7 @@
 
             <div class="card">
                 <h5>MultiViewState</h5>
-                <p:commandButton value="Clear State" action="#{tabbedView.clearMultiViewState}" update="msgs tabViewMVS" styleClass="mb-2 ui-button-warning" />
+                <p:commandButton value="Clear State" action="#{tabbedView.clearMultiViewState}" process="@this" update="msgs tabViewMVS" styleClass="mb-2 ui-button-warning" />
                 <p:tabView multiViewState="true" id="tabViewMVS">
                     <p:tab title="Header I">
                         <p class="m-0">

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -337,7 +337,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         this.addRefreshListener(function() {
 			
             // update error highlighting and set focusIndex
-            $(this.jqId + '>ul>li').each(function() {
+            this.headerContainer.each(function() {
                 var tabId = $('a', this).attr('href').slice(1);
                 tabId = PrimeFaces.escapeClientId(tabId);
                 if ($(tabId + ' .ui-state-error').length > 0 || $(tabId + ' .ui-message-error-detail').length > 0) {


### PR DESCRIPTION
Fix #9794

During testing I found a bug in the showcase: The "Clear State" button for the "MultiViewState" demo processed the whole view which lead to validation errors if the first and last name of the "Events and Validation" was not specified. I fixed this too by adding `process="@this"`.