### PR TITLE
Fix #11005: 13.0.4 FileDownload AJAX escape name

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -85,7 +85,7 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
         String uri = DynamicContentSrcBuilder.buildStreaming(context, currentComponent, value, false);
         String monitorKeyCookieName = ResourceUtils.getMonitorKeyCookieName(context, monitorKey);
         PrimeFaces.current().executeScript(String.format("PrimeFaces.download('%s', '%s', '%s', '%s')",
-                uri, content.getContentType(), content.getName(), monitorKeyCookieName));
+                uri, content.getContentType(), EscapeUtils.forJavaScript(content.getName()), monitorKeyCookieName));
     }
 
     protected void regularDownload(FacesContext context, StreamedContent content) {


### PR DESCRIPTION
Fix #11005: 13.0.4 FileDownload AJAX escape name