### PR TITLE
fix #10303: bug in CheckboxTreeNodeChildren:set in combination with sorting

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/CheckboxTreeNodeChildren.java
+++ b/primefaces/src/main/java/org/primefaces/model/CheckboxTreeNodeChildren.java
@@ -142,7 +142,6 @@ public class CheckboxTreeNodeChildren<T> extends TreeNodeList<T> {
 
             TreeNode previous = get(index);
             super.set(index, node);
-            previous.setParent(null);
             node.setParent(parent);
             updateRowKeys(parent);
             updateSelectionState(parent);


### PR DESCRIPTION

fix #10303: bug in CheckboxTreeNodeChildren:set

bug is fixed by removing the line that sets the parent of node `previous` to null
