### PR TITLE
Fix #10283: RowExpand revert to 12.0.0 behavior

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
@@ -34,7 +34,6 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.datatable.DataTableRenderer;
 import org.primefaces.component.datatable.DataTableState;
 import org.primefaces.component.rowexpansion.RowExpansion;
-import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.LangUtils;
 
 public class RowExpandFeature implements DataTableFeature {
@@ -91,7 +90,7 @@ public class RowExpandFeature implements DataTableFeature {
             writer.startElement("td", null);
             writer.writeAttribute("colspan", table.getColumnsCount(), null);
 
-            ComponentUtils.encodeIndexedId(context, table.getRowExpansion(), rowIndex);
+            table.getRowExpansion().encodeAll(context);
 
             writer.endElement("td");
 


### PR DESCRIPTION
Fix #10283: RowExpand revert to 12.0.0 behavior

In our testing we have a Table inside the row expander so everything works but the `AJAX source` id doesn't match the backend now.

Since people use RowExpansion for complex UI like tables inside of tables going to revert this for 13.0.0 we can revisit again later.

For example here is the AJAX source:
```
"frmTest:tblOuter:2:tblInner:2:0:btnSubmit": "frmTest:tblOuter:2:tblInner:2:0:btnSubmit",
```

But in `ComponentUtils.decodeBehaviors` its not matching up.

```java
if (behaviorsForEvent != null && !behaviorsForEvent.isEmpty()) {
                String behaviorSource = params.get(Constants.RequestParams.PARTIAL_SOURCE_PARAM);
                String clientId = component.getClientId(context);

                if (behaviorSource != null && clientId.equals(behaviorSource)) {
                    for (ClientBehavior behavior : behaviorsForEvent) {
                        behavior.decode(context, component);
                    }
                }
            }
```
