### PR TITLE
Fix #10921: Badge add onClick and delegate to target by default

### DIFF
--- a/docs/14_0_0/components/badge.md
+++ b/docs/14_0_0/components/badge.md
@@ -27,6 +27,7 @@ Badge is a small status indicator for another element.
 | styleClass | null | String | StyleClass of the badge.
 | icon | null | String | Icon of the badge as a CSS class.
 | iconPos | left | String | Position of the icon.
+| onclick | null | String | Client side callback to execute when the badge element clicked. If not set it delegates the click to its target element.
 | visible | true | Boolean | Whether to hide the badge (but render the children).
 
 ## Getting Started

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -14,6 +14,7 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     
 * Badge
     * Added `icon` and `iconPos` to allow icons to be used in badge
+    * Added 'onclick` to allow client side click of badge. If not set it delegates the click to its target element
 
 * DataExporter
     * Added `bufferSize` to control how many items are fetched at a time when `DataTable#lazy` is enabled

--- a/primefaces-showcase/src/main/webapp/ui/misc/badge.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/badge.xhtml
@@ -23,7 +23,7 @@
 	            <p:badge value="8" severity="success" styleClass="mr-2"></p:badge>
 	            <p:badge value="4" severity="info" styleClass="mr-2"></p:badge>
 	            <p:badge value="12" severity="warning" styleClass="mr-2"></p:badge>
-	            <p:badge value="3" severity="danger"></p:badge>
+	            <p:badge value="3" severity="danger" onclick="alert('danger clicked!')"></p:badge>
 
 	            <h5 class="mb-4">Positioned Badge</h5>
 	            <p:badge value="2">

--- a/primefaces/src/main/java/org/primefaces/component/badge/Badge.java
+++ b/primefaces/src/main/java/org/primefaces/component/badge/Badge.java
@@ -63,6 +63,7 @@ public class Badge extends BadgeBase {
                 .styleClass(getStyleClass())
                 .icon(getIcon())
                 .iconPos(getIconPos())
+                .onClick(getOnclick())
                 .visible(isVisible())
                 .build();
     }

--- a/primefaces/src/main/java/org/primefaces/component/badge/BadgeBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/badge/BadgeBase.java
@@ -40,7 +40,8 @@ public abstract class BadgeBase extends UIComponentBase implements Widget {
         styleClass,
         visible,
         icon,
-        iconPos
+        iconPos,
+        onclick
     }
 
     public BadgeBase() {
@@ -113,5 +114,13 @@ public abstract class BadgeBase extends UIComponentBase implements Widget {
 
     public void setIconPos(String iconPos) {
         getStateHelper().put(PropertyKeys.iconPos, iconPos);
+    }
+
+    public String getOnclick() {
+        return (String) getStateHelper().eval(PropertyKeys.onclick, null);
+    }
+
+    public void setOnclick(String onClick) {
+        getStateHelper().put(PropertyKeys.onclick, onClick);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/badge/BadgeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/badge/BadgeRenderer.java
@@ -119,6 +119,14 @@ public class BadgeRenderer extends CoreRenderer {
             writer.writeAttribute("style", model.getStyle(), "style");
         }
 
+        if (model.getOnclick() != null) {
+            writer.writeAttribute("onclick", model.getOnclick(), "onclick");
+        }
+        else if (renderChildren) {
+            // delegate click of badge to its child component
+            writer.writeAttribute("onclick", "$(this).next().click();", "onclick");
+        }
+
         encodeValue(context, badge, model);
         writer.endElement("span");
 

--- a/primefaces/src/main/java/org/primefaces/model/badge/BadgeModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/badge/BadgeModel.java
@@ -57,4 +57,8 @@ public interface BadgeModel {
 
     void setIconPos(String iconPos);
 
+    String getOnclick();
+
+    void setOnclick(String onClick);
+
 }

--- a/primefaces/src/main/java/org/primefaces/model/badge/DefaultBadgeModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/badge/DefaultBadgeModel.java
@@ -36,6 +36,7 @@ public class DefaultBadgeModel implements BadgeModel, Serializable {
     private String styleClass;
     private String icon;
     private String iconPos;
+    private String onClick;
     private boolean visible = true;
 
     @Override
@@ -118,6 +119,16 @@ public class DefaultBadgeModel implements BadgeModel, Serializable {
         this.iconPos = iconPos;
     }
 
+    @Override
+    public String getOnclick() {
+        return onClick;
+    }
+
+    @Override
+    public void setOnclick(String onClick) {
+        this.onClick = onClick;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -165,6 +176,11 @@ public class DefaultBadgeModel implements BadgeModel, Serializable {
             return this;
         }
 
+        public Builder onClick(String onClick) {
+            badgeModel.setOnclick(onClick);
+            return this;
+        }
+
         public Builder visible(boolean visible) {
             badgeModel.setVisible(visible);
             return this;
@@ -174,5 +190,4 @@ public class DefaultBadgeModel implements BadgeModel, Serializable {
             return badgeModel;
         }
     }
-
 }

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -33145,6 +33145,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Client side callback to execute when the badge element clicked.]]>
+            </description>
+            <name>onclick</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/badge/badge.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/badge/badge.css
@@ -8,6 +8,7 @@
 .ui-overlay-badge {
     position: relative;
     display: inline-block;
+    cursor: pointer;
 }
 
 .ui-overlay-badge .ui-badge {


### PR DESCRIPTION
Fix #10921: Badge add onClick and delegate to target by default

If no `onClick` is defined it will delegate the onClick to its target component or a custom onClick can be defined.