### PR TITLE
Fix #99: ConfirmDialog allow ajax=false submission

### DIFF
--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -12,6 +12,9 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     * `MOVE_SCRIPTS_TO_BOTTOM` adds new option `defer` to defer loading scripts
     * OS settings for `prefers-reduced-motion: reduce` is now respected and PF disables all animations
 
+* ConfirmDialog
+   * Added `ajax=false` support.
+
 * Accordion
     * Added `toggleSpeed` for toggle speed animation duration.
     * Added `scrollIntoView` to allow the active tab to be scrolled into the viewport

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001.java
@@ -47,6 +47,10 @@ public class ConfirmDialog001 implements Serializable {
         addMessage("Deleted", "Record deleted");
     }
 
+    public void nonAjax() {
+        addMessage("Non AJAX", "Full page submitted");
+    }
+
     public void addMessage(String summary, String detail) {
         TestUtils.addMessage(summary, detail);
     }

--- a/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog001.xhtml
@@ -14,12 +14,16 @@
         <h:form id="form">
             <p:messages id="message" showDetail="true"/>
 
-            <p:commandButton id="confirm" value="Confirm" action="#{confirmPopup001.confirm}" update="message" styleClass="p-mr-2" icon="pi pi-check">
+            <p:commandButton id="confirm" value="Confirm" action="#{confirmDialog001.confirm}" update="message" styleClass="p-mr-2" icon="pi pi-check">
                 <p:confirm header="Confirmation" message="Are you sure you want to proceed?" icon="pi pi-exclamation-triangle"/>
             </p:commandButton>
 
-            <p:commandButton id="delete" value="Delete" action="#{confirmPopup001.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
+            <p:commandButton id="delete" value="Delete" action="#{confirmDialog001.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
                 <p:confirm header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
+            </p:commandButton>
+            
+            <p:commandButton id="nonAjax" value="Non-Ajax" action="#{confirmDialog001.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
+                <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>
             </p:commandButton>
 
             <p:confirmDialog id="confirmdialog" global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">

--- a/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog002.xhtml
@@ -14,14 +14,18 @@
         <h:form id="form">
             <p:messages id="message" showDetail="true"/>
 
-            <p:commandLink id="confirm" value="Confirm" action="#{confirmPopup001.confirm}" update="message" styleClass="p-mr-2" icon="pi pi-check">
+            <p:commandLink id="confirm" value="Confirm" action="#{confirmDialog001.confirm}" update="message" styleClass="p-mr-2" icon="pi pi-check">
                 <p:confirm header="Confirmation" message="Are you sure you want to proceed?" icon="pi pi-exclamation-triangle"/>
             </p:commandLink>
 
-            <p:commandLink id="delete" value="Delete" action="#{confirmPopup001.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
+            <p:commandLink id="delete" value="Delete" action="#{confirmDialog001.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
                 <p:confirm header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
             </p:commandLink>
 
+            <p:commandLink id="nonAjax" value="Non-Ajax" action="#{confirmDialog001.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
+                <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>
+            </p:commandLink>
+            
             <p:confirmDialog id="confirmdialog" global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
                 <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes"/>
                 <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-flat"/>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
