### PR TITLE
Fix #10100: Tooltip should start its zIndex higher than default compo…

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -320,10 +320,12 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
      */
     align: function() {
         var $this = this;
+        // #10100 make sure z-Index is above any dynamically changing zindex like dialogs.
+        var zIndex = (PrimeFaces.nextZindex() + 1000);
         this.jq.css({
             left: '',
             top: '',
-            'z-index': PrimeFaces.nextZindex()
+            'z-index': zIndex
         });
 
         if (this.cfg.trackMouse && this.mouseEvent) {


### PR DESCRIPTION
Fix #10100: Tooltip should start its zIndex higher than default components

Basically dynamic allocation of zIndex is great for all normal components but because other components may change their zIndex while a tooltip is being displayed the safest fix to make its to just start Tooltips zIndex in a higher range.

PrimeReact actually tracks zIndexes by type so each can be given a starting range.

```js
    static zIndex = {
        modal: 1000,
        overlay: 1100,
        menu: 1200,
        tooltip: 1300,
        toast: 1400
    };
```