### PR TITLE
Fix #9882: Dialog width for saveState account for scrollbar.

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -712,7 +712,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.state = {
             width: this.jq.width(),
             height: this.jq.height(),
-            contentWidth: this.content.width(),
+            contentWidth: parseInt(this.content[0].style.width) || this.content.width(),
             contentHeight: this.content.height()
         };
 


### PR DESCRIPTION
Fix #9882: Dialog width for saveState account for scrollbar.
Fix #8989 8989

Because `jquery.width()` is accounting for the scrollbar this content is constanly shrinking.  So we must try and use the already calculated `style="width: 308px"` to use 308 and only fall back to `content.width()` if that is null or 0.