### PR TITLE
Fix #11188: GMap add key placeholder

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/addMarkers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/addMarkers.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=true"></script>
         <script>
             var currentMarker = null;
 

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/basic.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=true"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=true"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/circles.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/circles.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/controls.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/controls.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/event.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/event.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/geocode.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/geocode.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
         <script>
             function geocode() {
                 PF('geoMap').geocode(document.getElementById('address').value);

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/infoWindow.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/infoWindow.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/mapDialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/mapDialog.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/markerSelection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/markerSelection.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/markers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/markers.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/polygons.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/polygons.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/polylines.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/polylines.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/rectangles.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/rectangles.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/street.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/street.xhtml
@@ -6,7 +6,7 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+        <script src="https://maps.google.com/maps/api/js?key=XXX&amp;sensor=false"></script>
     </ui:define>
 
     <ui:define name="title">


### PR DESCRIPTION
Fix #11188: GMap add key placeholder

Confirmed this fixes the showcase when `XXX` is replaced by real key.