### PR TITLE
Fix #10805: HtmlSantitizer allow media elements

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/HtmlSanitizer.java
+++ b/primefaces/src/main/java/org/primefaces/util/HtmlSanitizer.java
@@ -38,6 +38,14 @@ public class HtmlSanitizer {
             .onElements("img")
             .toFactory();
 
+    private static final PolicyFactory HTML_MEDIA_SANITIZER = new HtmlPolicyBuilder()
+            .allowUrlProtocols("data", "http", "https")
+            .allowElements("video", "audio", "source", "iframe", "figure")
+            .allowAttributes("controls", "width", "height", "origin-size", "src", "allowfullscreen", "class", "style", "data-proportion", "data-align",
+                        "data-percentage", " data-size", "data-file-name", "data-file-size", "data-origin", "data-rotate", "data-index")
+            .onElements("video", "audio", "source", "iframe", "figure")
+            .toFactory();
+
     private static final PolicyFactory HTML_LINKS_SANITIZER = Sanitizers.LINKS
             .and(new HtmlPolicyBuilder()
             .allowElements("a")
@@ -59,7 +67,7 @@ public class HtmlSanitizer {
     }
 
     public static String sanitizeHtml(String value,
-            boolean allowBlocks, boolean allowFormatting, boolean allowLinks, boolean allowStyles, boolean allowImages) {
+            boolean allowBlocks, boolean allowFormatting, boolean allowLinks, boolean allowStyles, boolean allowMedia) {
 
         if (LangUtils.isBlank(value)) {
             return value;
@@ -78,8 +86,9 @@ public class HtmlSanitizer {
         if (allowStyles) {
             sanitizer = sanitizer.and(HTML_STYLES_SANITIZER);
         }
-        if (allowImages) {
+        if (allowMedia) {
             sanitizer = sanitizer.and(HTML_IMAGES_SANITIZER);
+            sanitizer = sanitizer.and(HTML_MEDIA_SANITIZER);
         }
 
         return sanitizer.sanitize(value);


### PR DESCRIPTION
Fix #10805: HtmlSantitizer allow media elements

We have the same fix in PF Extensions because the SunEditor does the same thing.