### PR TITLE
Fix #10079: Use pagehide event not unload if available

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1477,7 +1477,8 @@ if (!PrimeFaces.ajax) {
         }
     };
 
-    $(window).on('unload', function() {
+    var unloadEvent = ("onpagehide" in window) ? "pagehide" : "unload";
+    $(window).on(unloadEvent, function() {
         PrimeFaces.ajax.Queue.abortAll();
     });
 


### PR DESCRIPTION
Fix #10079: Use pagehide event not unload if available

@tandraschko I am using the same code that OmniFaces is using it uses the `pagehide` event and only falls back to `unload` if pagehide is not available.

> Instead of using the unload event, use the pagehide event. The pagehide event fires in all cases where the unload event currently fires, and it also fires when a page is put in the bfcache.