### PR TITLE
Fix #11860: 14.0.1 Dialog return focus ONLY if no other dialogs still open

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -387,6 +387,12 @@ PrimeFaces.widget.Dialog = PrimeFaces.widget.DynamicOverlayWidget.extend({
     returnFocus: function() {
         var el = this.focusedElementBeforeDialogOpened;
         if (el) {
+            // #11860 do not return focus to caller if other dialogs are still open
+            var otherDialogs = $(".ui-dialog:visible").length > 0;
+            if (otherDialogs) {
+                return;
+            }
+            // #11318 prevent scrolling in Chrome by using delayed execution
             PrimeFaces.queueTask(function() { el.focus({ preventScroll: true }) }, 100);
         }
     },


### PR DESCRIPTION
Fix #11860: 14.0.1 Dialog return focus ONLY if no other dialogs still open