### PR TITLE
Fix #10251: FileDownload allow disabling of `no-store`

### DIFF
--- a/docs/13_0_0/components/filedownload.md
+++ b/docs/13_0_0/components/filedownload.md
@@ -17,7 +17,6 @@ stream the binary data. FileDownload presents an easier way to do the same.
 | value | null | StreamedContent | A streamed content instance.
 | contentDisposition | attachment | String | Specifies display mode on non-AJAX downloads.
 | monitorKey | null | String | Optional key to support monitoring multiple filedownloads on same page.
-| cache | false | Boolean | Controls browser caching mode of the resource.
 
 ## Getting started with FileDownload
 A user command action is required to trigger the file-download process.
@@ -73,10 +72,6 @@ Please see our core documentation about it [Dynamic Content Streaming / Renderin
 On regular (non-AJAX) downloads, by default, content is displayed as an `attachment` with a download dialog box,
 another alternative is the `inline` mode, in this case browser will try to open the file internally without a prompt.
 Note that content disposition is not part of the http standard, although it is widely implemented.
-
-## Cache
-Most of the time you want to leave cache="false" which is the default to not cache the results.  However, in the case of PDF Downloads there have
-been issues with some browser like Chrome/Edge. See: https://github.com/primefaces/primefaces/issues/10251
 
 ## Monitor Status
 When fileDownload is used without AJAX, ajaxStatus cannot apply. Still PrimeFaces provides a feature

--- a/docs/13_0_0/components/filedownload.md
+++ b/docs/13_0_0/components/filedownload.md
@@ -17,6 +17,7 @@ stream the binary data. FileDownload presents an easier way to do the same.
 | value | null | StreamedContent | A streamed content instance.
 | contentDisposition | attachment | String | Specifies display mode on non-AJAX downloads.
 | monitorKey | null | String | Optional key to support monitoring multiple filedownloads on same page.
+| cache | false | Boolean | Controls browser caching mode of the resource.
 
 ## Getting started with FileDownload
 A user command action is required to trigger the file-download process.
@@ -72,6 +73,10 @@ Please see our core documentation about it [Dynamic Content Streaming / Renderin
 On regular (non-AJAX) downloads, by default, content is displayed as an `attachment` with a download dialog box,
 another alternative is the `inline` mode, in this case browser will try to open the file internally without a prompt.
 Note that content disposition is not part of the http standard, although it is widely implemented.
+
+## Cache
+Most of the time you want to leave cache="false" which is the default to not cache the results.  However, in the case of PDF Downloads there have
+been issues with some browser like Chrome/Edge. See: https://github.com/primefaces/primefaces/issues/10251
 
 ## Monitor Status
 When fileDownload is used without AJAX, ajaxStatus cannot apply. Still PrimeFaces provides a feature

--- a/docs/14_0_0/components/filedownload.md
+++ b/docs/14_0_0/components/filedownload.md
@@ -17,6 +17,7 @@ stream the binary data. FileDownload presents an easier way to do the same.
 | value | null | StreamedContent | A streamed content instance.
 | contentDisposition | attachment | String | Specifies display mode on non-AJAX downloads.
 | monitorKey | null | String | Optional key to support monitoring multiple filedownloads on same page.
+| store | false | Boolean | Controls the `no-store` attribute on the cache control header. Default is to include `no-store`.
 
 ## Getting started with FileDownload
 A user command action is required to trigger the file-download process.
@@ -72,6 +73,10 @@ Please see our core documentation about it [Dynamic Content Streaming / Renderin
 On regular (non-AJAX) downloads, by default, content is displayed as an `attachment` with a download dialog box,
 another alternative is the `inline` mode, in this case browser will try to open the file internally without a prompt.
 Note that content disposition is not part of the http standard, although it is widely implemented.
+
+## Browser Caching
+Most of the time you want to leave store="false" which is the default to not cache the results.  However, in the case of PDF Downloads there have
+been issues with some browser like Chrome/Edge. See: https://github.com/primefaces/primefaces/issues/10251
 
 ## Monitor Status
 When fileDownload is used without AJAX, ajaxStatus cannot apply. Still PrimeFaces provides a feature

--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -51,15 +51,18 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
 
     private ValueExpression monitorKey;
 
+    private ValueExpression cache;
+
     public FileDownloadActionListener() {
         ResourceUtils.addComponentResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
     }
 
-    public FileDownloadActionListener(ValueExpression value, ValueExpression contentDisposition, ValueExpression monitorKey) {
+    public FileDownloadActionListener(ValueExpression value, ValueExpression contentDisposition, ValueExpression monitorKey, ValueExpression cache) {
         this();
         this.value = value;
         this.contentDisposition = contentDisposition;
         this.monitorKey = monitorKey;
+        this.cache = cache;
     }
 
     @Override
@@ -101,7 +104,11 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
                 ? "/"
                 : externalContext.getRequestContextPath()); // Always add cookies to context root; see #3108
         ResourceUtils.addResponseCookie(context, monitorKeyCookieName, "true", cookieOptions);
-        ResourceUtils.addNoCacheControl(externalContext);
+
+        Boolean cache = contentDisposition != null ? (Boolean) this.cache.getValue(context.getELContext()) : Boolean.FALSE;
+        if (!cache) {
+            ResourceUtils.addNoCacheControl(externalContext);
+        }
 
         if (content.getContentLength() != null) {
             // we can't use externalContext.setResponseContentLength as our contentLength is a long

--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -51,18 +51,18 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
 
     private ValueExpression monitorKey;
 
-    private ValueExpression cache;
+    private ValueExpression store;
 
     public FileDownloadActionListener() {
         ResourceUtils.addComponentResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
     }
 
-    public FileDownloadActionListener(ValueExpression value, ValueExpression contentDisposition, ValueExpression monitorKey, ValueExpression cache) {
+    public FileDownloadActionListener(ValueExpression value, ValueExpression contentDisposition, ValueExpression monitorKey, ValueExpression store) {
         this();
         this.value = value;
         this.contentDisposition = contentDisposition;
         this.monitorKey = monitorKey;
-        this.cache = cache;
+        this.store = store;
     }
 
     @Override
@@ -105,10 +105,8 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
                 : externalContext.getRequestContextPath()); // Always add cookies to context root; see #3108
         ResourceUtils.addResponseCookie(context, monitorKeyCookieName, "true", cookieOptions);
 
-        Boolean cache = contentDisposition != null ? (Boolean) this.cache.getValue(context.getELContext()) : Boolean.FALSE;
-        if (!cache) {
-            ResourceUtils.addNoCacheControl(externalContext);
-        }
+        Boolean store = this.store != null ? (Boolean) this.store.getValue(context.getELContext()) : Boolean.FALSE;
+        ResourceUtils.addNoCacheControl(externalContext, store);
 
         if (content.getContentLength() != null) {
             // we can't use externalContext.setResponseContentLength as our contentLength is a long

--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadTagHandler.java
@@ -37,14 +37,14 @@ public class FileDownloadTagHandler extends TagHandler {
     private final TagAttribute value;
     private final TagAttribute contentDisposition;
     private final TagAttribute monitorKey;
-    private final TagAttribute cache;
+    private final TagAttribute store;
 
     public FileDownloadTagHandler(TagConfig tagConfig) {
         super(tagConfig);
         value = getRequiredAttribute("value");
         contentDisposition = getAttribute("contentDisposition");
         monitorKey = getAttribute("monitorKey");
-        cache = getAttribute("cache");
+        store = getAttribute("store");
     }
 
     @Override
@@ -56,7 +56,7 @@ public class FileDownloadTagHandler extends TagHandler {
         ValueExpression valueVE = value.getValueExpression(faceletContext, Object.class);
         ValueExpression contentDispositionVE = null;
         ValueExpression monitorKeyVE = null;
-        ValueExpression cacheVE = null;
+        ValueExpression storeVE = null;
 
         if (contentDisposition != null) {
             contentDispositionVE = contentDisposition.getValueExpression(faceletContext, String.class);
@@ -64,11 +64,11 @@ public class FileDownloadTagHandler extends TagHandler {
         if (monitorKey != null) {
             monitorKeyVE = monitorKey.getValueExpression(faceletContext, String.class);
         }
-        if (cache != null) {
-            cacheVE = cache.getValueExpression(faceletContext, Boolean.class);
+        if (store != null) {
+            storeVE = store.getValueExpression(faceletContext, Boolean.class);
         }
 
         ActionSource actionSource = (ActionSource) parent;
-        actionSource.addActionListener(new FileDownloadActionListener(valueVE, contentDispositionVE, monitorKeyVE, cacheVE));
+        actionSource.addActionListener(new FileDownloadActionListener(valueVE, contentDispositionVE, monitorKeyVE, storeVE));
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadTagHandler.java
@@ -37,12 +37,14 @@ public class FileDownloadTagHandler extends TagHandler {
     private final TagAttribute value;
     private final TagAttribute contentDisposition;
     private final TagAttribute monitorKey;
+    private final TagAttribute cache;
 
     public FileDownloadTagHandler(TagConfig tagConfig) {
         super(tagConfig);
         value = getRequiredAttribute("value");
         contentDisposition = getAttribute("contentDisposition");
         monitorKey = getAttribute("monitorKey");
+        cache = getAttribute("cache");
     }
 
     @Override
@@ -54,6 +56,7 @@ public class FileDownloadTagHandler extends TagHandler {
         ValueExpression valueVE = value.getValueExpression(faceletContext, Object.class);
         ValueExpression contentDispositionVE = null;
         ValueExpression monitorKeyVE = null;
+        ValueExpression cacheVE = null;
 
         if (contentDisposition != null) {
             contentDispositionVE = contentDisposition.getValueExpression(faceletContext, String.class);
@@ -61,8 +64,11 @@ public class FileDownloadTagHandler extends TagHandler {
         if (monitorKey != null) {
             monitorKeyVE = monitorKey.getValueExpression(faceletContext, String.class);
         }
+        if (cache != null) {
+            cacheVE = cache.getValueExpression(faceletContext, Boolean.class);
+        }
 
         ActionSource actionSource = (ActionSource) parent;
-        actionSource.addActionListener(new FileDownloadActionListener(valueVE, contentDispositionVE, monitorKeyVE));
+        actionSource.addActionListener(new FileDownloadActionListener(valueVE, contentDispositionVE, monitorKeyVE, cacheVE));
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
@@ -162,7 +162,23 @@ public class ResourceUtils {
      * @see <a href="https://github.com/primefaces/primefaces/issues/6359">FileDownload: configure Cache-Control</a>
      */
     public static void addNoCacheControl(ExternalContext externalContext) {
-        externalContext.setResponseHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        addNoCacheControl(externalContext, false);
+    }
+
+    /**
+     * Adds no cache pragma to the response to ensure it is not cached.  Dynamic downloads should always add this
+     * to prevent caching and for GDPR.
+     *
+     * @param externalContext the ExternalContext we add the pragma to
+     * @param store used to add no-store or exclude it if false
+     * @see <a href="https://github.com/primefaces/primefaces/issues/6359">FileDownload: configure Cache-Control</a>
+     */
+    public static void addNoCacheControl(ExternalContext externalContext, boolean store) {
+        String cacheControl = "no-cache, no-store, must-revalidate";
+        if (store) {
+            cacheControl = "no-cache, must-revalidate";
+        }
+        externalContext.setResponseHeader("Cache-Control", cacheControl);
         externalContext.setResponseHeader("Pragma", "no-cache");
         externalContext.setResponseHeader("Expires", "0");
     }

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -254,6 +254,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Controls browser caching mode of the resource. Default is false.]]>
+            </description>
+            <name>cache</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
 
     <tag>

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -229,36 +229,36 @@
     </tag>
 
     <tag>
-        <description>The legacy way to present dynamic binary data to the client is to write a servlet or a filter and stream the binary data.
-            FileDownload presents an easier way to do the same.
+        <description><![CDATA[The legacy way to present dynamic binary data to the client is to write a servlet or a filter and stream the binary data.
+            FileDownload presents an easier way to do the same.]]>
         </description>
         <tag-name>fileDownload</tag-name>
         <handler-class>
             org.primefaces.component.filedownload.FileDownloadTagHandler
         </handler-class>
         <attribute>
-            <description>A streamed content instance.</description>
+            <description><![CDATA[A streamed content instance.]]></description>
             <name>value</name>
             <required>true</required>
             <type>java.lang.Object</type>
         </attribute>
         <attribute>
-            <description>Specifies display mode (non-ajax), valid values are "attachment" (default) and "inline".</description>
+            <description><![CDATA[Specifies display mode (non-ajax), valid values are "attachment" (default) and "inline".]]></description>
             <name>contentDisposition</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
         <attribute>
-            <description>Defines setting cookie key for monitorDownload method on client side.</description>
+            <description><![CDATA[Defines setting cookie key for monitorDownload method on client side.]]></description>
             <name>monitorKey</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Controls browser caching mode of the resource. Default is false.]]>
+                <![CDATA[Controls the 'no-store' attribute on the cache control header. Default false is to include 'no-store'.]]>
             </description>
-            <name>cache</name>
+            <name>store</name>
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>


### PR DESCRIPTION
Fix #10251: FileDownload allow enabling of caching.

Added this as an enhancement for the PDF use case. FALSE by default.

**Update:** this PR only allows for disabling the `no-store` option not the rest of the caching values.