### PR TITLE
Fix #9941: Overlays hide tooltips on show/hide

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/confirmpopup/confirmpopup.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/confirmpopup/confirmpopup.js
@@ -142,9 +142,11 @@ PrimeFaces.widget.ConfirmPopup = PrimeFaces.widget.DynamicOverlayWidget.extend({
     
     /**
      * Makes the popup visible.
+     * @override
      * @param {string | JQuery} [target] Selector or DOM element of the target component that triggers this popup.
      */
     show: function(target) {
+        this._super();
         if (this.transition) {
             var $this = this;
 
@@ -170,9 +172,11 @@ PrimeFaces.widget.ConfirmPopup = PrimeFaces.widget.DynamicOverlayWidget.extend({
     
     /**
      * Hides the popup.
-     * @param {PrimeFaces.widget.ConfirmPopup.HideCallback} callback Callback that is invoked after this popup was closed.
+     * @override
+     * @param {PrimeFaces.widget.ConfirmPopup.HideCallback} [callback] Callback that is invoked after this popup was closed.
      */
     hide: function(callback) {
+        this._super();
         var $this = this;
 
         if (this.transition) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -931,6 +931,17 @@ if (!PrimeFaces.utils) {
                 return doc.documentElement.textContent;
             }
             return input;
+        },
+
+        /**
+         * Hide any currently displayed tooltips.
+         */
+        hideTooltips: function() {
+            PrimeFaces.getWidgetsByType(PrimeFaces.widget.Tooltip).forEach(
+                function(tooltip) {
+                    tooltip.hide();
+                }
+            );
         }
     };
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -708,6 +708,20 @@ if (!PrimeFaces.widget) {
          */
         getModalTabbables: function(){
             return null;
+        },
+
+        /**
+         * Base method to brings up the overlay panel so that is displayed and visible. Overridden in each subclass.
+         */
+        show: function() {
+            PrimeFaces.utils.hideTooltips();
+        },
+
+        /**
+         * Base method to hide this overlay panel so that it is not displayed anymore. Overridden in each subclass.
+         */
+        hide: function() {
+            PrimeFaces.utils.hideTooltips();
         }
     });
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -229,11 +229,13 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
      * in an AJAX request to the sever to retrieve the content. Also triggers the show behaviors registered for this
      * dialog.
      * 
+     * @override
      * @param {number | string} [duration] Durations are given in milliseconds; higher values indicate slower
      * animations, not faster ones. The strings `fast` and `slow` can be supplied to indicate durations of 200 and 600
      * milliseconds, respectively.
      */
     show: function(duration) {
+        this._super();
         if(this.isVisible()) {
             return;
         }
@@ -327,11 +329,13 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
     /**
      * Hide the dialog with an optional animation lasting for the given duration.
      * 
+     * @override
      * @param {number | string} [duration] Durations are given in milliseconds; higher values indicate slower
      * animations, not faster ones. The strings `fast` and `slow` can be supplied to indicate durations of 200 and 600
      * milliseconds, respectively.
      */
     hide: function(duration) {
+        this._super();
         if(!this.isVisible()) {
             return;
         }
@@ -594,6 +598,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
      */
     moveToTop: function() {
         this.jq.css('z-index', PrimeFaces.nextZindex());
+        PrimeFaces.utils.hideTooltips();
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
@@ -289,8 +289,10 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.DynamicOverlayWidget.extend(
 
     /**
      * Brings up the overlay panel with the available options.
+     * @override
      */
     show: function() {
+        this._super();
         var $this = this;
 
         if (this.transition) {
@@ -317,8 +319,10 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.DynamicOverlayWidget.extend(
 
     /**
      * Hides the overlay panel with the available options.
+     * @override
      */
     hide: function() {
+        this._super();
         if (this.panel.is(':visible') && this.transition) {
             var $this = this;
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -315,9 +315,11 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
     /**
      * Brings up the overlay panel so that is displayed and visible.
+     * @override
      * @param {string | JQuery} [target] ID or DOM element of the target component that triggers this overlay panel.
      */
     show: function(target) {
+        this._super();
         if (this.isVisible()) {
             return;
         }
@@ -431,9 +433,11 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
     /**
      * Hides this overlay panel so that it is not displayed anymore.
+     * @override
      * @param {() => void} [callback] Custom callback that is invoked after this overlay panel was closed.
      */
     hide: function(callback) {
+        this._super();
         if (this.transition) {
             var $this = this;
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.js
@@ -97,9 +97,11 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
     /**
      * Brings up this sidebar in case is is not already visible.
+     * @override
      * @param {boolean} reload If the dynamic content should be reloaded.
      */
     show: function(reload = false) {
+        this._super();
         if(this.isVisible()) {
             return;
         }
@@ -144,8 +146,10 @@ PrimeFaces.widget.Sidebar = PrimeFaces.widget.DynamicOverlayWidget.extend({
 
     /**
      * Hides this sidebara in case it is not already hidden.
+     * @override
      */
     hide: function() {
+        this._super();
         if(!this.isVisible()) {
             return;
         }


### PR DESCRIPTION
Fix #9941: Overlays hide tooltips on show/hide
Fix #10100: Hide tooltips on dialog focus

Adds base `show()` and `hide()` in OverlayWidget