### PR TITLE
Fix #10425: ColorPicker respect theme color

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker001Test.java
@@ -276,7 +276,7 @@ public class ColorPicker001Test extends AbstractColorPickerTest {
         assertNoJavascriptErrors();
         System.out.println("ColorPicker Config = " + cfg);
         Assertions.assertEquals("popup", cfg.getString("mode"));
-        Assertions.assertEquals("auto", cfg.getString("themeMode"));
+        Assertions.assertEquals("light", cfg.getString("themeMode"));
         Assertions.assertEquals("pill", cfg.getString("theme"));
         Assertions.assertEquals("en", cfg.getString("locale"));
         Assertions.assertEquals("Clear", cfg.getString("clearLabel"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker002Test.java
@@ -64,7 +64,7 @@ public class ColorPicker002Test extends AbstractColorPickerTest {
         assertNoJavascriptErrors();
         System.out.println("ColorPicker Config = " + cfg);
         Assertions.assertEquals("popup", cfg.getString("mode"));
-        Assertions.assertEquals("auto", cfg.getString("themeMode"));
+        Assertions.assertEquals("light", cfg.getString("themeMode"));
         Assertions.assertEquals("pill", cfg.getString("theme"));
         Assertions.assertEquals("nl", cfg.getString("locale"));
         Assertions.assertEquals("Wissen", cfg.getString("clearLabel"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker003Test.java
@@ -107,7 +107,9 @@ public class ColorPicker003Test extends AbstractColorPickerTest {
         assertNoJavascriptErrors();
         System.out.println("ColorPicker Config = " + cfg);
         Assertions.assertEquals("popup", cfg.getString("mode"));
-        Assertions.assertEquals("auto", cfg.getString("themeMode"));
+        if (cfg.has("themeMode")) {
+            Assertions.assertEquals("light", cfg.getString("themeMode"));
+        }
         Assertions.assertEquals("default", cfg.getString("theme"));
         Assertions.assertEquals("en", cfg.getString("locale"));
         Assertions.assertTrue(cfg.getBoolean("clearButton"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker004Test.java
@@ -242,7 +242,7 @@ public class ColorPicker004Test extends AbstractColorPickerTest {
         assertNoJavascriptErrors();
         System.out.println("ColorPicker Config = " + cfg);
         Assertions.assertEquals("inline", cfg.getString("mode"));
-        Assertions.assertEquals("auto", cfg.getString("themeMode"));
+        Assertions.assertEquals("light", cfg.getString("themeMode"));
         Assertions.assertEquals("large", cfg.getString("theme"));
         Assertions.assertEquals("en", cfg.getString("locale"));
         Assertions.assertTrue(cfg.getBoolean("formatToggle"));

--- a/primefaces/src/main/java/org/primefaces/component/colorpicker/ColorPickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/colorpicker/ColorPickerRenderer.java
@@ -163,7 +163,7 @@ public class ColorPickerRenderer extends InputRenderer {
                 .attr("defaultColor", value, null)
                 .attr("theme", colorPicker.getTheme())
                 .attr("theme", colorPicker.getTheme(), "default")
-                .attr("themeMode", colorPicker.getThemeMode(), "light")
+                .attr("themeMode", colorPicker.getThemeMode(), "auto")
                 .attr("format", colorPicker.getFormat(), "hex")
                 .attr("formatToggle", colorPicker.isFormatToggle(), false)
                 .attr("clearButton", colorPicker.isClearButton(), false)

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
@@ -96,6 +96,7 @@ PrimeFaces.widget.ColorPicker = PrimeFaces.widget.BaseWidget.extend({
         var $this = this;
         this.configureLocale();
         this.cfg.inline = !this.popup;
+        this.cfg.themeMode = this.cfg.themeMode || PrimeFaces.env.getThemeContrast();
         var settings = this.cfg;
         if (this.popup) {
             colorisInitialized = true;


### PR DESCRIPTION
Fix #10425: ColorPicker respect theme color

@jepsar this does it like we do Captcha if the user has it on "auto" we respect the theme or if they force "light" or "dark" it respects that.
