### PR TITLE
Fix #11314: Aria missing key default

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1225,7 +1225,8 @@
          */
         getAriaLabel: function(key) {
             var ariaLocaleSettings = this.getLocaleSettings()['aria'];
-            return (ariaLocaleSettings&&ariaLocaleSettings[key]) ? ariaLocaleSettings[key] : PrimeFaces.locales['en_US']['aria'][key];
+            var label = (ariaLocaleSettings&&ariaLocaleSettings[key]) ? ariaLocaleSettings[key] : PrimeFaces.locales['en_US']['aria'][key];
+            return label || "???"+key+"???";
         },
 
         /**


### PR DESCRIPTION
Fix #11314: Aria missing key default

When the aria key is missing instead of returning `undefined` it will return like JSF does `???pageLabel???` so there are no NPE's and it can easily be debugged what is wrong.