### PR TITLE
Fix #9955: TextEditor make readonly when disabled

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/texteditor/1-texteditor.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/texteditor/1-texteditor.js
@@ -88,6 +88,7 @@ PrimeFaces.widget.TextEditor = PrimeFaces.widget.DeferredWidget.extend({
         if (this.disabled) {
             this.input.attr("disabled", "disabled");
             this.jq.addClass("ui-state-disabled");
+            this.cfg.readOnly = true;
         }
 
         this.renderDeferred();


### PR DESCRIPTION
Fix #9955: TextEditor make readonly when disabled