### PR TITLE
Fix #9201: Growl support simultaneous sticky display

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/growl/growl.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/growl/growl.js
@@ -27,7 +27,9 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
         this._super(cfg);
 
         //create container
-        this.jq = $('<div id="' + this.id + '_container" class="ui-growl ui-widget" aria-live="polite"></div>');
+        var styleClass = "ui-growl ui-widget";
+        styleClass = this.cfg.sticky ? styleClass + " ui-growl-sticky" : styleClass;
+        this.jq = $('<div id="' + this.id + '_container" class="' + styleClass + '" aria-live="polite"></div>');
         this.jq.appendTo($(document.body));
 
         //render messages
@@ -40,7 +42,7 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
      * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
      */
     refresh: function(cfg) {
-    	this.cfg = cfg;
+        this.cfg = cfg;
         this.show(cfg.msgs);
 
         this.removeScriptElement(this.id);
@@ -77,7 +79,7 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
 
         this.jq.css('z-index', PrimeFaces.nextZindex());
 
-        if(!this.cfg.keepAlive) {
+        if (!this.cfg.keepAlive) {
             //clear previous messages
             this.removeAll();
         }
@@ -105,17 +107,17 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
         markup += '<div class="ui-growl-icon-close ui-icon ui-icon-closethick" style="display:none"></div>';
         markup += '<span class="ui-growl-image ui-growl-image-' + msg.severity + '" ></span>';
         // GitHub #5153 for screen readers
-        markup += '<span class="ui-growl-severity ui-helper-hidden-accessible">' + PrimeFaces.getAriaLabel('messages.'+msg.severity.toUpperCase()) + '</span>';
+        markup += '<span class="ui-growl-severity ui-helper-hidden-accessible">' + PrimeFaces.getAriaLabel('messages.' + msg.severity.toUpperCase()) + '</span>';
         markup += '<div class="ui-growl-message">';
         markup += '<span class="ui-growl-title"></span>';
         markup += '<p></p>';
         markup += '</div><div style="clear: both;"></div></div></div>';
 
         var message = $(markup),
-        summaryEL = message.find('span.ui-growl-title'),
-        detailEL = summaryEL.next();
+            summaryEL = message.find('span.ui-growl-title'),
+            detailEL = summaryEL.next();
 
-        if(this.cfg.escape) {
+        if (this.cfg.escape) {
             summaryEL.text(msg.summary);
             detailEL.text(msg.detail);
         }
@@ -136,30 +138,30 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
      */
     bindEvents: function(message) {
         var $this = this,
-        sticky = this.cfg.sticky;
+            sticky = this.cfg.sticky;
 
         message.on("mouseover", function() {
             var msg = $(this);
 
             //visuals
-            if(!msg.is(':animated')) {
+            if (!msg.is(':animated')) {
                 msg.find('div.ui-growl-icon-close:first').show();
             }
 
             // clear hide timeout on mouseover
-            if(!sticky) {
+            if (!sticky) {
                 clearTimeout(msg.data('timeout'));
             }
         })
-        .on("mouseout", function() {
-            //visuals
-            $(this).find('div.ui-growl-icon-close:first').hide();
+            .on("mouseout", function() {
+                //visuals
+                $(this).find('div.ui-growl-icon-close:first').hide();
 
-            // setup hide timeout again after mouseout
-            if(!sticky) {
-                $this.setRemovalTimeout(message);
-            }
-        });
+                // setup hide timeout again after mouseout
+                if (!sticky) {
+                    $this.setRemovalTimeout(message);
+                }
+            });
 
         //remove message on click of close icon
         var closeIcon = message.find('div.ui-growl-icon-close');
@@ -174,7 +176,7 @@ PrimeFaces.widget.Growl = PrimeFaces.widget.BaseWidget.extend({
         });
 
         //hide the message after given time if not sticky
-        if(!sticky) {
+        if (!sticky) {
             this.setRemovalTimeout(message);
         }
     },


### PR DESCRIPTION
Fix #9201: Growl support simultaneous sticky display

With this fix it simply adds a style `ui-growl-sticky` to the container allowing you to control sticky from non sticky separately with CSS like...

```css
body .ui-growl.ui-growl-sticky {
  top: 85px;
}

body .ui-growl {
  top: 170px;
}
```

Results in having them not stacked:
![image](https://github.com/primefaces/primefaces/assets/4399574/943b8d32-176d-4c91-99b7-a2cba4763912)

