### PR TITLE
Fix #10847: AutoComplete closes on Enter when no item is highlighted

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -512,6 +512,8 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
                             $this.preventInputChangeEvent = true;
                             highlightedItem.trigger("click");
                             $this.itemSelectedWithEnter = true;
+                        } else {
+                            $this.hide();
                         }
 
                         e.preventDefault();


### PR DESCRIPTION
Fix #10847.

Changes the behaviour of the AutoComplete on pressing Enter when no item is highlighted as proposed by WAI.

https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/#kbd_label