### PR TITLE
Fix #10379: Panel don't render labelledby if no header

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/panel/PanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/panel/PanelRenderer.java
@@ -136,11 +136,17 @@ public class PanelRenderer extends CoreRenderer {
 
         writer.writeAttribute(HTML.WIDGET_VAR, widgetVar, null);
         writer.writeAttribute(HTML.ARIA_ROLE, "region", null);
-        writer.writeAttribute(HTML.ARIA_LABELLEDBY, clientId + "_header", null);
+
+        boolean isRenderHeader = shouldRenderHeader(context, panel);
+        if (isRenderHeader) {
+            writer.writeAttribute(HTML.ARIA_LABELLEDBY, clientId + "_header", null);
+        }
 
         renderDynamicPassThruAttributes(context, panel);
 
-        encodeHeader(context, panel, optionsMenu);
+        if (isRenderHeader) {
+            encodeHeader(context, panel, optionsMenu);
+        }
         encodeContent(context, panel);
         encodeFooter(context, panel);
 
@@ -164,16 +170,23 @@ public class PanelRenderer extends CoreRenderer {
         writer.endElement("div");
     }
 
+    protected boolean shouldRenderHeader(FacesContext context, Panel panel) throws IOException {
+        UIComponent header = panel.getFacet("header");
+        String headerText = panel.getHeader();
+        boolean shouldRenderFacet = ComponentUtils.shouldRenderFacet(header, panel.isRenderEmptyFacets());
+
+        if (headerText == null && !shouldRenderFacet) {
+            return false;
+        }
+        return true;
+    }
+
     protected void encodeHeader(FacesContext context, Panel panel, Menu optionsMenu) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         UIComponent header = panel.getFacet("header");
         String headerText = panel.getHeader();
         String clientId = panel.getClientId(context);
         boolean shouldRenderFacet = ComponentUtils.shouldRenderFacet(header, panel.isRenderEmptyFacets());
-
-        if (headerText == null && !shouldRenderFacet) {
-            return;
-        }
 
         writer.startElement("div", null);
         writer.writeAttribute("id", panel.getClientId(context) + "_header", null);


### PR DESCRIPTION
Fix #10379: Panel don't render labelledby if no header