### PR TITLE
Fix #10549 - UITable: cache columns when possible

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable033.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable033.java
@@ -23,12 +23,6 @@
  */
 package org.primefaces.integrationtests.datatable;
 
-import lombok.Data;
-
-import javax.annotation.PostConstruct;
-import javax.faces.context.FacesContext;
-import javax.faces.view.ViewScoped;
-import javax.inject.Named;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
@@ -40,9 +34,15 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.faces.context.FacesContext;
+import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
+import javax.inject.Named;
+
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.primefaces.component.datatable.DataTable;
@@ -56,6 +56,7 @@ public class DataTable033 implements Serializable {
 
     private String columnTemplate = "id name country date status activity";
     private List<ColumnModel> columns;
+    private List<ColumnModel> columns2;
     private List<Customer> customers;
     private List<Customer> filteredCustomers;
     private Map<String, Class> validColumns;
@@ -82,6 +83,10 @@ public class DataTable033 implements Serializable {
                 columns.add(new ColumnModel(columnKey.toUpperCase(), columnKey, validColumns.get(key)));
             }
         }
+
+        columns2 = new ArrayList<>();
+        columns2.add(new ColumnModel("NAME", "name", String.class));
+        columns2.add(new ColumnModel("COUNTRY", "country", String.class));
     }
 
     public void updateColumns() {

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable033.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable033.xhtml
@@ -32,6 +32,9 @@
                         </f:facet>
                     </p:columns>
 
+                    <p:columns value="#{dataTable033.columns2}" var="column" headerText="#{column.header}" field="#{column.property}" />
+
+                    <p:column field="activity" />
                 </p:dataTable>
             </h:form>
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable033Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable033Test.java
@@ -23,6 +23,10 @@
  */
 package org.primefaces.integrationtests.datatable;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +35,7 @@ import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.DataTable;
 import org.primefaces.selenium.component.InputText;
+import org.primefaces.selenium.component.model.datatable.Header;
 
 public class DataTable033Test extends AbstractDataTableTest {
 
@@ -59,6 +64,40 @@ public class DataTable033Test extends AbstractDataTableTest {
         // reset filter
         page.dataTable.filter("ID", "");
         Assertions.assertSame(allRowsCount, page.dataTable.getRows().size());
+    }
+
+    @Test
+    @DisplayName("DataTable: multiple p:columns")
+    public void testHybridColumns(Page page) {
+        // switch column order now
+        page.template.setValue("id");
+        page.updateColumns.click();
+
+        Header header = page.dataTable.getHeader();
+        Assertions.assertEquals(4, header.getCells().size());
+        Assertions.assertEquals("ID", header.getCell(0).getColumnTitle().getText());
+        Assertions.assertEquals("NAME", header.getCell(1).getColumnTitle().getText());
+        Assertions.assertEquals("COUNTRY", header.getCell(2).getColumnTitle().getText());
+        Assertions.assertEquals("Activity", header.getCell(3).getColumnTitle().getText());
+
+        // test filter
+        long countryCount = page.dataTable.getRows().stream().filter(r -> r.getCell(1).getText().equals("Aruna Figeroa")).count();
+        page.dataTable.filter(1, "Aruna Figeroa");
+        Assertions.assertEquals(countryCount, page.dataTable.getRows().size());
+
+        // reset filter
+        page.dataTable.filter("NAME", "");
+
+        // test sort
+        List<String> sortedList = page.dataTable.getRows().stream()
+                .sorted(Comparator.comparing(r -> r.getCell(1).getText()))
+                .map(r -> r.getCell(1).getText())
+                .collect(Collectors.toList());
+        page.dataTable.sort("NAME");
+
+        List<String> sortedListPostFilter = page.dataTable.getRows().stream().map(r -> r.getCell(1).getText()).collect(Collectors.toList());
+        Assertions.assertEquals(sortedList.size(), sortedListPostFilter.size());
+        Assertions.assertLinesMatch(sortedList, sortedListPostFilter);
     }
 
     public static class Page extends AbstractPrimePage {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable033Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable033Test.java
@@ -95,7 +95,9 @@ public class DataTable033Test extends AbstractDataTableTest {
                 .collect(Collectors.toList());
         page.dataTable.sort("NAME");
 
-        List<String> sortedListPostFilter = page.dataTable.getRows().stream().map(r -> r.getCell(1).getText()).collect(Collectors.toList());
+        List<String> sortedListPostFilter = page.dataTable.getRows().stream()
+                .map(r -> r.getCell(1).getText())
+                .collect(Collectors.toList());
         Assertions.assertEquals(sortedList.size(), sortedListPostFilter.size());
         Assertions.assertLinesMatch(sortedList, sortedListPostFilter);
     }

--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -313,6 +313,7 @@ public interface ColumnAware {
             }
             else if (child instanceof Columns) {
                 Columns uiColumns = (Columns) child;
+                uiColumns.setRowIndex(-1);
                 for (int j = 0; j < uiColumns.getRowCount(); j++) {
                     DynamicColumn dynaColumn = new DynamicColumn(j, uiColumns, context);
                     columns.add(dynaColumn);
@@ -382,16 +383,6 @@ public interface ColumnAware {
         });
 
         return columnsCountWithSpan.intValue();
-    }
-
-    default void resetDynamicColumns() {
-        forEachColumn(false, false, false, column ->  {
-            if (column instanceof Columns) {
-                ((Columns) column).setRowIndex(-1);
-                setColumns(null);
-            }
-            return true;
-        });
     }
 
     Map<String, ColumnMeta> getColumnMeta();

--- a/primefaces/src/main/java/org/primefaces/component/api/UITable.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITable.java
@@ -609,7 +609,6 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
      * Resets all column related state after adding/removing/moving columns.
      */
     default void resetColumns() {
-        resetDynamicColumns();
         setColumns(null);
         setSortByAsMap(null);
         setFilterByAsMap(null);

--- a/primefaces/src/main/java/org/primefaces/component/columns/Columns.java
+++ b/primefaces/src/main/java/org/primefaces/component/columns/Columns.java
@@ -120,4 +120,11 @@ public class Columns extends ColumnsBase {
         this.dynamicColumns = dynamicColumns;
     }
 
+    @Override
+    public Object saveState(FacesContext context) {
+        dynamicColumns = null;
+        cellEditor = null;
+
+        return super.saveState(context);
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -680,18 +680,12 @@ public class DataTable extends DataTableBase {
             return this.columns;
         }
 
-        List<UIColumn> columns = collectColumns();
-
-        // lets cache it only when RENDER_RESPONSE is reached, the columns might change before reaching that phase
-        // see https://github.com/primefaces/primefaces/issues/2110
-        // do not cache if nested in iterator component and contains dynamic columns since number of columns may vary per iteration
-        // see https://github.com/primefaces/primefaces/issues/2154
-        if (getFacesContext().getCurrentPhaseId() == PhaseId.RENDER_RESPONSE
-                && (!isNestedWithinIterator() || columns.stream().noneMatch(DynamicColumn.class::isInstance))) {
-            this.columns = columns;
+        List<UIColumn> columnsTmp = collectColumns();
+        if (isCacheableColumns(columnsTmp)) {
+            this.columns = columnsTmp;
         }
 
-        return columns;
+        return columnsTmp;
     }
 
     @Override
@@ -1160,5 +1154,14 @@ public class DataTable extends DataTableBase {
         }
 
         return value;
+    }
+
+    protected boolean isCacheableColumns(List<UIColumn> columns) {
+        // lets cache it only when RENDER_RESPONSE is reached, the columns might change before reaching that phase
+        // see https://github.com/primefaces/primefaces/issues/2110
+        // do not cache if nested in iterator component and contains dynamic columns since number of columns may vary per iteration
+        // see https://github.com/primefaces/primefaces/issues/2154
+        return getFacesContext().getCurrentPhaseId() == PhaseId.RENDER_RESPONSE
+                && (!isNestedWithinIterator() || columns.stream().noneMatch(DynamicColumn.class::isInstance));
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -684,7 +684,10 @@ public class DataTable extends DataTableBase {
 
         // lets cache it only when RENDER_RESPONSE is reached, the columns might change before reaching that phase
         // see https://github.com/primefaces/primefaces/issues/2110
-        if (getFacesContext().getCurrentPhaseId() == PhaseId.RENDER_RESPONSE) {
+        // do not cache if nested in iterator component and contains dynamic columns since number of columns may vary per iteration
+        // see https://github.com/primefaces/primefaces/issues/2154
+        if (getFacesContext().getCurrentPhaseId() == PhaseId.RENDER_RESPONSE
+                && (!isNestedWithinIterator() || columns.stream().noneMatch(DynamicColumn.class::isInstance))) {
             this.columns = columns;
         }
 
@@ -924,38 +927,12 @@ public class DataTable extends DataTableBase {
             setValue(null);
         }
 
-        resetDynamicColumns();
-
         // reset component for MyFaces view pooling
         deferredEvents.clear();
         reset = false;
         columns = null;
 
         return super.saveState(context);
-    }
-
-    @Override
-    protected void preDecode(FacesContext context) {
-        resetDynamicColumns();
-        super.preDecode(context);
-    }
-
-    @Override
-    protected void preValidate(FacesContext context) {
-        resetDynamicColumns();
-        super.preValidate(context);
-    }
-
-    @Override
-    protected void preUpdate(FacesContext context) {
-        resetDynamicColumns();
-        super.preUpdate(context);
-    }
-
-    @Override
-    protected void preEncode(FacesContext context) {
-        resetDynamicColumns();
-        super.preEncode(context);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -142,8 +142,6 @@ public class DataTableRenderer extends DataRenderer {
             table.calculateRows();
             table.calculateFirst();
         }
-
-        table.resetDynamicColumns();
     }
 
     protected void encodeScript(FacesContext context, DataTable table) throws IOException {
@@ -1054,8 +1052,6 @@ public class DataTableRenderer extends DataRenderer {
         boolean encodeSummaryRow = (!summaryRows.isEmpty() && sort != null);
 
         for (int i = first; i < last; i++) {
-            table.resetDynamicColumns();
-
             table.setRowIndex(i);
             if (!table.isRowAvailable()) {
                 break;

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -338,8 +338,6 @@ public class TreeTable extends TreeTableBase {
 
     @Override
     public Object saveState(FacesContext context) {
-        resetDynamicColumns();
-
         // reset value when filtering is enabled
         // filtering stores the filtered values the value property, so it needs to be reset; see #7336
         if (isFilteringEnabled()) {
@@ -462,30 +460,6 @@ public class TreeTable extends TreeTableBase {
 
     public void setFilteredRowKeys(List<String> filteredRowKeys) {
         this.filteredRowKeys = filteredRowKeys;
-    }
-
-    @Override
-    protected void preDecode(FacesContext context) {
-        resetDynamicColumns();
-        super.preDecode(context);
-    }
-
-    @Override
-    protected void preValidate(FacesContext context) {
-        resetDynamicColumns();
-        super.preValidate(context);
-    }
-
-    @Override
-    protected void preUpdate(FacesContext context) {
-        resetDynamicColumns();
-        super.preUpdate(context);
-    }
-
-    @Override
-    protected void preEncode(FacesContext context) {
-        resetDynamicColumns();
-        super.preEncode(context);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -107,8 +107,6 @@ public class TreeTableRenderer extends DataRenderer {
         if (table.isSortingCurrentlyActive()) {
             TreeTableFeatures.sortFeature().sort(context, table);
         }
-
-        table.resetDynamicColumns();
     }
 
     protected void encodeScript(FacesContext context, TreeTable tt) throws IOException {


### PR DESCRIPTION
Fix #10549 - UITable: Rework caching columns