### PR TITLE
Showcase: Add missing tabs to DF showcase

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
@@ -31,10 +31,10 @@
             <f:attribute name="flatten" value="true"/>
         </p:tab>
         <p:tab title="/ui/df/viewResponsive.xhtml">
-            <f:attribute name="flatten" value="true"/>
+            <f:attribute name="flatten" value="false"/>
         </p:tab>
         <p:tab title="/ui/df/viewProductsLargerThanViewport.xhtml">
-            <f:attribute name="flatten" value="true"/>
+            <f:attribute name="flatten" value="false"/>
         </p:tab>
     </ui:define>
 

--- a/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
@@ -30,6 +30,12 @@
         <p:tab title="/ui/df/viewProducts.xhtml">
             <f:attribute name="flatten" value="true"/>
         </p:tab>
+        <p:tab title="/ui/df/viewResponsive.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
+        <p:tab title="/ui/df/viewProductsLargerThanViewport.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
     </ui:define>
 
 </ui:composition>

--- a/primefaces-showcase/src/main/webapp/ui/df/data.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/data.xhtml
@@ -27,4 +27,10 @@
         </div>
     </ui:define>
 
+    <ui:define name="more-source-tabs">
+        <p:tab title="/ui/df/selectProduct.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
+    </ui:define>
+
 </ui:composition>

--- a/primefaces-showcase/src/main/webapp/ui/df/level1.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level1.xhtml
@@ -1,3 +1,4 @@
+<!-- EXAMPLE-SOURCE-START -->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/primefaces-showcase/src/main/webapp/ui/df/level2.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level2.xhtml
@@ -1,3 +1,4 @@
+<!-- EXAMPLE-SOURCE-START -->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/primefaces-showcase/src/main/webapp/ui/df/level3.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level3.xhtml
@@ -1,3 +1,4 @@
+<!-- EXAMPLE-SOURCE-START -->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/primefaces-showcase/src/main/webapp/ui/df/nested.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/nested.xhtml
@@ -53,4 +53,16 @@
 
     </ui:define>
 
+    <ui:define name="more-source-tabs">
+        <p:tab title="/ui/df/level1.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
+        <p:tab title="/ui/df/level2.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
+        <p:tab title="/ui/df/level3.xhtml">
+            <f:attribute name="flatten" value="true"/>
+        </p:tab>
+    </ui:define>
+
 </ui:composition>

--- a/primefaces-showcase/src/main/webapp/ui/df/selectProduct.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/selectProduct.xhtml
@@ -1,3 +1,4 @@
+<!-- EXAMPLE-SOURCE-START -->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"

--- a/primefaces-showcase/src/main/webapp/ui/df/viewResponsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/viewResponsive.xhtml
@@ -1,3 +1,4 @@
+<!-- EXAMPLE-SOURCE-START -->
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"


### PR DESCRIPTION
These files are used on showcase demo, but are missing in implementation tabs.

This PR aims to add all relevant sources to the showcases.

However, when I run it locally to verify that it works as expected, `viewResponsive.xhtml` appears empty, as well as other sources added, except `viewProductsLargerThanViewport.xhtml` it is rendered correctly. I have no clue why.