### PR TITLE
Fix #10850: DatePicker fire dateSelect in multiple selection

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2823,6 +2823,11 @@
                         return !$this.isDateEquals(date, dateMeta);
                     });
                     this.updateModel(event, value);
+                    
+                    // #10850 notify unselect
+                    if (this.options.onSelect) {
+                        this.options.onSelect.call(this, event, value);
+                    }
                 }
                 else if (!this.options.maxDateCount || !this.value || this.options.maxDateCount > this.value.length) {
                     this.selectDate(event, dateMeta);


### PR DESCRIPTION
Fix #10850: DatePicker fire dateSelect in multiple selection

When unselecting a date in multiple mode it should fire the dateSelect with the current remaining selected dates.