### PR TITLE
Fix #10492: 13.0.1 ClamAV use timeout for connection timeout

### DIFF
--- a/primefaces/src/main/java/org/primefaces/virusscan/impl/ClamDaemonClient.java
+++ b/primefaces/src/main/java/org/primefaces/virusscan/impl/ClamDaemonClient.java
@@ -24,6 +24,7 @@
 package org.primefaces.virusscan.impl;
 
 import java.io.*;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -104,7 +105,6 @@ public class ClamDaemonClient {
      */
     public boolean ping() throws IOException {
         try (Socket s = getSocket(); OutputStream os = s.getOutputStream()) {
-            s.setSoTimeout(timeout);
             os.write(asBytes("zPING\0"));
             os.flush();
             try (InputStream is = s.getInputStream()) {
@@ -128,8 +128,6 @@ public class ClamDaemonClient {
      */
     public byte[] scan(final InputStream is) throws IOException {
         try (Socket s = getSocket(); OutputStream outs = new BufferedOutputStream(s.getOutputStream())) {
-            s.setSoTimeout(timeout);
-
             // handshake
             outs.write(asBytes("zINSTREAM\0"));
             outs.flush();
@@ -179,7 +177,10 @@ public class ClamDaemonClient {
      * @throws IOException if an I/O error occurs when creating the socket
      */
     protected Socket getSocket() throws IOException {
-        return new Socket(host, port);
+        Socket socket =  new Socket();
+        socket.setSoTimeout(timeout);
+        socket.connect(new InetSocketAddress(host, port), timeout);
+        return socket;
     }
 
     /**


### PR DESCRIPTION
Fix #10492: 13.0.1 ClamAV use timeout for connection timeout