### PR TITLE
PDF export minor refactor

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -135,7 +135,7 @@ public class DataTablePDFExporter extends DataTableExporter<Document, PDFOptions
     @Override
     protected void exportCellValue(FacesContext context, DataTable table, UIColumn col, ColumnValue columnValue, int index) {
         PdfPCell cell = createCell(col, new Paragraph(columnValue.toString(), cellFont));
-        pdfTable.addCell(cell);
+        addCell(pdfTable, cell);
     }
 
     @Override
@@ -159,6 +159,10 @@ public class DataTablePDFExporter extends DataTableExporter<Document, PDFOptions
         for (int i = 0; i < number; i++) {
             paragraph.add(new Paragraph(Constants.SPACE));
         }
+    }
+
+    protected void addCell(PdfPTable table, PdfPCell cell) {
+        table.addCell(cell);
     }
 
     protected void applyFacetOptions(ExporterOptions options) {
@@ -255,6 +259,6 @@ public class DataTablePDFExporter extends DataTableExporter<Document, PDFOptions
             cell.setColspan(colSpan);
         }
 
-        pdfTable.addCell(cell);
+        addCell(pdfTable, cell);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTablePDFExporter.java
@@ -135,7 +135,7 @@ public class TreeTablePDFExporter extends TreeTableExporter<Document, PDFOptions
     @Override
     protected void exportCellValue(FacesContext context, TreeTable table, UIColumn col, ColumnValue columnValue, int index) {
         PdfPCell cell = createCell(col, new Paragraph(columnValue.toString(), cellFont));
-        pdfTable.addCell(cell);
+        addCell(pdfTable, cell);
     }
 
     @Override
@@ -159,6 +159,10 @@ public class TreeTablePDFExporter extends TreeTableExporter<Document, PDFOptions
         for (int i = 0; i < number; i++) {
             paragraph.add(new Paragraph(Constants.SPACE));
         }
+    }
+
+    protected void addCell(PdfPTable table, PdfPCell cell) {
+        table.addCell(cell);
     }
 
     protected void applyFacetOptions(ExporterOptions options) {
@@ -255,6 +259,6 @@ public class TreeTablePDFExporter extends TreeTableExporter<Document, PDFOptions
             cell.setColspan(colSpan);
         }
 
-        pdfTable.addCell(cell);
+        addCell(pdfTable, cell);
     }
 }


### PR DESCRIPTION
@Rapster this minor refactor make my life easier when getting Quarkus Native mode working as it allows me to override just this tinier method similar to how I have to override add blank lines.

See this for an example of what I need to do: https://github.com/quarkiverse/quarkus-primefaces/blob/main/quarkus-primefaces/runtime/src/main/java/io/quarkus/primefaces/runtime/graal/SubstituteDataTablePdfExporter.java