### PR TITLE
Fix #2478: ColumnTogglerEvent giving access to UIColumn

### DIFF
--- a/docs/14_0_0/components/columntoggler.md
+++ b/docs/14_0_0/components/columntoggler.md
@@ -40,7 +40,7 @@ For this to contain meaningful ids your columns should define an id attribute ot
 
 | Event | Listener Parameter | Fired |
 | --- | --- | --- |
-| toggle | org.primefaces.event.ToggleEvent | On item selection/unselection. |
+| toggle | org.primefaces.event.ColumnToggleEvent | On item selection/unselection. |
 | close | org.primefaces.event.ToggleCloseEvent | On closing of toggler popup. |
 
 ## Client Side API

--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -24,17 +24,14 @@
 ## AutoComplete
 
   * `dropdownAriaLabel`, `emptyMessage`, `resultsMessage` properties have been moved to client side locale
+  
+## ColumnToggler
+
+  *  AJAX `toggle` event is now `org.primefaces.event.ColumnToggleEvent` giving access to `UIColumn` that was toggled
 
 ## DatePicker/Calendar
 
   * Locale `firstDay` renamed `firstDayOfWeek` to match other Prime libraries
-
-## FileUpload
-
-  * `invalidSizeMessage`, `invalidFileMessage`, `fileLimitMessage` are deprecated and will be removed in 15.0.0. PF i18n will be used for it.
-  * `maxFileSize`, `fileLimit`, `allowedTypes` are deprecated and will be removed in 15.0.0. Please attach `p:validateFile` to the `p:fileUpload` component.
-  * Simple FileUpload: Client side validation has been reimplemented with PrimeFaces CSV and support for `p:message(s)`/`p:growl`. Please make sure to enable CSV to use it.
-  * Simple FileUpload: filename is not displayed by default when `auto=true`, set `displayFilename=true` instead if you need it.
 
 ## DataTable
 
@@ -51,7 +48,14 @@ Few selection attributes have been renamed for consistency purposes:
   * `UIColumn#selectionMode` renamed to `selectionBox` and reworked. Since [13.0.0](https://github.com/primefaces/primefaces/issues/10129), `DataTable#selectionMode` is automatically deduced from `selection` value binding.
   
 !> Starting from 14.0.0, `DataTable#selectionMode` will be the single source of truth to configure whether selection should be `single` or `multiple`. To configure selection column, e.g display radiobutton or checkbox, `UIColumn#selectionBox` should be set to true. Whether it's a radiobutton or checkbox will depend on `DataTable#selectionMode`
- 
+
+## FileUpload
+
+  * `invalidSizeMessage`, `invalidFileMessage`, `fileLimitMessage` are deprecated and will be removed in 15.0.0. PF i18n will be used for it.
+  * `maxFileSize`, `fileLimit`, `allowedTypes` are deprecated and will be removed in 15.0.0. Please attach `p:validateFile` to the `p:fileUpload` component.
+  * Simple FileUpload: Client side validation has been reimplemented with PrimeFaces CSV and support for `p:message(s)`/`p:growl`. Please make sure to enable CSV to use it.
+  * Simple FileUpload: filename is not displayed by default when `auto=true`, set `displayFilename=true` instead if you need it.
+  
 ## MenuBar
 
   * `delay` has been renamed `showDelay` and new `hideDelay` property added

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/datatable/BasicView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/datatable/BasicView.java
@@ -26,10 +26,15 @@ package org.primefaces.showcase.view.data.datatable;
 import java.io.Serializable;
 import java.util.List;
 import javax.annotation.PostConstruct;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.primefaces.component.api.UIColumn;
+import org.primefaces.event.ColumnToggleEvent;
+import org.primefaces.model.Visibility;
 import org.primefaces.showcase.domain.Product;
 import org.primefaces.showcase.service.ProductService;
 
@@ -53,6 +58,15 @@ public class BasicView implements Serializable {
 
     public void setService(ProductService service) {
         this.service = service;
+    }
+
+    public void onToggle(ColumnToggleEvent e) {
+        Integer index = (Integer) e.getData();
+        UIColumn column = e.getColumn();
+        Visibility visibility = e.getVisibility();
+        String header = column.getAriaHeaderText() != null ? column.getAriaHeaderText() : column.getHeaderText();
+        FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_INFO, "Column " + index + " toggled: " + header + " " + visibility, null);
+        FacesContext.getCurrentInstance().addMessage(null, msg);
     }
 
 }

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/columnToggler.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/columnToggler.xhtml
@@ -18,6 +18,9 @@
 
     <ui:define name="implementation">
     <h:form>
