### PR TITLE
Fix #10284: Tree selection null check

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -78,7 +78,7 @@ public class TreeRenderer extends CoreRenderer {
         boolean multiple = tree.isMultipleSelectionMode();
         Class<?> selectionType = tree.getSelectionType();
 
-        if (multiple && !selectionType.isArray() && !List.class.isAssignableFrom(selectionType)) {
+        if (multiple && selectionType == null || (!selectionType.isArray() && !List.class.isAssignableFrom(selectionType))) {
             throw new FacesException("Multiple selection reference must be an Array or a List for Tree " + tree.getClientId());
         }
 


### PR DESCRIPTION
Fix #10284: Tree selection null check

Error was already there and now throws.

`javax.faces.FacesException: Multiple selection reference must be an Array or a List for Tree frmTest:j_idt8`