### PR TITLE
Fix #10950: Use original FacesMessage instead of constructing a new one if possible (13.x)

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/fileupload/FileUpload.java
+++ b/primefaces/src/main/java/org/primefaces/component/fileupload/FileUpload.java
@@ -104,7 +104,7 @@ public class FileUpload extends FileUploadBase {
 
                 context.addMessage(getClientId(), e instanceof ValidatorException
                         ? ((ValidatorException) e).getFacesMessage()
-                        : new FacesMessage(FacesMessage.SEVERITY_ERROR, e.getMessage(), null));
+                        : new FacesMessage(FacesMessage.SEVERITY_ERROR, e.getMessage(), ""));
             }
         }
     }

--- a/primefaces/src/main/java/org/primefaces/component/fileupload/FileUpload.java
+++ b/primefaces/src/main/java/org/primefaces/component/fileupload/FileUpload.java
@@ -101,7 +101,10 @@ public class FileUpload extends FileUploadBase {
             }
             catch (VirusException | ValidatorException e) {
                 setValid(false);
-                context.addMessage(getClientId(context), new FacesMessage(FacesMessage.SEVERITY_ERROR, e.getMessage(), null));
+
+                context.addMessage(getClientId(), e instanceof ValidatorException
+                        ? ((ValidatorException) e).getFacesMessage()
+                        : new FacesMessage(FacesMessage.SEVERITY_ERROR, e.getMessage(), null));
             }
         }
     }


### PR DESCRIPTION
Fixes #10950