### PR TITLE
Fix #10802 - Docs: Wizard docs reference incorrect FlowEvent method names

### DIFF
--- a/docs/10_0_0/components/wizard.md
+++ b/docs/10_0_0/components/wizard.md
@@ -178,12 +178,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/11_0_0/components/wizard.md
+++ b/docs/11_0_0/components/wizard.md
@@ -178,12 +178,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/12_0_0/components/wizard.md
+++ b/docs/12_0_0/components/wizard.md
@@ -178,12 +178,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/13_0_0/components/wizard.md
+++ b/docs/13_0_0/components/wizard.md
@@ -178,12 +178,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/14_0_0/components/wizard.md
+++ b/docs/14_0_0/components/wizard.md
@@ -178,12 +178,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/7_0/components/wizard.md
+++ b/docs/7_0/components/wizard.md
@@ -166,12 +166,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display

--- a/docs/8_0/components/wizard.md
+++ b/docs/8_0/components/wizard.md
@@ -174,12 +174,12 @@ flowListener.
 ```
 ```java
 public String handleFlow(FlowEvent event) {
-    String currentStepId = event.getCurrentStep();
-    String stepToGo = event.getNextStep();
+    String currentStepId = event.getOldStep();
+    String stepToGo = event.getNewStep();
     if(skip)
         return "confirm";
     else
-        return event.getNextStep();
+        return event.getNewStep();
 }
 ```
 Steps here are simply the ids of tab, by using a flowListener you can decide which step to display


### PR DESCRIPTION
Fix #10802 - Docs: Wizard docs reference incorrect FlowEvent method names