### PR TITLE
Fix #11630: MenuItem icon position set only if blank

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/menu/BaseMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/menu/BaseMenuRenderer.java
@@ -166,8 +166,10 @@ public abstract class BaseMenuRenderer extends MenuItemAwareRenderer {
     protected void encodeMenuItemContent(FacesContext context, AbstractMenu menu, MenuItem menuitem) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         Object value = menuitem.getValue();
-        boolean isRtl = ComponentUtils.isRTL(context, menu);
-        String iconPos = isRtl ? "right" : menuitem.getIconPos();
+        String iconPos = menuitem.getIconPos();
+        if (LangUtils.isBlank(iconPos)) {
+            iconPos = ComponentUtils.isRTL(context, menu) ? "right" : "left";
+        }
 
         if ("left".equals(iconPos)) {
             encodeIcon(writer, menu, menuitem, iconPos);


### PR DESCRIPTION
Fix #11630: MenuItem icon position set only if blank

I should only be defaulting the icon to right or left if the user has NOT set the icon

cc @jungm 