### PR TITLE
#7369 Don't save empty / default states

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/ImmutableSavedState.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ImmutableSavedState.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2023 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.api;
+
+import javax.faces.component.EditableValueHolder;
+
+public class ImmutableSavedState extends SavedState {
+
+    public ImmutableSavedState() {
+        super();
+    }
+
+    @Override
+    public void setSubmitted(boolean submitted) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setLocalValueSet(boolean localValueSet) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setValue(Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setValid(boolean valid) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSubmittedValue(Object submittedValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void populate(EditableValueHolder evh) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/SavedState.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/SavedState.java
@@ -33,7 +33,7 @@ import javax.faces.component.EditableValueHolder;
 @SuppressWarnings({"SerializableHasSerializationMethods", "NonSerializableFieldInSerializableClass"})
 public class SavedState implements Serializable {
 
-    public static final SavedState NULL_STATE = new SavedState();
+    public static final SavedState NULL_STATE = new ImmutableSavedState();
 
     private static final long serialVersionUID = 4325654657465654768L;
 

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -548,19 +548,9 @@ public class UIData extends javax.faces.component.UIData {
             return;
         }
 
-        SavedState state = null;
-
-        if (saved == null) {
-            state = new SavedState();
-        }
-
-        if (state == null) {
-            state = saved.get(componentClientId);
-
-            if (state == null) {
-                state = new SavedState();
-            }
-        }
+        SavedState state = saved != null
+                ? saved.computeIfAbsent(componentClientId, key -> new SavedState())
+                : new SavedState();
 
         state.setValue(input.getLocalValue());
         state.setValid(input.isValid());

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -550,7 +550,6 @@ public class UIData extends javax.faces.component.UIData {
 
         if (saved == null) {
             state = new SavedState();
-            getStateHelper().put(PropertyKeys.saved, componentClientId, state);
         }
 
         if (state == null) {
@@ -558,7 +557,6 @@ public class UIData extends javax.faces.component.UIData {
 
             if (state == null) {
                 state = new SavedState();
-                getStateHelper().put(PropertyKeys.saved, componentClientId, state);
             }
         }
 
@@ -566,6 +564,7 @@ public class UIData extends javax.faces.component.UIData {
         state.setValid(input.isValid());
         state.setSubmittedValue(input.getSubmittedValue());
         state.setLocalValueSet(input.isLocalValueSet());
+        getStateHelper().put(PropertyKeys.saved, componentClientId, state);
     }
 
     protected boolean isDefaultAndEmpty(EditableValueHolder input) {

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -500,28 +500,7 @@ public class UIData extends javax.faces.component.UIData {
         Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
 
         if (component instanceof EditableValueHolder) {
-            EditableValueHolder input = (EditableValueHolder) component;
-            SavedState state = null;
-            String componentClientId = component.getClientId(context);
-
-            if (saved == null) {
-                state = new SavedState();
-                getStateHelper().put(PropertyKeys.saved, componentClientId, state);
-            }
-
-            if (state == null) {
-                state = saved.get(componentClientId);
-
-                if (state == null) {
-                    state = new SavedState();
-                    getStateHelper().put(PropertyKeys.saved, componentClientId, state);
-                }
-            }
-
-            state.setValue(input.getLocalValue());
-            state.setValid(input.isValid());
-            state.setSubmittedValue(input.getSubmittedValue());
-            state.setLocalValueSet(input.isLocalValueSet());
+            saveInputState((EditableValueHolder) component, context);
         }
         else if (component instanceof UIForm) {
             UIForm form = (UIForm) component;
@@ -557,7 +536,43 @@ public class UIData extends javax.faces.component.UIData {
                 saveDescendantState(facet, context);
             }
         }
+    }
 
+    protected void saveInputState(EditableValueHolder input, FacesContext context) {
+        String componentClientId = ((UIComponent) input).getClientId(context);
+        if (isDefaultAndEmpty(input)) {
+            getStateHelper().remove(PropertyKeys.saved, componentClientId);
+            return;
+        }
+
+        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
+        SavedState state = null;
+
+        if (saved == null) {
+            state = new SavedState();
+            getStateHelper().put(PropertyKeys.saved, componentClientId, state);
+        }
+
+        if (state == null) {
+            state = saved.get(componentClientId);
+
+            if (state == null) {
+                state = new SavedState();
+                getStateHelper().put(PropertyKeys.saved, componentClientId, state);
+            }
+        }
+
+        state.setValue(input.getLocalValue());
+        state.setValid(input.isValid());
+        state.setSubmittedValue(input.getSubmittedValue());
+        state.setLocalValueSet(input.isLocalValueSet());
+    }
+
+    protected boolean isDefaultAndEmpty(EditableValueHolder input) {
+        return input.getLocalValue() == null
+                && input.isValid()
+                && input.getSubmittedValue() == null
+                && !input.isLocalValueSet();
     }
 
     protected void restoreDescendantState() {
@@ -578,9 +593,12 @@ public class UIData extends javax.faces.component.UIData {
     }
 
     protected void restoreDescendantState(UIComponent component, FacesContext context) {
+        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
+        if (saved == null) {
+            return;
+        }
         String id = component.getId();
         component.setId(id); //reset the client id
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
 
         if (component instanceof EditableValueHolder) {
             EditableValueHolder input = (EditableValueHolder) component;

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -64,7 +64,6 @@ public class UIData extends javax.faces.component.UIData {
 
     private static final Logger LOGGER = Logger.getLogger(UIData.class.getName());
     private static final String SB_ID = UIData.class.getName() + "#id";
-    private static final SavedState EMPTY_SAVED_STATE = new SavedState();
 
     private final Map<String, Object> _rowTransientStates = new HashMap<>();
     private Map<String, Object> _rowDeltaStates = new HashMap<>();
@@ -632,11 +631,11 @@ public class UIData extends javax.faces.component.UIData {
     protected SavedState getSavedState(UIComponent component, FacesContext context) {
         Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
         if (saved == null) {
-            return EMPTY_SAVED_STATE;
+            return SavedState.NULL_STATE;
         }
         String componentClientId = component.getClientId(context);
         SavedState state = saved.get(componentClientId);
-        return state == null ? EMPTY_SAVED_STATE : state;
+        return state == null ? SavedState.NULL_STATE : state;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -540,13 +540,15 @@ public class UIData extends javax.faces.component.UIData {
     }
 
     protected void saveInputState(EditableValueHolder input, FacesContext context) {
+        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
         String componentClientId = ((UIComponent) input).getClientId(context);
         if (isDefaultAndEmpty(input)) {
-            getStateHelper().remove(PropertyKeys.saved, componentClientId);
+            if (saved != null) {
+                saved.remove(componentClientId);
+            }
             return;
         }
 
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
         SavedState state = null;
 
         if (saved == null) {

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -571,8 +571,7 @@ public class UIData extends javax.faces.component.UIData {
     protected boolean isDefaultAndEmpty(EditableValueHolder input) {
         return input.getLocalValue() == null
                 && input.isValid()
-                && input.getSubmittedValue() == null
-                && !input.isLocalValueSet();
+                && input.getSubmittedValue() == null;
     }
 
     protected void restoreDescendantState() {

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -64,6 +64,7 @@ public class UIData extends javax.faces.component.UIData {
 
     private static final Logger LOGGER = Logger.getLogger(UIData.class.getName());
     private static final String SB_ID = UIData.class.getName() + "#id";
+    private static final SavedState EMPTY_SAVED_STATE = new SavedState();
 
     private final Map<String, Object> _rowTransientStates = new HashMap<>();
     private Map<String, Object> _rowDeltaStates = new HashMap<>();
@@ -608,7 +609,6 @@ public class UIData extends javax.faces.component.UIData {
             SavedState state = getSavedState(component, context);
 
             form.setSubmitted(state.getSubmitted());
-            state.setSubmitted(form.isSubmitted());
         }
 
         //restore state of children
@@ -630,13 +630,11 @@ public class UIData extends javax.faces.component.UIData {
     protected SavedState getSavedState(UIComponent component, FacesContext context) {
         Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
         if (saved == null) {
-            return new SavedState();
+            return EMPTY_SAVED_STATE;
         }
         String componentClientId = component.getClientId(context);
         SavedState state = saved.get(componentClientId);
-        return state == null
-                ? new SavedState()
-                : state;
+        return state == null ? EMPTY_SAVED_STATE : state;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -591,21 +591,12 @@ public class UIData extends javax.faces.component.UIData {
     }
 
     protected void restoreDescendantState(UIComponent component, FacesContext context) {
-        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
-        if (saved == null) {
-            return;
-        }
         String id = component.getId();
         component.setId(id); //reset the client id
 
         if (component instanceof EditableValueHolder) {
             EditableValueHolder input = (EditableValueHolder) component;
-            String componentClientId = component.getClientId(context);
-
-            SavedState state = saved.get(componentClientId);
-            if (state == null) {
-                state = new SavedState();
-            }
+            SavedState state = getSavedState(component, context);
 
             input.setValue(state.getValue());
             input.setValid(state.isValid());
@@ -614,11 +605,7 @@ public class UIData extends javax.faces.component.UIData {
         }
         else if (component instanceof UIForm) {
             UIForm form = (UIForm) component;
-            String componentClientId = component.getClientId(context);
-            SavedState state = saved.get(componentClientId);
-            if (state == null) {
-                state = new SavedState();
-            }
+            SavedState state = getSavedState(component, context);
 
             form.setSubmitted(state.getSubmitted());
             state.setSubmitted(form.isSubmitted());
@@ -638,7 +625,18 @@ public class UIData extends javax.faces.component.UIData {
                 restoreDescendantState(facet, context);
             }
         }
+    }
 
+    protected SavedState getSavedState(UIComponent component, FacesContext context) {
+        Map<String, SavedState> saved = (Map<String, SavedState>) getStateHelper().get(PropertyKeys.saved);
+        if (saved == null) {
+            return new SavedState();
+        }
+        String componentClientId = component.getClientId(context);
+        SavedState state = saved.get(componentClientId);
+        return state == null
+                ? new SavedState()
+                : state;
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -634,8 +634,7 @@ public class UIData extends javax.faces.component.UIData {
             return SavedState.NULL_STATE;
         }
         String componentClientId = component.getClientId(context);
-        SavedState state = saved.get(componentClientId);
-        return state == null ? SavedState.NULL_STATE : state;
+        return saved.getOrDefault(componentClientId, SavedState.NULL_STATE);
     }
 
     @Override


### PR DESCRIPTION
It's not really possible to only store the actual filter from the filter facet, but I've noticed that checking for the state helps a lot. Basically you don't need to store the state of inputs that are default / empty. This drastically drops the amount of inputs the state is saved for.

Fixes #7369