### PR TITLE
Fix #3551: Datatable remember multiple selection between AJAX updates

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable005.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable005.xhtml
@@ -17,7 +17,8 @@
             </p:messages>
 
             <p:dataTable id="datatable" value="#{dataTable005.progLanguages}" var="lang"
-                         selection="#{dataTable005.selectedProgLanguages}" rowKey="#{lang.id}">
+                         selection="#{dataTable005.selectedProgLanguages}" rowKey="#{lang.id}" 
+                         selectionMode="multiple">
                 <p:column field="id"/>
 
                 <p:column field="name"/>
@@ -27,6 +28,7 @@
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable005.submit}"/>
             <p:commandButton id="buttonUpdate" value="Update" update="datatable"/>
+            <p:commandButton id="buttonProcess" value="Process" update="datatable" process="@this"/>
         </h:form>
 
     </h:body>

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable005Array.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable005Array.xhtml
@@ -27,6 +27,7 @@
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable005Array.submit}"/>
             <p:commandButton id="buttonUpdate" value="Update" update="datatable"/>
+            <p:commandButton id="buttonProcess" value="Process" update="datatable" process="@this"/>
         </h:form>
 
     </h:body>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005Test.java
@@ -119,6 +119,34 @@ class DataTable005Test extends AbstractDataTableTest {
         assertMessage("Selected ProgrammingLanguage(s)", "1,3,4,5");
     }
 
+    @ParameterizedTest
+    @MethodSource("provideXhtmls")
+    @Order(3)
+    @DisplayName("DataTable:GitHub #3551 selection remain selected after AJAX update of table")
+    void selectionUpdateKeepSelection(String xhtml) {
+        // Arrange
+        goTo(xhtml);
+        DataTable dataTable = getDataTable();
+        assertNotNull(dataTable);
+
+        // Act
+        Actions actions = new Actions(getWebDriver());
+        actions.keyDown(Keys.META).click(dataTable.getCell(2, 0).getWebElement()).keyUp(Keys.META).perform();
+        actions.keyDown(Keys.SHIFT).click(dataTable.getCell(4, 0).getWebElement()).keyUp(Keys.SHIFT).perform();
+        getButtonProcess().click();
+
+        // Assert
+        dataTable = getDataTable();
+        assertConfiguration(dataTable.getWidgetConfiguration());
+
+        // make sure rows 3,4,5 are still selected and 0,1 not selected
+        assertCss(dataTable.getRow(0).getWebElement(), "ui-widget-content", "ui-datatable-even", "ui-datatable-selectable");
+        assertCss(dataTable.getRow(1).getWebElement(), "ui-widget-content", "ui-datatable-odd", "ui-datatable-selectable");
+        assertCss(dataTable.getRow(2).getWebElement(), "ui-widget-content", "ui-datatable-even", "ui-datatable-selectable", "ui-state-highlight");
+        assertCss(dataTable.getRow(3).getWebElement(), "ui-widget-content", "ui-datatable-odd", "ui-datatable-selectable", "ui-state-highlight");
+        assertCss(dataTable.getRow(4).getWebElement(), "ui-widget-content", "ui-datatable-even", "ui-datatable-selectable", "ui-state-highlight");
+    }
+
     private void assertMessage(String summary, String detail) {
         assertTrue(getMessages().getMessage(0).getSummary().contains(summary));
         assertTrue(getMessages().getMessage(0).getDetail().contains(detail));
@@ -150,5 +178,9 @@ class DataTable005Test extends AbstractDataTableTest {
 
     private CommandButton getButtonUpdate() {
         return PrimeSelenium.createFragment(CommandButton.class, By.id("form:buttonUpdate"));
+    }
+
+    private CommandButton getButtonProcess() {
+        return PrimeSelenium.createFragment(CommandButton.class, By.id("form:buttonProcess"));
     }
 }


### PR DESCRIPTION
Fix #3551: Datatable remember multiple selection between AJAX updates

This PR stores the `rowMeta` and not just the `index` of the rows selected between AJAX updates.  This allows a lookup by the `rowKey` to find the rows selected again or if they have changed (aka removed) indexes in between AJAX updates it can still find the correct rows by row key.

- Store `rowMeta` with `rowKey` instead of `rowIndex`
- After AJAX update if these have values lookup the new row by its `rowKey`
- Select rows that were selected before the AJAX update

