### PR TITLE
Fix #10918: Column(s) filterPlaceholder property

### DIFF
--- a/docs/14_0_0/components/column.md
+++ b/docs/14_0_0/components/column.md
@@ -40,11 +40,12 @@ treetable and more.
 | filterMatchMode | startsWith | String | Match mode for filtering.
 | filterMaxLength | null | Integer | Maximum number of characters for an input filter.
 | filterPosition | bottom | String | Location of the column filter with respect to header content. Options are 'bottom'(default) and 'top'.
+| filterPlaceholder | null | String | Placeholder for plain input text style filters.
 | filterStyle | null | String | Inline style of the filter element
 | filterStyleClass | null | String | Style class of the filter element
 | filterValue | null | Object | Value of the filter field.
 | footerText | null | String | Shortcut for footer facet.
-| groupRow | false | Boolean | Speficies whether to group rows based on the column data.
+| groupRow | false | Boolean | Specifies whether to group rows based on the column data.
 | headerText | null | String | Shortcut for header facet.
 | nullSortOrder             | 1                  | Integer          |  Defines where the null values are placed in ascending sort order. Default value is "1" meaning null values are placed at the end in ascending mode and at beginning in descending mode. Set to "-1" for the opposite behavior.
 | resizable | true | Boolean | Specifies resizable feature at column level. Datatable's resizableColumns must be enabled to use this option.

--- a/docs/14_0_0/components/columns.md
+++ b/docs/14_0_0/components/columns.md
@@ -38,6 +38,8 @@ Columns is used by datatable to create columns dynamically.
 | filterMatchMode | startsWith | String | Match mode for filtering.
 | filterMaxLength | null | Integer | Maximum number of characters for an input filter.
 | filterOptions | null | Object | A collection of selectitems for filter dropdown.
+| filterPosition | bottom | String | Location of the column filter with respect to header content. Options are 'bottom'(default) and 'top'.
+| filterPlaceholder | null | String | Placeholder for plain input text style filters.
 | filterStyle | null | String | Inline style of the filter element
 | filterStyleClass | null | String | Style class of the filter element
 | filterValue | null | Object | Value of the filter field.

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -22,6 +22,7 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     * JPALazyDataModel now supports case insensitive filters with `setCaseSensitive(false);`
     * JPALazyDataModel now supports wildcard filters with `setWildcardSupport(true);` so you can use `*`, `%`, `_` or `?` in filter
     * JPALazyDataModel now supports builder pattern for constructor.
+    * Added `filterPlaceholder` for `Column` and `Columns`
 
 * Messages
     * Added `clearMessages` widget method to clear all current messages.
@@ -36,6 +37,9 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
 * TieredMenu
     * Added `showDelay` delay in milliseconds before displaying the submenu. Default is 0 meaning immediate.
     * Added `hideDelay` delay in milliseconds before hiding the submenu., if 0 not hidden until document.click(). Default is 0.
+    
+* TreeTable
+    * Added `filterPlaceholder` for `Column` and `Columns`
     
 * Wizard
     * Added `disableOnAjax` attribute to disable next and back navigation buttons during Ajax requests triggered by them.

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/filter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/filter.xhtml
@@ -47,7 +47,7 @@
 
                     </f:facet>
 
-                    <p:column headerText="Name" sortBy="#{customer.name}" filterBy="#{customer.name}" filterMatchMode="contains">
+                    <p:column headerText="Name" sortBy="#{customer.name}" filterBy="#{customer.name}" filterMatchMode="contains" filterPlaceholder="Filter By Name">
                         <h:outputText value="#{customer.name}" />
                     </p:column>
 

--- a/primefaces/src/main/java/org/primefaces/component/api/DynamicColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/DynamicColumn.java
@@ -363,4 +363,9 @@ public class DynamicColumn implements UIColumn {
         return columns.getTitle();
     }
 
+    @Override
+    public String getFilterPlaceholder() {
+        return columns.getFilterPlaceholder();
+    }
+
 }

