### PR TITLE
Fix #11791: InputNumber allow Number.class to be decimal

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -392,7 +392,7 @@ public class InputNumberRenderer extends InputRenderer {
         return formatForPlugin(maximum);
     }
 
-    private boolean isIntegral(FacesContext context, InputNumber inputNumber, Object value) {
+    protected boolean isIntegral(FacesContext context, InputNumber inputNumber, Object value) {
         if (value != null) {
             return value instanceof Long
                     || value instanceof Integer
@@ -402,7 +402,9 @@ public class InputNumberRenderer extends InputRenderer {
         }
 
         Class<?> type = getTypeFromValueExpression(context, inputNumber);
-        if (type == null) {
+
+        // #11791 Number is the superclass for all the types so it could be a decimal
+        if (type == null || type == Number.class) {
             return false;
         }
 

--- a/primefaces/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
@@ -26,9 +26,13 @@ package org.primefaces.component.inputnumber;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,7 +57,7 @@ class InputNumberTest {
 
     @BeforeEach
     void setup() {
-        renderer = new InputNumberRenderer();
+        renderer = spy(new InputNumberRenderer());
         context = mock(FacesContext.class);
         externalContext = mock(ExternalContext.class);
         elContext = mock(ELContext.class);
@@ -194,6 +198,34 @@ class InputNumberTest {
         setupValues("1", true, "0", "2", false);
         renderer.decode(context, inputNumber);
         assertNull(inputNumber.getSubmittedValue());
+    }
+
+    @Test
+    void isIntegral() {
+        // values
+        doReturn(BigDecimal.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertFalse(renderer.isIntegral(context, inputNumber, BigDecimal.valueOf(5.5)));
+        doReturn(Number.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertFalse(renderer.isIntegral(context, inputNumber, BigDecimal.valueOf(5.5)));
+        doReturn(Number.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, Integer.valueOf(3)));
+
+        // nulls
+        doReturn(Integer.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, null));
+        doReturn(Short.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, null));
+        doReturn(Byte.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, null));
+        doReturn(BigInteger.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, null));
+        doReturn(Long.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertTrue(renderer.isIntegral(context, inputNumber, null));
+        doReturn(BigDecimal.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertFalse(renderer.isIntegral(context, inputNumber, null));
+        // GitHub #11791
+        doReturn(Number.class).when(renderer).getTypeFromValueExpression(context, inputNumber);
+        assertFalse(renderer.isIntegral(context, inputNumber, null));
     }
 
 }


### PR DESCRIPTION
Fix #11791: InputNumber all Number.class to be decimal

With unit tests showing the fix