### PR TITLE
PanelGrid remove deprecation warning for table layout

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
@@ -56,14 +56,8 @@ public class PanelGridRenderer extends CoreRenderer {
         }
     }
 
-    /**
-     * @deprecated in 13.0.0 remove in 14.0.0
-     */
-    @Deprecated
     public void encodeLegacyTableLayout(FacesContext context, PanelGrid grid) throws IOException {
         String clientId = grid.getClientId(context);
-        logDevelopmentWarning(context, "Table layout is deprecated and will be removed in future release. Please switch to responsive layout. ClientId: "
-                + clientId);
         ResponseWriter writer = context.getResponseWriter();
         int columns = grid.getColumns();
         String style = grid.getStyle();


### PR DESCRIPTION
In our 70+ apps we use this everywhere as this used to be the only way to do it.  We already made responsive the default but I want to remove this warning as I don't think we should remove this from PanelGrid anytime soon.  All the others I am still OK with removing.