### PR TITLE
Fix #11809: 13.0.9 SelectOneMenu keyup only check printable keys

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -674,7 +674,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
             }
         })
         .on('keyup.ui-selectonemenu', function(e) {
-            if (PrimeFaces.utils.ignoreFilterKey(e)) {
+            if (PrimeFaces.utils.ignoreFilterKey(e) || !PrimeFaces.utils.isPrintableKey(e)) {
                 return;
             }
 


### PR DESCRIPTION
Fix #11809: 13.0.9 SelectOneMenu keyup only check printable keys