### PR TITLE
Fix #10658: CSP wrap FastStringWriter

### DIFF
--- a/primefaces/src/main/java/org/primefaces/csp/CspPartialResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspPartialResponseWriter.java
@@ -24,12 +24,14 @@
 package org.primefaces.csp;
 
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Map;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.PartialResponseWriter;
+import javax.faces.context.ResponseWriter;
 
 import org.primefaces.context.PartialResponseWriterWrapper;
 import org.primefaces.context.PrimeRequestContext;
@@ -163,6 +165,11 @@ public class CspPartialResponseWriter extends PartialResponseWriterWrapper {
     @Override
     public void close() throws IOException {
         cspResponseWriter.close();
+    }
+
+    @Override
+    public ResponseWriter cloneWithWriter(Writer writer) {
+        return new CspResponseWriter(getWrapped().cloneWithWriter(writer), this.cspState);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/csp/CspResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspResponseWriter.java
@@ -256,6 +256,6 @@ public class CspResponseWriter extends ResponseWriterWrapper {
 
     @Override
     public ResponseWriter cloneWithWriter(Writer writer) {
-        return getWrapped().cloneWithWriter(writer);
+        return new CspResponseWriter(getWrapped().cloneWithWriter(writer), this.cspState);
     }
 }


### PR DESCRIPTION
Fix #10658: CSP wrap FastStringWriter

Previously it was just delegating to `return getWrapped().cloneWithWriter(writer);` which was just wrapping the underlying MyFaces or Mojarra HtmlResponseWriter not accounting for CSP.