### PR TITLE
update touchswipe.js to 1.6.19

### DIFF
--- a/docs/14_0_0/core/thirdpartylibs.md
+++ b/docs/14_0_0/core/thirdpartylibs.md
@@ -36,5 +36,5 @@ are many other third party libraries and plugins used to support features.
 | [Raphaël](../jsdocs/interfaces/node_modules__types_raphael.RaphaelStatic.html) | 2.3.0 | http://raphaeljs.com |
 | [Signature](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#signature) | 1.2.0 | http://keith-wood.name/signature.html |
 | [Timeline](../jsdocs/modules/node_modules_vis_timeline_declarations.html) | 7.7.2 | https://github.com/visjs/vis-timeline |
-| [TouchSwipe](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#swipe) | 1.6.18 | https://github.com/mattbryson/TouchSwipe-Jquery-Plugin |
-| [WebcamJS](../jsdocs/modules/src_PrimeFaces.Webcam.html) | 1.0.26 | http://github.com/jhuckaby |
+| [TouchSwipe](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#swipe) | 1.6.19 | https://github.com/mattbryson/TouchSwipe-Jquery-Plugin |
+| [WebcamJS](../jsdocs/modules/src_PrimeFaces.Webcam.html) | 1.0.26 | https://github.com/jhuckaby/webcamjs |

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/touch/touchswipe.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/touch/touchswipe.js
@@ -1,6 +1,6 @@
 /*
  * @fileOverview TouchSwipe - jQuery Plugin
- * @version 1.6.18
+ * @version 1.6.19
  *
  * @author Matt Bryson http://www.github.com/mattbryson
  * @see https://github.com/mattbryson/TouchSwipe-Jquery-Plugin
@@ -55,7 +55,7 @@
  * 			- Added "all" fingers value to the fingers property, so any combination of fingers triggers the swipe, allowing event handlers to check the finger count
  *
  * $Date: 2012-09-08 (Thurs, 9 Aug 2012) $
- * $version: 1.3.3	- Code tidy prep for minefied version
+ * $version: 1.3.3	- Code tidy prep for min version
  *
  * $Date: 2012-04-10 (wed, 4 Oct 2012) $
  * $version: 1.4.0	- Added pinch support, pinchIn and pinchOut
@@ -123,10 +123,13 @@
  *
  * $Date: 2016-04-29 (Fri, 29 April 2016) $
  * $version 1.6.16    - Swipes with 0 distance now allow default events to trigger.  So tapping any form elements or A tags will allow default interaction, but swiping will trigger a swipe.
-                        Removed the a, input, select etc from the excluded Children list as the 0 distance tap solves that issue.
-* $Date: 2016-05-19  (Fri, 29 April 2016) $
-* $version 1.6.17     - Fixed context issue when calling instance methods via $("selector").swipe("method");
-* $version 1.6.18     - now honors fallbackToMouseEvents=false for MS Pointer events when a Mouse is used.
+ *                       Removed the a, input, select etc from the excluded Children list as the 0 distance tap solves that issue.
+ * $Date: 2016-05-19  (Fri, 29 April 2016) $
+ * $version 1.6.17     - Fixed context issue when calling instance methods via $("selector").swipe("method");
+ * $version 1.6.18     - now honors fallbackToMouseEvents=false for MS Pointer events when a Mouse is used.
+ * 
+ * $Date: 2018-09-17  (Mon, 17 September 2018) $
+ * $version 1.6.19     - replaced jQuery bind with on, replaced deprecated `navigator.pointerEvents` with `window.PointerEvents`
 
  */
 
@@ -195,9 +198,9 @@
 
     SUPPORTS_TOUCH = 'ontouchstart' in window,
 
-    SUPPORTS_POINTER_IE10 = window.navigator.msPointerEnabled && !window.navigator.pointerEnabled && !SUPPORTS_TOUCH,
+    SUPPORTS_POINTER_IE10 = window.navigator.msPointerEnabled && !window.PointerEvent && !SUPPORTS_TOUCH,
 
-    SUPPORTS_POINTER = (window.navigator.pointerEnabled || window.navigator.msPointerEnabled) && !SUPPORTS_TOUCH,
+    SUPPORTS_POINTER = (window.PointerEvent || window.navigator.msPointerEnabled) && !SUPPORTS_TOUCH,
 
     PLUGIN_NS = 'TouchSwipe';
 
@@ -232,13 +235,13 @@
   * @property {boolean} [triggerOnTouchEnd=true] If true, the swipe events are triggered when the touch end event is received (user releases finger).  If false, it will be triggered on reaching the threshold, and then cancel the touch event automatically.
   * @property {boolean} [triggerOnTouchLeave=false] If true, then when the user leaves the swipe object, the swipe will end and trigger appropriate handlers.
   * @property {string|undefined} [allowPageScroll='auto'] How the browser handles page scrolls when the user is swiping on a touchSwipe object. See {@link $.fn.swipe.pageScroll}.  <br/><br/>
-  									<code>"auto"</code> : all undefined swipes will cause the page to scroll in that direction. <br/>
-  									<code>"none"</code> : the page will not scroll when user swipes. <br/>
-  									<code>"horizontal"</code> : will force page to scroll on horizontal swipes. <br/>
-  									<code>"vertical"</code> : will force page to scroll on vertical swipes. <br/>
-  * @property {boolean} [fallbackToMouseEvents=true] If true mouse events are used when run on a non touch device, false will stop swipes being triggered by mouse events on non tocuh devices.
+                    <code>"auto"</code> : all undefined swipes will cause the page to scroll in that direction. <br/>
+                    <code>"none"</code> : the page will not scroll when user swipes. <br/>
+                    <code>"horizontal"</code> : will force page to scroll on horizontal swipes. <br/>
+                    <code>"vertical"</code> : will force page to scroll on vertical swipes. <br/>
+  * @property {boolean} [fallbackToMouseEvents=true] If true mouse events are used when run on a non touch device, false will stop swipes being triggered by mouse events on non touch devices.
   * @property {string} [excludedElements=".noSwipe"] A jquery selector that specifies child elements that do NOT trigger swipes. By default this excludes elements with the class .noSwipe .
-  * @property {boolean} [preventDefaultEvents=true] by default default events are cancelled, so the page doesn't move.  You can dissable this so both native events fire as well as your handlers.
+  * @property {boolean} [preventDefaultEvents=true] by default default events are cancelled, so the page doesn't move.  You can disable this so both native events fire as well as your handlers.
 
   */
   var defaults = {
@@ -862,7 +865,7 @@
         triggerHandler(event, phase);
       } else if (options.triggerOnTouchEnd || (options.triggerOnTouchEnd === false && phase === PHASE_MOVE)) {
         //call this on jq event so we are cross browser
-        if (options.preventDefaultEvents !== false) {
+        if (options.preventDefaultEvents !== false && jqEvent.cancelable !== false) {
           jqEvent.preventDefault();
         }
         phase = PHASE_END;


### PR DESCRIPTION
While fixing #11022 I noticed that the touchswipe.js version in primefaces is outdated.
Changelog of 1.6.19:
- replaced jQuery bind with on (this was already internally fixed with #5938 )
- replaced deprecated `navigator.pointerEvents` with `window.PointerEvents`

I tested locally and it works.