### PR TITLE
Fix #10365: ImageCropper originalFilename for streamed content

### DIFF
--- a/docs/13_0_0/components/imagecropper.md
+++ b/docs/13_0_0/components/imagecropper.md
@@ -69,7 +69,7 @@ about the crop process. Following table describes CroppedImage properties.
 
 | Property | Type | Description
 | --- | --- | --- |
-originalFileName | String | Name of the original file that’s cropped
+originalFileName | String | Name of the original file that’s cropped. If using StreamedContent it will be the name set on the stream or `unknown.png` if NULL.
 bytes | byte[] | Contents of the cropped area as a byte array
 left | int | Left coordinate
 right | int | Right coordinate

--- a/docs/14_0_0/components/imagecropper.md
+++ b/docs/14_0_0/components/imagecropper.md
@@ -69,7 +69,7 @@ about the crop process. Following table describes CroppedImage properties.
 
 | Property | Type | Description
 | --- | --- | --- |
-originalFileName | String | Name of the original file that’s cropped
+originalFileName | String | Name of the original file that’s cropped. If using StreamedContent it will be the name set on the stream or `unknown.png` if NULL.
 bytes | byte[] | Contents of the cropped area as a byte array
 left | int | Left coordinate
 right | int | Right coordinate

--- a/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -218,6 +218,10 @@ public class ImageCropperRenderer extends CoreRenderer {
             else {
                 throw new IllegalArgumentException("ImageCropper 'image' must be either a String relative path or a StreamedObject.");
             }
+            if (LangUtils.isBlank(originalFileName)) {
+                // most likely stream.getName was not set by user
+                originalFileName = "unknown." + format;
+            }
 
             return new CroppedImage(originalFileName, croppedOutImage.toByteArray(), x, y, w, h);
         }


### PR DESCRIPTION
Fix #10365: ImageCropper originalFilename for streamed content

Give the file a default name instead of NULL if the user forgets to set the name on the stream.