### PR TITLE
Fix #10557: 13.0.2 Rating not setting value on cancel event

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/rating/Rating001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/rating/Rating001.java
@@ -51,7 +51,7 @@ public class Rating001 implements Serializable {
     }
 
     public void oncancel() {
-        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, "Cancel Event", "Rate Reset");
+        FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, "Cancel Event", "Rate Reset:" + rating1);
         FacesContext.getCurrentInstance().addMessage(null, message);
     }
 }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/rating/Rating001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/rating/Rating001Test.java
@@ -61,7 +61,7 @@ public class Rating001Test extends AbstractPrimePageTest {
         // Assert
         Assertions.assertNull(rating.getValue());
         Assertions.assertEquals("Cancel Event", messages.getMessage(0).getSummary());
-        Assertions.assertEquals("Rate Reset", messages.getMessage(0).getDetail());
+        Assertions.assertEquals("Rate Reset:null", messages.getMessage(0).getDetail());
         assertConfiguration(rating.getWidgetConfiguration());
     }
 
@@ -88,7 +88,7 @@ public class Rating001Test extends AbstractPrimePageTest {
         // Assert
         Assertions.assertNull(rating.getValue());
         Assertions.assertEquals("Cancel Event", messages.getMessage(0).getSummary());
-        Assertions.assertEquals("Rate Reset", messages.getMessage(0).getDetail());
+        Assertions.assertEquals("Rate Reset:null", messages.getMessage(0).getDetail());
         assertConfiguration(rating.getWidgetConfiguration());
     }
 
@@ -254,6 +254,28 @@ public class Rating001Test extends AbstractPrimePageTest {
         // Assert
         // 4 is the exact middle between min=0 max=8 which is range default
         Assertions.assertEquals(4L, rating.getValue());
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("Rating: cancel the value and check it should be NULL server side")
+    public void testCancelSetsNull(Page page) {
+        // Arrange
+        Rating rating = page.ratingAjax;
+        Messages messages = page.messages;
+        Assertions.assertNull(rating.getValue());
+
+        // Act
+        rating.setValue(3);
+        rating.cancel();
+        Assertions.assertEquals("Cancel Event", messages.getMessage(0).getSummary());
+        Assertions.assertEquals("Rate Reset:null", messages.getMessage(0).getDetail());
+
+        // Act
+        page.submit.click();
+
+        // Assert
+        Assertions.assertNull(rating.getValue());
     }
 
     private JSONObject assertConfiguration(JSONObject cfg) {

--- a/primefaces/src/main/java/org/primefaces/component/rating/Rating.java
+++ b/primefaces/src/main/java/org/primefaces/component/rating/Rating.java
@@ -53,7 +53,7 @@ public class Rating extends RatingBase {
     private static final String DEFAULT_EVENT = "rate";
     private static final Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()
             .put("rate", RateEvent.class)
-            .put("cancel", null)
+            .put("cancel", RateEvent.class)
             .build();
     private static final Collection<String> EVENT_NAMES = BEHAVIOR_EVENT_MAPPING.keySet();
 
@@ -81,11 +81,8 @@ public class Rating extends RatingBase {
         if (event instanceof AjaxBehaviorEvent) {
             String eventName = context.getExternalContext().getRequestParameterMap().get(Constants.RequestParams.PARTIAL_BEHAVIOR_EVENT_PARAM);
 
-            if ("rate".equals(eventName)) {
+            if ("rate".equals(eventName) || "cancel".equals(eventName)) {
                 customEvents.put(eventName, (AjaxBehaviorEvent) event);
-            }
-            else if ("cancel".equals(eventName)) {
-                super.queueEvent(event);
             }
         }
         else {
@@ -99,8 +96,11 @@ public class Rating extends RatingBase {
 
         if (isValid() && customEvents != null) {
             for (Map.Entry<String, AjaxBehaviorEvent> event : customEvents.entrySet()) {
+                String eventName = event.getKey();
                 AjaxBehaviorEvent behaviorEvent = event.getValue();
-                RateEvent rateEvent = new RateEvent(this, behaviorEvent.getBehavior(), getValue());
+                Object value = "cancel".equals(eventName) ? null : getValue();
+                setValue(value);
+                RateEvent rateEvent = new RateEvent(this, behaviorEvent.getBehavior(), value);
 
                 rateEvent.setPhaseId(behaviorEvent.getPhaseId());
 


### PR DESCRIPTION
Fix #10557: 13.0.2 Rating not setting value on cancel event