### PR TITLE
Fix #11125: Filter triggered by cut and paste

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -583,7 +583,14 @@ if (!PrimeFaces.utils) {
          * @return {boolean} `true` if the key is a meta key, or `false` otherwise.
          */
         isMetaKey: function(e) {
-            return PrimeFaces.env.browser.mac ? e.metaKey : e.ctrlKey;
+            if (e.originalEvent) {
+                // original event returns the metakey value at the time the event was generated
+                return PrimeFaces.env.browser.mac ? e.originalEvent.metaKey : e.originalEvent.ctrlKey;
+            }
+            else {
+                // jQuery returns the real time value of the meta key
+                return PrimeFaces.env.browser.mac ? e.metaKey  : e.ctrlKey;
+            }
         },
 
         /**
@@ -603,18 +610,14 @@ if (!PrimeFaces.utils) {
         isPrintableKey: function(e) {
             return e && e.key && (e.key.length === 1 || e.key === 'Unidentified');
         },
-
+        
         /**
-         * Ignores unprintable keys on filter input text box. Useful in filter input events in many components.
+         * Checks if the key pressed is cut, copy, or paste.
          * @param {JQuery.TriggeredEvent} e The key event that occurred.
-         * @return {boolean} `true` if the one of the keys to ignore was pressed, or `false` otherwise.
+         * @return {boolean} `true` if the key is cut/copy/paste, or `false` otherwise.
          */
-        ignoreFilterKey: function(e) {
+        isClipboardKey: function(e) {
             switch (e.key) {
-                case 'Backspace':
-                case 'Enter':
-                case 'Delete':
-                    return false;
                 case 'a':
                 case 'A':
                 case 'c':
@@ -623,8 +626,28 @@ if (!PrimeFaces.utils) {
                 case 'X':
                 case 'v':
                 case 'V':
-                    // allow select all, cut, copy, paste
                     return PrimeFaces.utils.isMetaKey(e);
+                default:
+                    return false;
+            }
+        },
+
+        /**
+         * Ignores unprintable keys on filter input text box. Useful in filter input events in many components.
+         * @param {JQuery.TriggeredEvent} e The key event that occurred.
+         * @return {boolean} `true` if the one of the keys to ignore was pressed, or `false` otherwise.
+         */
+        ignoreFilterKey: function(e) {
+            // cut copy paste allows filter to trigger
+            if (PrimeFaces.utils.isClipboardKey(e)) {
+                return false;
+            }
+            // backspace,enter,delete trigger a filter as well as printable key like 'a'
+            switch (e.key) {
+                case 'Backspace':
+                case 'Enter':
+                case 'Delete':
+                    return false;
                 default:
                     return !PrimeFaces.utils.isPrintableKey(e);
             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -143,6 +143,7 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
                 break;
                 
                 case 'Backspace':
+                case 'Delete':
                     return;
 
                 default:
@@ -151,7 +152,11 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
             }
 
             // #8958 allow TAB, F1, F12 etc
-            if (PrimeFaces.utils.ignoreFilterKey(e)) {
+            if (!PrimeFaces.utils.isPrintableKey(e)) {
+                return;
+            }
+            // #10714 allow clipboard events
+            if (PrimeFaces.utils.isClipboardKey(e)) {
                 return;
             }
 


### PR DESCRIPTION
Fix #11125: Filter triggered by cut and paste
Fix #10714 (Improved)

I learned something new that if you use `e.ctrlKey` on the jquery event it lazily evaluates so if you have let go of the CTRL key by the time the JS runs it will report `false` . You have to check `e.originalEvent.ctrlKey` which was the event at the time the key was pressed no matter when the JS executes!