### PR TITLE
Fix #10726: Radio add ui-state-readonly

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -109,6 +109,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
                 .add(GridLayoutUtils.getResponsiveClass(flex))
                 .add(radio.getStyleClass())
                 .add(SelectOneRadio.STYLE_CLASS)
+                .add(radio.isReadonly(), "ui-state-readonly")
                 .build();
         String labelledBy = radio.getLabel();
 
@@ -193,6 +194,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
         String styleClass = getStyleClassBuilder(context)
                 .add(radio.getStyleClass())
                 .add(SelectOneRadio.STYLE_CLASS)
+                .add(radio.isReadonly(), "ui-state-readonly")
                 .build();
         String labelledBy = radio.getLabel();
 
@@ -242,6 +244,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
             String styleClass = getStyleClassBuilder(context)
                     .add(radio.getStyleClass())
                     .add(SelectOneRadio.STYLE_CLASS)
+                    .add(radio.isReadonly(), "ui-state-readonly")
                     .build();
             String labelledBy = radio.getLabel();
             writer.startElement("span", radio);


### PR DESCRIPTION
Fix #10726: Radio add ui-state-readonly

Added this CSS class so the radio group can be styled for readonly by themes or customized by users.