+        <p:growl>
+            <p:autoUpdate />
+        </p:growl>
         <div class="card">
         <div class="flex justify-content-between">
            <div>
@@ -40,13 +43,13 @@
                         <div>
                             <p:commandButton id="toggler" type="button" value="Columns" icon="pi pi-align-justify"/>
                             <p:columnToggler datasource="products" trigger="toggler">
-                                <p:ajax />
+                                <p:ajax event="toggle" listener="#{dtBasicView.onToggle}"/>
                             </p:columnToggler>
                         </div>
                     </div>
                 </f:facet>
 
-                <p:column>
+                <p:column ariaHeaderText="Code">
                     <f:facet name="header">
                         <h:outputText value="Code" title="Code"/>
                     </f:facet>

--- a/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
+++ b/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
@@ -34,6 +34,9 @@ import javax.faces.event.AjaxBehaviorEvent;
 import javax.faces.event.BehaviorEvent;
 import javax.faces.event.FacesEvent;
 
+import org.primefaces.component.api.UIColumn;
+import org.primefaces.component.datatable.DataTable;
+import org.primefaces.event.ColumnToggleEvent;
 import org.primefaces.event.ToggleCloseEvent;
 import org.primefaces.event.ToggleEvent;
 import org.primefaces.expression.SearchExpressionUtils;
@@ -87,7 +90,8 @@ public class ColumnToggler extends ColumnTogglerBase {
             Visibility visibility = Visibility.valueOf(params.get(clientId + "_visibility"));
             int index = Integer.parseInt(params.get(clientId + "_index"));
 
-            super.queueEvent(new ToggleEvent(this, ((AjaxBehaviorEvent) event).getBehavior(), visibility, index));
+            UIColumn column = ((DataTable) getDataSourceComponent()).getColumns().get(index);
+            super.queueEvent(new ColumnToggleEvent(this, ((AjaxBehaviorEvent) event).getBehavior(), column, visibility, index));
         }
         else if (event instanceof AjaxBehaviorEvent && "close".equals(eventName)) {
             String clientId = this.getClientId(context);

--- a/primefaces/src/main/java/org/primefaces/event/ColumnToggleEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/ColumnToggleEvent.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.event;
+
+import javax.faces.component.UIComponent;
+import javax.faces.component.behavior.Behavior;
+import org.primefaces.component.api.UIColumn;
+import org.primefaces.model.Visibility;
+
+public class ColumnToggleEvent extends ToggleEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient UIColumn column;
+
+    public ColumnToggleEvent(UIComponent component, Behavior behavior, UIColumn column, Visibility visibility, Object data) {
+        super(component, behavior, visibility, data);
+        this.column = column;
+    }
+
+    public UIColumn getColumn() {
+        return column;
+    }
+}


### PR DESCRIPTION
Fix #2478: ColumnTogglerEvent giving access to UIColumn

This gives access to the `UIColumn` that was toggled so you can do...

```java
    public void onToggle(ColumnToggleEvent e) {
        Integer index = (Integer) e.getData();
        UIColumn column = e.getColumn();
        Visibility visibility = e.getVisibility();
        String header = column.getAriaHeaderText() != null ? column.getAriaHeaderText() : column.getHeaderText();
        FacesMessage msg = new FacesMessage(FacesMessage.SEVERITY_INFO, "Column " + index + " toggled: " + header + " " + visibility, null);
        FacesContext.getCurrentInstance().addMessage(null, msg);
    }
```

Backwards compatible since it extends `ToggleEvent`.