### PR TITLE
Fix #10721: SelectOneMenu return focus to input

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1007,6 +1007,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
                 onExited: function() {
                     $this.panel.css('z-index', '');
                     $this.keyboardTarget.attr('aria-expanded', false);
+                    $this.keyboardTarget.trigger('focus.ui-selectonemenu');
                 }
             });
         }


### PR DESCRIPTION
Fix #10721: SelectOneMenu return focus to input