### PR TITLE
Fix #10592: HideNoSelectionOption handle string boolean

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -44,7 +44,7 @@ public abstract class SelectRenderer extends InputRenderer {
     protected boolean isHideNoSelection(UIComponent component) {
         Object attribute = component.getAttributes().get("hideNoSelectionOption");
         if (attribute instanceof String) {
-            attribute = Boolean.parseBoolean(Objects.toString(attribute));
+            attribute = Boolean.parseBoolean((String) attribute);
         }
         return Boolean.TRUE.equals(attribute);
     }

--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -43,6 +43,9 @@ public abstract class SelectRenderer extends InputRenderer {
 
     protected boolean isHideNoSelection(UIComponent component) {
         Object attribute = component.getAttributes().get("hideNoSelectionOption");
+        if (attribute instanceof String) {
+            attribute = Boolean.parseBoolean(Objects.toString(attribute));
+        }
         return Boolean.TRUE.equals(attribute);
     }
 


### PR DESCRIPTION
Fix #10592: HideNoSelectionOption handle string boolean

If you used `hideNoSelectionOption="true"` it would not work only `hideNoSelectionOption="#{true}"` which is confusing for most users including myself who was stumped why it didn't work.