### PR TITLE
Fix #11407: Chips allow comma as separator again

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/chips/ChipsRenderer.java
@@ -210,7 +210,7 @@ public class ChipsRenderer extends InputRenderer {
                 .attr("addOnBlur", chips.isAddOnBlur(), false)
                 .attr("addOnPaste", chips.isAddOnPaste(), false)
                 .attr("unique", chips.isUnique(), false)
-                .attr("separator", chips.getSeparator(), ",");
+                .attr("separator", chips.getSeparator());
 
         encodeClientBehaviors(context, chips);
 


### PR DESCRIPTION
Fix #11407: Chips allow comma as separator again