### PR TITLE
Fix #9798: CellEditEvent access whole row/node edited

### DIFF
--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -28,6 +28,7 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     * JPALazyDataModel now supports wildcard filters with `setWildcardSupport(true);` so you can use `*`, `%`, `_` or `?` in filter
     * JPALazyDataModel now supports builder pattern for constructor.
     * Added `filterPlaceholder` for `Column` and `Columns`
+    * Added `rowData` to `CellEditEvent` which contains the entire row from the cell being edited.
 
 * Messages
     * Added `clearMessages` widget method to clear all current messages.

--- a/docs/migrationguide/13_0_0.md
+++ b/docs/migrationguide/13_0_0.md
@@ -1,6 +1,6 @@
 # Migration guide 12.0.0 -> 13.0.0
 
-> :warning: **JSF 2.0 and 2.1 support is deprecated in 13.0.0 and will be removed in 14.0.0!**
+!> **JSF 2.0 and 2.1 support is deprecated in 13.0.0 and will be removed in 14.0.0!**
 
 ## Core
   * Internet Explorer support has been completely removed

--- a/primefaces/src/main/java/org/primefaces/event/CellEditEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/CellEditEvent.java
@@ -45,15 +45,35 @@ public class CellEditEvent<T> extends AbstractAjaxBehaviorEvent {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Old value of the cell
+     */
     private T oldValue;
 
+    /**
+     * New value of the cell
+     */
     private T newValue;
 
+    /**
+     * (Optional) Row Index used only for DataTable to identify row
+     */
     private int rowIndex;
 
+    /**
+     * (Optional) Row Key used only for TreeTable to identify TreeNode
+     */
+    private String rowKey;
+
+    /**
+     * Column of the cell being edited
+     */
     private UIColumn column;
 
-    private String rowKey;
+    /**
+     * Data contained in the DataTable row or TreeTable node.
+     */
+    private Object rowData;
 
     public CellEditEvent(UIComponent component, Behavior behavior, int rowIndex, UIColumn column) {
         super(component, behavior);
@@ -85,6 +105,13 @@ public class CellEditEvent<T> extends AbstractAjaxBehaviorEvent {
         return newValue;
     }
 
+    public Object getRowData() {
+        if (rowData == null) {
+            rowData = resolveRowData();
+        }
+        return rowData;
+    }
+
     public int getRowIndex() {
         return rowIndex;
     }
@@ -95,6 +122,20 @@ public class CellEditEvent<T> extends AbstractAjaxBehaviorEvent {
 
     public String getRowKey() {
         return rowKey;
+    }
+
+    private Object resolveRowData() {
+        if (source instanceof UIData) {
+            DataTable data = (DataTable) source;
+            data.setRowModel(rowIndex);
+            return data.getRowData();
+        }
+        else if (source instanceof UITree) {
+            TreeTable data = (TreeTable) source;
+            data.setRowKey(data.getValue(), rowKey);
+            return data.getRowNode();
+        }
+        return null;
     }
 
     private T resolveValue() {


### PR DESCRIPTION
Fix #9798: CellEditEvent access whole row/node edited

This PR solves the issue by allowing access to the whole row "lazily" from the CellEdit event if you want to get say the primary key of the row being edited etc.