### PR TITLE
Fix #9929: PrimeFaces Selenium: DatePicker-regression with Chrome (Driver) 111

### DIFF
--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
@@ -155,7 +155,7 @@ public abstract class DatePicker extends AbstractInputComponent {
     }
 
     public LocalDateTime getValue() {
-        if (getWidgetDate() == null) {
+        if (hasDate() == false) {
             return null;
         }
 
@@ -166,7 +166,7 @@ public abstract class DatePicker extends AbstractInputComponent {
     }
 
     public LocalDate getValueAsLocalDate() {
-        if (getWidgetDate() == null) {
+        if (hasDate() == false) {
             return null;
         }
         Long dayOfMonth = PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".getDate().getDate();");
@@ -219,6 +219,15 @@ public abstract class DatePicker extends AbstractInputComponent {
      */
     public String getWidgetDate() {
         return PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".getDate();");
+    }
+
+    /**
+     * Checks whether a date is selected
+     *
+     * @return true if a date is selected.
+     */
+    public boolean hasDate() {
+        return PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".hasDate();");
     }
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -462,6 +462,14 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
+     * Checks whether a date is selected.
+     * @returns {boolean}
+     */
+    hasDate: function() {
+        return (this.getDate() instanceof Date);
+    },
+
+    /**
      * Sets the displayed visible calendar date. This refers to the currently displayed month page.
      * @param {string | Date | Date[]} date The date to be shown in the calendar.
      */

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -463,7 +463,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
 
     /**
      * Checks whether a date is selected.
-     * @returns {boolean}
+     * @returns {boolean} true if a date is selected.
      */
     hasDate: function() {
         return (this.getDate() instanceof Date);


### PR DESCRIPTION
IMO it´s still a regression with Chrome (Driver) 111, but i try to apply a work-around so IT und CI are passing again.