### PR TITLE
Fix #10209 - DataTable: Filter usage modify the value object type

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1229,7 +1229,7 @@ public class DataTable extends DataTableBase {
                 }
             }
             catch (ReflectiveOperationException e) {
-                Logger.getLogger(FilterFeature.class.getName()).log(Level.SEVERE, e.getMessage());
+                Logger.getLogger(DataTable.class.getName()).log(Level.SEVERE, e.getMessage());
             }
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -1229,7 +1229,7 @@ public class DataTable extends DataTableBase {
                 }
             }
             catch (ReflectiveOperationException e) {
-                Logger.getLogger(DataTable.class.getName()).log(Level.SEVERE, e.getMessage());
+                LOGGER.log(Level.SEVERE, e.getMessage());
             }
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -291,7 +291,7 @@ public class DataTable extends DataTableBase {
             if (ve != null) {
                 List<?> filteredValue = getFilteredValue();
                 if (filteredValue != null) {
-                    setValue(convertFilteredValueIfNecessary(getFacesContext(), this, filteredValue));
+                    setValue(convertIntoObjectValueType(getFacesContext(), this, filteredValue));
                 }
             }
             else {
@@ -1211,21 +1211,21 @@ public class DataTable extends DataTableBase {
         return null;
     }
 
-    public static Object convertFilteredValueIfNecessary(FacesContext context, DataTable table, List<?> filtered) {
+    public static Object convertIntoObjectValueType(FacesContext context, DataTable table, List<?> value) {
         Class<?> expectedType = ELUtils.getType(context, table.getValueExpression("value"));
         if (expectedType != null && DataModel.class.isAssignableFrom(expectedType)) {
             try {
                 if (ListDataModel.class.isAssignableFrom(expectedType)) {
-                    return expectedType.getConstructor(List.class).newInstance(filtered);
+                    return expectedType.getConstructor(List.class).newInstance(value);
                 }
                 else if (CollectionDataModel.class.isAssignableFrom(expectedType)) {
-                    return expectedType.getConstructor(Collection.class).newInstance(filtered);
+                    return expectedType.getConstructor(Collection.class).newInstance(value);
                 }
                 else if (IterableDataModel.class.isAssignableFrom(expectedType)) {
-                    return expectedType.getConstructor(Iterable.class).newInstance(filtered);
+                    return expectedType.getConstructor(Iterable.class).newInstance(value);
                 }
                 else if (ArrayDataModel.class.isAssignableFrom(expectedType)) {
-                    return expectedType.getConstructor(Object[].class).newInstance(filtered.toArray());
+                    return expectedType.getConstructor(Object[].class).newInstance(value.toArray());
                 }
             }
             catch (ReflectiveOperationException e) {
@@ -1233,6 +1233,6 @@ public class DataTable extends DataTableBase {
             }
         }
 
-        return filtered;
+        return value;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -38,7 +38,9 @@ import javax.faces.component.visit.VisitCallback;
 import javax.faces.component.visit.VisitContext;
 import javax.faces.context.FacesContext;
 import javax.faces.event.*;
+import javax.faces.model.ArrayDataModel;
 import javax.faces.model.DataModel;
+import javax.faces.model.ListDataModel;
 
 import org.primefaces.PrimeFaces;
 import org.primefaces.component.api.DynamicColumn;
@@ -287,9 +289,9 @@ public class DataTable extends DataTableBase {
 
             ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
             if (ve != null) {
-                Object filteredValue = getFilteredValue();
+                List<?> filteredValue = getFilteredValue();
                 if (filteredValue != null) {
-                    setValue(filteredValue);
+                    setValue(convertFilteredValueIfNecessary(getFacesContext(), this, filteredValue));
                 }
             }
             else {
@@ -951,15 +953,15 @@ public class DataTable extends DataTableBase {
         return iterableChildren;
     }
 
-    public java.util.List<?> getFilteredValue() {
+    public List<?> getFilteredValue() {
         ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
         if (ve != null) {
-            return (java.util.List<?>) ve.getValue(getFacesContext().getELContext());
+            return (List<?>) ve.getValue(getFacesContext().getELContext());
         }
         return null;
     }
 
-    public void setFilteredValue(java.util.List<?> filteredValue) {
+    public void setFilteredValue(List<?> filteredValue) {
         ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
         if (ve != null) {
             ve.setValue(getFacesContext().getELContext(), filteredValue);
@@ -1207,5 +1209,30 @@ public class DataTable extends DataTableBase {
             return (LazyDataModel<?>) getDataModel();
         }
         return null;
+    }
+
+    public static Object convertFilteredValueIfNecessary(FacesContext context, DataTable table, List<?> filtered) {
+        Class<?> expectedType = ELUtils.getType(context, table.getValueExpression("value"));
+        if (expectedType != null && DataModel.class.isAssignableFrom(expectedType)) {
+            try {
+                if (ListDataModel.class.isAssignableFrom(expectedType)) {
+                    return expectedType.getConstructor(List.class).newInstance(filtered);
+                }
+                else if (CollectionDataModel.class.isAssignableFrom(expectedType)) {
+                    return expectedType.getConstructor(Collection.class).newInstance(filtered);
+                }
+                else if (IterableDataModel.class.isAssignableFrom(expectedType)) {
+                    return expectedType.getConstructor(Iterable.class).newInstance(filtered);
+                }
+                else if (ArrayDataModel.class.isAssignableFrom(expectedType)) {
+                    return expectedType.getConstructor(Object[].class).newInstance(filtered.toArray());
+                }
+            }
+            catch (ReflectiveOperationException e) {
+                Logger.getLogger(FilterFeature.class.getName()).log(Level.SEVERE, e.getMessage());
+            }
+        }
+
+        return filtered;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
@@ -181,7 +181,7 @@ public class FilterFeature implements DataTableFeature {
 
         //save filtered data
         table.setFilteredValue(filtered);
-        table.setValue(DataTable.convertFilteredValueIfNecessary(context, table, filtered));
+        table.setValue(DataTable.convertIntoObjectValueType(context, table, filtered));
         table.setRowIndex(-1); //reset datamodel
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/FilterFeature.java
@@ -181,7 +181,7 @@ public class FilterFeature implements DataTableFeature {
 
         //save filtered data
         table.setFilteredValue(filtered);
-        table.setValue(filtered);
+        table.setValue(DataTable.convertFilteredValueIfNecessary(context, table, filtered));
         table.setRowIndex(-1); //reset datamodel
     }
 }


### PR DESCRIPTION
I tried to keep it very simple for now, but indeed we should keep DataTable#value consistent before/after filtering.

Out of topic: `CollectionDataModel` and `CollectionDataModel` should not be used in 2.3 and above, PF should only support it when it's necessary. IMO, they should be mark as deprecated

Fix #10209