### PR TITLE
Fix #11590: InputMask handle escape character '\'

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputmask/InputMaskRenderer.java
@@ -87,23 +87,31 @@ public class InputMaskRenderer extends InputRenderer {
 
     protected Pattern translateMaskIntoRegex(StringBuilder regex, String mask) {
         boolean optionalFound = false;
+        boolean escapeFound = false;
 
         for (char c : mask.toCharArray()) {
             if (c == '[' || c == ']') {
                 optionalFound = true;
             }
+            else if (c == '\\') {
+                escapeFound = true;
+            }
             else {
-                regex.append(translateMaskCharIntoRegex(c, optionalFound));
+                regex.append(translateMaskCharIntoRegex(c, optionalFound, escapeFound));
+                escapeFound = false;
             }
         }
         return Pattern.compile(regex.toString());
     }
 
-    protected String translateMaskCharIntoRegex(char c, boolean optional) {
+    protected String translateMaskCharIntoRegex(char c, boolean optional, boolean escapeFound) {
         String translated;
 
-        if (c == '[' || c == ']') {
-            return ""; //should be ignored
+        if (escapeFound) {
+            return String.valueOf(c);
+        }
+        else if (c == '[' || c == ']') {
+            return Constants.EMPTY_STRING; //should be ignored
         }
         else if (c == '9') {
             translated = "[0-9]";

--- a/primefaces/src/test/java/org/primefaces/component/inputmask/InputMaskRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/inputmask/InputMaskRendererTest.java
@@ -45,4 +45,18 @@ class InputMaskRendererTest {
         assertEquals("[0-9][0-9]?[0-9]?[0-9]?", result.pattern());
     }
 
+    @Test
+    void translateMaskIntoRegex_EscapeCharacter_GitHub11590() {
+        // Arrange
+        InputMaskRenderer comp = new InputMaskRenderer();
+        StringBuilder sb = new StringBuilder();
+        String mask = "\\G.9";
+
+        // Act
+        Pattern result = comp.translateMaskIntoRegex(sb, mask);
+
+        // Assert
+        assertEquals("G\\.[0-9]", result.pattern());
+    }
+
 }


### PR DESCRIPTION
Fix #11590: InputMask handle escape character '\'
Fix #11497