### PR TITLE
Fix #11318: 13.0.6 Dialog return focus prevent scrolling

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -380,7 +380,7 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
     returnFocus: function() {
         var el = this.focusedElementBeforeDialogOpened;
         if (el) {
-            el.focus({ preventScroll: true });
+            setTimeout(function() { el.focus({ preventScroll: true }) }, 100);
         }
     },
 


### PR DESCRIPTION
Fix #11318: 13.0.6 Dialog return focus prevent scrolling