### PR TITLE
#9908 improve messages docs

### DIFF
--- a/docs/10_0_0/components/growl.md
+++ b/docs/10_0_0/components/growl.md
@@ -33,7 +33,7 @@ for | null | String | The clientId or name of associated key, takes precedence w
 escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 keepAlive | false | Boolean | Defines if previous messages should be kept on a new message is shown.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting Started with Growl
 Growl usage is similar to standard h:messages component. Simply place growl anywhere on your

--- a/docs/10_0_0/components/message.md
+++ b/docs/10_0_0/components/message.md
@@ -32,7 +32,7 @@ escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Message
 Message usage is exactly same as standard message.
@@ -42,11 +42,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -70,6 +71,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/10_0_0/components/messages.md
+++ b/docs/10_0_0/components/messages.md
@@ -33,7 +33,7 @@ closable | false | Boolean | Adds a close icon to hide the messages.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 showIcon | true | Boolean | Defines if severity icons would be displayed.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Messages
 Message usage is exactly same as standard messages.
@@ -85,5 +85,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/11_0_0/components/growl.md
+++ b/docs/11_0_0/components/growl.md
@@ -33,7 +33,7 @@ for | null | String | The clientId or name of associated key, takes precedence w
 escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 keepAlive | false | Boolean | Defines if previous messages should be kept on a new message is shown.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting Started with Growl
 Growl usage is similar to standard h:messages component. Simply place growl anywhere on your

--- a/docs/11_0_0/components/message.md
+++ b/docs/11_0_0/components/message.md
@@ -32,7 +32,7 @@ escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Message
 Message usage is exactly same as standard message.
@@ -42,11 +42,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -70,6 +71,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/11_0_0/components/messages.md
+++ b/docs/11_0_0/components/messages.md
@@ -34,7 +34,7 @@ closable | false | Boolean | Adds a close icon to hide the messages.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 showIcon | true | Boolean | Defines if severity icons would be displayed.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Messages
 Message usage is exactly same as standard messages.
@@ -95,5 +95,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/12_0_0/components/growl.md
+++ b/docs/12_0_0/components/growl.md
@@ -33,7 +33,7 @@ for | null | String | The clientId or name of associated key, takes precedence w
 escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 keepAlive | false | Boolean | Defines if previous messages should be kept on a new message is shown.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting Started with Growl
 Growl usage is similar to standard h:messages component. Simply place growl anywhere on your

--- a/docs/12_0_0/components/message.md
+++ b/docs/12_0_0/components/message.md
@@ -32,7 +32,7 @@ escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Message
 Message usage is exactly same as standard message.
@@ -42,11 +42,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -70,6 +71,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/12_0_0/components/messages.md
+++ b/docs/12_0_0/components/messages.md
@@ -34,7 +34,7 @@ closable | false | Boolean | Adds a close icon to hide the messages.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 showIcon | true | Boolean | Defines if severity icons would be displayed.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Messages
 Message usage is exactly same as standard messages.
@@ -95,5 +95,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/13_0_0/components/growl.md
+++ b/docs/13_0_0/components/growl.md
@@ -33,7 +33,7 @@ for | null | String | The clientId or name of associated key, takes precedence w
 escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 keepAlive | false | Boolean | Defines if previous messages should be kept on a new message is shown.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting Started with Growl
 Growl usage is similar to standard h:messages component. Simply place growl anywhere on your

--- a/docs/13_0_0/components/message.md
+++ b/docs/13_0_0/components/message.md
@@ -32,7 +32,7 @@ escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Message
 Message usage is exactly same as standard message.
@@ -42,11 +42,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -70,6 +71,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/13_0_0/components/messages.md
+++ b/docs/13_0_0/components/messages.md
@@ -34,7 +34,7 @@ closable | false | Boolean | Adds a close icon to hide the messages.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 showIcon | true | Boolean | Defines if severity icons would be displayed.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Messages
 Message usage is exactly same as standard messages.
@@ -95,5 +95,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/13_0_0/gettingstarted/whatsnew.md
+++ b/docs/13_0_0/gettingstarted/whatsnew.md
@@ -70,6 +70,8 @@ This page contains a list of big features. Please check the GitHub issues for al
     * Added attribute `ariaLabel` to allow screen reader support on button and `title` for tooltip.
 * SplitButton
     * Added attribute `filterNormalize` to allow normalized filtering (without accents).
+* StaticMessage
+    * Added attribute `display` with supported values `both` (default), `icon` and `text`.
 * Panel
     * Added `multiViewState` to keep panel state across views.
 * Menu

--- a/docs/7_0/components/message.md
+++ b/docs/7_0/components/message.md
@@ -39,11 +39,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -67,6 +68,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/7_0/components/messages.md
+++ b/docs/7_0/components/messages.md
@@ -83,5 +83,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/8_0/components/growl.md
+++ b/docs/8_0/components/growl.md
@@ -31,7 +31,7 @@ for | null | String | The clientId or name of associated key, takes precedence w
 escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 keepAlive | false | Boolean | Defines if previous messages should be kept on a new message is shown.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting Started with Growl
 Growl usage is similar to standard h:messages component. Simply place growl anywhere on your

--- a/docs/8_0/components/message.md
+++ b/docs/8_0/components/message.md
@@ -30,7 +30,7 @@ escape | true | Boolean | Defines whether HTML would be escaped or not.
 severity | null | String | Comma separated list of severities to display only.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Message
 Message usage is exactly same as standard message.
@@ -40,11 +40,12 @@ Message usage is exactly same as standard message.
 <p:message for="txt" />
 ```
 ## Display Mode
-Message component has three different display modes;
+Message component has four different display modes;
 
 - text : Only message text is displayed.
 - icon : Only message severity is displayed and message text is visible as a tooltip.
 - both (default) : Both icon and text are displayed.
+- tooltip : Message text is visible as a tooltip of the target component.
 
 ## Severity Levels
 Using severity attribute, you can define which severities can be displayed by the component. For
@@ -68,6 +69,7 @@ Full list of CSS selectors of message is as follows;
 ui-message-{severity} | Container element of the message
 ui-message-{severity}-summary | Summary text
 ui-message-{severity}-detail | Detail text
+ui-message-{severity}-icon | Icon of the message
 
-{severity} can be ‘info’, ‘error’, ‘warn’ and error.
+{severity} can be `info`, `warn`, `error` and `fatal`.
 

--- a/docs/8_0/components/messages.md
+++ b/docs/8_0/components/messages.md
@@ -33,7 +33,7 @@ closable | false | Boolean | Adds a close icon to hide the messages.
 style | null | String | Inline style of the component.
 styleClass | null | String | Style class of the component.
 showIcon | true | Boolean | Defines if severity icons would be displayed.
-skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summaray are equals.
+skipDetailIfEqualsSummary | false | Boolean | Defines if rendering of the detail text should be skipped, if the detail and summary are equals.
 
 ## Getting started with Messages
 Message usage is exactly same as standard messages.
@@ -85,5 +85,5 @@ ui-messages-{severity}-summary | Summary text
 ui-messages-{severity}-detail | Detail text
 ui-messages-{severity}-icon | Icon of the message.
 
-* {severity} can be ‘info’, ‘error’, ‘warn’ and error.
+* {severity} can be `info`, `warn`, `error` and `fatal`.
 


### PR DESCRIPTION
Add the new `display` attribute of StaticMessage in 13.0 changelog
Fix severities in Message and Messages
Added `tooltip` display mode and icon class to Message
Fix typo (summaray -> summary) in Growl, Messages and Message

#9908