### PR TITLE
Fix #11830: 13.0.9 Spinner prevent value outside min/max range

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerBase.java
@@ -95,7 +95,7 @@ public abstract class SpinnerBase extends AbstractPrimeHtmlInputText implements 
     }
 
     public double getMin() {
-        return (Double) getStateHelper().eval(PropertyKeys.min, Double.MIN_VALUE);
+        return (Double) getStateHelper().eval(PropertyKeys.min, -Double.MAX_VALUE);
     }
 
     public void setMin(double min) {

--- a/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -48,7 +48,7 @@ public class SpinnerRenderer extends InputRenderer {
 
         String submittedValue = context.getExternalContext().getRequestParameterMap().get(spinner.getClientId(context) + "_input");
 
-        if (submittedValue != null) {
+        if (LangUtils.isNotEmpty(submittedValue)) {
             String prefix = spinner.getPrefix();
             String suffix = spinner.getSuffix();
 
@@ -63,6 +63,12 @@ public class SpinnerRenderer extends InputRenderer {
             }
             if (LangUtils.isNotEmpty(spinner.getDecimalSeparator())) {
                 submittedValue = submittedValue.replace(spinner.getDecimalSeparator(), ".");
+            }
+
+            // GitHub #11830 prevent value outside of minimum or maximum range
+            double submittedNumber = Double.parseDouble(submittedValue);
+            if (submittedNumber < spinner.getMin() || submittedNumber > spinner.getMax()) {
+                return;
             }
         }
 
@@ -92,7 +98,7 @@ public class SpinnerRenderer extends InputRenderer {
         wb.init("Spinner", spinner)
                 .attr("step", spinner.getStepFactor(), 1.0)
                 .attr("round", spinner.isRound(), false)
-                .attr("min", spinner.getMin(), Double.MIN_VALUE)
+                .attr("min", spinner.getMin(), -Double.MAX_VALUE)
                 .attr("max", spinner.getMax(), Double.MAX_VALUE)
                 .attr("prefix", spinner.getPrefix(), null)
                 .attr("suffix", spinner.getSuffix(), null)


### PR DESCRIPTION
Fix #11830: 13.0.9 Spinner prevent value outside min/max range