### PR TITLE
Fix #10804: TabView focusOnLastActiveTab default false

### DIFF
--- a/docs/13_0_0/components/tabview.md
+++ b/docs/13_0_0/components/tabview.md
@@ -44,7 +44,7 @@ TabView is a container component to group content in tabs.
 | touchable      | null    | Boolean    | Enable touch support (if the browser supports it). Default is the global primefaces.TOUCHABLE, which can be overwritten on component level.
 | multiViewState | false   | Boolean    | Whether to keep TabView state across views, defaults to false.
 | focusOnError   | false   | Boolean    | Whether to focus the first tab that contains an error after form submission.
-| focusOnLastActiveTab   | true   | Boolean    | Whether to focus on the last active tab that a user selected.
+| focusOnLastActiveTab   | false   | Boolean    | Whether to focus on the last active tab that a user selected.
 
 ## Getting started with the TabView
 TabView requires one more child tab components to display. Titles can also be defined by using

--- a/docs/14_0_0/components/tabview.md
+++ b/docs/14_0_0/components/tabview.md
@@ -44,7 +44,7 @@ TabView is a container component to group content in tabs.
 | touchable      | null    | Boolean    | Enable touch support (if the browser supports it). Default is the global primefaces.TOUCHABLE, which can be overwritten on component level.
 | multiViewState | false   | Boolean    | Whether to keep TabView state across views, defaults to false.
 | focusOnError   | false   | Boolean    | Whether to focus the first tab that contains an error after form submission.
-| focusOnLastActiveTab   | true   | Boolean    | Whether to focus on the last active tab that a user selected.
+| focusOnLastActiveTab   | false   | Boolean    | Whether to focus on the last active tab that a user selected.
 
 ## Getting started with the TabView
 TabView requires one more child tab components to display. Titles can also be defined by using

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
@@ -188,7 +188,7 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
     }
 
     public boolean isFocusOnLastActiveTab() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.focusOnLastActiveTab, true);
+        return (Boolean) getStateHelper().eval(PropertyKeys.focusOnLastActiveTab, false);
     }
 
     public void setFocusOnLastActiveTab(boolean focusOnLastActiveTab) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -119,7 +119,7 @@ public class TabViewRenderer extends CoreRenderer {
                 .attr("scrollable", tabView.isScrollable())
                 .attr("tabindex", tabView.getTabindex(), null)
                 .attr("focusOnError", tabView.isFocusOnError(), false)
-                .attr("focusOnLastActiveTab", tabView.isFocusOnLastActiveTab(), true)
+                .attr("focusOnLastActiveTab", tabView.isFocusOnLastActiveTab(), false)
                 .attr("touchable", ComponentUtils.isTouchable(context, tabView),  true)
                 .attr("multiViewState", tabView.isMultiViewState(), false);
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -28109,7 +28109,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Whether to focus the first tab that contains an error after form submission.]]>
+                <![CDATA[Whether to focus the first tab that contains an error after form submission. Default is false.]]>
             </description>
             <name>focusOnError</name>
             <required>false</required>
@@ -28117,7 +28117,7 @@
         </attribute>
          <attribute>
             <description>
-                <![CDATA[Whether to focus on the last active tab that a user selected.]]>
+                <![CDATA[Whether to focus on the last active tab that a user selected. Default is false.]]>
             </description>
             <name>focusOnLastActiveTab</name>
             <required>false</required>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -78,7 +78,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         this.focusedTabHeader = null;
         this.tabindex = this.cfg.tabindex||0;
         this.cfg.focusOnError = this.cfg.focusOnError || false;
-        this.cfg.focusOnLastActiveTab = this.cfg.focusOnLastActiveTab === undefined ? true : this.cfg.focusOnLastActiveTab;
+        this.cfg.focusOnLastActiveTab = this.cfg.focusOnLastActiveTab || false;
 
         if(this.cfg.scrollable) {
             this.navscroller = this.jq.children('.ui-tabs-navscroller');


### PR DESCRIPTION
Fix #10804: TabView focusOnLastActiveTab default false

This defaults it back to behavior of pre-13.0 and can be enabled by turning it on with `focusOnLastActiveTab=true`