### PR TITLE
Fix #10334 - DataTable: dynamic columns have wrong order after sorting

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -313,10 +313,7 @@ public interface ColumnAware {
             }
             else if (child instanceof Columns) {
                 Columns uiColumns = (Columns) child;
-                for (int j = 0; j < uiColumns.getRowCount(); j++) {
-                    DynamicColumn dynaColumn = new DynamicColumn(j, uiColumns, context);
-                    columns.add(dynaColumn);
-                }
+                columns.addAll(uiColumns.getDynamicColumns());
             }
         }
 
@@ -388,6 +385,7 @@ public interface ColumnAware {
         forEachColumn(false, false, false, column ->  {
             if (column instanceof Columns) {
                 ((Columns) column).setRowIndex(-1);
+                ((Columns) column).setDynamicColumns(null);
                 setColumns(null);
             }
             return true;

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1074,8 +1074,6 @@ public class DataTableRenderer extends DataRenderer {
         boolean encodeSummaryRow = (summaryRow != null && sort != null);
 
         for (int i = first; i < last; i++) {
-            table.resetDynamicColumns();
-
             table.setRowIndex(i);
             if (!table.isRowAvailable()) {
                 break;


### PR DESCRIPTION
I think the whole caching columns thing and resetDynamicColumns have to be revisited. For example, Columns#dynamicColumns should not be lazy loaded, depending the rowIndex set on DataTable, dynamic column clientIds can be wrong (that was the issue).

Or there is something I might be missing... I'll tag it as a draft since the real fix requires a lot more than that . i'll think about ist once #6409 is merged