### PR TITLE
Fix #10335: AutoComplete don't render header facets if emptyMessage

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -530,6 +530,10 @@ public class AutoCompleteRenderer extends InputRenderer {
     }
 
     protected void encodeSuggestionsAsTable(FacesContext context, AutoComplete ac, Object items, Converter converter) throws IOException {
+        // do not render table if empty message and there are no records
+        if (LangUtils.isNotBlank(ac.getEmptyMessage()) && (items == null || ((Collection) items).isEmpty())) {
+            return;
+        }
         ResponseWriter writer = context.getResponseWriter();
         String var = ac.getVar();
         boolean pojo = var != null;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.css
@@ -153,6 +153,7 @@
 
 .ui-autocomplete-empty-message {
     padding:3px 5px;
+    width: 100%;
 }
 
 .ui-autocomplete-panel .ui-autocomplete-group {


### PR DESCRIPTION
Fix #10335: AutoComplete don't render header facets if emptyMessage