### PR TITLE
Fix #10044: 13.0.1 DatePicker viewdate default to input date first

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -69,6 +69,9 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         // auto detect touch interface for mobile
         this.cfg.autoDetectDisplay = (this.cfg.autoDetectDisplay === undefined) ? true : this.cfg.autoDetectDisplay;
         this.cfg.responsiveBreakpoint = this.cfg.responsiveBreakpoint || 576;
+        
+        // default date should be input value before widget value
+        this.cfg.defaultDate = this.input.val() || this.cfg.defaultDate;
 
         //i18n and l7n
         this.configureLocale();


### PR DESCRIPTION
Fix #10044: 13.0.1 DatePicker viewdate default to input date first