### PR TITLE
Fix #10880: SelectOne better re-focus handling

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1014,8 +1014,13 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
                 onExited: function() {
                     $this.panel.css('z-index', '');
                     $this.keyboardTarget.attr('aria-expanded', false);
+
+                    // refocus input if not tabbing and active is owned by this component
                     if (!$this.isTabbing) {
-                        $this.keyboardTarget.trigger('focus.ui-selectonemenu');
+                        var activeElement = $(document.activeElement);
+                        if ($this.jq.has(activeElement).length || $this.panel.has(activeElement).length) {
+                            $this.keyboardTarget.trigger('focus.ui-selectonemenu');
+                        }
                     }
                     $this.isTabbing = false;
                 }


### PR DESCRIPTION
Fix #10880: SelectOne better re-focus handling

Tested this well.  Basically it will only refocus the input if the active element is part of the SelectOne so if you press ESC, or click to select an item.  But if you TAB or Click outside the SelectOne is does not re-focus the input