### PR TITLE
Fix #10189: Dialog should render not displayed

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dialog/Dialog001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dialog/Dialog001Test.java
@@ -43,6 +43,7 @@ public class Dialog001Test extends AbstractPrimePageTest {
     public void testShowWidget(Page page) {
         // Arrange
         Dialog dialog = page.dialog;
+        Assertions.assertFalse(dialog.isVisible());
 
         // Act
         dialog.show();

--- a/primefaces/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/dialog/DialogRenderer.java
@@ -99,7 +99,7 @@ public class DialogRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = dialog.getClientId(context);
         String positionType = dialog.getPositionType();
-        String style = dialog.getStyle();
+        String style = getStyleBuilder(context).add(dialog.getStyle()).add("display", "none").build();
         String styleClass = dialog.getStyleClass();
         styleClass = styleClass == null ? Dialog.CONTAINER_CLASS : Dialog.CONTAINER_CLASS + " " + styleClass;
 


### PR DESCRIPTION
Fix #10189: Dialog should render not displayed

Right now the dialog CSS goes like this.

Initial Page Load: `no element style`

Show: `display:block`

Hide: `display: none`

Show: `display: block`

Hide: `display:none`

The initial state should be `display:none`