### PR TITLE
Fix #10283: EncodeIndexed must replace all instances of the id

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -32,6 +32,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
@@ -67,6 +69,9 @@ public class ComponentUtils {
 
     // marker for a undefined value when a null check is not reliable enough
     private static final Object UNDEFINED_VALUE = new Object();
+
+    // regex for finding ID's
+    private static final Pattern ID_PATTERN = Pattern.compile("\\sid=\"(.*?)\"");
 
     private ComponentUtils() {
     }
@@ -632,7 +637,22 @@ public class ComponentUtils {
         // append index to all id's
         char separator = UINamingContainer.getSeparatorChar(context);
         String encodedComponent = fsw.toString();
-        encodedComponent = encodedComponent.replaceAll("\\sid=\"(.*?)\"", " id=\"$1" + separator + index + "\"");
+
+        // find all id's to replace
+        Matcher matcher = ID_PATTERN.matcher(encodedComponent);
+
+        // grab all the unique ID's found
+        Set<String> ids = new HashSet<>(5);
+        while (matcher.find()) {
+            String id = matcher.group(1);
+            if (!ids.contains(id)) {
+                ids.add(id);
+                // replace each id with an indexed version
+                String replaceId = id + separator + index;
+                encodedComponent = encodedComponent.replaceAll(id, replaceId);
+            }
+        }
+
         writer.write(encodedComponent);
     }
 


### PR DESCRIPTION
Fix #10283: EncodeIndexed must replace all instances of the id

Found the issue is that i was only replacing `id=_id_5:j_id_7:0:j_id_f"` with `id="_id_5:j_id_7:0:j_id_f:0` and not all instances of that ID found as it could be used in scripts.

For example..

```js
PrimeFaces.ab({s:&quot;j_id_5:j_id_7:0:j_id_f&quot;,f:&quot;j_id_5&quot;});return false;}]);
```
Should be:
```js
PrimeFaces.ab({s:&quot;j_id_5:j_id_7:0:j_id_f:0&quot;,f:&quot;j_id_5&quot;});return false;}]);
```
