### PR TITLE
Fix #11824: AjaxStatus always hide in oncomplete

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js
@@ -182,10 +182,12 @@ PrimeFaces.widget.AjaxStatus = PrimeFaces.widget.BaseWidget.extend({
                 return;
             }
 
-            // skip hiding success/error, if no complete-facet is defined
+            // #11824 we must hide all facets and show either complete or default
+            facets.hide();
+
+            // Show complete-facet if defined, else show default facet
             if (facet.length > 0) {
-                facets.hide();
-                facet.show(); 
+                facet.show();
             }
         }
     },


### PR DESCRIPTION
Fix #11824: AjaxStatus always hide in oncomplete

@tandraschko here is a simpler PR that doesn't refactor into switch statement.  If you look at @stolp scenario he simply doens't defined a `compelte` facet which is perfectly valid so the ajax status never goes away.