### PR TITLE
add disabled attribute to contextmenu (#9863)

### DIFF
--- a/docs/13_0_0/components/contextmenu.md
+++ b/docs/13_0_0/components/contextmenu.md
@@ -21,6 +21,7 @@ ContextMenu provides an overlay menu displayed on mouse right-click event.
 | --- | --- | --- | --- |
 | id | null | String | Unique identifier of the component
 | rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
+| disabled | false | Boolean | If true, prevents menu from being shown
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 | widgetVar | null | String | Name of the client side widget.
 | for | null | String | Id of the component to attach to

--- a/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuBase.java
@@ -40,6 +40,7 @@ public abstract class ContextMenuBase extends AbstractMenu implements Widget, To
         style,
         styleClass,
         model,
+        disabled,
         nodeType,
         event,
         beforeShow,
@@ -110,6 +111,14 @@ public abstract class ContextMenuBase extends AbstractMenu implements Widget, To
 
     public void setModel(org.primefaces.model.menu.MenuModel model) {
         getStateHelper().put(PropertyKeys.model, model);
+    }
+
+    public Boolean isDisabled() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.disabled, false);
+    }
+
+    public void setDisabled(Boolean disabled) {
+        getStateHelper().put(PropertyKeys.disabled, disabled);
     }
 
     public String getNodeType() {

--- a/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
@@ -61,7 +61,8 @@ public class ContextMenuRenderer extends TieredMenuRenderer {
                 .attr("selectionMode", menu.getSelectionMode(), "multiple")
                 .callback("beforeShow", "function(event)", menu.getBeforeShow())
                 .attr("targetFilter", menu.getTargetFilter(), null)
-                .attr("touchable", ComponentUtils.isTouchable(context, menu),  true);
+                .attr("touchable", ComponentUtils.isTouchable(context, menu),  true)
+                .attr("disabled", menu.isDisabled(), false);
 
         wb.finish();
     }

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -7412,6 +7412,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[If true, prevents menu from being shown.]]>
+            </description>
+            <name>disabled</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Type of tree nodes to get attached.]]>
             </description>
             <name>nodeType</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.contextmenu.js
@@ -49,6 +49,7 @@
  * @prop {string} cfg.target Client ID of the target widget.
  * @prop {string} cfg.targetFilter Selector to filter the elements to attach the menu.
  * @prop {string} cfg.targetWidgetVar Widget variable of the target widget.
+ * @prop {boolean} cfg.disabled If true, prevents menu from being shown.
  */
 PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
 
@@ -270,7 +271,7 @@ PrimeFaces.widget.ContextMenu = PrimeFaces.widget.TieredMenu.extend({
     show: function(e) {
         var $this = this;
 
-        if(this.cfg.targetFilter && $(e.target).is(':not(' + this.cfg.targetFilter + ')')) {
+        if(this.cfg.disabled || this.cfg.targetFilter && $(e.target).is(':not(' + this.cfg.targetFilter + ')')) {
             return;
         }
 


### PR DESCRIPTION
Advantages/differences over using `rendered`:

- ajax updates can target the context menu itself, no longer necessary to target the parent
- there's no need to call destroy on the widget (https://github.com/primefaces/primefaces/issues/9863#issuecomment-1454724751)

Fix #9863 #9926
CC @melloware 