### PR TITLE
Fix #10046: InputNumber must delay registering events until CSP is done

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/inputnumber/InputNumber007Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/inputnumber/InputNumber007Test.java
@@ -39,9 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InputNumber007Test extends AbstractPrimePageTest {
 
-    // @Test
-    // @Order(1)
-    // @DisplayName("InputNumber: no valueChange event after it has been updated, is blurred and NO inputs were made")
+    @Test
+    @Order(1)
+    @DisplayName("InputNumber: no valueChange event after it has been updated, is blurred and NO inputs were made")
     public void testNoValueChangeEventAfterUpdate(Page page) {
         // Arrange
         Messages messages = page.messages;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/inputnumber/1-inputnumber.js
@@ -54,9 +54,6 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
         //Visual effects
         PrimeFaces.skinInput(this.input);
 
-        this.wrapEvents();
-        this.bindInputEvents();
-
         this.autonumeric = new AutoNumeric(this.jqId + '_input', this.cfg);
 
         if (this.initialValue !== "") {
@@ -71,6 +68,10 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
         //pfs metadata
         this.input.data(PrimeFaces.CLIENT_ID_DATA, this.id);
         this.hiddenInput.data(PrimeFaces.CLIENT_ID_DATA, this.id);
+
+        // GitHub #10046 delay registering events until CSP has registered
+        var $this = this;
+        setTimeout(function () {$this.wrapEvents();}, 0);
     },
 
     /**
@@ -142,11 +143,11 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
         this.input.prop('onchange', null).off('change').on('change.inputnumber', function(e) {
 
             var newValue = $this.copyValueToHiddenInput();
-            if (Number(newValue) === Number($this.initialValue)) {
-                // #10046 do not call on Change if the value has not changed
+            // #10046 do not call on Change if the value has not changed
+            if (newValue === $this.initialValue || 
+                ($this.initialValue !== '' && newValue !== '' && Number(newValue) === Number($this.initialValue))) {
                 return false;
             }
-            
             if (originalOnchange && originalOnchange.call(this, e) === false) {
                 $this.setValueToHiddenInput(newValue);
                 return false;
@@ -166,6 +167,8 @@ PrimeFaces.widget.InputNumber = PrimeFaces.widget.BaseWidget.extend({
                 return false;
             }
         });
+
+        this.bindInputEvents();
     },
 
     /**


### PR DESCRIPTION
Fix #10046: InputNumber must delay registering events until CSP is done
Fix #10074

Basically because CSP Register happens AFTER the widget init the `wrapEvents` method is not doing what is intended when running in CSP mode.