@@ -43,7 +43,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(1)
-    @DisplayName("ConfirmDialog: Show the dialog")
+    @DisplayName("ConfirmDialog: Button Show the dialog")
     void showDialog(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -60,7 +60,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(2)
-    @DisplayName("ConfirmDialog: Show widget method")
+    @DisplayName("ConfirmDialog: Button Show widget method")
     void showWidget(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -74,7 +74,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(3)
-    @DisplayName("ConfirmDialog: Hide widget method")
+    @DisplayName("ConfirmDialog: Button Hide widget method")
     void hideWidget(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -90,7 +90,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(4)
-    @DisplayName("ConfirmDialog: Confirm button pressing NO")
+    @DisplayName("ConfirmDialog: Button Confirm button pressing NO")
     void confirmNo(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -107,7 +107,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(5)
-    @DisplayName("ConfirmDialog: Confirm button pressing YES")
+    @DisplayName("ConfirmDialog: Button Confirm button pressing YES")
     void confirmYes(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -124,7 +124,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(6)
-    @DisplayName("ConfirmDialog: Delete button pressing NO")
+    @DisplayName("ConfirmDialog: Button Delete button pressing NO")
     void deleteNo(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -141,7 +141,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(7)
-    @DisplayName("ConfirmDialog: Delete button pressing YES")
+    @DisplayName("ConfirmDialog: Button Delete button pressing YES")
     void deleteYes(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -153,6 +153,41 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
         // Assert
         assertEquals("Record deleted", page.message.getMessage(0).getDetail());
+        assertDialog(page, false);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("ConfirmDialog: Button Non AJAX button pressing NO")
+    void nonAjaxNo(Page page) {
+        // Arrange
+        ConfirmDialog dialog = page.dialog;
+        assertFalse(dialog.isVisible());
+        page.nonAjax.click();
+
+        // Act
+        dialog.getNoButton().click();
+
+        // Assert
+        assertTrue(page.message.isEmpty());
+        assertDialog(page, false);
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("ConfirmDialog: Button Non AJAX button pressing YES")
+    void nonAjaxYes(Page page) {
+        // Arrange
+        ConfirmDialog dialog = page.dialog;
+        assertFalse(dialog.isVisible());
+        page.nonAjax.click();
+
+        // Act
+        PrimeSelenium.guardHttp(dialog.getYesButton().getRoot()).click();
+
+        // Assert
+        //PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(page.message));
+        //assertEquals("Full page submitted", page.message.getMessage(0).getDetail());
         assertDialog(page, false);
     }
 
@@ -208,6 +243,9 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
 
         @FindBy(id = "form:delete")
         CommandButton delete;
+
+        @FindBy(id = "form:nonAjax")
+        CommandButton nonAjax;
 
         @Override
         public String getLocation() {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog002Test.java
@@ -43,7 +43,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(1)
-    @DisplayName("ConfirmDialog: Show the dialog")
+    @DisplayName("ConfirmDialog: Link Show the dialog")
     void showDialog(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -60,7 +60,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(2)
-    @DisplayName("ConfirmDialog: Show widget method")
+    @DisplayName("ConfirmDialog: Link Show widget method")
     void showWidget(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -74,7 +74,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(3)
-    @DisplayName("ConfirmDialog: Hide widget method")
+    @DisplayName("ConfirmDialog: Link Hide widget method")
     void hideWidget(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -90,7 +90,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(4)
-    @DisplayName("ConfirmDialog: Confirm button pressing NO")
+    @DisplayName("ConfirmDialog: Link Confirm button pressing NO")
     void confirmNo(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -107,7 +107,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(5)
-    @DisplayName("ConfirmDialog: Confirm button pressing YES")
+    @DisplayName("ConfirmDialog: Link Confirm button pressing YES")
     void confirmYes(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -124,7 +124,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(6)
-    @DisplayName("ConfirmDialog: Delete button pressing NO")
+    @DisplayName("ConfirmDialog: Link Delete button pressing NO")
     void deleteNo(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -141,7 +141,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
     @Test
     @Order(7)
-    @DisplayName("ConfirmDialog: Delete button pressing YES")
+    @DisplayName("ConfirmDialog: Link Delete button pressing YES")
     void deleteYes(Page page) {
         // Arrange
         ConfirmDialog dialog = page.dialog;
@@ -153,6 +153,41 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
         // Assert
         assertEquals("Record deleted", page.message.getMessage(0).getDetail());
+        assertDialog(page, false);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("ConfirmDialog: Link Non AJAX button pressing NO")
+    void nonAjaxNo(Page page) {
+        // Arrange
+        ConfirmDialog dialog = page.dialog;
+        assertFalse(dialog.isVisible());
+        page.nonAjax.click();
+
+        // Act
+        dialog.getNoButton().click();
+
+        // Assert
+        assertTrue(page.message.isEmpty());
+        assertDialog(page, false);
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("ConfirmDialog: Link Non AJAX button pressing YES")
+    void nonAjaxYes(Page page) {
+        // Arrange
+        ConfirmDialog dialog = page.dialog;
+        assertFalse(dialog.isVisible());
+        page.nonAjax.click();
+
+        // Act
+        dialog.getYesButton().click();
+
+        // Assert
+        //PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(page.message));
+        //assertEquals("Full page submitted", page.message.getMessage(0).getDetail());
         assertDialog(page, false);
     }
 
@@ -208,6 +243,9 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
         @FindBy(id = "form:delete")
         CommandLink delete;
+
+        @FindBy(id = "form:nonAjax")
+        CommandLink nonAjax;
 
         @Override
         public String getLocation() {

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/overlay/ConfirmView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/overlay/ConfirmView.java
@@ -40,6 +40,10 @@ public class ConfirmView {
         addMessage("Confirmed", "Record deleted");
     }
 
+    public void nonAjax() {
+        addMessage("Non AJAX", "Full page submitted");
+    }
+
     public void addMessage(String summary, String detail) {
         FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_INFO, summary, detail);
         FacesContext.getCurrentInstance().addMessage(null, message);

--- a/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
@@ -25,8 +25,12 @@
                     <p:confirm header="Confirmation" message="Are you sure you want to proceed?" icon="pi pi-exclamation-triangle"/>
                 </p:commandButton>
 
-                <p:commandButton value="Delete" action="#{confirmView.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
+                <p:commandButton value="Delete" action="#{confirmView.delete}" update="message" styleClass="ui-button-danger mr-2" icon="pi pi-times">
                     <p:confirm header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
+                </p:commandButton>
+                
+                 <p:commandButton value="Non-Ajax" action="#{confirmView.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
+                    <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>
                 </p:commandButton>
 
                 <p:confirmDialog global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -198,6 +198,18 @@ if (!PrimeFaces.ajax) {
 
                 return $.inArray(sourceId, triggers) !== -1;
             },
+            
+            /**
+             * Is this script an AJAX request?
+             * @param {string} script the JS script to check
+             * @returns {boolean} `true` if this script contains an AJAX request
+             */
+            isAjaxRequest: function(script) {
+                return script.includes("PrimeFaces.ab(") || script.includes("pf.ab(")
+                    || script.includes("mojarra.ab(")
+                    || script.includes("myfaces.ab(")
+                    || script.includes("jsf.ajax.request") || script.includes("faces.ajax.request");
+            },
 
             /**
              * Updates the main hidden input element for each form.

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -939,8 +939,16 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
                 if(el.hasClass('ui-confirmdialog-yes') && PrimeFaces.confirmSource) {
                     var id = PrimeFaces.confirmSource.get(0);
                     var js = PrimeFaces.confirmSource.data('pfconfirmcommand');
-
-                    PrimeFaces.csp.executeEvent(id, js, e);
+                    
+                    // Test if the function matches the pattern
+                    if (PrimeFaces.ajax.Utils.isAjaxRequest(js)) {
+                        // command is ajax=true
+                        PrimeFaces.csp.executeEvent(id, js, e);
+                    }
+                    else {
+                        // command is ajax=false
+                        $(id).removeAttr("data-pfconfirmcommand").removeAttr("onclick").click();
+                    }
 
                     PrimeFaces.confirmDialog.hide();
                     PrimeFaces.confirmSource = null;


### PR DESCRIPTION
Fix #99: ConfirmDialog allow ajax=false submission

- [x] Integration Tests Added
- [x] Showcase example added
- [x] Basically if the function passed to the confirm dialog is EMPTY we know this is AJAX=false so remove the existing `onclick` event which brough up the dialog and then `click` the button.