### PR TITLE
Fix #5710: 13.0.5 OverlayPanel destroy widget if target is removed from DOM

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/overlaypanel/OverlayPanel002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/overlaypanel/OverlayPanel002Test.java
@@ -112,8 +112,7 @@ public class OverlayPanel002Test extends AbstractPrimePageTest {
         page.btnDestroy.click();
 
         // Assert
-        Assertions.assertFalse(overlayPanel.isDisplayed());
-        assertConfiguration(overlayPanel.getWidgetConfiguration(), "@(body)");
+        assertNotPresent(overlayPanel);
     }
 
     @Test

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -191,6 +191,11 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
             });
 
         this.bindAutoHide();
+        
+        // GitHub #5710 Helper to destroy overlay if its target is destroyed
+        $this.target.off('remove.overlay').on('remove.overlay', function() {
+            $this.destroy();
+        });
     },
 
     /**


### PR DESCRIPTION
Fix #5710: 13.0.5 OverlayPanel destroy widget if target is removed from DOM