### PR TITLE
Fix #10922: 13.0.3 Spinner prefix breaks with min value

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/spinner/Spinner004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/spinner/Spinner004Test.java
@@ -51,7 +51,7 @@ public class Spinner004Test extends AbstractPrimePageTest {
         page.button.click();
 
         // Assert
-        Assertions.assertEquals("€0.33", spinner.getValue());
+        Assertions.assertEquals("€0,33", spinner.getValue());
         assertOutputLabel(page, "0.33");
         assertConfiguration(spinner.getWidgetConfiguration());
     }
@@ -69,7 +69,7 @@ public class Spinner004Test extends AbstractPrimePageTest {
         page.button.click();
 
         // Assert
-        Assertions.assertEquals("€1456.78", spinner.getValue()); // TODO: this expected result seems odd to me
+        Assertions.assertEquals("€1.456,78", spinner.getValue());
         assertOutputLabel(page, "1456.78");
         assertConfiguration(spinner.getWidgetConfiguration());
     }

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/SpinnerView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/SpinnerView.java
@@ -33,7 +33,7 @@ public class SpinnerView {
     private int number1;
     private double number2;
     private int number3;
-    private int number4;
+    private int number4 = 15;
     private int number5;
     private int number6;
     private int number7;

--- a/primefaces-showcase/src/main/webapp/ui/input/spinner.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/spinner.xhtml
@@ -52,7 +52,7 @@
 
                     <div class="field col-12 md:col-4">
                         <p:outputLabel for="@next" value="Prefix"/>
-                        <p:spinner id="prefix" value="#{spinnerView.number4}" prefix="$" min="0"/>
+                        <p:spinner id="prefix" value="#{spinnerView.number4}" prefix="$" min="10" max="50"/>
                     </div>
 
                     <div class="field col-12 md:col-4">

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -3,8 +3,6 @@
  *
  * Spinner is an input component to provide a numerical input via increment and decrement buttons.
  *
- * @prop {number} cursorOffset Index where the number starts in the input field's string value, i.e. after the
- * {@link SpinnerCfg.prefix}.
  * @prop {JQuery} downButton The DOM element for the button that decrements this spinner's value.
  * @prop {JQuery} input The DOM element for the input with the current value.
  * @prop {number} timer The set-timeout ID for the timer for incrementing or decrementing this spinner when an arrow key
@@ -52,7 +50,6 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
         if (this.cfg.decimalSeparator == undefined) {
           this.cfg.decimalSeparator = '.';
         }
-        this.cursorOffset = this.cfg.prefix ? this.cfg.prefix.length: 0;
         this.cfg.modifyValueOnWheel = this.cfg.modifyValueOnWheel !== false;
 
         var inputValue = this.input.val();
@@ -291,6 +288,9 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
      */
     parseValue: function(value) {
         var parsedValue;
+        if(this.cfg.prefix && value && isNaN(value) && value.indexOf(this.cfg.prefix) === 0) {
+            value = value.substring(this.cfg.prefix.length, value.length);
+        }
         if(this.cfg.precision) {
             parsedValue = parseFloat(value);
         } else {


### PR DESCRIPTION
Fix #10922: 13.0.3 Spinner prefix breaks with min value