### PR TITLE
Fix #10694: 13.0.2 Splitter hide until initial sizing complete

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/splitter/splitter.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/splitter/splitter.js
@@ -76,12 +76,14 @@ PrimeFaces.widget.Splitter = PrimeFaces.widget.BaseWidget.extend({
         }
 
         if (!initialized) {
+            this.jq.hide();
             this.panels.each(function(i, panel) {
                 var panelInitialSize = panel.dataset && panel.dataset.size;
                 var panelSize = panelInitialSize || (100 / $this.panels.length);
                 $this.panelSizes[i] = panelSize;
                 panel.style.flexBasis = 'calc(' + panelSize + '% - ' + (($this.panels.length - 1) * $this.cfg.gutterSize) + 'px)';
             });
+            this.jq.show();
         }
     },
 


### PR DESCRIPTION
Fix #10694: 13.0.2 Splitter hide until initial sizing complete