### PR TITLE
Fix #10679: MoveScriptsToBottom deferred

### DIFF
--- a/docs/14_0_0/gettingstarted/configuration.md
+++ b/docs/14_0_0/gettingstarted/configuration.md
@@ -28,7 +28,7 @@ pattern of JavaEE. Here is the list of all configuration options defined with a 
 | INTERPOLATE_CLIENT_SIDE_VALIDATION_MESSAGES | false | Whether to load messages for the client side validation (CSV) from server via the MessageInterpolator. |
 | LEGACY_WIDGET_NAMESPACE | false | Enables window scope so that widgets can be accessed using widgetVar.method() in addition to default PF namespace approach like PF('widgetVar').method(). |
 | MARK_INPUT_AS_INVALID_ON_ERROR_MSG | false | Marks a input as invalid, when a FacesMessage is added for a UIInput with 'SEVERITY_ERROR'. This will show the red border on the client side, when the input is updated. |
-| MOVE_SCRIPTS_TO_BOTTOM | false | Moves all inline scripts to end of body tag for better performance and smaller HTML output. |
+| MOVE_SCRIPTS_TO_BOTTOM | false | Moves all inline scripts to end of body tag for better performance and smaller HTML output.  Values `true`, `false` and `defer`. Defer will set the scripts to the `defer` script attribute. |
 | MULTI_VIEW_STATE_STORE | session | Store MultiViewState per Session ('session') or per ClientWindow ('client-window') |
 | PRIME_ICONS | true | Auto includes PrimeIcons font based icons. True by default for most themes use PrimeIcons. Only disable if you know you do not use PrimeIcons. |
 | RESET_VALUES | false | When enabled, AJAX updated inputs are always reset. |

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -8,6 +8,9 @@ This page contains a list of big features. Please check the GitHub issues for al
 
 Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../migrationguide/14_0_0) for more enhancements and changes.
 
+* Core
+    * `MOVE_SCRIPTS_TO_BOTTOM` adds new option `defer` to defer loading scripts
+
 * Accordion
     * Added `toggleSpeed` for toggle speed animation duration.
     * Added `scrollIntoView` to allow the active tab to be scrolled into the viewport

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomState.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomState.java
@@ -33,11 +33,18 @@ public class MoveScriptsToBottomState implements Serializable {
     private Map<String, List<Map<String, String>>> includes;
     private Map<String, List<String>> inlines;
     private int savedInlineTags;
+    private boolean deferred;
 
     public MoveScriptsToBottomState() {
         includes = new HashMap<>(1);
         inlines = new HashMap<>(1);
         savedInlineTags = -1;
+        deferred = false;
+    }
+
+    public MoveScriptsToBottomState(boolean deferred) {
+        this();
+        this.deferred = deferred;
     }
 
     public void addInclude(String type, Map<String, String> includeAttributes) {
@@ -66,5 +73,9 @@ public class MoveScriptsToBottomState implements Serializable {
 
     public int getSavedInlineTags() {
         return savedInlineTags;
+    }
+
+    public boolean isDeferred() {
+        return deferred;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/config/PrimeConfiguration.java
+++ b/primefaces/src/main/java/org/primefaces/config/PrimeConfiguration.java
@@ -54,6 +54,7 @@ public class PrimeConfiguration {
     private final boolean interpolateClientSideValidationMessages;
     private final boolean earlyPostParamEvaluation;
     private final boolean moveScriptsToBottom;
+    private final boolean moveScriptsToBottomDeferred;
     private final boolean html5Compliance;
     private boolean csp;
     private boolean policyProvided;
@@ -123,8 +124,21 @@ public class PrimeConfiguration {
         value = externalContext.getInitParameter(Constants.ContextParams.CLIENT_SIDE_LOCALISATION);
         clientSideLocalizationEnabled = Boolean.parseBoolean(value);
 
-        value = externalContext.getInitParameter(Constants.ContextParams.MOVE_SCRIPTS_TO_BOTTOM);
-        moveScriptsToBottom = Boolean.parseBoolean(value);
+        value = Objects.toString(externalContext.getInitParameter(Constants.ContextParams.MOVE_SCRIPTS_TO_BOTTOM));
+        switch (value) {
+            case "true":
+                moveScriptsToBottom = Boolean.TRUE;
+                moveScriptsToBottomDeferred = Boolean.FALSE;
+                break;
+            case "defer":
+                moveScriptsToBottom = Boolean.TRUE;
+                moveScriptsToBottomDeferred = Boolean.TRUE;
+                break;
+            default:
+                moveScriptsToBottom = Boolean.FALSE;
+                moveScriptsToBottomDeferred = Boolean.FALSE;
+                break;
+        }
 
         value = externalContext.getInitParameter(Constants.ContextParams.HTML5_COMPLIANCE);
         html5Compliance = Boolean.parseBoolean(value);
@@ -256,6 +270,10 @@ public class PrimeConfiguration {
 
     public boolean isMoveScriptsToBottom() {
         return moveScriptsToBottom;
+    }
+
+    public boolean isMoveScriptsToBottomDeferred() {
+        return moveScriptsToBottomDeferred;
     }
 
     public boolean isHtml5Compliant() {

--- a/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
@@ -59,7 +59,7 @@ public class PrimeFacesContext extends FacesContextWrapper {
 
         moveScriptsToBottom = config.isMoveScriptsToBottom();
         if (moveScriptsToBottom) {
-            moveScriptsToBottomState = new MoveScriptsToBottomState();
+            moveScriptsToBottomState = new MoveScriptsToBottomState(config.isMoveScriptsToBottomDeferred());
         }
 
         csp = config.isCsp();


### PR DESCRIPTION
Fix #10679: MoveScriptsToBottom deferred

From reading this Stack Overflow: https://stackoverflow.com/questions/12416307/is-it-necessary-to-put-scripts-at-the-bottom-of-a-page-when-using-the-defer-at

Basically this PR does exactly that.  I can't measure how much faster it loads or prevents the browser from doing dumb stuff as it was already pretty quick on my machine.

- [x] Integration tests
- [x] Make it optional based on Context param value "defer" instead of "true"