### PR TITLE
Fix #11385: 13.0.6 OverlayPanel only remove if not inside target

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/overlaypanel/overlaypanel.js
@@ -191,10 +191,13 @@ PrimeFaces.widget.OverlayPanel = PrimeFaces.widget.DynamicOverlayWidget.extend({
             });
 
         this.bindAutoHide();
-        
+
         // GitHub #5710 Helper to destroy overlay if its target is destroyed
         $this.target.off('remove.overlay').on('remove.overlay', function() {
-            $this.destroy();
+            // only destroy the overlay if it lives outside of the target
+            if (!$.contains($this.target[0], $this.jq[0])) {
+                $this.destroy();
+            }
         });
     },
 


### PR DESCRIPTION
Fix #11385: 13.0.6 OverlayPanel only remove if not inside target