### PR TITLE
Fix LazyDataModel#loadOne doc

### DIFF
--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -57,7 +57,7 @@
   * Using Column custom `sortFunction` signature change now requires a third parameter `SortMeta` like `public int sortByModel(Object car1, Object car2, SortMeta sortMeta)`
   * `JpaLazyDataModel` renamed to `JPALazyDataModel`
   * `JPALazyDataModel`: deprecated constructors, use `JPALazyDataModel.builder()` instead
-  * 'LazyDataModel': 'getRowData()` overload has been renamed `loadOne()` to load a single row
+  * 'LazyDataModel': `getRowData(rowIndex, sortBy, filterBy)` overload has been renamed `loadOne()` to load a single row
 
 ### DataTable Selection
 

--- a/primefaces/src/main/java/org/primefaces/model/LazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/LazyDataModel.java
@@ -116,8 +116,8 @@ public abstract class LazyDataModel<T> extends DataModel<T> implements Selectabl
      * Loads a single row for the rowIndex provided.
      *
      * @param rowIndex the row index to load
-     * @param sortBy a map with all sort information (only relevant for DataTable, not for eg DataView)
-     * @param filterBy a map with all filter information (only relevant for DataTable, not for eg DataView)
+     * @param sortBy a map with all sort information
+     * @param filterBy a map with all filter information
      * @return the data
      */
     public T loadOne(int rowIndex, Map<String, SortMeta> sortBy, Map<String, FilterMeta> filterBy) {


### PR DESCRIPTION
@melloware @tandraschko I changed the doc a bit.

- As I don't want people to freak out when they'll read getRowData and rename in the same sentence, I put the full signature to make sure what we're talking about here...
- Also, `LazyDataModel#loadOne` is a convenient method here to just fetch one element (it was not really necessary to introduce it, but my guess is, who knows in the future, could be useful? (That's why I removed the mention of DataTable in the javadoc, even though only this component is using it so far)