### PR TITLE
Fix #10628: TabView: swipe on mobile enabled but fails on last item

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -693,7 +693,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
      * @return {number} The number of tabs.
      */
     getLength: function() {
-        return this.navContainer.children().filter(':not(.ui-tabs-actions)').length;
+        return this.headerContainer.length;
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -693,7 +693,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
      * @return {number} The number of tabs.
      */
     getLength: function() {
-        return this.navContainer.children().length;
+        return this.navContainer.children().filter(':not(.ui-tabs-actions)').length;
     },
 
     /**


### PR DESCRIPTION
Fix #10628: TabView: swipe on mobile enabled but fails on last item

If `f:facet name="actions"` is used in a TabView it causes `getLength()` to return an incorrect value. This change will ignore any actions elements that may be there.