### PR TITLE
Fix #10874: `InputSwitch` has been deprecated since 10.0 and will be removed in 15.0.0

### DIFF
--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -11,6 +11,7 @@
   
 ## Deprecated
   * Apache Commons FileUpload support has been deprecated for native uploading now that Servlet 3.0 is the minimum requirement. Please report any issues if native uploading does not work for your needs.
+  * `InputSwitch` has been deprecated since 10.0 and will be removed in 15.0.0
 
 ## AutoComplete
   * `dropdownAriaLabel`, `emptyMessage`, `resultsMessage` properties have been moved to client side locale

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/InputSwitch.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/InputSwitch.java
@@ -30,7 +30,7 @@ import org.primefaces.selenium.component.base.AbstractToggleComponent;
  *
  * @deprecated since 10.0 and removal possible anytime after that
  */
-@Deprecated
+@Deprecated(since = "10.0", forRemoval  =  true)
 public abstract class InputSwitch extends AbstractToggleComponent {
 
 }

--- a/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitch.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitch.java
@@ -31,6 +31,12 @@ import javax.faces.event.BehaviorEvent;
 
 import org.primefaces.util.MapBuilder;
 
+/**
+*
+* @deprecated in 10.0 use ToggleSwitch
+*
+*/
+@Deprecated(since = "10.0", forRemoval  =  true)
 @ResourceDependency(library = "primefaces", name = "components.css")
 @ResourceDependency(library = "primefaces", name = "inputswitch/inputswitch.css")
 @ResourceDependency(library = "primefaces", name = "jquery/jquery.js")

--- a/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitchBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitchBase.java
@@ -29,6 +29,12 @@ import javax.faces.component.behavior.ClientBehaviorHolder;
 import org.primefaces.component.api.PrimeClientBehaviorHolder;
 import org.primefaces.component.api.Widget;
 
+/**
+*
+* @deprecated in 10.0 use ToggleSwitch
+*
+*/
+@Deprecated(since = "10.0", forRemoval = true)
 public abstract class InputSwitchBase extends UIInput implements Widget, ClientBehaviorHolder, PrimeClientBehaviorHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";

--- a/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputswitch/InputSwitchRenderer.java
@@ -34,6 +34,12 @@ import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.HTML;
 import org.primefaces.util.WidgetBuilder;
 
+/**
+*
+* @deprecated in 10.0 use ToggleSwitch
+*
+*/
+@Deprecated(since = "10.0", forRemoval = true)
 public class InputSwitchRenderer extends InputRenderer {
 
     @Override

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -14099,7 +14099,7 @@
     </tag>
     <tag>
         <description>
-            <![CDATA[]]>
+            <![CDATA[Deprecated since 10.0 for removal in 15.0.0)]]>
         </description>
         <tag-name>inputSwitch</tag-name>
         <component>


### PR DESCRIPTION
Fix #10874: `InputSwitch` has been deprecated since 10.0 and will be removed in 15.0.0