### PR TITLE
Fix #3454: Confirm beforeShow docs

### DIFF
--- a/docs/10_0_0/components/confirm.md
+++ b/docs/10_0_0/components/confirm.md
@@ -19,6 +19,7 @@ Confirm is a behavior element used to integrate with global confirm dialog/popup
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | true | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog/popup topic in next section for details.

--- a/docs/11_0_0/components/confirm.md
+++ b/docs/11_0_0/components/confirm.md
@@ -19,6 +19,7 @@ Confirm is a behavior element used to integrate with global confirm dialog/popup
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | true | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog/popup topic in next section for details.

--- a/docs/12_0_0/components/confirm.md
+++ b/docs/12_0_0/components/confirm.md
@@ -20,6 +20,7 @@ Confirm is a behavior element used to integrate with global confirm dialog/popup
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | true | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog/popup topic in next section for details.

--- a/docs/13_0_0/components/confirm.md
+++ b/docs/13_0_0/components/confirm.md
@@ -20,6 +20,7 @@ Confirm is a behavior element used to integrate with global confirm dialog/popup
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | true | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog/popup topic in next section for details.

--- a/docs/14_0_0/components/confirm.md
+++ b/docs/14_0_0/components/confirm.md
@@ -20,6 +20,7 @@ Confirm is a behavior element used to integrate with global confirm dialog/popup
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | true | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog/popup topic in next section for details.

--- a/docs/7_0/components/confirm.md
+++ b/docs/7_0/components/confirm.md
@@ -18,6 +18,7 @@ Confirm is a behavior element used to integrate with global confirm dialog.
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | false | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog topic in next section for details.

--- a/docs/8_0/components/confirm.md
+++ b/docs/8_0/components/confirm.md
@@ -18,6 +18,7 @@ Confirm is a behavior element used to integrate with global confirm dialog.
 | icon | null | String | Icon to display next to message.
 | disabled | false | Boolean | Disables confirm behavior when true.
 | escape | false | Boolean | Whether to escape the message.
+| beforeShow | null | String | Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.
 
 ## Getting started with Confirm
 See global confirm dialog topic in next section for details.

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -533,6 +533,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.]]>
+            </description>
+            <name>beforeShow</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
 
     <tag>


### PR DESCRIPTION
Fix #3454: Confirm beforeShow docs

This has been there since 6.2 but never added to the taglib or docs!