### PR TITLE
Fix #10839: Improved deferred widget handling

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1028,8 +1028,13 @@
          * return `true` when the widget was rendered, or `false` when the widget still needs to be rendered later.
          */
         addDeferredRender: function(widgetId, containerId, fn) {
-            this.removeDeferredRenders(widgetId); // remove existing
-            this.deferredRenders.push({widget: widgetId, container: containerId, callback: fn});
+            // remove existing
+            this.deferredRenders = this.deferredRenders.filter(deferredRender => {
+                return !(deferredRender.widget === widgetId && deferredRender.container === containerId);
+            });
+
+            // add new
+            this.deferredRenders.push({ widget: widgetId, container: containerId, callback: fn });
         },
 
         /**
@@ -1045,13 +1050,9 @@
          * @param {string} widgetId The ID of a deferred widget.
          */
         removeDeferredRenders: function(widgetId) {
-            for(var i = (this.deferredRenders.length - 1); i >= 0; i--) {
-                var deferredRender = this.deferredRenders[i];
-
-                if(deferredRender.widget === widgetId) {
-                    this.deferredRenders.splice(i, 1);
-                }
-            }
+            this.deferredRenders = this.deferredRenders.filter(function(deferredRender) {
+                return deferredRender.widget !== widgetId;
+            });
         },
 
         /**


### PR DESCRIPTION
Fix #10839: Improved deferred widget handling

 Basically `widgetID` is not enough it has to be the `widgetId` and `containerId` combo before removing it.