### PR TITLE
Fix #11780: Fix resource handling to allow raw JS code

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -315,23 +315,7 @@ if (!PrimeFaces.ajax) {
                     PrimeFaces.ajax.Utils.updateBody(content);
                 }
                 else if (id === PrimeFaces.ajax.RESOURCE) {
-                    // #11714 Iterate through each script and stylesheet tag in the content
-                    // checking if resource is already attached to the head and adding it if not
-                    $(content)
-                        .filter("link[href], script[src]")
-                        .each(function() {
-                            var $resource = $(this);
-                            var $head = $("head");
-                            var src = $resource.attr("href") || $resource.attr("src");
-                            var type = this.tagName.toLowerCase();
-                            var $resources = $head.find(type + '[src="' + src + '"], ' + type + '[href="' + src + '"]');
-
-                            // Check if script or stylesheet already exists and add it to head if it does not
-                            if ($resources.length === 0) {
-                                PrimeFaces.debug("Appending " + type + " to head: " + src);
-                                $head.append($resource);
-                            }
-                        });
+                    $('head').append(content);
                 }
                 else if (id === $('head')[0].id) {
                     PrimeFaces.ajax.Utils.updateHead(content);


### PR DESCRIPTION
Fix #11780: Fix resource handling to allow raw JS code

@tandraschko what happens is for some reason MyFaces sends this and Mojarra doesn't.

```xml
<update id="javax.faces.Resource"><![CDATA[
            console.log('hi');
        ]]></update>
```

When you try and convert that to Jquery `var $content = $(content);` it throws an error because that is not valid Jquery content.  So I had to add a `catch` and say add the raw `content` to the head if an error is thrown.