### PR TITLE
Revert "Fix #10334 - DataTable: dynamic columns have wrong order after sorting"

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -313,7 +313,10 @@ public interface ColumnAware {
             }
             else if (child instanceof Columns) {
                 Columns uiColumns = (Columns) child;
-                columns.addAll(uiColumns.getDynamicColumns());
+                for (int j = 0; j < uiColumns.getRowCount(); j++) {
+                    DynamicColumn dynaColumn = new DynamicColumn(j, uiColumns, context);
+                    columns.add(dynaColumn);
+                }
             }
         }
 


### PR DESCRIPTION
Reverts primefaces/primefaces#10339

Using showcase http://localhost:8080/showcase/ui/data/datatable/columns.xhtml

Update to 4 columns, 5 headers are displayed but rows displays 4 cells...