### PR TITLE
IT: TextExporter Serializable

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/dataexporter/TextExporter.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/dataexporter/TextExporter.java
@@ -26,6 +26,7 @@ package org.primefaces.integrationtests.dataexporter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import javax.faces.FacesException;
@@ -38,7 +39,9 @@ import org.primefaces.component.export.ExporterOptions;
 import org.primefaces.component.export.ExporterUtils;
 import org.primefaces.util.EscapeUtils;
 
-public class TextExporter extends DataTableExporter<PrintWriter, ExporterOptions> {
+public class TextExporter extends DataTableExporter<PrintWriter, ExporterOptions> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     public TextExporter() {
         super(null, Collections.emptySet(), false);


### PR DESCRIPTION
WARNING: Cannot serialize session attribute [openWebBeansSessionContext] for session [6CB8E2ED773CE3CBAB12D97158EB611F]
java.io.NotSerializableException: org.primefaces.integrationtests.dataexporter.TextExporter
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at java.util.HashMap.internalWriteEntries(HashMap.java:1817)
	at java.util.HashMap.writeObject(HashMap.java:1364)