### PR TITLE
Fix #11739: DragDrop/Resizable add destroy listeners

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dragdrop/dragdrop.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dragdrop/dragdrop.js
@@ -40,27 +40,33 @@ PrimeFaces.widget.Draggable = PrimeFaces.widget.BaseWidget.extend({
         this.jqTarget = $(PrimeFaces.escapeClientId(this.cfg.target));
         this.cfg.cancel = this.cfg.cancel || "input,textarea,button,select,option";
 
-        if(this.cfg.appendTo) {
+        if (this.cfg.appendTo) {
             this.cfg.appendTo = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.jq, this.cfg.appendTo);
         }
-        
+
         var $this = this;
 
         this.cfg.start = function(event, ui) {
-            if($this.cfg.onStart) {
+            if ($this.cfg.onStart) {
                 $this.cfg.onStart.call($this, event, ui);
             }
         };
-        
+
         this.cfg.stop = function(event, ui) {
-            if($this.cfg.onStop) {
+            if ($this.cfg.onStop) {
                 $this.cfg.onStop.call($this, event, ui);
             }
         };
-        
+
         this.jqTarget.draggable(this.cfg);
+
+        this.addDestroyListener(function() {
+            if ($this.jqTarget.length) {
+                $this.jqTarget.draggable('destroy');
+            }
+        });
     }
-    
+
 });
 
 /**
@@ -99,6 +105,13 @@ PrimeFaces.widget.Droppable = PrimeFaces.widget.BaseWidget.extend({
         this.bindDropListener();
 
         this.jqTarget.droppable(this.cfg);
+
+        var $this = this;
+        this.addDestroyListener(function() {
+            if ($this.jqTarget.length) {
+                $this.jqTarget.droppable('destroy');
+            }
+        });
     },
 
     /**
@@ -106,27 +119,27 @@ PrimeFaces.widget.Droppable = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     bindDropListener: function() {
-        var _self = this;
+        var $this = this;
 
         this.cfg.drop = function(event, ui) {
-            if(_self.cfg.onDrop) {
-                _self.cfg.onDrop.call(_self, event, ui);
+            if ($this.cfg.onDrop) {
+                $this.cfg.onDrop.call($this, event, ui);
             }
-            if(_self.cfg.behaviors) {
-                var dropBehavior = _self.cfg.behaviors['drop'];
+            if ($this.cfg.behaviors) {
+                var dropBehavior = $this.cfg.behaviors['drop'];
 
-                if(dropBehavior) {
+                if (dropBehavior) {
                     var ext = {
                         params: [
-                            {name: _self.id + '_dragId', value: ui.draggable.attr('id')},
-                            {name: _self.id + '_dropId', value: _self.cfg.target}
+                            { name: $this.id + '_dragId', value: ui.draggable.attr('id') },
+                            { name: $this.id + '_dropId', value: $this.cfg.target }
                         ]
                     };
 
-                    dropBehavior.call(_self, ext);
+                    dropBehavior.call($this, ext);
                 }
             }
         };
     }
-    
+
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/resizable/resizable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/resizable/resizable.js
@@ -62,7 +62,7 @@ PrimeFaces.widget.Resizable = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     renderDeferred: function() {
-        if(this.jqTarget.is(':visible')) {
+        if (this.jqTarget.is(':visible')) {
             this._render();
         }
         else {
@@ -85,7 +85,7 @@ PrimeFaces.widget.Resizable = PrimeFaces.widget.BaseWidget.extend({
      * @return {boolean} `true` if the target widget is visible, or `false` otherwise.
      */
     render: function() {
-        if(this.jqTarget.is(':visible')) {
+        if (this.jqTarget.is(':visible')) {
             this._render();
             return true;
         }
@@ -98,37 +98,43 @@ PrimeFaces.widget.Resizable = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     _render: function() {
-        if(this.cfg.ajaxResize) {
+        if (this.cfg.ajaxResize) {
             this.cfg.formId = $(this.target).parents('form:first').attr('id');
         }
 
         if (this.cfg.isContainment) {
-        	this.cfg.containment = PrimeFaces.escapeClientId(this.cfg.parentComponentId);
+            this.cfg.containment = PrimeFaces.escapeClientId(this.cfg.parentComponentId);
         }
 
-        var _self = this;
+        var $this = this;
 
         this.cfg.stop = function(event, ui) {
-            if(_self.cfg.onStop) {
-                _self.cfg.onStop.call(_self, event, ui);
+            if ($this.cfg.onStop) {
+                $this.cfg.onStop.call($this, event, ui);
             }
 
-            _self.fireAjaxResizeEvent(event, ui);
+            $this.fireAjaxResizeEvent(event, ui);
         };
 
         this.cfg.start = function(event, ui) {
-            if(_self.cfg.onStart) {
-                _self.cfg.onStart.call(_self, event, ui);
+            if ($this.cfg.onStart) {
+                $this.cfg.onStart.call($this, event, ui);
             }
         };
 
         this.cfg.resize = function(event, ui) {
-            if(_self.cfg.onResize) {
-                _self.cfg.onResize.call(_self, event, ui);
+            if ($this.cfg.onResize) {
+                $this.cfg.onResize.call($this, event, ui);
             }
         };
 
         this.jqTarget.resizable(this.cfg);
+
+        this.addDestroyListener(function() {
+            if ($this.jqTarget.length) {
+                $this.jqTarget.resizable('destroy');
+            }
+        });
 
         this.removeScriptElement(this.id);
     },
@@ -140,11 +146,11 @@ PrimeFaces.widget.Resizable = PrimeFaces.widget.BaseWidget.extend({
      * @param {JQueryUI.ResizableUIParams} ui Data of the resize event.
      */
     fireAjaxResizeEvent: function(event, ui) {
-        if(this.hasBehavior('resize')) {
+        if (this.hasBehavior('resize')) {
             var ext = {
                 params: [
-                    {name: this.id + '_width', value: parseInt(ui.helper.width())},
-                    {name: this.id + '_height', value: parseInt(ui.helper.height())}
+                    { name: this.id + '_width', value: parseInt(ui.helper.width()) },
+                    { name: this.id + '_height', value: parseInt(ui.helper.height()) }
                 ]
             };
 


### PR DESCRIPTION
Fix #11739: DragDrop/Resizable add destroy listeners

These two widgets have not been touched in along time so i changed `_self` to `$this` to match the rest of our widgets for standards.