### PR TITLE
Removed barbecue and twitter4j from showcase

### DIFF
--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -106,13 +106,6 @@
             <artifactId>mime-types</artifactId>
         </dependency>
 
-        <!-- Twitter API -->
-        <dependency>
-            <groupId>org.twitter4j</groupId>
-            <artifactId>twitter4j-core</artifactId>
-            <version>3.0.6</version>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -121,11 +114,6 @@
         </dependency>
 
         <!-- GraphicImage -->
-        <dependency>
-            <groupId>net.sourceforge.barbecue</groupId>
-            <artifactId>barbecue</artifactId>
-            <version>1.5-beta1</version>
-        </dependency>
         <dependency>
             <groupId>jfree</groupId>
             <artifactId>jfreechart</artifactId>


### PR DESCRIPTION
These two dependencies look like they are no longer being used in the Showcase I can find no reference to them