### PR TITLE
Fix #11513: Tree wrong dnd index for sibling going down

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tree/tree.vertical.js
@@ -754,6 +754,15 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
                 draggedSourceKeys = draggedSourceKeys.filter(function(key) {
                     return $.inArray(key, $this.invalidSourceKeys) === -1;
                 });
+                
+                // #11513 dndIndex is based on whether you are dragging up or down
+                var dndIndex = dropPoint.prevAll('li.ui-treenode').length;
+                if (parseInt(dragNodeKey) < dndIndex) {
+                    var nextDndIndex = dropPoint.nextAll('li.ui-treenode').length;
+                    if (nextDndIndex > 0) {
+                        dndIndex = nextDndIndex;
+                    }
+                }
 
                 if (draggedSourceKeys && draggedSourceKeys.length) {
                     draggedSourceKeys = draggedSourceKeys.reverse().join(',');
@@ -761,7 +770,7 @@ PrimeFaces.widget.VerticalTree = PrimeFaces.widget.BaseTree.extend({
                         'dragNodeKey': draggedSourceKeys,
                         'dropNodeKey': dropNodeKey,
                         'dragSource': dragSource.id,
-                        'dndIndex': dropPoint.prevAll('li.ui-treenode').length,
+                        'dndIndex': dndIndex,
                         'transfer': transfer,
                         'isDroppedNodeCopy': isDroppedNodeCopy
                     });


### PR DESCRIPTION
Fix #11513: Tree wrong dnd index for sibling going down

This has been wrong for a long time.  I was always doing `prevAll.length` and never `nextAll.length` so when moving a sibling down it was off by 1 error.