### PR TITLE
Fix #11598: 13.0.8 Datatable sticky z-index with existing sticky

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1180,7 +1180,7 @@
          * Increment and return the next `z-index` for CSS as a string.
          * Note that jQuery will no longer accept numeric values in {@link JQuery.css | $.fn.css} as of version 4.0.
          *
-         *  @return {string} the next `z-index` as a string.
+         * @return {string} the next `z-index` as a string.
          */
         nextZindex: function() {
             return String(++PrimeFaces.zindex);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -986,7 +986,34 @@ if (!PrimeFaces.utils) {
                 return doc.documentElement.textContent;
             }
             return input;
-        }
+        },
+
+        /**
+         * Retrieves the subsequent z-index for a sticky element. Typically, a sticky element requires a 
+         * z-index higher than the current one, but certain scenarios arise, such as when an overlay mask 
+         * is present or when there are multiple sticky elements on the page, necessitating a z-index 
+         * one lower than the highest among them.
+         *
+         * @return {string} the next `z-index` as a string.
+         * @see {@link https://github.com/primefaces/primefaces/issues/10299|GitHub Issue 10299}
+         * @see {@link https://github.com/primefaces/primefaces/issues/9259|GitHub Issue 9259}
+         */
+        nextStickyZindex: function() {
+            // Get the z-index of the highest visible sticky, or use PrimeFaces.nextZindex() + 1 if none found
+            var zIndex = $('.ui-sticky:visible').last().zIndex() || PrimeFaces.nextZindex() + 1;
+
+            // GitHub #9295 Adjust z-index based on overlays
+            var overlays = $('.ui-widget-overlay:visible');
+            if (overlays.length) {
+                overlays.each(function() {
+                    var currentZIndex = $(this).zIndex() - 1;
+                    zIndex = Math.min(currentZIndex, zIndex);
+                });
+            }
+
+            // Decrease zIndex by 1 and return
+            return zIndex - 1;
+        },
     };
 
 }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4767,7 +4767,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
             if (scrollTop + fixedElementsHeight > tableOffset.top) {
                 if (!$this.stickyContainer.hasClass('ui-shadow ui-sticky')) {
-                    $this.stickyContainer.css({ 'z-index': PrimeFaces.nextZindex() });
+                    $this.stickyContainer.css({ 'z-index': PrimeFaces.utils.nextStickyZindex() });
                 }
                 $this.stickyContainer.css({
                     'position': 'fixed',
@@ -4792,7 +4792,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 }).removeClass('ui-shadow ui-sticky');
 
                 if ($this.stickyContainer.is(':hidden')) {
-                    $this.stickyContainer.css({ 'z-index': PrimeFaces.nextZindex() });
+                    $this.stickyContainer.css({ 'z-index': PrimeFaces.utils.nextStickyZindex() });
                     $this.stickyContainer.show();
                 }
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/sticky/sticky.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/sticky/sticky.js
@@ -88,20 +88,10 @@ PrimeFaces.widget.Sticky = PrimeFaces.widget.BaseWidget.extend({
             var win = $(window),
                 winScrollTop = win.scrollTop();
 
-            // GitHub #9295 look for overlays and make sure sticky is not higher
-            var overlays = $('.ui-widget-overlay');
-            var zIndex = PrimeFaces.nextZindex();
-            if (overlays.length) {
-                overlays.each(function() {
-                    var currentZIndex = $(this).zIndex() - 1;
-                    zIndex = currentZIndex < zIndex ? currentZIndex : zIndex;
-                });
-            }
-
             this.target.css({
                 'position': 'fixed',
                 'top': this.cfg.margin + 'px',
-                'z-index': zIndex
+                'z-index': PrimeFaces.utils.nextStickyZindex()
             })
             .addClass('ui-shadow ui-sticky');
 


### PR DESCRIPTION
Fix #11598: 13.0.8 Datatable sticky z-index with existing sticky

Tested against:

- [x] Showcase Sticky and Datatable Sticky examples
- [x] Reproducer from #9295 
- [x] Reproducer from #11598 