### PR TITLE
Fix #10677: JPALazyDataModel case sensitive filters

### DIFF
--- a/docs/14_0_0/components/datatable.md
+++ b/docs/14_0_0/components/datatable.md
@@ -953,7 +953,17 @@ or provide a existing JSF `Converter`:
 new JpaLazyDataModel<>(MyEntity.class, () -> entityManager, myConverter);
 ```
 
+or use the builder pattern to enable case insensitive searching and other features:
+
+```java
+JpaLazyDataModel<MyEntity> lazyDataModel = new JpaLazyDataModel.Builder<>(MyEntity.class, () -> entityManager)
+    .rowKeyField("id")
+    .caseSensitive(false)
+    .build();
+```
+
 Also you can add global filters via:
+
 ```java
 new JpaLazyDataModel<>(MyEntity.class, () -> entityManager) {
     @Override

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -20,6 +20,10 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
 
 * DataExporter
     * Added `bufferSize` to control how many items are fetched at a time when `DataTable#lazy` is enabled
+    
+* DataTable
+    * JPALazyDataModel now supports case insensitive filters with `setCaseSensitive(false);`
+    * JPALazyDataModel now supports builder pattern for constructor.
   
 ### PrimeFaces Selenium 
 

--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -73,12 +73,29 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
     }
 
     /**
+     * Private constructor when using the builder pattern.
+     * @param builder the builder.
+     */
+    public JpaLazyDataModel(Builder<T> builder) {
+        Objects.requireNonNull(builder.entityClass, "EntityClass must not be null");
+        Objects.requireNonNull(builder.entityManager, "EnittyManager must not be null");
+        this.entityClass = builder.entityClass;
+        this.entityManager = builder.entityManager;
+        this.rowKeyField = builder.rowKeyField;
+        this.setRowKeyField(builder.rowKeyField);
+        this.setCaseSensitive(builder.caseSensitive);
+        this.setConverter(builder.converter);
+    }
+
+    /**
      * Constructs a JpaLazyDataModel for usage without enabled selection.
      *
      * @param entityClass The entity class
      * @param entityManager The {@link EntityManager}
      */
     public JpaLazyDataModel(Class<T> entityClass, SerializableSupplier<EntityManager> entityManager) {
+        Objects.requireNonNull(entityClass, "EntityClass must not be null");
+        Objects.requireNonNull(entityManager, "EnittyManager must not be null");
         this.entityClass = entityClass;
         this.entityManager = entityManager;
     }
@@ -417,5 +434,37 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
+    }
+
+    public static class Builder<T> {
+        private Class<T> entityClass;
+        private SerializableSupplier<EntityManager> entityManager;
+        private String rowKeyField;
+        private Converter converter;
+        private boolean caseSensitive = true;
+
+        public Builder(Class<T> entityClass, SerializableSupplier<EntityManager> entityManager) {
+            this.entityClass = entityClass;
+            this.entityManager = entityManager;
+        }
+
+        public Builder<T> converter(Converter converter) {
+            this.converter = converter;
+            return this;
+        }
+
+        public Builder<T> rowKeyField(String rowKeyField) {
+            this.rowKeyField = rowKeyField;
+            return this;
+        }
+
+        public Builder<T> caseSensitive(boolean caseSensitive) {
+            this.caseSensitive = caseSensitive;
+            return this;
+        }
+
+        public JpaLazyDataModel<T> build() {
+            return new JpaLazyDataModel<>(this);
+        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -61,7 +61,7 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
     protected Class<T> entityClass;
     protected SerializableSupplier<EntityManager> entityManager;
     protected String rowKeyField;
-    protected boolean caseSensitive = false;
+    protected boolean caseSensitive = true;
 
     private transient Lazy<Method> rowKeyGetter;
 

--- a/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JpaLazyDataModel.java
@@ -212,6 +212,7 @@ public class JpaLazyDataModel<T> extends LazyDataModel<T> implements Serializabl
             case NOT_CONTAINS:
                 return cb.notLike(fieldExpressionAsString.get(), "%" + getStringFilterValue(filterValue) + "%");
             case EXACT:
+                return cb.equal(fieldExpressionAsString.get(), getStringFilterValue(filterValue));
             case EQUALS:
                 return cb.equal(fieldExpression, filterValue);
             case NOT_EXACT:


### PR DESCRIPTION
cc @FlipWarthog 

We took this code from our current implementation at a client to make the string filters case sensitive by default but can be disabled with `setCaseSensitive(false);`