### PR TITLE
Fix #11452 - 13.0.6 DataTable: LazyDataModel.load gets invoked multip…

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/LazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/LazyDataModel.java
@@ -107,8 +107,16 @@ public abstract class LazyDataModel<T> extends ListDataModel<T> implements Selec
                         + ", when basic rowKey algorithm is not used [component=%s,view=%s]."));
     }
 
+    /**
+     * Loads a single row for the rowIndex provided.
+     *
+     * @param rowIndex the row index to load
+     * @param sortBy a map with all sort information (only relevant for DataTable, not for eg DataView)
+     * @param filterBy a map with all filter information (only relevant for DataTable, not for eg DataView)
+     * @return the data
+     */
     public T getRowData(int rowIndex, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {
-        List<T> loaded = load(rowIndex, rowIndex + 1, sortBy, filterBy);
+        List<T> loaded = load(rowIndex, 1, sortBy, filterBy);
         if (loaded == null || loaded.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
Fix #11452 - 13.0.6 DataTable: LazyDataModel.load gets invoked multiple times

This is the bare minimum change and without method rename for 13.x