### PR TITLE
Fix #11290: Datatable selection disabled issues

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1497,7 +1497,7 @@ public class DataTableRenderer extends DataRenderer {
 
             writer.writeAttribute("id", table.getClientId(context) + "_" + rowKey + "_checkbox", null);
             writer.writeAttribute("role", "checkbox", null);
-            writer.writeAttribute("tabindex", "0", null);
+            writer.writeAttribute("tabindex", disabled ? "-1" : "0", null);
             writer.writeAttribute(HTML.ARIA_LABEL, ariaRowLabel, null);
             writer.writeAttribute(HTML.ARIA_CHECKED, String.valueOf(checked), null);
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4834,10 +4834,11 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 checkboxes = this.tbody.find('> tr > td.ui-selection-column > div.ui-chkbox > .ui-chkbox-box');
                 enabledCheckboxes = checkboxes.filter(':not(.ui-state-disabled)');
                 disabledCheckboxes = checkboxes.filter('.ui-state-disabled');
-                selectedCheckboxes = checkboxes.filter("div[aria-checked='true']");
+                selectedCheckboxes = enabledCheckboxes.filter("div[aria-checked='true']");
             }
 
-            if(enabledCheckboxes.length && enabledCheckboxes.length === selectedCheckboxes.length)
+            var totalEnabled = enabledCheckboxes.length;
+            if(totalEnabled && totalEnabled === selectedCheckboxes.length)
                this.checkHeaderCheckbox();
             else
                this.uncheckHeaderCheckbox();


### PR DESCRIPTION
Fix #11290: Datatable selection disabled issues

- [x] When looking for to Select All it was counting enabled checkboxes === selected boxes but not checking whether those enabled were actually selected.
- [x] TabIndex must be disabled if the checkbox is disabled.