### PR TITLE
Fix #11650: Datatable do not make first/last column resizable after drop

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4594,7 +4594,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                 //drop right
                 if(dropLocation > 0) {
                     if($this.cfg.resizableColumns) {
-                        if(droppedColumnHeader.next().length) {
+                        if(droppedColumnHeader.next().length === 0) {
                             droppedColumnHeader.children('span.ui-column-resizer').show();
                             draggedColumnHeader.children('span.ui-column-resizer').hide();
                         }


### PR DESCRIPTION
Fix #11650: Datatable do not make first/last column resizable after drop

