### PR TITLE
Fix #3210: Dialog reimplement minimize

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/dialog/dialog004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/dialog/dialog004.xhtml
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate />
+            </p:messages>
+
+			<p:dialog header="Minimizable" id="dlg" widgetVar="dlg"
+				minHeight="40" width="350" showEffect="fade" minimizable="true"
+				maximizable="true">
+				<p class="m-0">Lorem ipsum dolor sit amet, consectetur
+					adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+					dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+					exercitation ullamco laboris nisi ut aliquip ex ea commodo
+					consequat. Duis aute irure dolor in reprehenderit in voluptate
+					velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+					occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+					mollit anim id est laborum.</p>
+			</p:dialog>
+		</h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dialog/Dialog004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dialog/Dialog004Test.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.dialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.*;
+
+class Dialog004Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Dialog: #3210 Minimize reimplemented to mini")
+    void minimize(Page page) {
+        // Arrange
+        Dialog dialog = page.dialog;
+        dialog.show();
+        assertTrue(dialog.isVisible());
+        assertDisplayed(dialog.getMinimizeButton());
+        assertNotPresent(page.minimizedClone);
+
+        // Act
+        dialog.toggleMinimize();
+
+        // Assert
+        assertPresent(page.minimizedClone);
+        assertCss(page.minimizedClone, "ui-dialog-minimized");
+        assertTrue(dialog.isVisible()); // visible is true even for minimized
+        assertFalse(dialog.isDisplayed()); // dialog is in DOM but hidden
+        assertConfiguration(dialog.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Dialog: #3210 Minimize reimplemented from mini")
+    void minimizeRestore(Page page) {
+        // Arrange
+        Dialog dialog = page.dialog;
+        dialog.show();
+        assertTrue(dialog.isVisible());
+        assertDisplayed(dialog.getMinimizeButton());
+        dialog.toggleMinimize();
+        assertFalse(dialog.isDisplayed()); // dialog is in DOM but hidden
+        assertPresent(page.minimizedClone);
+
+        // Act
+        dialog.toggleMinimize(); // toggle minimize
+
+        // Assert
+        assertNotPresent(page.minimizedClone); // clone destroyed
+        assertTrue(dialog.isVisible()); // visible is true even for minimized
+        assertTrue(dialog.isDisplayed()); // dialog is in displayed
+        assertConfiguration(dialog.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Dialog: Maximimize")
+    void maximize(Page page) {
+        // Arrange
+        Dialog dialog = page.dialog;
+        dialog.show();
+        assertTrue(dialog.isVisible());
+        assertDisplayed(dialog.getMaximizeButton());
+
+        // Act
+        dialog.toggleMaximize();
+
+        // Assert
+        assertCss(dialog, "ui-dialog-maximized");
+        assertTrue(dialog.isVisible());
+        assertTrue(dialog.isDisplayed());
+        assertConfiguration(dialog.getWidgetConfiguration());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("Dialog Config = " + cfg);
+        assertTrue(cfg.getBoolean("draggable"));
+        assertTrue(cfg.getBoolean("cache"));
+        assertTrue(cfg.getBoolean("resizable"));
+        assertFalse(cfg.has("modal"));
+        assertEquals("350", cfg.getString("width"));
+        assertEquals("auto", cfg.getString("height"));
+        assertEquals("center", cfg.getString("position"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:dlg")
+        Dialog dialog;
+
+        @FindBy(id = "form:dlg_clone")
+        Dialog minimizedClone;
+
+        @Override
+        public String getLocation() {
+            return "dialog/dialog004.xhtml";
+        }
+    }
+}

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Dialog.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Dialog.java
@@ -40,12 +40,49 @@ public abstract class Dialog extends AbstractComponent {
     @FindBy(className = "ui-dialog-title")
     private WebElement title;
 
+    @FindBy(className = "ui-dialog-titlebar-close")
+    private WebElement closeButton;
+
+    @FindBy(className = "ui-dialog-titlebar-minimize")
+    private WebElement minimizeButton;
+
+    @FindBy(className = "ui-dialog-titlebar-maximize")
+    private WebElement maximizeButton;
+
     public WebElement getContent() {
         return content;
     }
 
     public String getTitle() {
         return title.getText();
+    }
+
+    public WebElement getCloseButton() {
+        return closeButton;
+    }
+
+    public void setCloseButton(WebElement closeButton) {
+        this.closeButton = closeButton;
+    }
+
+    public WebElement getMinimizeButton() {
+        return minimizeButton;
+    }
+
+    public void setMinimizeButton(WebElement minimizeButton) {
+        this.minimizeButton = minimizeButton;
+    }
+
+    public WebElement getMaximizeButton() {
+        return maximizeButton;
+    }
+
+    public void setMaximizeButton(WebElement maximizeButton) {
+        this.maximizeButton = maximizeButton;
+    }
+
+    public void setContent(WebElement content) {
+        this.content = content;
     }
 
     /**
@@ -55,6 +92,20 @@ public abstract class Dialog extends AbstractComponent {
      */
     public boolean isVisible() {
         return PrimeSelenium.executeScript("return " + getWidgetByIdScript() + ".isVisible();");
+    }
+
+    /**
+     * Minimize the dialog.
+     */
+    public void toggleMinimize() {
+        PrimeSelenium.executeScript(getWidgetByIdScript() + ".toggleMinimize();");
+    }
+
+    /**
+     * Maximize the dialog.
+     */
+    public void toggleMaximize() {
+        PrimeSelenium.executeScript(getWidgetByIdScript() + ".toggleMaximize();");
     }
 
     /**


### PR DESCRIPTION
Fix #3210: Dialog reimplement minimize
Fix #3206

- Clone the dialog and remove everything but the title bar
- `hide()` the actual dialog on minimize and put this clone in the docking area
- On restore destroy the clone and just `show()` the original dialog again

This fixes all issues related to the DOM being detached and re-attached and losing event handlers like Editor etc.