### PR TITLE
Fix #3921: Menu rebind trigger after AJAX update

### DIFF
--- a/docs/14_0_0/components/slidemenu.md
+++ b/docs/14_0_0/components/slidemenu.md
@@ -23,14 +23,14 @@ id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
 binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 widgetVar | null | String | Name of the client side widget.
-model | null | MenuModel | MenuModel instance for programmatic menu.
-style | null | String | Inline style of the component.
-styleClass | null | String | Style class of the component.
-backLabel | Back | String | Text for back link.
-trigger | null | String | Id of the component whose triggerEvent will show the dynamic positioned menu.
 my | null | String | Corner of menu to align with trigger element.
 at | null | String | Corner of trigger to align with menu element.
+backLabel | Back | String | Text for back link.
+model | null | MenuModel | MenuModel instance for programmatic menu.
 overlay | false | Boolean | Defines positioning, when enabled menu is displayed with absolute position relative to the trigger. Default is false, meaning static positioning.
+style | null | String | Inline style of the component.
+styleClass | null | String | Style class of the component.
+trigger | null | String | Id of the component whose triggerEvent will show the dynamic positioned menu.
 triggerEvent | click | String | Event name of trigger that will show the dynamic positioned menu.
 
 ## Getting started with the SlideMenu

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -103,7 +103,7 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
 
         //listen global ajax send and complete callbacks
         $(document).on('pfAjaxSend.' + this.id, function(e, xhr, settings) {
-            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings, true)) {
+            if (!$this.cfg.blocked && PrimeFaces.ajax.Utils.isXhrSourceATrigger($this, settings, true)) {
                 $this.show();
             }
             else {
@@ -111,39 +111,15 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
                 PrimeFaces.queueTask(function() { $this.alignOverlay() });
             }
         }).on('pfAjaxComplete.' + this.id, function(e, xhr, settings) {
-            if (!$this.cfg.blocked && $this.isXhrSourceATrigger(settings, false)) {
+            if (!$this.cfg.blocked && PrimeFaces.ajax.Utils.isXhrSourceATrigger($this, settings, false)) {
                 $this.hide();
             }
         }).on('pfAjaxUpdated.' + this.id, function(e, xhr, settings) {
             // subscribe to all DOM update events so we can resize even if another DOM element changed
-            if (!$this.cfg.blocked && !$this.isXhrSourceATrigger(settings, true)) {
+            if (!$this.cfg.blocked && !PrimeFaces.ajax.Utils.isXhrSourceATrigger($this, settings, true)) {
                 PrimeFaces.queueTask(function() { $this.alignOverlay() });
             }
         });
-    },
-
-    /**
-     * Checks whether one of component's triggers equals the source ID from the provided settings.
-     *
-     * @param {JQuery.AjaxSettings} settings containing source ID.
-     * @param {boolean} triggerMustExist flag to check if the trigger must exist
-     * @returns {boolean} `true` if if one of component's triggers equals the source ID from the provided settings.
-     * @private
-     */
-    isXhrSourceATrigger: function(settings, triggerMustExist) {
-        var sourceId = PrimeFaces.ajax.Utils.getSourceId(settings);
-        if (!sourceId) {
-            return false;
-        }
-        // we must evaluate it each time as the DOM might has been changed
-        var triggers = PrimeFaces.expressions.SearchExpressionFacade.resolveComponents(this.jq, this.cfg.triggers);
-
-        // if trigger is null it has been removed from DOM so we need to hide the block UI
-        if (!triggers || triggers.length === 0) {
-            return !triggerMustExist;
-        }
-
-        return $.inArray(sourceId, triggers) !== -1;
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -175,6 +175,31 @@ if (!PrimeFaces.ajax) {
             },
 
             /**
+             * Checks whether one of component's triggers equals the source ID from the provided settings.
+             *
+             * @param {PrimeFaces.widget.BaseWidget} widget of the component to check for being the source.
+             * @param {JQuery.AjaxSettings} settings containing source ID.
+             * @param {boolean} triggerMustExist flag to check if the trigger must exist
+             * @returns {boolean} `true` if if one of component's triggers equals the source ID from the provided settings.
+             */
+            isXhrSourceATrigger: function(widget, settings, triggerMustExist) {
+                var sourceId = PrimeFaces.ajax.Utils.getSourceId(settings);
+                if (!sourceId) {
+                    return false;
+                }
+                var cfgTrigger = widget.cfg.trigger || widget.cfg.triggers;
+                // we must evaluate it each time as the DOM might has been changed
+                var triggers = PrimeFaces.expressions.SearchExpressionFacade.resolveComponents(widget.jq, cfgTrigger);
+
+                // if trigger is null it has been removed from DOM so we need to hide the block UI
+                if (!triggers || triggers.length === 0) {
+                    return !triggerMustExist;
+                }
+
+                return $.inArray(sourceId, triggers) !== -1;
+            },
+
+            /**
              * Updates the main hidden input element for each form.
              * @param {string} name Name of the hidden form input element, usually the same as the form.
              * @param {string} value Value to set on the hidden input element.


### PR DESCRIPTION
Fix #3921: Menu rebind trigger after AJAX update

Basically working off what I already did in BlockUI.

- [x]  Refactor `isXhrSourceATrigger` to Ajax Utils now its shared between these two
- [x] When an AJAX update happens on the `trigger` then re-evaluate and re-bind the trigger.

[pf-3921.zip](https://github.com/primefaces/primefaces/files/13787009/pf-3921.zip)

Reproducer shows the issue in 13.0.0 and shows its fixed in 14.0.0
