### PR TITLE
Fix #4725: Column accessible header text

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/crud.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/crud.xhtml
@@ -86,7 +86,7 @@
                         <h:outputText styleClass="product-badge status-#{product.inventoryStatus.name().toLowerCase()}"
                             value="#{product.inventoryStatus.text}" />
                     </p:column>
-                    <p:column exportable="false">
+                    <p:column exportable="false" ariaHeaderText="Actions">
                         <p:commandButton icon="pi pi-pencil" update=":dialogs:manage-product-content"
                             oncomplete="PF('manageProductDialog').show()"
                             styleClass="edit-button rounded-button ui-button-success" process="@this">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/expansion.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/expansion.xhtml
@@ -23,7 +23,7 @@
                     <f:facet name="header">
                         Expand rows to see detailed information
                     </f:facet>
-                    <p:column style="width:2rem">
+                    <p:column style="width:2rem" ariaHeaderText="Row Toggler">
                         <p:rowToggler/>
                     </p:column>
 

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/basic.xhtml
@@ -32,7 +32,7 @@
                     <p:column headerText="Type">
                         <h:outputText value="#{document.type}"/>
                     </p:column>
-                    <p:column style="width:3rem">
+                    <p:column style="width:3rem" ariaHeaderText="Actions">
                         <p:commandButton update=":form:documentPanel" oncomplete="PF('documentDialog').show()"
                                        title="View Detail" icon="pi pi-search">
                             <f:setPropertyActionListener value="#{document}" target="#{ttBasicView.selectedDocument}"/>

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -710,9 +710,15 @@ public class DataTableRenderer extends DataRenderer {
 
         UIComponent header = column.getFacet("header");
         String headerText = column.getHeaderText();
+        String ariaHeaderText = column.getAriaHeaderText();
+        String titleStyleClass = getStyleClassBuilder(context)
+                .add(DataTable.COLUMN_TITLE_CLASS)
+                .add(LangUtils.isNotBlank(ariaHeaderText), "ui-helper-hidden-accessible")
+                .build();
+        headerText = LangUtils.isNotBlank(headerText) ? headerText : ariaHeaderText;
 
         writer.startElement("span", null);
-        writer.writeAttribute("class", DataTable.COLUMN_TITLE_CLASS, null);
+        writer.writeAttribute("class", titleStyleClass, null);
 
         if (FacetUtils.shouldRenderFacet(header, table.isRenderEmptyFacets())) {
             header.encodeAll(context);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -623,6 +623,13 @@ public class TreeTableRenderer extends DataRenderer {
         ResponseWriter writer = context.getResponseWriter();
         UIComponent header = column.getFacet("header");
         String headerText = column.getHeaderText();
+        String ariaHeaderText = column.getAriaHeaderText();
+        headerText = LangUtils.isNotBlank(headerText) ? headerText : ariaHeaderText;
+
+        String titlestyleClass = getStyleClassBuilder(context)
+                .add("ui-column-title")
+                .add(LangUtils.isNotBlank(ariaHeaderText), "ui-helper-hidden-accessible")
+                .build();
 
         boolean columnVisible = column.isVisible();
         if (columnMeta != null && columnMeta.getVisible() != null) {
@@ -687,13 +694,13 @@ public class TreeTableRenderer extends DataRenderer {
         }
 
         writer.startElement("span", null);
-        writer.writeAttribute("class", "ui-column-title", null);
+        writer.writeAttribute("class", titlestyleClass, null);
 
         if (FacetUtils.shouldRenderFacet(header)) {
             header.encodeAll(context);
         }
         else if (headerText != null) {
-            writer.writeText(headerText, null);
+            writer.writeText(headerText, "headerText");
         }
 
         writer.endElement("span");


### PR DESCRIPTION
Fix #4725: Column accessible header text

We already had a column attrbribute for `ariaHeaderText` to displaying screen reader text on columns that do not have a header.

For example...

```xml
<p:column style="width:2rem" ariaHeaderText="Row Toggler">
   <p:rowToggler/>
</p:column>
```

Generates this HTML with `hidden-accessible` so we don't have empty `TH` tags.

```xml
<th id="j_id_7j:j_id_7k:j_id_7m" class="ui-state-default" aria-label="Row Toggler" scope="col" style="width:2rem">
   <span class="ui-column-title ui-helper-hidden-accessible">Row Toggler</span>
</th>
```