### PR TITLE
Fix #10609: Colorpicker double conversion

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/colorpicker/ColorPicker003Test.java
@@ -110,7 +110,7 @@ public class ColorPicker003Test extends AbstractColorPickerTest {
         if (cfg.has("themeMode")) {
             Assertions.assertEquals("light", cfg.getString("themeMode"));
         }
-        Assertions.assertEquals("default", cfg.getString("theme"));
+        Assertions.assertFalse(cfg.has("theme"));
         Assertions.assertEquals("en", cfg.getString("locale"));
         Assertions.assertTrue(cfg.getBoolean("clearButton"));
         Assertions.assertTrue(cfg.getBoolean("closeButton"));

--- a/primefaces/src/main/java/org/primefaces/component/colorpicker/ColorPickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/colorpicker/ColorPickerRenderer.java
@@ -32,7 +32,6 @@ import javax.faces.component.UINamingContainer;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
-
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.*;
 
@@ -63,7 +62,7 @@ public class ColorPickerRenderer extends InputRenderer {
             if (!COLOR_PATTERN.matcher(submittedValue).matches()) {
                 submittedValue = Constants.EMPTY_STRING;
             }
-            colorPicker.setSubmittedValue(ComponentUtils.getConvertedValue(context, component, submittedValue));
+            colorPicker.setSubmittedValue(submittedValue);
         }
 
         decodeBehaviors(context, component);
@@ -161,7 +160,6 @@ public class ColorPickerRenderer extends InputRenderer {
                 .attr("locale", colorPicker.calculateLocale(context).toString())
                 .attr("mode", colorPicker.getMode())
                 .attr("defaultColor", value, null)
-                .attr("theme", colorPicker.getTheme())
                 .attr("theme", colorPicker.getTheme(), "default")
                 .attr("themeMode", colorPicker.getThemeMode(), "auto")
                 .attr("format", colorPicker.getFormat(), "hex")


### PR DESCRIPTION
Fix #10609: Colorpicker double conversion

I have confirmed that removing this line causes it to be called only once and properly.

**Before:**
```
getAsString null
getAsObject #853232
getAsObject 853232
Color = 853232
```

**After:** 
```
getAsString null
getAsObject #853232
Color = 853232
```