### PR TITLE
Move IOBiConsumer into org.primefaces.util

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/badge/BadgeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/badge/BadgeRenderer.java
@@ -29,7 +29,7 @@ import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
-import org.primefaces.functional.IOBiConsumer;
+import org.primefaces.util.IOBiConsumer;
 import org.primefaces.model.badge.BadgeModel;
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.LangUtils;

--- a/primefaces/src/main/java/org/primefaces/util/IOBiConsumer.java
+++ b/primefaces/src/main/java/org/primefaces/util/IOBiConsumer.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.functional;
+package org.primefaces.util;
 
 import java.io.IOException;
 import java.util.Objects;


### PR DESCRIPTION
Here I think we should have something like FailableConsumer from commons-lang