### PR TITLE
Fix #10970: BlockUI delay binding global triggers until UI is loaded

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -40,7 +40,9 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
         this.render();
 
         if (this.cfg.triggers) {
-            this.bindTriggers();
+            // #10970 must wait until all components have been rendered and ready
+            var $this = this;
+            PrimeFaces.queueTask(function() { $this.bindTriggers() }, 1);
         }
 
         if (this.cfg.blocked) {


### PR DESCRIPTION
Fix #10970: BlockUI delay binding global triggers until UI is loaded

Basically this just delays it until the UI thread is back which is after the panel has been rendered and AJAX is fired