### PR TITLE
JPALazyDataModel: remove constructors in favor of builder pattern

### DIFF
--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -49,11 +49,10 @@
 ## DataTable
 
   * Using Column custom `sortFunction` signature change now requires a third parameter `SortMeta` like `public int sortByModel(Object car1, Object car2, SortMeta sortMeta)`
-  * `JpaLazyDataModel` renamed to `JPALazyDataModel`
-  * `JPALazyDataModel`: deprecated constructors, use `JPALazyDataModel.builder()` instead
+  * `JpaLazyDataModel` renamed to `JPALazyDataModel`, and initialization by constructors removed _(no backward compatibility)_, use `JPALazyDataModel.builder()` instead
   * `LazyDataModel#getRowData(rowIndex, sortBy, filterBy)` has been renamed `loadOne()` to load a single row
 
-### DataTable Selection
+### DataTable selection
 
 Few selection attributes have been renamed for consistency purposes:
   * `rowSelectMode` renamed to `selectionRowMode`

--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -70,51 +70,6 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
         // NOOP
     }
 
-    /**
-     * Constructs a JpaLazyDataModel for usage without enabled selection.
-     *
-     * @param entityClass The entity class
-     * @param entityManager The {@link EntityManager}
-     *
-     * @deprecated Use {@link JPALazyDataModel#builder()} instead
-     */
-    @Deprecated
-    public JPALazyDataModel(Class<T> entityClass, SerializableSupplier<EntityManager> entityManager) {
-        this.entityClass = entityClass;
-        this.entityManager = entityManager;
-    }
-
-    /**
-     * Constructs a JpaLazyDataModel with selection support.
-     *
-     * @param entityClass The entity class
-     * @param entityManager The {@link EntityManager}
-     * @param rowKeyField The name of the rowKey property (e.g. "id")
-     *
-     * @deprecated Use {@link JPALazyDataModel#builder()} instead
-     */
-    @Deprecated
-    public JPALazyDataModel(Class<T> entityClass, SerializableSupplier<EntityManager> entityManager, String rowKeyField) {
-        this(entityClass, entityManager);
-        this.rowKeyField = rowKeyField;
-    }
-
-    /**
-     * Constructs a JpaLazyDataModel with selection support, with an already existing {@link Converter}.
-     *
-     * @param entityClass The entity class
-     * @param entityManager The {@link EntityManager}
-     * @param rowKeyConverter The converter, which will be used for converting the entity to a rowKey and vice versa
-     *
-     * @deprecated Use {@link JPALazyDataModel#builder()} instead
-     */
-    @Deprecated
-    public JPALazyDataModel(Class<T> entityClass, SerializableSupplier<EntityManager> entityManager, Converter<T> rowKeyConverter) {
-        super(rowKeyConverter);
-        this.entityClass = entityClass;
-        this.entityManager = entityManager;
-    }
-
     @Override
     public int count(Map<String, FilterMeta> filterBy) {
         EntityManager em = entityManager.get();
@@ -370,7 +325,7 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
         private final JPALazyDataModel<T> model;
 
         public Builder() {
-            model = new JPALazyDataModel<>(null, null, (String) null);
+            model = new JPALazyDataModel<>();
         }
 
         public Builder<T> entityClass(Class<T> entityClass) {


### PR DESCRIPTION
Since #10776, JPALazyDataModel is no longer backward compatible, from what I read on discord, a few people have already switched to builder pattern, don't think we should be bother at this point