### PR TITLE
Fix #10001: TreeTable contextMenu

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -220,7 +220,7 @@ public class TreeTable extends TreeTableBase {
                 wrapperEvent = new NodeCollapseEvent(this, behaviorEvent.getBehavior(), node);
                 wrapperEvent.setPhaseId(PhaseId.APPLY_REQUEST_VALUES);
             }
-            else if ("select".equals(eventName) || "contextMenu".equals(eventName)) {
+            else if ("select".equals(eventName)) {
                 String nodeKey = params.get(clientId + "_instantSelection");
                 setRowKey(root, nodeKey);
                 TreeNode node = getRowNode();
@@ -228,6 +228,15 @@ public class TreeTable extends TreeTableBase {
                 wrapperEvent = new NodeSelectEvent(this, behaviorEvent.getBehavior(), node);
                 wrapperEvent.setPhaseId(behaviorEvent.getPhaseId());
             }
+            else if ("contextMenu".equals(eventName)) {
+                String nodeKey = params.get(clientId + "_instantSelection");
+                setRowKey(root, nodeKey);
+                TreeNode node = getRowNode();
+
+                wrapperEvent = new NodeSelectEvent(this, behaviorEvent.getBehavior(), node, true);
+                wrapperEvent.setPhaseId(behaviorEvent.getPhaseId());
+            }
+
             else if ("unselect".equals(eventName)) {
                 String nodeKey = params.get(clientId + "_instantUnselection");
                 setRowKey(root, nodeKey);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/treetable/treetable.js
@@ -1025,7 +1025,7 @@ PrimeFaces.widget.TreeTable = PrimeFaces.widget.DeferredWidget.extend({
             if(this.isSingleSelection() || !selected ) {
                 this.unselectAllNodes();
             }
-            this.selectNode(node);
+            this.selectNode(node, true);
         }
 
         this.fireSelectEvent(nodeKey, 'contextMenu');


### PR DESCRIPTION

Fix #10001: TreeTable contextMenu

In the case where the action is given by a contextMenu I used the constructor of NodeSelectEvent which sets isContextMenu to true.