### PR TITLE
Fix #5665  Chartjs: fixes to allow timeseries bar chart

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/chartjs/ChartJsView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/chartjs/ChartJsView.java
@@ -348,7 +348,7 @@ public class ChartJsView implements Serializable {
         BarChartDataSet barDataSet = new BarChartDataSet();
         barDataSet.setLabel("My First Dataset");
 
-        List<Number> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>();
         values.add(65);
         values.add(59);
         values.add(80);
@@ -436,7 +436,7 @@ public class ChartJsView implements Serializable {
         barDataSet.setBackgroundColor("rgba(255, 99, 132, 0.2)");
         barDataSet.setBorderColor("rgb(255, 99, 132)");
         barDataSet.setBorderWidth(1);
-        List<Number> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>();
         values.add(65);
         values.add(59);
         values.add(80);
@@ -451,7 +451,7 @@ public class ChartJsView implements Serializable {
         barDataSet2.setBackgroundColor("rgba(255, 159, 64, 0.2)");
         barDataSet2.setBorderColor("rgb(255, 159, 64)");
         barDataSet2.setBorderWidth(1);
-        List<Number> values2 = new ArrayList<>();
+        List<Object> values2 = new ArrayList<>();
         values2.add(85);
         values2.add(69);
         values2.add(20);
@@ -502,7 +502,7 @@ public class ChartJsView implements Serializable {
         HorizontalBarChartDataSet hbarDataSet = new HorizontalBarChartDataSet();
         hbarDataSet.setLabel("My First Dataset");
 
-        List<Number> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>();
         values.add(65);
         values.add(59);
         values.add(80);
@@ -572,7 +572,7 @@ public class ChartJsView implements Serializable {
         BarChartDataSet barDataSet = new BarChartDataSet();
         barDataSet.setLabel("Dataset 1");
         barDataSet.setBackgroundColor("rgb(255, 99, 132)");
-        List<Number> dataVal = new ArrayList<>();
+        List<Object> dataVal = new ArrayList<>();
         dataVal.add(62);
         dataVal.add(-58);
         dataVal.add(-49);
@@ -585,7 +585,7 @@ public class ChartJsView implements Serializable {
         BarChartDataSet barDataSet2 = new BarChartDataSet();
         barDataSet2.setLabel("Dataset 2");
         barDataSet2.setBackgroundColor("rgb(54, 162, 235)");
-        List<Number> dataVal2 = new ArrayList<>();
+        List<Object> dataVal2 = new ArrayList<>();
         dataVal2.add(-1);
         dataVal2.add(32);
         dataVal2.add(-52);
@@ -598,7 +598,7 @@ public class ChartJsView implements Serializable {
         BarChartDataSet barDataSet3 = new BarChartDataSet();
         barDataSet3.setLabel("Dataset 3");
         barDataSet3.setBackgroundColor("rgb(75, 192, 192)");
-        List<Number> dataVal3 = new ArrayList<>();
+        List<Object> dataVal3 = new ArrayList<>();
         dataVal3.add(-44);
         dataVal3.add(25);
         dataVal3.add(15);
@@ -655,7 +655,7 @@ public class ChartJsView implements Serializable {
         barDataSet.setLabel("Dataset 1");
         barDataSet.setBackgroundColor("rgb(255, 99, 132)");
         barDataSet.setStack("Stack 0");
-        List<Number> dataVal = new ArrayList<>();
+        List<Object> dataVal = new ArrayList<>();
         dataVal.add(-32);
         dataVal.add(-70);
         dataVal.add(-33);
@@ -669,7 +669,7 @@ public class ChartJsView implements Serializable {
         barDataSet2.setLabel("Dataset 2");
         barDataSet2.setBackgroundColor("rgb(54, 162, 235)");
         barDataSet2.setStack("Stack 0");
-        List<Number> dataVal2 = new ArrayList<>();
+        List<Object> dataVal2 = new ArrayList<>();
         dataVal2.add(83);
         dataVal2.add(18);
         dataVal2.add(86);
@@ -683,7 +683,7 @@ public class ChartJsView implements Serializable {
         barDataSet3.setLabel("Dataset 3");
         barDataSet3.setBackgroundColor("rgb(75, 192, 192)");
         barDataSet3.setStack("Stack 1");
-        List<Number> dataVal3 = new ArrayList<>();
+        List<Object> dataVal3 = new ArrayList<>();
         dataVal3.add(-45);
         dataVal3.add(73);
         dataVal3.add(-25);
@@ -900,7 +900,7 @@ public class ChartJsView implements Serializable {
         ChartData data = new ChartData();
 
         BarChartDataSet dataSet = new BarChartDataSet();
-        List<Number> values = new ArrayList<>();
+        List<Object> values = new ArrayList<>();
         values.add(10);
         values.add(20);
         values.add(30);

--- a/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/CartesianTime.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/axes/cartesian/CartesianTime.java
@@ -34,7 +34,7 @@ import org.primefaces.util.FastStringWriter;
  * From ChartJs version 3.8.0
  * @see <a href="https://www.chartjs.org/docs/3.8.0/axes/cartesian/time.html#time-units">ChartJS Time</a>
  */
-public abstract class CartesianTime implements Serializable {
+public class CartesianTime implements Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/primefaces/src/main/java/org/primefaces/model/charts/bar/BarChartDataSet.java
+++ b/primefaces/src/main/java/org/primefaces/model/charts/bar/BarChartDataSet.java
@@ -38,7 +38,7 @@ public class BarChartDataSet extends ChartDataSet {
 
     private static final long serialVersionUID = 1L;
 
-    private List<Number> data;
+    private List<Object> data;
     private String label;
     private String xaxisID;
     private String yaxisID;
@@ -54,20 +54,20 @@ public class BarChartDataSet extends ChartDataSet {
     private Object hoverBorderRadius;
 
     /**
-     * Gets the list of data in this dataSet
+     * Gets the list of data in this dataSet. Can either be a Number or a type of ChartJs Point.
      *
-     * @return List&#60;Number&#62; list of data
+     * @return List&#60;Object&#62; list of data
      */
-    public List<Number> getData() {
+    public List<Object> getData() {
         return data;
     }
 
     /**
-     * Sets the list of data in this dataSet
+     * Sets the list of data in this dataSet. Can either be a Number or a type of ChartJs Point.
      *
-     * @param data List&#60;Number&#62; list of data
+     * @param data List&#60;Object&#62; list of data
      */
-    public void setData(List<Number> data) {
+    public void setData(List<Object> data) {
         this.data = data;
     }
 


### PR DESCRIPTION
Fix #5665 ChartJS Time Values

1. `BarChartDataSet` should allow `NumericPoint` to be used as data, useful to create timeseries bar charts.

2. `CartesianTime` probably was mistakenly left as abstract. It can be used in `CartesianLinearAxes.time` but can't be created without extending (which is redundant).