### PR TITLE
Fix #11230: 13.0.5 CommandLink disabledOnAjax fix

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandlink.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.commandlink.js
@@ -50,20 +50,20 @@ PrimeFaces.widget.CommandLink = PrimeFaces.widget.BaseWidget.extend({
 
         if (this.cfg.disableOnAjax !== false) {
             $(document).on('pfAjaxSend.' + this.id, function(e, xhr, settings) {
-                $this.ajaxCount++;
-                if ($this.ajaxCount > 1) {
-                    return;
-                }
                 if (PrimeFaces.ajax.Utils.isXhrSource($this, settings)) {
+                    $this.ajaxCount++;
+                    if ($this.ajaxCount > 1) {
+                        return;
+                    }
                     $this.jq.addClass('ui-state-loading');
                     $this.disable();
                 }
             }).on('pfAjaxComplete.' + this.id, function(e, xhr, settings) {
-                $this.ajaxCount--;
-                if ($this.ajaxCount > 0) {
-                    return;
-                }
                 if (PrimeFaces.ajax.Utils.isXhrSource($this, settings)) {
+                    $this.ajaxCount--;
+                    if ($this.ajaxCount > 0) {
+                        return;
+                    }
                     $this.jq.removeClass('ui-state-loading');
                     if (!$this.cfg.disabledAttr) {
                         $this.enable();


### PR DESCRIPTION
Fix #11230: 13.0.5 CommandLink disabledOnAjax fix