### PR TITLE
Fix and improve 14.0.0 migration guide

### DIFF
--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -72,7 +72,7 @@ Few selection attributes have been renamed for consistency purposes:
   * `org.primefaces.model.file.UploadedFile` now required new overridden method `getWebkitRelativePath()` see: https://github.com/primefaces/primefaces/pull/10272
   * Apache Commons FileUpload deprecated
   * `invalidSizeMessage`, `invalidFileMessage`, `fileLimitMessage` are deprecated and will be removed in 15.0.0. PF i18n will be used for it.
-  * `sizeLimit`, `fileLimit`, `allowedTypes` are deprecated and will be removed in 15.0.0. Please attach `p:validateFile` to the `p:fileUpload` component.
+  * `sizeLimit`, `fileLimit`, `allowTypes` are deprecated and will be removed in 15.0.0. Please attach `p:validateFile` to the `p:fileUpload` component.
   * Simple FileUpload: Client side validation has been re-implemented with PrimeFaces CSV and support for `p:message(s)`/`p:growl`. Please make sure to enable CSV to use it.
   * Simple FileUpload: filename is not displayed by default when `auto=true`, set `displayFilename=true` instead if you need it.
   * Explicitly add `<p:message>` element to print file validation errors. Use attribute `showDetails="true"` in case you want to print the detailed messages.
@@ -87,7 +87,7 @@ Few selection attributes have been renamed for consistency purposes:
 
 ## PickList
 
-  * `addLabel, addAllLabel, removeLabel, removeAllLabel, moveUpLabel,  moveTopLabel, moveDownLabel,  moveBottomLabel` properties have been moved to client side locale
+  * `addLabel, addAllLabel, removeLabel, removeAllLabel, moveUpLabel,  moveTopLabel, moveDownLabel,  moveBottomLabel` properties have been moved to client side locale, see https://github.com/primefaces/primefaces/pull/10418
   * `transfer` and `reorder` events now fire `change` events on the source and target inputs to make it consistent with other inputs
 
 ## SelectOneRadio


### PR DESCRIPTION
- I corrected the name of the FileUpload attribute `allowTypes`.
- I also added a link to the PR that moved the PickList labels to the client side locale, so it is easier to find the new names as they are different.