### PR TITLE
Fix #10226: CSV byte order mark for UTF-8

### DIFF
--- a/primefaces-integration-tests/src/test/resources/org/primefaces/integrationtests/dataexporter/languages-pageonly.csv
+++ b/primefaces-integration-tests/src/test/resources/org/primefaces/integrationtests/dataexporter/languages-pageonly.csv
@@ -1,3 +1,3 @@
-"ID","Type","Name"
+﻿"ID","Type","Name"
 "4","INTERPRETED","TypeScript"
 "5","INTERPRETED","Python"

--- a/primefaces-integration-tests/src/test/resources/org/primefaces/integrationtests/dataexporter/languages.csv
+++ b/primefaces-integration-tests/src/test/resources/org/primefaces/integrationtests/dataexporter/languages.csv
@@ -1,4 +1,4 @@
-"ID","Type","Name","First appeared"
+﻿"ID","Type","Name","First appeared"
 "1","COMPILED","Java","1995"
 "2","COMPILED","C#","2000"
 "3","INTERPRETED","JavaScript","1995"

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableCSVExporter.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.EnumSet;
 import javax.faces.FacesException;
 import javax.faces.context.FacesContext;
@@ -55,8 +56,13 @@ public class DataTableCSVExporter extends DataTableExporter<PrintWriter, CSVOpti
     @Override
     protected PrintWriter createDocument(FacesContext context) throws IOException {
         try {
-            OutputStreamWriter osw = new OutputStreamWriter(os(), exportConfiguration.getEncodingType());
-            return new PrintWriter(osw);
+            String encoding = exportConfiguration.getEncodingType();
+            OutputStreamWriter osw = new OutputStreamWriter(os(), encoding);
+            PrintWriter writer = new PrintWriter(osw);
+            if (StandardCharsets.UTF_8.name().equals(encoding)) {
+                writer.write("\ufeff"); // byte order mark for UTF-8
+            }
+            return writer;
         }
         catch (UnsupportedEncodingException e) {
             throw new FacesException(e);

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
@@ -26,6 +26,7 @@ package org.primefaces.component.export;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
@@ -80,7 +81,7 @@ public class DataExporter implements ActionListener, StateHolder {
         String exportAs = (String) type.getValue(elContext);
         String outputFileName = (String) fileName.getValue(elContext);
 
-        String encodingType = "UTF-8";
+        String encodingType = StandardCharsets.UTF_8.name();
         if (encoding != null) {
             encodingType = (String) encoding.getValue(elContext);
         }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import javax.faces.FacesException;
 import javax.faces.context.FacesContext;
@@ -55,8 +56,13 @@ public class TreeTableCSVExporter extends TreeTableExporter<PrintWriter, CSVOpti
     @Override
     protected PrintWriter createDocument(FacesContext context) throws IOException {
         try {
-            OutputStreamWriter osw = new OutputStreamWriter(os(), exportConfiguration.getEncodingType());
-            return new PrintWriter(osw);
+            String encoding = exportConfiguration.getEncodingType();
+            OutputStreamWriter osw = new OutputStreamWriter(os(), encoding);
+            PrintWriter writer = new PrintWriter(osw);
+            if (StandardCharsets.UTF_8.name().equals(encoding)) {
+                writer.write("\ufeff"); // byte order mark for UTF-8
+            }
+            return writer;
         }
         catch (UnsupportedEncodingException e) {
             throw new FacesException(e);


### PR DESCRIPTION
Fix #10226: CSV byte order mark for UTF-8