### PR TITLE
Fix  #11201: Update TabView Accessibility

### DIFF
--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
@@ -40,7 +40,7 @@ import org.primefaces.selenium.component.model.Tab;
  */
 public abstract class TabView extends AbstractComponent {
 
-    @FindBy(xpath = "//*[@role='tab']")
+    @FindBy(css = ".ui-tabs-header")
     private List<WebElement> headers;
 
     @FindBy(css = ".ui-tabs-panel")
@@ -53,7 +53,7 @@ public abstract class TabView extends AbstractComponent {
             List<Tab> tabs = new ArrayList<>();
 
             headers.forEach(headerElt -> {
-                String title = headerElt.getText();
+                String title = headerElt.findElement(By.tagName("a")).getText();
                 int index = getIndexOfHeader(headerElt);
                 WebElement content = contents.get(index);
 
@@ -89,7 +89,7 @@ public abstract class TabView extends AbstractComponent {
      * @return the selected tab
      */
     public Tab getSelectedTab() {
-        WebElement selectedTabHeader = findElement(By.className("ui-tabs-selected")).findElement(By.tagName("a"));
+        WebElement selectedTabHeader = findElement(By.className("ui-tabs-selected"));
         int index = getIndexOfHeader(selectedTabHeader);
 
         return getTabs().get(index);

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
@@ -40,10 +40,10 @@ import org.primefaces.selenium.component.model.Tab;
  */
 public abstract class TabView extends AbstractComponent {
 
-    @FindBy(css = ".ui-tabs-header")
+    @FindBy(xpath = "//*[@role='tab']")
     private List<WebElement> headers;
 
-    @FindBy(css = ".ui-tabs-panel")
+    @FindBy(xpath = "//*[@role='tabpanel']")
     private List<WebElement> contents;
 
     private List<Tab> tabs = null;
@@ -52,13 +52,15 @@ public abstract class TabView extends AbstractComponent {
         if (tabs == null) {
             List<Tab> tabs = new ArrayList<>();
 
-            headers.forEach(headerElt -> {
+            for (int i = 0; i < headers.size(); i++) {
+                WebElement headerElt = headers.get(i);
                 String title = headerElt.findElement(By.tagName("a")).getText();
                 int index = getIndexOfHeader(headerElt);
-                WebElement content = contents.get(index);
+                // Assuming contents are aligned with headers
+                WebElement content = contents.size() > i ? contents.get(i) : null;
 
                 tabs.add(new Tab(title, index, headerElt, content));
-            });
+            }
 
             this.tabs = tabs;
         }
@@ -74,12 +76,19 @@ public abstract class TabView extends AbstractComponent {
     public void toggleTab(int index) {
         final JSONObject cfg = getWidgetConfiguration();
         final boolean isDynamic = cfg.has("dynamic") && cfg.getBoolean("dynamic");
+        WebElement tabToToggle = headers.get(index); // Assumes headers are correctly identified
 
-        if (isDynamic || ComponentUtils.hasAjaxBehavior(getRoot(), "tabChange")) {
-            PrimeSelenium.guardAjax(headers.get(index)).click();
+        if (tabToToggle != null) {
+            if (isDynamic || ComponentUtils.hasAjaxBehavior(getRoot(), "tabChange")) {
+                PrimeSelenium.guardAjax(tabToToggle).click();
+            }
+            else {
+                tabToToggle.click();
+            }
         }
         else {
-            headers.get(index).click();
+            // Handle the case where the tab is not found or index is out of range
+            throw new NoSuchElementException("Tab at index " + index + " not found.");
         }
     }
 
@@ -96,6 +105,10 @@ public abstract class TabView extends AbstractComponent {
     }
 
     private Integer getIndexOfHeader(WebElement headerElt) {
-        return Integer.parseInt(headerElt.getAttribute("data-index"));
+        String id = headerElt.getAttribute("id");
+        if (id != null && id.contains("_header")) {
+            return Integer.parseInt(id.substring(id.lastIndexOf('-') + 1, id.indexOf("_header")));
+        }
+        return null;
     }
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
@@ -53,7 +53,7 @@ public abstract class TabView extends AbstractComponent {
             List<Tab> tabs = new ArrayList<>();
 
             headers.forEach(headerElt -> {
-                String title = headerElt.findElement(By.tagName("a")).getText();
+                String title = headerElt.getText();
                 int index = getIndexOfHeader(headerElt);
                 WebElement content = contents.get(index);
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
@@ -89,7 +89,7 @@ public abstract class TabView extends AbstractComponent {
      * @return the selected tab
      */
     public Tab getSelectedTab() {
-        WebElement selectedTabHeader = findElement(new By.ByClassName("ui-tabs-selected"));
+        WebElement selectedTabHeader = findElement(By.className("ui-tabs-selected")).findElement(By.tagName("a"));
         int index = getIndexOfHeader(selectedTabHeader);
 
         return getTabs().get(index);

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
@@ -39,7 +39,8 @@ public abstract class TabBase extends UIPanel {
         closable,
         titletip,
         ariaLabel,
-        menuTitle
+        menuTitle,
+        id
     }
 
     public TabBase() {
@@ -113,6 +114,14 @@ public abstract class TabBase extends UIPanel {
 
     public void setMenuTitle(String menuTitle) {
         getStateHelper().put(PropertyKeys.menuTitle, menuTitle);
+    }
+
+    public String getId() {
+        return (String) getStateHelper().eval(PropertyKeys.id, null);
+    }
+
+    public void setId(String id) {
+        getStateHelper().put(PropertyKeys.id, id);
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
@@ -39,8 +39,7 @@ public abstract class TabBase extends UIPanel {
         closable,
         titletip,
         ariaLabel,
-        menuTitle,
-        id
+        menuTitle
     }
 
     public TabBase() {
@@ -114,14 +113,6 @@ public abstract class TabBase extends UIPanel {
 
     public void setMenuTitle(String menuTitle) {
         getStateHelper().put(PropertyKeys.menuTitle, menuTitle);
-    }
-
-    public String getId() {
-        return (String) getStateHelper().eval(PropertyKeys.id, null);
-    }
-
-    public void setId(String id) {
-        getStateHelper().put(PropertyKeys.id, id);
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -262,26 +262,24 @@ public class TabViewRenderer extends CoreRenderer {
         }
 
         //title
+        String tabHeaderId = tab.getClientId(context) + "_header";
+        String tabContentId = tab.getClientId(context) + "_content";
         writer.startElement("a", null);
         writer.writeAttribute("href", "#" + tab.getClientId(context), null);
-        String tabId = tab.getId();
-        if (tabId == null) {
-            tabId = "tab-" + index;
-            tab.setId(tabId);
-        }
-        writer.writeAttribute("id", tabId, null);
+        writer.writeAttribute("id", tabHeaderId, null);
         writer.writeAttribute("role", "tab", null);
         writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
         writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
         writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("data-index", index, null);
-        writer.writeAttribute("aria-controls", tab.getClientId(context), null);
-        if(active) {
+        writer.writeAttribute("aria-controls", tabContentId, null);
+        if (active) {
             writer.writeAttribute("tabindex", "0", null);
         } else {
             writer.writeAttribute("tabindex", "-1", null);
         }
-        if (!FacetUtils.shouldRenderFacet(titleFacet)) {
+        if (!FacetUtils.shouldRenderFacet(titleFacet))
+        {
             String tabTitle = tab.getTitle();
             if (tabTitle != null) {
                 writer.writeText(tabTitle, null);
@@ -338,14 +336,16 @@ public class TabViewRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String styleClass = active ? TabView.ACTIVE_TAB_CONTENT_CLASS : TabView.INACTIVE_TAB_CONTENT_CLASS;
 
+        String tabHeaderId = tab.getClientId(context) + "_header";
+        String tabContentId = tab.getClientId(context) + "_content";
         writer.startElement("div", null);
-        writer.writeAttribute("id", tab.getClientId(context), null);
+        writer.writeAttribute("id", tabContentId, null);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "tabpanel", null);
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute("data-index", index, null);
         writer.writeAttribute("tabindex", "0", null);
-        writer.writeAttribute("aria-labelledby", tab.getId(), null);
+        writer.writeAttribute("aria-labelledby", tabHeaderId, null);
 
         if (dynamic) {
             if (active) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -275,11 +275,11 @@ public class TabViewRenderer extends CoreRenderer {
         writer.writeAttribute("aria-controls", tabContentId, null);
         if (active) {
             writer.writeAttribute("tabindex", "0", null);
-        } else {
+        }
+        else {
             writer.writeAttribute("tabindex", "-1", null);
         }
-        if (!FacetUtils.shouldRenderFacet(titleFacet))
-        {
+        if (!FacetUtils.shouldRenderFacet(titleFacet)) {
             String tabTitle = tab.getTitle();
             if (tabTitle != null) {
                 writer.writeText(tabTitle, null);

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -267,6 +267,7 @@ public class TabViewRenderer extends CoreRenderer {
         String tabId = tab.getId();
         if (tabId == null) {
             tabId = "tab-" + index;
+            tab.setId(tabId);
         }
         writer.writeAttribute("id", tabId, null);
         writer.writeAttribute("role", "tab", null);
@@ -344,7 +345,7 @@ public class TabViewRenderer extends CoreRenderer {
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute("data-index", index, null);
         writer.writeAttribute("tabindex", "0", null);
-        writer.writeAttribute("aria-labelledby", tabId, null);
+        writer.writeAttribute("aria-labelledby", tab.getId(), null);
 
         if (dynamic) {
             if (active) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -237,13 +237,12 @@ public class TabViewRenderer extends CoreRenderer {
             throws IOException {
         boolean withFacet = false;
         ResponseWriter writer = context.getResponseWriter();
-        String defaultStyleClass = active ? TabView.ACTIVE_TAB_HEADER_CLASS : TabView.INACTIVE_TAB_HEADER_CLASS;
-        defaultStyleClass = defaultStyleClass + " ui-corner-" + tabView.getOrientation();   //cornering
-        if (tab.isDisabled()) {
-            defaultStyleClass = defaultStyleClass + " ui-state-disabled";
-        }
-        String styleClass = tab.getTitleStyleClass();
-        styleClass = (styleClass == null) ? defaultStyleClass : defaultStyleClass + " " + styleClass;
+        String styleClass = getStyleClassBuilder(context)
+                .add(active, TabView.ACTIVE_TAB_HEADER_CLASS, TabView.INACTIVE_TAB_HEADER_CLASS)
+                .add("ui-corner-" + tabView.getOrientation())
+                .add(tab.isDisabled(), "ui-state-disabled")
+                .add(tab.getTitleStyleClass())
+                .build();
         UIComponent titleFacet = tab.getFacet("title");
         String tabindex = tab.isDisabled() ? "-1" : tabView.getTabindex();
 
@@ -316,7 +315,8 @@ public class TabViewRenderer extends CoreRenderer {
 
         tabView.forEachTab((tab, i, active) -> {
             try {
-                encodeTabContent(context, tab, i, active, dynamic, repeating);
+                String tabindex = active ? tabView.getTabindex() : "-1";
+                encodeTabContent(context, tab, i, active, dynamic, repeating, tabindex);
             }
             catch (IOException ex) {
                 throw new FacesException(ex);
@@ -326,11 +326,10 @@ public class TabViewRenderer extends CoreRenderer {
         writer.endElement("div");
     }
 
-    protected void encodeTabContent(FacesContext context, Tab tab, int index, boolean active, boolean dynamic, boolean repeating)
+    protected void encodeTabContent(FacesContext context, Tab tab, int index, boolean active, boolean dynamic, boolean repeating, String tabindex)
             throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String styleClass = active ? TabView.ACTIVE_TAB_CONTENT_CLASS : TabView.INACTIVE_TAB_CONTENT_CLASS;
-
         String clientId = tab.getClientId(context);
         String tabHeaderId = clientId + "_header";
         writer.startElement("div", null);
@@ -340,7 +339,7 @@ public class TabViewRenderer extends CoreRenderer {
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute(HTML.ARIA_LABELLEDBY, tabHeaderId, null);
         writer.writeAttribute("data-index", index, null);
-        writer.writeAttribute("tabindex", "0", null);
+        writer.writeAttribute("tabindex", tabindex, null);
 
         if (dynamic) {
             if (active) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -254,6 +254,7 @@ public class TabViewRenderer extends CoreRenderer {
         writer.startElement("li", tab);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "presentation", null);
+        writer.writeAttribute("data-index", index, null);
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
         }

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -253,25 +253,33 @@ public class TabViewRenderer extends CoreRenderer {
         //header container
         writer.startElement("li", tab);
         writer.writeAttribute("class", styleClass, null);
-        writer.writeAttribute("role", "tab", null);
-        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
-        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
-        writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
-        writer.writeAttribute("data-index", index, null);
+        writer.writeAttribute("role", "presentation", null);
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
         }
         if (tab.getTitletip() != null) {
             writer.writeAttribute("title", tab.getTitletip(), null);
         }
-        if (tabindex != null) {
-            writer.writeAttribute("tabindex", tabindex, null);
-        }
 
         //title
         writer.startElement("a", null);
         writer.writeAttribute("href", "#" + tab.getClientId(context), null);
-        writer.writeAttribute("tabindex", "-1", null);
+        String tabId = tab.getId();
+        if (tabId == null) {
+            tabId = "tab-" + index;
+        }
+        writer.writeAttribute("id", tabId, null);
+        writer.writeAttribute("role", "tab", null);
+        writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
+        writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
+        writer.writeAttribute("data-index", index, null);
+        writer.writeAttribute("aria-controls", tab.getClientId(context), null);
+        if(active) {
+            writer.writeAttribute("tabindex", "0", null);
+        } else {
+            writer.writeAttribute("tabindex", "-1", null);
+        }
         if (!FacetUtils.shouldRenderFacet(titleFacet)) {
             String tabTitle = tab.getTitle();
             if (tabTitle != null) {
@@ -335,6 +343,8 @@ public class TabViewRenderer extends CoreRenderer {
         writer.writeAttribute("role", "tabpanel", null);
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute("data-index", index, null);
+        writer.writeAttribute("tabindex", "0", null);
+        writer.writeAttribute("aria-labelledby", tabId, null);
 
         if (dynamic) {
             if (active) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -134,16 +134,13 @@ public class TabViewRenderer extends CoreRenderer {
         String clientId = tabView.getClientId(context);
         String widgetVar = tabView.resolveWidgetVar(context);
         String orientation = tabView.getOrientation();
-        String styleClass = tabView.getStyleClass();
-        String defaultStyleClass = TabView.CONTAINER_CLASS + " ui-tabs-" + orientation;
-        if (tabView.isScrollable()) {
-            defaultStyleClass = defaultStyleClass + " " + TabView.SCROLLABLE_TABS_CLASS;
-        }
-        styleClass = styleClass == null ? defaultStyleClass : defaultStyleClass + " " + styleClass;
-
-        if (ComponentUtils.isRTL(context, tabView)) {
-            styleClass += " ui-tabs-rtl";
-        }
+        String styleClass = getStyleClassBuilder(context)
+                .add(TabView.CONTAINER_CLASS)
+                .add("ui-tabs-" + orientation)
+                .add(tabView.isScrollable(), TabView.SCROLLABLE_TABS_CLASS)
+                .add(tabView.getStyleClass())
+                .add(ComponentUtils.isRTL(context, tabView), "ui-tabs-rtl")
+                .build();
 
         writer.startElement("div", tabView);
         writer.writeAttribute("id", clientId, null);
@@ -265,21 +262,17 @@ public class TabViewRenderer extends CoreRenderer {
         //title
         String clientId = tab.getClientId(context);
         String tabHeaderId = clientId + "_header";
-        String tabContentId = clientId + "_content";
         writer.startElement("a", null);
-        writer.writeAttribute("href", "#" + tab.getClientId(context), null);
         writer.writeAttribute("id", tabHeaderId, null);
+        writer.writeAttribute("href", "#" + clientId, null);
         writer.writeAttribute("role", "tab", null);
         writer.writeAttribute(HTML.ARIA_EXPANDED, String.valueOf(active), null);
         writer.writeAttribute(HTML.ARIA_SELECTED, String.valueOf(active), null);
         writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("data-index", index, null);
-        writer.writeAttribute("aria-controls", tabContentId, null);
-        if (active) {
-            writer.writeAttribute("tabindex", "0", null);
-        }
-        else {
-            writer.writeAttribute("tabindex", "-1", null);
+        writer.writeAttribute("aria-controls", clientId, null);
+        if (tabindex != null) {
+            writer.writeAttribute("tabindex", tabindex, null);
         }
         if (!FacetUtils.shouldRenderFacet(titleFacet)) {
             String tabTitle = tab.getTitle();
@@ -340,15 +333,14 @@ public class TabViewRenderer extends CoreRenderer {
 
         String clientId = tab.getClientId(context);
         String tabHeaderId = clientId + "_header";
-        String tabContentId = clientId + "_content";
         writer.startElement("div", null);
-        writer.writeAttribute("id", tabContentId, null);
+        writer.writeAttribute("id", clientId, null);
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "tabpanel", null);
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
+        writer.writeAttribute(HTML.ARIA_LABELLEDBY, tabHeaderId, null);
         writer.writeAttribute("data-index", index, null);
         writer.writeAttribute("tabindex", "0", null);
-        writer.writeAttribute("aria-labelledby", tabHeaderId, null);
 
         if (dynamic) {
             if (active) {

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -262,8 +262,9 @@ public class TabViewRenderer extends CoreRenderer {
         }
 
         //title
-        String tabHeaderId = tab.getClientId(context) + "_header";
-        String tabContentId = tab.getClientId(context) + "_content";
+        String clientId = tab.getClientId(context);
+        String tabHeaderId = clientId + "_header";
+        String tabContentId = clientId + "_content";
         writer.startElement("a", null);
         writer.writeAttribute("href", "#" + tab.getClientId(context), null);
         writer.writeAttribute("id", tabHeaderId, null);
@@ -336,8 +337,9 @@ public class TabViewRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String styleClass = active ? TabView.ACTIVE_TAB_CONTENT_CLASS : TabView.INACTIVE_TAB_CONTENT_CLASS;
 
-        String tabHeaderId = tab.getClientId(context) + "_header";
-        String tabContentId = tab.getClientId(context) + "_content";
+        String clientId = tab.getClientId(context);
+        String tabHeaderId = clientId + "_header";
+        String tabContentId = clientId + "_content";
         writer.startElement("div", null);
         writer.writeAttribute("id", tabContentId, null);
         writer.writeAttribute("class", styleClass, null);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -282,10 +282,11 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
             tabs = this.headerContainer;
 
         /* For Screen Reader and Keyboard accessibility */
-        tabs.not('.ui-state-disabled').attr('tabindex', this.tabindex);
+        tabs = tabs.not('.ui-state-disabled').find('a');
+        tabs.attr('tabindex', this.tabindex);
 
         tabs.on('focus.tabview', function(e) {
-            var focusedTab = $(this);
+            var focusedTab = $(this).parent();
 
             if(!focusedTab.hasClass('ui-state-disabled')) {
                 focusedTab.addClass('ui-tabs-outline');
@@ -301,47 +302,43 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
             }
         })
         .on('blur.tabview', function(){
-            $(this).removeClass('ui-tabs-outline');
+            $(this).parent().removeClass('ui-tabs-outline');
         })
         .on('keydown.tabview', function(e) {
-            var element = $(this);
-            var keyCode = e.code;
-            if(PrimeFaces.utils.isActionKey(e) && !element.hasClass('ui-state-disabled')) {
-                $this.select(element.index());
-                e.preventDefault();
-            } else {
-                switch(keyCode) {
-                    case 'ArrowRight':
-                        var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
-                        if(nextTab.length) {
-                            nextTab.trigger('focus.tabview');
-                        }
+            var element = $(this).parent();
+            switch (e.code) {
+                case 'ArrowRight':
+                    var nextTab = element.nextAll('.ui-tabs-header:not(.ui-state-disabled)');
+                    if (nextTab.length) {
+                        nextTab.first().find('a').trigger('focus.tabview');
+                    }
+                    e.preventDefault();
+                    break;
+                case 'ArrowLeft':
+                    var prevTab = element.prevAll('.ui-tabs-header:not(.ui-state-disabled)');
+                    if (prevTab.length) {
+                        prevTab.first().find('a').trigger('focus.tabview');
+                    }
+                    e.preventDefault();
+                    break;
+                case 'NumpadEnter':
+                case 'Enter':
+                case 'Space':
+                    if (!element.hasClass('ui-state-disabled')) {
+                        $this.select(element.data('index'));
                         e.preventDefault();
-                        break;
-                    case 'ArrowLeft':
-                        var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
-                        if(prevTab.length) {
-                            prevTab.trigger('focus.tabview');
-                        }
-                        e.preventDefault();
-                        break;
-                    case 'NumpadEnter':
-                    case 'Enter':
-                    case 'Space':
-                        $this.select(element.index());
-                        e.preventDefault();
-                        break;
-                    case 'Home':
-                    case 'PageUp':
-                        $this.headerContainer.first().trigger('focus.tabview');
-                        e.preventDefault();
-                        break;
-                    case 'End':
-                    case 'PageDown':
-                        $this.headerContainer.last().trigger('focus.tabview');
-                        e.preventDefault();
-                        break;
-                }
+                    }
+                    break;
+                case 'Home':
+                case 'PageUp':
+                    $this.headerContainer.first().find('a').trigger('focus.tabview');
+                    e.preventDefault();
+                    break;
+                case 'End':
+                case 'PageDown':
+                    $this.headerContainer.last().find('a').trigger('focus.tabview');
+                    e.preventDefault();
+                    break;
             }
         });
 
@@ -584,16 +581,16 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         //aria
         oldPanel.attr('aria-hidden', true);
         oldPanel.addClass('ui-helper-hidden');
-        oldHeader.attr('aria-expanded', false);
-        oldHeader.attr('aria-selected', false);
+        oldHeader.find('a').attr('aria-expanded', false);
+        oldHeader.find('a').attr('aria-selected', false);
         if(hasOldActions) {
             oldActions.attr('aria-hidden', true);
         }
 
         newPanel.attr('aria-hidden', false);
         newPanel.removeClass('ui-helper-hidden');
-        newHeader.attr('aria-expanded', true);
-        newHeader.attr('aria-selected', true);
+        newHeader.find('a').attr('aria-expanded', true);
+        newHeader.find('a').attr('aria-selected', true);
         if(hasNewActions) {
             newActions.attr('aria-hidden', false);
         }
@@ -822,7 +819,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
      * @param {number} index 0-based index of the tab to disable.
      */
     disable: function(index) {
-        this.headerContainer.eq(index).addClass('ui-state-disabled').attr('tabindex', '-1');
+        this.headerContainer.eq(index).addClass('ui-state-disabled').find('a').attr('tabindex', '-1');
     },
 
     /**
@@ -830,7 +827,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
      * @param {number} index 0-based index of the tab to enable.
      */
     enable: function(index) {
-        this.headerContainer.eq(index).removeClass('ui-state-disabled').attr('tabindex', this.tabindex);
+        this.headerContainer.eq(index).removeClass('ui-state-disabled').find('a').attr('tabindex', this.tabindex);
     },
 
     /**

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -305,8 +305,55 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         })
         .on('keydown.tabview', function(e) {
             var element = $(this);
+            var keyCode = e.which;
             if(PrimeFaces.utils.isActionKey(e) && !element.hasClass('ui-state-disabled')) {
                 $this.select(element.index());
+                e.preventDefault();
+            }
+            // Right arrow key
+            else if(keyCode === $.ui.keyCode.RIGHT) {
+                var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
+                if(nextTab.length) {
+                    nextTab.trigger('focus.tabview');
+                }
+                e.preventDefault();
+            }
+            // Left arrow key
+            else if(keyCode === $.ui.keyCode.LEFT) {
+                var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
+                if(prevTab.length) {
+                    prevTab.trigger('focus.tabview');
+                }
+                e.preventDefault();
+            }
+            // Enter or Space key
+            if(keyCode === $.ui.keyCode.ENTER || keyCode === $.ui.keyCode.SPACE) {
+                $this.select(element.index());
+                e.preventDefault();
+            }
+            // Home key
+            else if(keyCode === $.ui.keyCode.HOME) {
+                $this.headerContainer.first().trigger('focus.tabview');
+                e.preventDefault();
+            }
+            // End key
+            else if(keyCode === $.ui.keyCode.END) {
+                $this.headerContainer.last().trigger('focus.tabview');
+                e.preventDefault();
+            }
+            // Page up key
+            else if(keyCode === $.ui.keyCode.PAGE_UP) {
+                // Scroll to the first tab header
+                $this.scrollPanel.scrollTop(0);
+                $this.headerContainer.first().trigger('focus.tabview');
+                e.preventDefault();
+            }
+            // Page down key
+            else if(keyCode === $.ui.keyCode.PAGE_DOWN) {
+                // Scroll to the last tab header
+                var scrollPanelHeight = $this.scrollPanel[0].scrollHeight;
+                $this.scrollPanel.scrollTop(scrollPanelHeight);
+                $this.headerContainer.last().trigger('focus.tabview');
                 e.preventDefault();
             }
         });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -305,14 +305,14 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
         })
         .on('keydown.tabview', function(e) {
             var element = $(this);
-            var keyCode = e.which;
+            var keyCode = e.code;
             if(PrimeFaces.utils.isActionKey(e) && !element.hasClass('ui-state-disabled')) {
                 $this.select(element.index());
                 e.preventDefault();
             } else {
                 switch(keyCode) {
                     // Right arrow key
-                    case $.ui.keyCode.RIGHT:
+                    case 'ArrowRight':
                         var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
                         if(nextTab.length) {
                             nextTab.trigger('focus.tabview');
@@ -320,7 +320,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         e.preventDefault();
                         break;
                     // Left arrow key
-                    case $.ui.keyCode.LEFT:
+                    case 'ArrowLeft':
                         var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
                         if(prevTab.length) {
                             prevTab.trigger('focus.tabview');
@@ -328,29 +328,29 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         e.preventDefault();
                         break;
                     // Space and Enter key
-                    case $.ui.keyCode.ENTER:
-                    case $.ui.keyCode.SPACE:
+                    case 'NumpadEnter':
+                    case 'Space':
                         $this.select(element.index());
                         e.preventDefault();
                         break;
                     // Home key
-                    case $.ui.keyCode.HOME:
+                    case 'Home':
                         $this.headerContainer.first().trigger('focus.tabview');
                         e.preventDefault();
                         break;
                     // End key
-                    case $.ui.keyCode.END:
+                    case 'End':
                         $this.headerContainer.last().trigger('focus.tabview');
                         e.preventDefault();
                         break;
                     // Page up key
-                    case $.ui.keyCode.PAGE_UP:
+                    case 'PageUp':
                         $this.scrollPanel.scrollTop(0);
                         $this.headerContainer.first().trigger('focus.tabview');
                         e.preventDefault();
                         break;
                     // Page down key
-                    case $.ui.keyCode.PAGE_DOWN:
+                    case 'PageDown':
                         var scrollPanelHeight = $this.scrollPanel[0].scrollHeight;
                         $this.scrollPanel.scrollTop(scrollPanelHeight);
                         $this.headerContainer.last().trigger('focus.tabview');

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -329,6 +329,7 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         break;
                     // Space and Enter key
                     case 'NumpadEnter':
+                    case 'Enter':
                     case 'Space':
                         $this.select(element.index());
                         e.preventDefault();

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -344,19 +344,6 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         $this.headerContainer.last().trigger('focus.tabview');
                         e.preventDefault();
                         break;
-                    // Page up key
-                    case 'PageUp':
-                        $this.scrollPanel.scrollTop(0);
-                        $this.headerContainer.first().trigger('focus.tabview');
-                        e.preventDefault();
-                        break;
-                    // Page down key
-                    case 'PageDown':
-                        var scrollPanelHeight = $this.scrollPanel[0].scrollHeight;
-                        $this.scrollPanel.scrollTop(scrollPanelHeight);
-                        $this.headerContainer.last().trigger('focus.tabview');
-                        e.preventDefault();
-                        break;
                 }
             }
         });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -309,52 +309,54 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
             if(PrimeFaces.utils.isActionKey(e) && !element.hasClass('ui-state-disabled')) {
                 $this.select(element.index());
                 e.preventDefault();
-            }
-            // Right arrow key
-            else if(keyCode === $.ui.keyCode.RIGHT) {
-                var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
-                if(nextTab.length) {
-                    nextTab.trigger('focus.tabview');
+            } else {
+                switch(keyCode) {
+                    // Right arrow key
+                    case $.ui.keyCode.RIGHT:
+                        var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
+                        if(nextTab.length) {
+                            nextTab.trigger('focus.tabview');
+                        }
+                        e.preventDefault();
+                        break;
+                    // Left arrow key
+                    case $.ui.keyCode.LEFT:
+                        var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
+                        if(prevTab.length) {
+                            prevTab.trigger('focus.tabview');
+                        }
+                        e.preventDefault();
+                        break;
+                    // Space and Enter key
+                    case $.ui.keyCode.ENTER:
+                    case $.ui.keyCode.SPACE:
+                        $this.select(element.index());
+                        e.preventDefault();
+                        break;
+                    // Home key
+                    case $.ui.keyCode.HOME:
+                        $this.headerContainer.first().trigger('focus.tabview');
+                        e.preventDefault();
+                        break;
+                    // End key
+                    case $.ui.keyCode.END:
+                        $this.headerContainer.last().trigger('focus.tabview');
+                        e.preventDefault();
+                        break;
+                    // Page up key
+                    case $.ui.keyCode.PAGE_UP:
+                        $this.scrollPanel.scrollTop(0);
+                        $this.headerContainer.first().trigger('focus.tabview');
+                        e.preventDefault();
+                        break;
+                    // Page down key
+                    case $.ui.keyCode.PAGE_DOWN:
+                        var scrollPanelHeight = $this.scrollPanel[0].scrollHeight;
+                        $this.scrollPanel.scrollTop(scrollPanelHeight);
+                        $this.headerContainer.last().trigger('focus.tabview');
+                        e.preventDefault();
+                        break;
                 }
-                e.preventDefault();
-            }
-            // Left arrow key
-            else if(keyCode === $.ui.keyCode.LEFT) {
-                var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
-                if(prevTab.length) {
-                    prevTab.trigger('focus.tabview');
-                }
-                e.preventDefault();
-            }
-            // Enter or Space key
-            if(keyCode === $.ui.keyCode.ENTER || keyCode === $.ui.keyCode.SPACE) {
-                $this.select(element.index());
-                e.preventDefault();
-            }
-            // Home key
-            else if(keyCode === $.ui.keyCode.HOME) {
-                $this.headerContainer.first().trigger('focus.tabview');
-                e.preventDefault();
-            }
-            // End key
-            else if(keyCode === $.ui.keyCode.END) {
-                $this.headerContainer.last().trigger('focus.tabview');
-                e.preventDefault();
-            }
-            // Page up key
-            else if(keyCode === $.ui.keyCode.PAGE_UP) {
-                // Scroll to the first tab header
-                $this.scrollPanel.scrollTop(0);
-                $this.headerContainer.first().trigger('focus.tabview');
-                e.preventDefault();
-            }
-            // Page down key
-            else if(keyCode === $.ui.keyCode.PAGE_DOWN) {
-                // Scroll to the last tab header
-                var scrollPanelHeight = $this.scrollPanel[0].scrollHeight;
-                $this.scrollPanel.scrollTop(scrollPanelHeight);
-                $this.headerContainer.last().trigger('focus.tabview');
-                e.preventDefault();
             }
         });
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -311,7 +311,6 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                 e.preventDefault();
             } else {
                 switch(keyCode) {
-                    // Right arrow key
                     case 'ArrowRight':
                         var nextTab = element.nextAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
                         if(nextTab.length) {
@@ -319,7 +318,6 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         }
                         e.preventDefault();
                         break;
-                    // Left arrow key
                     case 'ArrowLeft':
                         var prevTab = element.prevAll('.ui-tabview-nav:not(.ui-state-disabled)').first();
                         if(prevTab.length) {
@@ -327,20 +325,19 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
                         }
                         e.preventDefault();
                         break;
-                    // Space and Enter key
                     case 'NumpadEnter':
                     case 'Enter':
                     case 'Space':
                         $this.select(element.index());
                         e.preventDefault();
                         break;
-                    // Home key
                     case 'Home':
+                    case 'PageUp':
                         $this.headerContainer.first().trigger('focus.tabview');
                         e.preventDefault();
                         break;
-                    // End key
                     case 'End':
+                    case 'PageDown':
                         $this.headerContainer.last().trigger('focus.tabview');
                         e.preventDefault();
                         break;


### PR DESCRIPTION
Fix  [#11201](https://github.com/primefaces/primefaces/issues/11201): Update TabView Accessibility

### Changes
**Structural**
- Move all the aria attributes from the `li` elements and shift them to the `a` element
- In the `li` element we won't set the `tabindex="-1"` attribute because having them, we cannot focus on them by the keyboard when navigating with the Tab and Shift + Tab keys.
- Add the attribute `role="presentation"` to the `li` element after
- In the `a` element, add functionality that if `aria-selected="true"` then `tabindex="0"`, otherwise `tabindex="-1"`
- Generate an `id` dynamically for the `a` element if not provided (ex - `id="tab-1"`), and this value will be referred to in the attribute `aria-labelledby="tab-1"` of the corresponding div with the attribute `role="tabpanel"`
- Generate an `id` dynamically for the div element if not provided with the attribute `role="tabpanel"` (ex - `id="tabpanel-1"`), and this value will be referred to in the attribute `aria-controls="tabpanel-1"` of the corresponding `a` element with the attribute `role="tab"`
- Add a `tabindex="0"` to each `div` element with attribute `role="tabpanel"` to make the component easier for inexperienced keyboard-only users to navigate

**Functional**
_This will be a manually activated tab_
- <kbd>Left</kbd> = highlight the previous tab without activating it.
- <kbd>Right</kbd> = highlight the next tab without activating it.
- <kbd>Enter</kbd> or <kbd>Space</kbd> = activate the currently highlighted tab.
- <kbd>Home</kbd> / <kbd>PageUp</kbd>_(optional)_ = highlight the first tab without activating it.
- <kbd>End</kbd> /  <kbd>PageDown</kbd> _(optional)_ = highlight the last tab without activating it.