### PR TITLE
Fix #11569: Core JS setGlobalLocaleValue

### DIFF
--- a/docs/14_0_0/core/localization.md
+++ b/docs/14_0_0/core/localization.md
@@ -316,6 +316,15 @@ if (window.PrimeFaces) {
 
 ```
 
+### Overwrite Global Value
+
+In certain situations, you might find it necessary to unify all locales to a single value. For instance, if you wish to establish `firstDayOfWeek=1` uniformly across all locales. 
+The function `setGlobalLocaleValue` is available for precisely this purpose, ensuring consistency by applying the same value across all locales. Example usage:
+
+```js
+PrimeFaces.setGlobalLocaleValue('firstDayOfWeek', 1);
+```
+
 ### Usage
 
 To add another locale to the API, first create the locale object first with settings and assign it as a

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -12,6 +12,7 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     * `MOVE_SCRIPTS_TO_BOTTOM` adds new option `defer` to defer loading scripts.
     * OS settings for `prefers-reduced-motion: reduce` is now respected and PF disables all animations.
     * Minimum inline Ajax load animation duration via `PrimeFaces.ajax.minLoadAnimation`.
+    * Client side `PrimeFaces.setGlobalLocaleValue(xxx);` if you need to set the same value in all locales.
 
 * Chart
    * A new more flexible version of Chart.js can be used `<p:chart>` allowing raw JSON or [XDEV Chart.js Java Model](https://github.com/xdev-software/chartjs-java-model)

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1239,6 +1239,35 @@
             var locale = this.getLocaleSettings();
             return (locale&&locale[key]) ? locale[key] : PrimeFaces.locales['en_US'][key];
         },
+        
+        /**
+         * Loop over all locales and set the label to the new value in all locales.
+         * @param {string} localeKey The locale key
+         * @param {string} localeValue The locale value
+         */
+        setGlobalLocaleValue: function(localeKey, localeValue) {
+            // Recursive function to iterate over nested objects
+            function iterateLocale(locale, lkey, lvalue) {
+                for (var key in locale) {
+                    if (typeof locale[key] === 'object') {
+                        // If the value is an object, call the function recursively
+                        iterateLocale(locale[key], lkey, lvalue);
+                    } else {
+                        // Otherwise, set the new value if found
+                        if (key === lkey) {
+                            locale[key] = lvalue;
+                        }
+                    }
+                }
+            }
+
+            // iterate over all locales and try and set the key in each locale
+            for (var lang in PrimeFaces.locales) {
+                if (typeof PrimeFaces.locales[lang] === 'object') {
+                    iterateLocale(PrimeFaces.locales[lang], localeKey, localeValue)
+                }
+            }
+        },
 
         /**
          * For 4.0 jQuery deprecated $.trim in favor of PrimeFaces.trim however that does not handle


### PR DESCRIPTION
Fix #11569: Core JS setGlobalLocaleValue

This will work even if the value is nested in `aria` or any other section.

Setting a top level value
```js
PrimeFaces.setGlobalLocaleValue('firstDayOfWeek', 1);
```

Setting an ARIA label:
```js
PrimeFaces.setGlobalLocaleValue('colorpicker.CLEAR', 'Test');
```