### PR TITLE
Fix #5649: Log dev warning if first is not evenly divisible by rows

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1022,7 +1022,7 @@ public class DataTableRenderer extends DataRenderer {
             rowCountToRender = rows == 0 ? rowCount : rows;
 
             // #5649 check for invalid first value
-            if (first % rows != 0) {
+            if (rows > 0 && first % rows != 0) {
                 logDevelopmentWarning(context, String.format("%s Invalid 'first' value %d is not divisible evenly by 'rows' %d", clientId, first, rows));
             }
         }


### PR DESCRIPTION
Fix #5649: Log dev warning if first is not evenly divisible by rows

Prevents DIV BY ZERO error if `rows === 0`