### PR TITLE
Fix #11421: Ignore ColumnRenderer helper in components using columns

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -38,6 +38,7 @@ import org.primefaces.event.AutoCompleteEvent;
 import org.primefaces.expression.SearchExpressionUtils;
 import org.primefaces.renderkit.InputRenderer;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.FacetUtils;
 import org.primefaces.util.HTML;
 import org.primefaces.util.LangUtils;
@@ -506,7 +507,11 @@ public class AutoCompleteRenderer extends InputRenderer {
         Converter converter = ComponentUtils.getConverter(context, ac);
 
         if (customContent) {
+            Object helperKey = context.getAttributes().remove(Constants.HELPER_RENDERER);
             encodeSuggestionsAsTable(context, ac, items, converter);
+            if (helperKey != null) {
+                context.getAttributes().put(Constants.HELPER_RENDERER, helperKey);
+            }
         }
         else {
             encodeSuggestionsAsList(context, ac, items, converter);

--- a/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenuRenderer.java
@@ -459,6 +459,7 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
         boolean customContent = menu.getVar() != null;
 
         if (customContent) {
+            Object helperKey = context.getAttributes().remove(Constants.HELPER_RENDERER);
             List<Column> columns = menu.getColumns();
 
             writer.startElement("table", null);
@@ -470,6 +471,9 @@ public class SelectCheckboxMenuRenderer extends SelectManyRenderer {
             encodeOptionsAsTable(context, menu, selectItems, columns);
             writer.endElement("tbody");
             writer.endElement("table");
+            if (helperKey != null) {
+                context.getAttributes().put(Constants.HELPER_RENDERER, helperKey);
+            }
         }
         else {
             // Rendering was moved to the client - see renderPanelContentFromHiddenSelect as part of forms.selectcheckboxmenu.js

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -364,6 +364,7 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
         boolean customContent = menu.getVar() != null;
 
         if (customContent) {
+            Object helperKey = context.getAttributes().remove(Constants.HELPER_RENDERER);
             List<Column> columns = menu.getColumns();
 
             writer.startElement("table", null);
@@ -375,6 +376,9 @@ public class SelectOneMenuRenderer extends SelectOneRenderer {
             encodeOptionsAsTable(context, menu, selectItems, columns);
             writer.endElement("tbody");
             writer.endElement("table");
+            if (helperKey != null) {
+                context.getAttributes().put(Constants.HELPER_RENDERER, helperKey);
+            }
         }
         else {
             // Rendering was moved to the client - see renderPanelContentFromHiddenSelect as part of forms.selectonemenu.js


### PR DESCRIPTION
Fix #11421: Ignore ColumnRenderer helper in components using columns

This PR does it the "easy" way.  Note we need to do this on all components that have custom "Column Rendering".