### PR TITLE
Fix #11824: AjaxStatus always hide in oncomplete

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus001.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import lombok.Data;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+import java.io.Serializable;
+
+@Named
+@RequestScoped
+@Data
+public class AjaxStatus001 implements Serializable {
+
+    private static final long serialVersionUID = -7518459955779385834L;
+
+    public void twoSeconds() {
+        try {
+            Thread.sleep(2000);
+        }
+        catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus001.xhtml
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<p:ajaxStatus id="ajaxStatus" style="display:block; padding: 0">
+
+			<f:facet name="default">
+			    <span id="defaultStatus">Default Displayed!</span>
+			</f:facet>
+
+			<f:facet name="start">
+				 <span id="startStatus">Start Facet!</span>
+			</f:facet>
+
+		</p:ajaxStatus>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Submit" update="@form" action="#{ajaxStatus001.twoSeconds}"/>
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus002.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<p:ajaxStatus id="ajaxStatus" style="display:block; padding: 0">
+
+			<f:facet name="default">
+				<span id="defaultStatus">Default Displayed!</span>
+			</f:facet>
+
+			<f:facet name="start">
+				<span id="startStatus">Start Facet!</span>
+			</f:facet>
+
+			<f:facet name="complete">
+				<span id="completeStatus">Complete Facet!</span>
+			</f:facet>
+
+		</p:ajaxStatus>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Submit" update="@form"
+				action="#{ajaxStatus001.twoSeconds}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus003.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<p:ajaxStatus id="ajaxStatus" style="display:block; padding: 0">
+
+			<f:facet name="default">
+				<span id="defaultStatus">Default Displayed!</span>
+			</f:facet>
+
+			<f:facet name="start">
+				<span id="startStatus">Start Facet!</span>
+			</f:facet>
+
+			<f:facet name="success">
+				<span id="successStatus">Success Facet!</span>
+			</f:facet>
+
+		</p:ajaxStatus>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Submit" update="@form"
+				action="#{ajaxStatus001.twoSeconds}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus004.xhtml
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<p:ajaxStatus id="ajaxStatus" style="display:block; padding: 0">
+
+			<f:facet name="default">
+				<span id="defaultStatus">Default Displayed!</span>
+			</f:facet>
+
+			<f:facet name="start">
+				<span id="startStatus">Start Facet!</span>
+			</f:facet>
+
+			<f:facet name="success">
+				<span id="successStatus">Success Facet!</span>
+			</f:facet>
+
+			<f:facet name="complete">
+				<span id="completeStatus">Complete Facet!</span>
+			</f:facet>
+
+		</p:ajaxStatus>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Submit" update="@form"
+				action="#{ajaxStatus001.twoSeconds}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus005.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxstatus/ajaxStatus005.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<p:ajaxStatus id="ajaxStatus" style="display:block; padding: 0">
+
+			<f:facet name="default">
+				<span id="defaultStatus">Default Displayed!</span>
+			</f:facet>
+
+			<f:facet name="start">
+				<span id="startStatus">Start Facet!</span>
+			</f:facet>
+
+			<f:facet name="error">
+				<span id="errorStatus">Error Facet!</span>
+			</f:facet>
+
+		</p:ajaxStatus>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Simulate Error" update="@form"
+				action="#{ajaxStatus001.twoSeconds}"
+				oncomplete="$(document).trigger('pfAjaxError');" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus001Test.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+class AjaxStatus001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxStatus: GitHub #11824 Make sure no status if there is no complete facet defined")
+    void noCompleteFacet1(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.click();
+
+        // Assert
+        assertEquals("", ajaxStatus.getText());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("AjaxStatus: GitHub #11824 Check Start Facet is used and then removed when AJAX is complete")
+    void noCompleteFacet2(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.clickUnguarded();
+
+        // Assert
+        assertEquals("Start Facet!", ajaxStatus.getText());
+        TestUtils.wait(3000);
+        assertEquals("", ajaxStatus.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "ajaxStatus")
+        WebElement ajaxStatus;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxstatus/ajaxStatus001.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus002Test.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+class AjaxStatus002Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxStatus: Make sure complete facet is displayed")
+    void completeFacet(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.clickUnguarded();
+
+        // Assert
+        assertEquals("Start Facet!", ajaxStatus.getText());
+        TestUtils.wait(3000);
+        assertEquals("Complete Facet!", ajaxStatus.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "ajaxStatus")
+        WebElement ajaxStatus;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxstatus/ajaxStatus002.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus003Test.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+class AjaxStatus003Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxStatus: Make sure success facet is displayed")
+    void successFacet(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.clickUnguarded();
+
+        // Assert
+        assertEquals("Start Facet!", ajaxStatus.getText());
+        TestUtils.wait(3000);
+        assertEquals("Success Facet!", ajaxStatus.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "ajaxStatus")
+        WebElement ajaxStatus;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxstatus/ajaxStatus003.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus004Test.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+class AjaxStatus004Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxStatus: Make sure all facets are displayed")
+    void allFacets(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.clickUnguarded();
+
+        // Assert
+        assertEquals("Start Facet!", ajaxStatus.getText());
+        TestUtils.wait(3000);
+        assertEquals("Complete Facet!", ajaxStatus.getText());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "ajaxStatus")
+        WebElement ajaxStatus;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxstatus/ajaxStatus004.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxstatus/AjaxStatus005Test.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxstatus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+class AjaxStatus005Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxStatus: Make sure error facet is displayed")
+    void errorFacet(Page page) {
+        // Arrange
+        WebElement ajaxStatus = page.ajaxStatus;
+        assertEquals("Default Displayed!", ajaxStatus.getText());
+
+        // Act
+        page.button.clickUnguarded();
+
+        // Assert
+        assertEquals("Start Facet!", ajaxStatus.getText());
+        TestUtils.wait(3000);
+        assertEquals("Error Facet!", ajaxStatus.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "ajaxStatus")
+        WebElement ajaxStatus;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxstatus/ajaxStatus005.xhtml";
+        }
+    }
+}


### PR DESCRIPTION
Fix #11824: AjaxStatus always hide in oncomplete

This answers the question asked previously...

> Could anyone explain this to me?

```js
if (event !== 'complete' || this.jq.children().filter(this.toFacetId('complete')).length) {
            this.jq.children().hide().filter(this.toFacetId(event)).show();
        }
```

Basically upon `oncomplete` we must call `facets.hide()` because we are done.

cc @stolp 

The code is easier to read below than in the change:

```js
    trigger: function(event, args) {
        var callback = this.cfg[event];
        if (callback) {
            callback.apply(document, args);
        }

        // Get the facet based on the event
        var facets = this.jq.children();
        var facet = facets.filter(this.toFacetId(event));

        // We have the following events:
        // 1) start
        // 2) success or error
        // 3) complete
        switch (event) {
            case 'start':
                // always hide other facets on start
                facets.hide();
                
                if (facet.length > 0) {
                    facet.show();
                }
                break;

            case 'success':
            case 'error':
                // we now expect that either a complete or success/error facet is defined
                // if no success/error is defined, lets just rely upon the complete-facet
                if (facet.length > 0) {
                    facets.hide();
                    facet.show();
                }
                break;

            case 'complete':
                var pfArgs = args[2];
                // if the current request leads in a redirect, skip hiding the previous facet (in best case this is the start-facet)
                // when a sucess/error-facet is defined, this wont work as expected as the 'redirect' information is not available before
                if (!pfArgs || pfArgs.redirect) {
                    return;
                }
                
                // #11824 we must hide all facets and show either complete or default
                facets.hide();

                // Show complete-facet if defined, else show default facet
                if (facet.length > 0) {
                    facet.show();
                }
                break;
        }
    }
 ```
 
 the only important change is moving the hide in the `complete`
 
 ```js
                // #11824 we must hide all facets and show either complete or default
                facets.hide();
```
