### PR TITLE
Fix #10365: ImageCropper originalFilename for streamed content

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -206,7 +206,20 @@ public class ImageCropperRenderer extends CoreRenderer {
             String format = guessImageFormat(stream.getContentType(), stream.getName());
             ImageIO.write(cropped, format, croppedOutImage);
 
-            return new CroppedImage(cropper.getImage().toString(), croppedOutImage.toByteArray(), x, y, w, h);
+            Object imageObject = cropper.getImage();
+            String originalFileName;
+            if (imageObject instanceof String) {
+                originalFileName = (String) imageObject;
+            }
+            else if (imageObject instanceof StreamedContent) {
+                StreamedContent streamedContentTmp = (StreamedContent) imageObject;
+                originalFileName = streamedContentTmp.getName();
+            }
+            else {
+                throw new IllegalArgumentException("ImageCropper 'image' must be either a String relative path or a StreamedObject.");
+            }
+
+            return new CroppedImage(originalFileName, croppedOutImage.toByteArray(), x, y, w, h);
         }
         catch (IOException e) {
             throw new ConverterException(e);
@@ -291,7 +304,7 @@ public class ImageCropperRenderer extends CoreRenderer {
                 contentType = streamedContentTmp.getContentType();
             }
             else {
-                throw new IllegalArgumentException("'image' must be either an String relative path or a StreamedObject.");
+                throw new IllegalArgumentException("ImageCropper 'image' must be either a String relative path or a StreamedObject.");
             }
         }
 

--- a/primefaces/src/test/java/org/primefaces/component/imagecropper/ImageCropperRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/imagecropper/ImageCropperRendererTest.java
@@ -97,7 +97,7 @@ public class ImageCropperRendererTest {
         }
         catch (IllegalArgumentException e) {
             String message = e.getMessage();
-            if (!"'image' must be either an String relative path or a StreamedObject.".equals(message)) {
+            if (!"ImageCropper 'image' must be either a String relative path or a StreamedObject.".equals(message)) {
                 Assertions.fail("should thrown IllegalArgumentException with message: " + message);
             }
         }


### PR DESCRIPTION
Fix #10365: ImageCropper originalFilename for streamed content