### PR TITLE
Fix #11504: Redundant ARIA role grid/gridcell

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/column/renderer/PanelGridBodyColumnRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/column/renderer/PanelGridBodyColumnRenderer.java
@@ -42,7 +42,6 @@ public class PanelGridBodyColumnRenderer extends CoreRenderer implements HelperC
         styleClass = (styleClass == null) ? PanelGrid.CELL_CLASS : PanelGrid.CELL_CLASS + " " + styleClass;
 
         writer.startElement("td", null);
-        writer.writeAttribute("role", "gridcell", null);
         writer.writeAttribute("class", styleClass, null);
 
         if (style != null) {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -376,7 +376,7 @@ public class DataTableRenderer extends DataRenderer {
         }
 
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
         if (tableStyle != null) {
             writer.writeAttribute("style", tableStyle, null);
         }
@@ -517,7 +517,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.writeAttribute("class", containerBoxClass, null);
 
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
         if (tableStyle != null) {
             writer.writeAttribute("style", tableStyle, null);
         }
@@ -553,7 +553,7 @@ public class DataTableRenderer extends DataRenderer {
             }
         }
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
 
         if (tableStyle != null) {
             writer.writeAttribute("style", tableStyle, null);
@@ -586,7 +586,7 @@ public class DataTableRenderer extends DataRenderer {
         writer.writeAttribute("class", DataTable.VIRTUALSCROLL_WRAPPER_CLASS, null);
 
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
         writer.writeAttribute("class", tableStyleClass, null);
 
         if (tableStyle != null) {
@@ -1256,20 +1256,20 @@ public class DataTableRenderer extends DataRenderer {
         int rowspan = column.getRowspan();
 
         writer.startElement("td", null);
-        writer.writeAttribute("role", "gridcell", null);
+        writer.writeAttribute("data-role", "gridcell", null);
         if (colspan != 1) {
             writer.writeAttribute("colspan", colspan, null);
         }
         if (rowspan != 1) {
             writer.writeAttribute("rowspan", rowspan, null);
         }
-        if (style != null) {
+        if (LangUtils.isNotBlank(style)) {
             writer.writeAttribute("style", style, null);
         }
-        if (styleClass != null) {
+        if (LangUtils.isNotBlank(styleClass)) {
             writer.writeAttribute("class", styleClass, null);
         }
-        if (title != null) {
+        if (LangUtils.isNotBlank(title)) {
             writer.writeAttribute("title", title, null);
         }
         UIComponent component = (column instanceof UIComponent) ? (UIComponent) column : null;

--- a/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/panelgrid/PanelGridRenderer.java
@@ -37,6 +37,7 @@ import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
 import org.primefaces.util.FacetUtils;
 import org.primefaces.util.GridLayoutUtils;
+import org.primefaces.util.LangUtils;
 
 public class PanelGridRenderer extends CoreRenderer {
 
@@ -157,7 +158,7 @@ public class PanelGridRenderer extends CoreRenderer {
                                  ? PanelGrid.CELL_CLASS + " " + columnClasses[colMod].trim()
                                  : PanelGrid.CELL_CLASS;
             writer.startElement("td", null);
-            writer.writeAttribute("role", "gridcell", null);
+            writer.writeAttribute("data-role", "gridcell", null);
             writer.writeAttribute("class", columnClass, null);
             child.encodeAll(context);
             writer.endElement("td");
@@ -193,7 +194,7 @@ public class PanelGridRenderer extends CoreRenderer {
                     String rowStyleClass = i % 2 == 0
                                            ? PanelGrid.TABLE_ROW_CLASS + " " + PanelGrid.EVEN_ROW_CLASS
                                            : PanelGrid.TABLE_ROW_CLASS + " " + PanelGrid.ODD_ROW_CLASS;
-                    encodeRow(context, (Row) child, "gridcell", rowStyleClass, PanelGrid.CELL_CLASS);
+                    encodeRow(context, (Row) child, "", rowStyleClass, PanelGrid.CELL_CLASS);
                 }
                 else {
                     child.encodeAll(context);
@@ -236,10 +237,13 @@ public class PanelGridRenderer extends CoreRenderer {
                 if (shouldWriteId(column)) {
                     writer.writeAttribute("id", column.getClientId(context), null);
                 }
-                writer.writeAttribute("role", columnRole, null);
-                writer.writeAttribute("class", styleClass, null);
-
-                if (column.getStyle() != null) {
+                if (LangUtils.isNotBlank(columnRole)) {
+                    writer.writeAttribute("role", columnRole, null);
+                }
+                if (LangUtils.isNotBlank(styleClass)) {
+                    writer.writeAttribute("class", styleClass, null);
+                }
+                if (LangUtils.isNotBlank(column.getStyle())) {
                     writer.writeAttribute("style", column.getStyle(), null);
                 }
                 if (column.getColspan() > 1) {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -270,7 +270,7 @@ public class TreeTableRenderer extends DataRenderer {
             writer.writeAttribute("style", "height:" + scrollHeight + "px", null);
         }
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
 
         if (tableStyle != null) {
             writer.writeAttribute("style", tableStyle, null);
@@ -299,7 +299,7 @@ public class TreeTableRenderer extends DataRenderer {
         writer.writeAttribute("class", containerBoxClass, null);
 
         writer.startElement("table", null);
-        writer.writeAttribute("role", "grid", null);
+        writer.writeAttribute("data-role", "grid", null);
         if (tableStyle != null) {
             writer.writeAttribute("style", tableStyle, null);
         }
@@ -559,7 +559,7 @@ public class TreeTableRenderer extends DataRenderer {
                 }
 
                 writer.startElement("td", null);
-                writer.writeAttribute("role", "gridcell", null);
+                writer.writeAttribute("data-role", "gridcell", null);
                 if (columnStyle != null) {
                     writer.writeAttribute("style", columnStyle, null);
                 }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -294,7 +294,7 @@
 }
 
 /** Reflow **/
-.ui-datatable-reflow .ui-datatable-data td[role="gridcell"] .ui-column-title,
+.ui-datatable-reflow .ui-datatable-data td[data-role="gridcell"] .ui-column-title,
 .ui-datatable-reflow .ui-expanded-row-content td .ui-column-title {
     display: none;
 }
@@ -336,7 +336,7 @@
         display: none;
     }
 
-    .ui-datatable-reflow .ui-datatable-data td[role="gridcell"]:not(.ui-helper-hidden) { 
+    .ui-datatable-reflow .ui-datatable-data td[data-role="gridcell"]:not(.ui-helper-hidden) { 
         text-align: left;
         display: block;
         border: 0px none;
@@ -357,7 +357,7 @@
         border-right: 0px none;
     }
 
-    .ui-datatable-reflow .ui-datatable-data td[role="gridcell"] .ui-column-title { 
+    .ui-datatable-reflow .ui-datatable-data td[data-role="gridcell"] .ui-column-title { 
         padding: .4em; 
         min-width: 30%; 
         display: inline-block;


### PR DESCRIPTION
Fix #11504: Redundant ARIA role grid/gridcell

Switched them to `data-role` elements just in case and updated reflow CSS to use the data element.

ARIA's Section 3.2 Avoid Redundant Roles.

https://www.w3.org/TR/html-aria/#avoid-specifying-redundant-roles

```xml
<!-- Avoid doing this! -->
<button role="button">...</button>
```