### PR TITLE
Fix #9772 - Remove duplication of DataTable#loadLazyData

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
@@ -252,10 +252,11 @@ public class UIPageableData extends UIData implements Pageable, TouchAware {
 
             if (rowCount > 0 && first >= rowCount) {
                 int numberOfPages = (int) Math.ceil(rowCount * 1d / rows);
+                int newFirst = Math.max((numberOfPages - 1) * rows, 0);
 
-                setFirst(Math.max((numberOfPages - 1) * rows, 0));
+                setFirst(newFirst);
 
-                return true;
+                return first != newFirst;
             }
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
@@ -331,11 +331,11 @@ public class UIPageableData extends UIData implements Pageable, TouchAware {
 
     public void updatePaginationData(FacesContext context) {
         setRowIndex(-1);
-        String componentClientId = getClientId(context);
+        String clientId = getClientId(context);
         Map<String, String> params = context.getExternalContext().getRequestParameterMap();
 
-        String firstParam = params.get(componentClientId + "_first");
-        String rowsParam = params.get(componentClientId + "_rows");
+        String firstParam = params.get(clientId + "_first");
+        String rowsParam = params.get(clientId + "_rows");
 
         if (!isRowsPerPageValid(rowsParam)) {
             throw new IllegalArgumentException("Unsupported rows per page value: " + rowsParam);

--- a/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIPageableData.java
@@ -24,7 +24,6 @@
 package org.primefaces.component.api;
 
 import java.util.Map;
-
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
@@ -244,7 +243,7 @@ public class UIPageableData extends UIData implements Pageable, TouchAware {
         }
     }
 
-    public void calculateFirst() {
+    public boolean calculateFirst() {
         int rows = getRows();
 
         if (rows > 0) {
@@ -255,8 +254,12 @@ public class UIPageableData extends UIData implements Pageable, TouchAware {
                 int numberOfPages = (int) Math.ceil(rowCount * 1d / rows);
 
                 setFirst(Math.max((numberOfPages - 1) * rows, 0));
+
+                return true;
             }
         }
+
+        return false;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -500,7 +500,8 @@ public class DataTable extends DataTableBase {
                 int scrollRows = getScrollRows();
                 int virtualScrollRows = (scrollRows * 2);
                 rows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
-            } else {
+            }
+            else {
                 rows = getRows();
             }
             loadLazyScrollData(first, rows);

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -508,7 +508,7 @@ public class DataTable extends DataTableBase {
             FacesContext context = getFacesContext();
             if (isClientCacheRequest(context)) {
                 Map<String, String> params = context.getExternalContext().getRequestParameterMap();
-                first = Integer.parseInt(params.get(getClientId(context) + "_first")) + getRows();
+                first = Integer.parseInt(params.get(getClientId(context) + "_first")) + rows;
             }
 
             loadLazyScrollData(first, rows);

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -500,6 +500,10 @@ public class DataTable extends DataTableBase {
                 int virtualScrollRows = (scrollRows * 2);
                 rows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
             } else {
+                LazyDataModel<?> lazyModel = getLazyDataModel();
+                Map<String, FilterMeta> filterBy = getActiveFilterMeta();
+                lazyModel.setRowCount(lazyModel.count(filterBy));
+
                 calculateFirst();
                 first = getFirst();
                 rows = getRows();
@@ -531,8 +535,7 @@ public class DataTable extends DataTableBase {
         lazyModel.setWrappedData(data == null ? Collections.emptyList() : data);
 
         //Update paginator/livescroller for callback
-        FacesContext context = getFacesContext();
-        if (ComponentUtils.isRequestSource(this, context) && (isPaginator() || isLiveScroll() || isVirtualScroll())) {
+        if (ComponentUtils.isRequestSource(this, getFacesContext()) && (isPaginator() || isLiveScroll() || isVirtualScroll())) {
             PrimeFaces.current().ajax().addCallbackParam("totalRecords", lazyModel.getRowCount());
         }
     }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -175,7 +175,6 @@ public class DataTable extends DataTableBase {
             .build();
 
     private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
-    private static final Logger LOGGER = Logger.getLogger(DataTable.class.getName());
 
     private boolean reset = false;
     private List<UIColumn> columns;

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -481,7 +481,7 @@ public class DataTable extends DataTableBase {
     }
 
     public void loadLazyDataIfRequired() {
-        if (isLazy() && getDataModel().getWrappedData() == null) {
+        if (getDataModel().getWrappedData() == null) {
             loadLazyDataIfEnabled();
         }
     }
@@ -489,7 +489,7 @@ public class DataTable extends DataTableBase {
     public boolean loadLazyDataIfEnabled() {
         LazyDataModel<?> lazyModel = getLazyDataModel();
         if (lazyModel != null) {
-            int first = 0;
+            int first = getFirst();
             int rows = 0;
 
             if (isLiveScroll()) {
@@ -501,7 +501,6 @@ public class DataTable extends DataTableBase {
                 int virtualScrollRows = (scrollRows * 2);
                 rows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
             } else {
-                first = getFirst();
                 rows = getRows();
             }
             loadLazyScrollData(first, rows);

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -175,6 +175,7 @@ public class DataTable extends DataTableBase {
             .build();
 
     private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
+    private static final Logger LOGGER = Logger.getLogger(DataTable.class.getName());
 
     private boolean reset = false;
     private List<UIColumn> columns;
@@ -519,8 +520,11 @@ public class DataTable extends DataTableBase {
         Map<String, FilterMeta> filterBy = getActiveFilterMeta();
         model.setRowCount(model.count(filterBy));
 
+        setFirst(offset);
+
         if (calculateFirst()) {
             offset = getFirst();
+            LOGGER.warning(() -> "DataTable#loadLazyScrollData: offset has been recalculated due to overflow (first >= rowCount)");
         }
 
         FacesContext context = getFacesContext();
@@ -532,7 +536,7 @@ public class DataTable extends DataTableBase {
         List<?> data = model.load(offset, rows, getActiveSortMeta(), getActiveFilterMeta());
         model.setPageSize(rows);
         // set empty list if model returns null; this avoids multiple calls while visiting the component+rows
-        model.setWrappedData(Optional.ofNullable(data).orElse(Collections.emptyList()));
+        model.setWrappedData(data != null ? data : Collections.emptyList());
 
         //Update paginator/livescroller for callback
         if (ComponentUtils.isRequestSource(this, getFacesContext()) && (isPaginator() || isLiveScroll() || isVirtualScroll())) {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -123,23 +123,7 @@ public class DataTableRenderer extends DataRenderer {
             table.setScrollOffset(0);
         }
 
-        if (table.isLazy()) {
-            if (table.isLiveScroll()) {
-                table.loadLazyScrollData(0, table.getScrollRows());
-            }
-            else if (table.isVirtualScroll()) {
-                int rows = table.getRows();
-                int scrollRows = table.getScrollRows();
-                int virtualScrollRows = (scrollRows * 2);
-                scrollRows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
-
-                table.loadLazyScrollData(0, scrollRows);
-            }
-            else {
-                table.loadLazyData();
-            }
-        }
-        else {
+        if (!table.loadLazyDataIfEnabled()) {
             if (table.isFilteringCurrentlyActive()) {
                 DataTableFeatures.filterFeature().filter(context, table);
             }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -109,7 +109,7 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
             if (rowCount > 0) {
                 table.setFirst(0);
                 table.setRows(rowCount);
-                table.clearLazyCache();
+                table.clearLazyCache(); // I think it is useless since wrappeddata gets intialize in DataTable#loadLazyScrollData
                 table.loadLazyDataIfEnabled();
             }
 
@@ -121,7 +121,7 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
             table.setFirst(first);
             table.setRows(rows);
             table.setRowIndex(-1);
-            table.clearLazyCache();
+            table.clearLazyCache(); // same here
             lazyDataModel.setWrappedData(wrappedData);
             lazyDataModel.setPageSize(rows);
             lazyDataModel.setRowIndex(-1);

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -109,7 +109,7 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
             if (rowCount > 0) {
                 table.setFirst(0);
                 table.setRows(rowCount);
-                table.clearLazyCache(); // I think it is useless since wrappeddata gets intialize in DataTable#loadLazyScrollData
+                table.clearLazyCache(); // Why? wrappeddata gets initialize right after in DataTable#loadLazyScrollData
                 table.loadLazyDataIfEnabled();
             }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -26,7 +26,9 @@ package org.primefaces.component.datatable.export;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.el.MethodExpression;
 import javax.faces.FacesException;
@@ -108,7 +110,7 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
                 table.setFirst(0);
                 table.setRows(rowCount);
                 table.clearLazyCache();
-                table.loadLazyData();
+                table.loadLazyDataIfEnabled();
             }
 
             for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -109,7 +109,6 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
             if (rowCount > 0) {
                 table.setFirst(0);
                 table.setRows(rowCount);
-                table.clearLazyCache(); // Why? wrappeddata gets initialize right after in DataTable#loadLazyScrollData
                 table.loadLazyDataIfEnabled();
             }
 
@@ -121,7 +120,6 @@ public abstract class DataTableExporter extends TableExporter<DataTable> {
             table.setFirst(first);
             table.setRows(rows);
             table.setRowIndex(-1);
-            table.clearLazyCache(); // same here
             lazyDataModel.setWrappedData(wrappedData);
             lazyDataModel.setPageSize(rows);
             lazyDataModel.setRowIndex(-1);

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
@@ -90,23 +90,7 @@ public class FilterFeature implements DataTableFeature {
 
     @Override
     public void encode(FacesContext context, DataTableRenderer renderer, DataTable table) throws IOException {
-        if (table.isLazy()) {
-            if (table.isLiveScroll()) {
-                table.loadLazyScrollData(0, table.getScrollRows());
-            }
-            else if (table.isVirtualScroll()) {
-                int rows = table.getRows();
-                int scrollRows = table.getScrollRows();
-                int virtualScrollRows = (scrollRows * 2);
-                scrollRows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
-
-                table.loadLazyScrollData(0, scrollRows);
-            }
-            else {
-                table.loadLazyData();
-            }
-        }
-        else {
+        if (!table.loadLazyDataIfEnabled()) {
             filter(context, table);
 
             // update filtered value accordingly to take account sorting

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/PageFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/PageFeature.java
@@ -39,8 +39,8 @@ public class PageFeature implements DataTableFeature {
 
         boolean isPageState = table.isPageStateRequest(context);
 
-        if (table.isLazy() && !isPageState) {
-            table.loadLazyData();
+        if (!isPageState) {
+            table.loadLazyDataIfEnabled();
         }
 
         if (!isPageState && !table.isFullUpdateRequest(context)) {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/SortFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/SortFeature.java
@@ -91,23 +91,7 @@ public class SortFeature implements DataTableFeature {
     public void encode(FacesContext context, DataTableRenderer renderer, DataTable table) throws IOException {
         table.setFirst(0);
 
-        if (table.isLazy()) {
-            if (table.isLiveScroll()) {
-                table.loadLazyScrollData(0, table.getScrollRows());
-            }
-            else if (table.isVirtualScroll()) {
-                int rows = table.getRows();
-                int scrollRows = table.getScrollRows();
-                int virtualScrollRows = (scrollRows * 2);
-                scrollRows = (rows == 0) ? virtualScrollRows : Math.min(virtualScrollRows, rows);
-
-                table.loadLazyScrollData(0, scrollRows);
-            }
-            else {
-                table.loadLazyData();
-            }
-        }
-        else {
+        if (!table.loadLazyDataIfEnabled()) {
             //reset the value given in the filter feature property before sorting
             if (table.isFullUpdateRequest(context)) {
                 table.setValue(null);


### PR DESCRIPTION
Out of topic but few things I'm seeing with scrolling, what exists so far:

<html>
<body>

property | default value | type | description
-- | -- | -- | --
liveScroll | false | Boolean | Enables live scrolling.
scrollRows | 0 | Integer | Number of rows to load on live scroll.
scrollable | false | Boolean | Makes data scrollable with fixed header.
virtualScroll | false | Boolean | Loads data on demand as the scrollbar gets close to the bottom. Default is false.
scrollOffset | 0 | Integer |  (not documented and only for live scrolling)
<!--EndFragment-->

</body>
</html>


What it could be:

<html>
<body>

property | default value | type | description
-- | -- | -- | --
scrollMode | null| string| Possibles value: simple, live (aka infinite), virtual

</body>
</html>

`scrollRows`: suggests the number of rows fetched is different than the number of items displayed, why not reusing rows property, that's how pagination works and that's what scrolling does (loading a chunk is same as loading a page). If I look at the showcase, rows is 40 and scrollRows is 20, and what dt does is fetching scrollRows * 2... So I'm pretty sure this property is useless

`scrollHeight`: I don't see why user has to define this, it's actually annoying to do so
