### PR TITLE
Fix #10309: BlockUI must hide if source is no longer in DOM

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -135,6 +135,11 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         // we must evaluate it each time as the DOM might has been changed
         var triggers = PrimeFaces.expressions.SearchExpressionFacade.resolveComponents(this.cfg.triggers);
 
+        // if trigger is null it has been removed from DOM so we need to hide the block UI
+        if (!triggers || triggers.length === 0) {
+            return true;
+        }
+
         return $.inArray(sourceId, triggers) !== -1;
     },
 


### PR DESCRIPTION
Fix #10309: BlockUI must hide if source is no longer in DOM