### PR TITLE
Fix #10845: MoveScriptsToBottom do not touch non JS scripts

### DIFF
--- a/primefaces/src/test/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriterTest.java
+++ b/primefaces/src/test/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriterTest.java
@@ -160,6 +160,39 @@ public class MoveScriptsToBottomResponseWriterTest {
         verify(wrappedWriter, times(2)).endElement("script");
     }
 
+    /**
+     * https://github.com/primefaces/primefaces/issues/10845
+     */
+    @Test
+    public void testMultipleInlineScriptsNonJavascript() throws IOException {
+        writer.startElement("body", null);
+        verify(wrappedWriter).startElement("body", null);
+
+        writer.startElement("script", null);
+        writer.writeAttribute("type", "application/ld+json", null);
+        writer.writeText("JSONLinkingData1", null);
+        writer.endElement("script");
+
+        writer.startElement("script", null);
+        // default type is text/javascript
+        writer.writeText("javascript2", null);
+        writer.endElement("script");
+
+        writer.startElement("script", null);
+        writer.writeAttribute("type", "application/ld+json", null);
+        writer.writeText("JSONLinkingData2", null);
+        writer.endElement("script");
+
+        writer.endElement("body");
+
+        // assert both LD files are still in their own inline script
+        verify(wrappedWriter, times(3)).startElement("script", null);
+        verify(wrappedWriter).write(matches("(?s).*JSONLinkingData1(?!.*javascript2.*).*"));
+        verify(wrappedWriter).write(matches("(?s).*javascript2(?!.*JSONLinkingData1.*).*"));
+        verify(wrappedWriter).write(matches("(?s).*JSONLinkingData2(?!.*javascript2.*).*"));
+        verify(wrappedWriter, times(3)).endElement("script");
+    }
+
     @Test
     public void testPassthroughAttributes() throws IOException {
         writer.startElement("body", null);


### PR DESCRIPTION
Fix #10845: MoveScriptsToBottom do not touch non JS scripts

I added 2 LD scripts and this is what it does now.

```xml
<script id="5044e51c-58f4-4e6c-a972-2b4d3d228e12" type="application/ld+json">
{
    "@context": "http://schema.org",
    "@type": "WebSite",
    "url": "http://website.com",
    "name": "wbs",
    "description": "Web Studio"
}
</script>
<script id="ae75b71e-331d-4c11-b4cf-db316fc5e7a3" type="application/ld+json">
{
    "@context": "http://schema.org",
    "@type": "WebSite2",
    "url": "https://coder2.com",
    "name": “Coder2”,
    "description": “Platform to learn code2”
}
</script>
```