### PR TITLE
Fix regression after trying to fix #10656

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -101,6 +101,8 @@ public abstract class DataTableExporter<P, O extends ExporterOptions> extends Ta
 
             if (batchSize > 0) {
                 List<?> wrappedData = lazyDataModel.getWrappedData();
+                int pageSize = lazyDataModel.getPageSize();
+                lazyDataModel.setPageSize(batchSize);
                 int offset = 0;
                 List<Object> items;
 
@@ -116,6 +118,7 @@ public abstract class DataTableExporter<P, O extends ExporterOptions> extends Ta
                 //restore
                 table.setRowIndex(-1);
                 lazyDataModel.setWrappedData(wrappedData);
+                lazyDataModel.setPageSize(pageSize);
                 lazyDataModel.setRowIndex(-1);
             }
         }


### PR DESCRIPTION
Quite unlucky on this one, i've been testing the whole time with value 10 which is same value as rows value. Once bufferSize gets higher than pageSize, rowIndex is recalculated in LazyDataModel#setRowIndex (for reason I don't know...) and goes back to 0

@jasonex7 You can checkout this PR and try if it works for you (just to be sure this time 😄 )