### PR TITLE
Fix #10397: 13.0.1 AutoComplete escape text properly

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -808,8 +808,10 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                     var queryResults = isCustomContent ? this.panel.children().find('span') : this.items;
                     queryResults.filter(':not(.ui-autocomplete-moretext)').each(function() {
                         var item = $(this);
-                        var text = $this.cfg.escape ? item.html() : item.text();
-                        item.html(text.replace(re, '<span class="ui-autocomplete-query">$&</span>'));
+                        var escape = $this.cfg.escape;
+                        var text = escape ? item.html() : item.text();
+                        var escaped_re = escape ? /${PrimeFaces.escapeHTML(text)}/g : /${text}/g;
+                        item.html(text.replace(escaped_re, '<span class="ui-autocomplete-query">$&</span>'));
                     });
                 }
             }


### PR DESCRIPTION
Fix #10397: 13.0.1 AutoComplete escape text properly