--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -157,6 +157,8 @@ public interface UIColumn {
 
     String getFilterPosition();
 
+    String getFilterPlaceholder();
+
     UIComponent getFacet(String facet);
 
     Object getFilterBy();

--- a/primefaces/src/main/java/org/primefaces/component/column/ColumnBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/column/ColumnBase.java
@@ -56,6 +56,7 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
         filterMatchMode,
         filterMaxLength,
         filterPosition,
+        filterPlaceholder,
         filterStyle,
         filterStyleClass,
         filterValue,
@@ -166,6 +167,15 @@ public abstract class ColumnBase extends UIColumn implements org.primefaces.comp
     @Override
     public String getFilterPosition() {
         return (String) getStateHelper().eval(PropertyKeys.filterPosition, "bottom");
+    }
+
+    @Override
+    public String getFilterPlaceholder() {
+        return (String) getStateHelper().eval(PropertyKeys.filterPlaceholder, null);
+    }
+
+    public void setFilterPlaceholder(String filterPlaceholder) {
+        getStateHelper().put(PropertyKeys.filterPlaceholder, filterPlaceholder);
     }
 
     public void setFilterPosition(String filterPosition) {

--- a/primefaces/src/main/java/org/primefaces/component/columns/ColumnsBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/columns/ColumnsBase.java
@@ -53,6 +53,7 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
         filterMatchMode,
         filterMaxLength,
         filterPosition,
+        filterPlaceholder,
         filterStyle,
         filterStyleClass,
         filterValue,
@@ -166,6 +167,15 @@ public abstract class ColumnsBase extends UIData implements UIColumn {
 
     public void setFilterPosition(String filterPosition) {
         getStateHelper().put(PropertyKeys.filterPosition, filterPosition);
+    }
+
+    @Override
+    public String getFilterPlaceholder() {
+        return (String) getStateHelper().eval(PropertyKeys.filterPlaceholder, null);
+    }
+
+    public void setFilterPlaceholder(String filterPlaceholder) {
+        getStateHelper().put(PropertyKeys.filterPlaceholder, filterPlaceholder);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -797,6 +797,10 @@ public class DataTableRenderer extends DataRenderer {
             writer.writeAttribute("maxlength", column.getFilterMaxLength(), null);
         }
 
+        if (column.getFilterPlaceholder() != null) {
+            writer.writeAttribute("placeholder", column.getFilterPlaceholder(), null);
+        }
+
         writer.endElement("input");
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -797,7 +797,7 @@ public class DataTableRenderer extends DataRenderer {
             writer.writeAttribute("maxlength", column.getFilterMaxLength(), null);
         }
 
-        if (column.getFilterPlaceholder() != null) {
+        if (LangUtils.isNotBlank(column.getFilterPlaceholder())) {
             writer.writeAttribute("placeholder", column.getFilterPlaceholder(), null);
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -770,6 +770,10 @@ public class TreeTableRenderer extends DataRenderer {
                 writer.writeAttribute("maxlength", column.getFilterMaxLength(), null);
             }
 
+            if (column.getFilterPlaceholder() != null) {
+                writer.writeAttribute("placeholder", column.getFilterPlaceholder(), null);
+            }
+
             writer.endElement("input");
         }
         else {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -51,6 +51,7 @@ import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.HTML;
+import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 import static org.primefaces.component.api.UITree.ROOT_ROW_KEY;
 
@@ -770,7 +771,7 @@ public class TreeTableRenderer extends DataRenderer {
                 writer.writeAttribute("maxlength", column.getFilterMaxLength(), null);
             }
 
-            if (column.getFilterPlaceholder() != null) {
+            if (LangUtils.isNotBlank(column.getFilterPlaceholder())) {
                 writer.writeAttribute("placeholder", column.getFilterPlaceholder(), null);
             }
 

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -5564,6 +5564,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Placeholder for plain input text style filters.]]>
+            </description>
+            <name>filterPlaceholder</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines the number of rows the column spans.]]>
             </description>
             <name>rowspan</name>
@@ -6012,6 +6020,14 @@
                 <![CDATA[Location of the column filter with respect to header content. Options are 'bottom'(default) and 'top'.]]>
             </description>
             <name>filterPosition</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Placeholder for plain input text style filters.]]>
+            </description>
+            <name>filterPlaceholder</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>


### PR DESCRIPTION
Fix #10918: Column(s) filterPlaceholder property

Makes it consistent with the other 3 prime libraries.