### PR TITLE
Fix #11914: Allow both URN and URI Taglib

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For a full list of the available downloads, please visit the [download page](htt
 	xmlns:pt="jakarta.faces.passthrough"
 	xmlns:jsf="jakarta.faces"
 	xmlns:ui="jakarta.faces.facelets"
-	xmlns:p="http://primefaces.org/ui">
+	xmlns:p="primefaces">
 
 	<h:head>
 

--- a/primefaces-integration-tests-jakarta/src/main/resources/META-INF/integrationtests.taglib.xml
+++ b/primefaces-integration-tests-jakarta/src/main/resources/META-INF/integrationtests.taglib.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<facelet-taglib version="2.0"
-                xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facelettaglibrary_2_0.xsd">
+<facelet-taglib version="4.0"
+                xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd">
 
     <namespace>http://primefaces.org/ui/integrationtests</namespace>
 

--- a/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/beans.xml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.2" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 
 </beans>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/faces-config.xml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<faces-config version="2.2"
-              xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<faces-config version="4.0"
+              xmlns="https://jakarta.ee/xml/ns/jakartaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd">
 
     <application>
         <action-listener>org.primefaces.application.DialogActionListener</action-listener>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/web.xml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-         version="3.1">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>primefaces-integration-tests</display-name>
 

--- a/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001Dynamic.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001Dynamic.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax2.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax2.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax3.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/datatable/dataTable001DynamicOtherSyntax3.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/error.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/error.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-integration-tests-jakarta/src/main/webapp/inputnumber/inputNumber001.xhtml
+++ b/primefaces-integration-tests-jakarta/src/main/webapp/inputnumber/inputNumber001.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:f="http://xmlns.jcp.org/jsf/core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>

--- a/primefaces-showcase/src/main/webapp/WEB-INF/config.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/config.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:f="jakarta.faces.core"
                 xmlns:h="jakarta.faces.html" xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="primefaces">
 
     <div class="layout-config">
         <div class="layout-config-content-wrapper">

--- a/primefaces-showcase/src/main/webapp/WEB-INF/footer.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/footer.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-    xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui">
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces">
     <div class="layout-footer">
         <div class="layout-footer-left">
             <span>PrimeFaces v#{app.primeFacesVersion} by </span>

--- a/primefaces-showcase/src/main/webapp/WEB-INF/menu.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/menu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="primefaces">
 
     <div class="layout-sidebar">
         <div class="layout-sidebar-filter ui-fluid ui-input-filled">

--- a/primefaces-showcase/src/main/webapp/WEB-INF/tags/tabscode.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/tags/tabscode.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="primefaces">
 
     <!-- EXAMPLE-SOURCE-START -->
 

--- a/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
@@ -3,7 +3,7 @@
       xmlns:h="jakarta.faces.html"
       xmlns:f="jakarta.faces.core"
       xmlns:ui="jakarta.faces.facelets"
-      xmlns:p="http://primefaces.org/ui"
+      xmlns:p="primefaces"
       xmlns:sc="http://primefaces.org/ui/showcase"
       lang="#{p:language()}" xml:lang="#{p:language()}">
 

--- a/primefaces-showcase/src/main/webapp/WEB-INF/topbar.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/topbar.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-                xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui">
+                xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces">
 
     <div class="layout-topbar">
         <a class="menu-button" tabindex="0">

--- a/primefaces-showcase/src/main/webapp/accessibility.xhtml
+++ b/primefaces-showcase/src/main/webapp/accessibility.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-                xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="content">
         <div class="content-section introduction">

--- a/primefaces-showcase/src/main/webapp/colors.xhtml
+++ b/primefaces-showcase/src/main/webapp/colors.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-                xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
     <ui:define name="head">
         <style>
             .color-stack {

--- a/primefaces-showcase/src/main/webapp/error.xhtml
+++ b/primefaces-showcase/src/main/webapp/error.xhtml
@@ -2,7 +2,7 @@
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="content">

--- a/primefaces-showcase/src/main/webapp/getstarted.xhtml
+++ b/primefaces-showcase/src/main/webapp/getstarted.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-    xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="content">
         <div class="content-section documentation">
@@ -22,7 +22,7 @@
             <p>PrimeFaces namespace is necessary to add PrimeFaces components to your pages.</p>
 
 <pre><code class="language-xml">
-&lt;html xmlns:p="http://primefaces.org/ui"&gt;
+&lt;html xmlns:p="primefaces"&gt;
 &lt;/html&gt;
 
 </code></pre>
@@ -34,7 +34,7 @@
 &lt;html xmlns="http://www.w3.org/1999/xhtml"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:p="http://primefaces.org/ui"&gt;
+    xmlns:p="primefaces"&gt;
     
     &lt;h:head&gt;
     &lt;/h:head&gt;

--- a/primefaces-showcase/src/main/webapp/icons.xhtml
+++ b/primefaces-showcase/src/main/webapp/icons.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/index.xhtml
+++ b/primefaces-showcase/src/main/webapp/index.xhtml
@@ -2,7 +2,7 @@
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     
     <ui:define name="content">

--- a/primefaces-showcase/src/main/webapp/primeflex/setup.xhtml
+++ b/primefaces-showcase/src/main/webapp/primeflex/setup.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-    xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="content">
         <div class="content-section documentation">

--- a/primefaces-showcase/src/main/webapp/resources/composite/inputTextWrapper.xhtml
+++ b/primefaces-showcase/src/main/webapp/resources/composite/inputTextWrapper.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
       xmlns:f="jakarta.faces.core"
-      xmlns:p="http://primefaces.org/ui"
+      xmlns:p="primefaces"
       xmlns:composite="jakarta.faces.composite">
 
     <composite:interface>

--- a/primefaces-showcase/src/main/webapp/resources/composite/inputTextWrapperWrapper.xhtml
+++ b/primefaces-showcase/src/main/webapp/resources/composite/inputTextWrapperWrapper.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
       xmlns:f="jakarta.faces.core"
-      xmlns:p="http://primefaces.org/ui"
+      xmlns:p="primefaces"
       xmlns:composite="jakarta.faces.composite"
       xmlns:mycomposites="jakarta.faces.composite">
 

--- a/primefaces-showcase/src/main/webapp/support.xhtml
+++ b/primefaces-showcase/src/main/webapp/support.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-    xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
         <style>

--- a/primefaces-showcase/src/main/webapp/test.xhtml
+++ b/primefaces-showcase/src/main/webapp/test.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="jakarta.faces.facelets"
 	xmlns:f="jakarta.faces.core"
-	xmlns:p="http://primefaces.org/ui"
+	xmlns:p="primefaces"
 	xmlns:h="jakarta.faces.html">
 
 <h:head>

--- a/primefaces-showcase/src/main/webapp/theming.xhtml
+++ b/primefaces-showcase/src/main/webapp/theming.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-    xmlns:ui="jakarta.faces.facelets" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:ui="jakarta.faces.facelets" xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
         <style>

--- a/primefaces-showcase/src/main/webapp/ui/ajax/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/dropdown.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/dropdown.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/fragment.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/fragment.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/lifecycle.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/lifecycle.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/observer.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/observer.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/partialSubmit.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/partialSubmit.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/poll.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/poll.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/process.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/process.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/remoteCommand.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/remoteCommand.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/search.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/search.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/selector.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/selector.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/status.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/status.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/ajax/validation.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/validation.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/button.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/button.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/button/commandButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/commandButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
                 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/button/commandLink.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/commandLink.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/link.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/link.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/linkButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/linkButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/productDetail.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/productDetail.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/speedDial.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/speedDial.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui" xmlns:h="jakarta.faces.html"
+                xmlns:p="primefaces" xmlns:h="jakarta.faces.html"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/button/splitButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/button/splitButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/chart/bar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/bar.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/chart/bubble.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/bubble.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/chart/custom.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/custom.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
 	xmlns:ui="jakarta.faces.facelets"
 	xmlns:h="jakarta.faces.html"
-	xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+	xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
         <script>

--- a/primefaces-showcase/src/main/webapp/ui/chart/doughnut.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/doughnut.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/chart/export.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/export.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     <ui:define name="head">
         <script>

--- a/primefaces-showcase/src/main/webapp/ui/chart/facet.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/facet.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
 

--- a/primefaces-showcase/src/main/webapp/ui/chart/line.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/line.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/chart/pie.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/pie.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/chart/polararea.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/polararea.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/chart/radar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/radar.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/chart/scatter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/chart/scatter.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/csv/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/csv/bean.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/bean.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/csv/complex.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/complex.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:pt="jakarta.faces.passthrough"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/csv/custom.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/custom.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/csv/event.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/event.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/csv/immediate.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/immediate.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/carousel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/carousel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:fn="jakarta.tags.functions"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/chronoline.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/chronoline.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
 

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataexporter/treetable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataexporter/treetable.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datagrid/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datagrid/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datagrid/multiViewState.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datagrid/multiViewState.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datagrid/responsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datagrid/responsive.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datalist/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datalist/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datalist/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datalist/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datalist/multiViewState.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datalist/multiViewState.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datalist/paginator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datalist/paginator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datascroller/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datascroller/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datascroller/inline.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datascroller/inline.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datascroller/loader.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datascroller/loader.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datascroller/loading.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datascroller/loading.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/addRow.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/addRow.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/basic.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:f="jakarta.faces.core"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/columnResize.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/columnResize.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/columnToggler.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/columnToggler.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/columns.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/columns.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/contextMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/contextMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/crud.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/crud.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core" xmlns:ui="jakarta.faces.facelets"
-    xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">
         DataTable <span class="subitem">Crud</span>

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/displayPriority.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/displayPriority.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">
         DataTable <span class="subitem">Display Priority</span>

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/edit.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/edit.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/expansion.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/expansion.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/facets.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/facets.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:fn="jakarta.tags.functions"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/field.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/field.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:f="jakarta.faces.core"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/filter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/filter.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/gridlines.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/gridlines.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:f="jakarta.faces.core"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/group.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/group.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">
         DataTable <span class="subitem">Group</span>

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/multiViewState.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/multiViewState.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/paginator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/paginator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/reorder.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/reorder.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">
         DataTable <span class="subitem">Reorder</span>

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/responsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/responsive.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/rowColor.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/rowColor.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/rowGroup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/rowGroup.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/rowTitle.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/rowTitle.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/rtl.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/rtl.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/scroll.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/scroll.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/selection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/selection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/size.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/size.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:f="jakarta.faces.core"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/sort.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/sort.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/sticky.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/sticky.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/striped.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/striped.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:f="jakarta.faces.core"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/subtable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/subtable.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:f="jakarta.faces.core"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/dataview/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataview/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataview/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataview/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataview/multiViewState.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataview/multiViewState.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/dataview/responsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/dataview/responsive.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/diagram/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/diagram/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/diagram/editable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/diagram/editable.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml"
 >
 

--- a/primefaces-showcase/src/main/webapp/ui/data/diagram/flowchart.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/diagram/flowchart.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/diagram/hierarchical.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/diagram/hierarchical.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/diagram/statemachine.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/diagram/statemachine.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/addMarkers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/addMarkers.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/circles.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/circles.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/controls.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/controls.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/event.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/event.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/geocode.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/geocode.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/infoWindow.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/infoWindow.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/mapDialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/mapDialog.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/markerSelection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/markerSelection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/markers.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/markers.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/polygons.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/polygons.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/polylines.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/polylines.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/rectangles.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/rectangles.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/gmap/street.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/gmap/street.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/htree/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/htree/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/htree/contextMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/htree/contextMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/htree/events.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/htree/events.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/htree/icon.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/htree/icon.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/htree/selection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/htree/selection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/mindmap.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/mindmap.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/orderList.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/orderList.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/organigram.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/organigram.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:fn="jakarta.tags.functions"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/pickList.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/pickList.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/configuration.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/configuration.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/extender.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/extender.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/schedule/localization.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/schedule/localization.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/tagCloud.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tagCloud.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/allEvents.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/allEvents.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/custom.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/custom.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/dragdrop.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/dragdrop.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/editServer.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/editServer.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml"
                 xmlns:sc="http://primefaces.org/ui/showcase">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/grouping.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/grouping.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml"
                 xmlns:sc="http://primefaces.org/ui/showcase">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/lazy.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/lazy.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml"
                 xmlns:sc="http://primefaces.org/ui/showcase">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/limitRange.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/limitRange.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/linked.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/linked.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/timeline/nestedGrouping.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/timeline/nestedGrouping.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml"
                 xmlns:sc="http://primefaces.org/ui/showcase">
 

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/animate.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/animate.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/contextMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/contextMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/dragdrop.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/dragdrop.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/events.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/events.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/filter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/filter.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/icon.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/icon.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/lazyloading.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/lazyloading.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/rtl.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/rtl.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/tree/selection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/tree/selection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/columns.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/columns.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
                 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/contextMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/contextMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/displayPriority.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/displayPriority.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/edit.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/edit.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     <ui:define name="head">
         <style>

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/events.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/events.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/filter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/filter.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/gridlines.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/gridlines.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/multiViewState.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/multiViewState.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/paginator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/paginator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/resize.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/resize.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
                 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/responsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/responsive.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/scroll.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/scroll.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/selection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/selection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/size.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/size.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/data/treetable/sort.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/treetable/sort.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/df/data.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/data.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/df/level1.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level1.xhtml
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
       xmlns:f="jakarta.faces.core"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Level 1</title>

--- a/primefaces-showcase/src/main/webapp/ui/df/level2.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level2.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Level 2</title>

--- a/primefaces-showcase/src/main/webapp/ui/df/level3.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/level3.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 <h:head>
     <title>Level 3</title>
     <style>

--- a/primefaces-showcase/src/main/webapp/ui/df/message.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/message.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/df/nested.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/nested.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/df/selectProduct.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/selectProduct.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Products</title>

--- a/primefaces-showcase/src/main/webapp/ui/df/viewProducts.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/viewProducts.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Products</title>

--- a/primefaces-showcase/src/main/webapp/ui/df/viewProductsLargerThanViewport.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/viewProductsLargerThanViewport.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Products</title>

--- a/primefaces-showcase/src/main/webapp/ui/df/viewResponsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/df/viewResponsive.xhtml
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="jakarta.faces.html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="primefaces">
 
 <h:head>
     <title>Responsive Dialog</title>

--- a/primefaces-showcase/src/main/webapp/ui/dnd/custom.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/dnd/custom.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/dnd/dataTable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/dnd/dataTable.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/dnd/dataView.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/dnd/dataView.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/dnd/draggable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/dnd/draggable.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/file/download.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/download.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     <ui:define name="head">
         <script>

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/auto.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/auto.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/basicAuto.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/basicAuto.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/chunked.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/chunked.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/dnd.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/dnd.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/multiple.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/multiple.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/single.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/single.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/tooltips.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/tooltips.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/autoComplete.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/autoComplete.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/booleanButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/booleanButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/booleanCheckbox.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/booleanCheckbox.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/calendar/calendar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/calendar/calendar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/cascadeSelect.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/cascadeSelect.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/chips.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/chips.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/colorPicker.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/colorPicker.xhtml
@@ -2,7 +2,7 @@
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
         <style>

--- a/primefaces-showcase/src/main/webapp/ui/input/colorPickerInline.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/colorPickerInline.xhtml
@@ -2,7 +2,7 @@
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
@@ -2,7 +2,7 @@
 	xmlns:ui="jakarta.faces.facelets"
 	xmlns:h="jakarta.faces.html"
 	xmlns:f="jakarta.faces.core"
-	xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+	xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
 	<ui:define name="head">
 		<script>

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/metadata.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/metadata.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/formLayout.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/formLayout.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inplace.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inplace.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
                 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inputGroup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputGroup.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inputMask.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputMask.xhtml
@@ -1,5 +1,5 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets"
-    xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core" xmlns:p="http://primefaces.org/ui"
+    xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core" xmlns:p="primefaces"
     template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inputNumber.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputNumber.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inputText.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputText.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/inputTextarea.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/inputTextarea.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/keyFilter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/keyFilter.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/keyboard.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/keyboard.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/knob.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/knob.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
 

--- a/primefaces-showcase/src/main/webapp/ui/input/listbox.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/listbox.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/manyButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/manyButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/manyCheckbox.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/manyCheckbox.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/manyMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/manyMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/multiSelectListbox.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/multiSelectListbox.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/oneButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/oneButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/oneMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/oneMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/oneRadio.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/oneRadio.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/input/password.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/password.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/rating.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/rating.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/signature.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/signature.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/slider.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/slider.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/spinner.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/spinner.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/textEditor.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/textEditor.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/toggleSwitch.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/toggleSwitch.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/input/triStateCheckbox.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/triStateCheckbox.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/breadcrumb.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/breadcrumb.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/target.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/target.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/tiered.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/contextmenu/tiered.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/dock.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/dock.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/megaMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/megaMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/menu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/menubar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menubar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/panelMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/panelMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/slideMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/slideMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/stack.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/stack.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/menu/steps.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/steps.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/tabMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/menu/tieredMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/tieredMenu.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/message/growl.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/message/growl.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/message/messages.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/message/messages.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/message/staticMessage.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/message/staticMessage.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/autoUpdate.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/autoUpdate.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/avatar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/avatar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/badge.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/badge.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/cache.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/cache.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:sc="http://primefaces.org/ui/showcase"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/captcha.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/captcha.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/chip.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/chip.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/clock.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/clock.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/context.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/context.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/csp.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/csp.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/defaultcommand/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/defaultcommand/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/defaultcommand/multiple.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/defaultcommand/multiple.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/effect.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/effect.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/exceptionHandler.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/exceptionHandler.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/feedReader.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/feedReader.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/floatLabel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/floatLabel.xhtml
@@ -2,7 +2,7 @@
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:p="http://primefaces.org/ui"
+    xmlns:p="primefaces"
     xmlns:composite="jakarta.faces.composite"
     template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/misc/focus.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/focus.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/hotkey.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/hotkey.xhtml
@@ -1,7 +1,7 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/idleMonitor.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/idleMonitor.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/importConstants.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/importConstants.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/lifecycle.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/lifecycle.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/log.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/log.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/outputLabel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/outputLabel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:composite="jakarta.faces.composite"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/misc/printer.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/printer.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/progressBar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/progressBar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/resetInput.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/resetInput.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/resizable.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/resizable.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     <ui:define name="title">
         Resizable

--- a/primefaces-showcase/src/main/webapp/ui/misc/scrollTop.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/scrollTop.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/separator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/separator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/skeleton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/skeleton.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/spacer.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/spacer.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/spotlight.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/spotlight.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/misc/sticky.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/sticky.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/tag.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/tag.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/terminal/autocomplete.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/terminal/autocomplete.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/misc/terminal/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/terminal/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/audio.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/audio.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/barcode.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/barcode.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/compare.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/compare.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/cropper.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/cropper.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/fileupload.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/cropper/fileupload.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/autoplay.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/autoplay.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/basic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/basic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/caption.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/caption.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/dynamic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/dynamic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/fullscreen.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/fullscreen.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/indicator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/indicator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/navigator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/navigator.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/programmatic.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/programmatic.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/responsive.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/responsive.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/thumbnail.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/galleria/thumbnail.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/graphicImage.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/graphicImage.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/media.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/media.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/photocam/deviceSelection.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/photocam/deviceSelection.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/photocam/photoCam.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/photocam/photoCam.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/switch.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/switch.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/multimedia/video.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/video.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/confirmPopup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/confirmPopup.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/dialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/dialog.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/overlayPanel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/overlayPanel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/sidebar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/sidebar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipGlobal.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipGlobal.xhtml
@@ -3,7 +3,7 @@
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
                 xmlns:pt="jakarta.faces.passthrough"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/accordionPanel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/accordionPanel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/card.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/card.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 xmlns:f="jakarta.faces.core"
                 template="/WEB-INF/template.xhtml">
 

--- a/primefaces-showcase/src/main/webapp/ui/panel/dashboard.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/dashboard.xhtml
@@ -2,7 +2,7 @@
     xmlns:ui="jakarta.faces.facelets"
     xmlns:h="jakarta.faces.html"
     xmlns:f="jakarta.faces.core"
-    xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+    xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
         <style>

--- a/primefaces-showcase/src/main/webapp/ui/panel/divider.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/divider.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/fieldset.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/fieldset.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/flexGrid.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/flexGrid.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/panel/grid.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/grid.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/panel/notificationBar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/notificationBar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/ui/panel/outputPanel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/outputPanel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/panel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/panel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/panelGrid.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/panelGrid.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/scrollPanel.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/scrollPanel.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/splitter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/splitter.xhtml
@@ -1,6 +1,6 @@
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="jakarta.faces.facelets"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/tabView.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/tabView.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/toolbar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/toolbar.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">

--- a/primefaces-showcase/src/main/webapp/ui/panel/wizard.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/panel/wizard.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">

--- a/primefaces-showcase/src/main/webapp/uikit.xhtml
+++ b/primefaces-showcase/src/main/webapp/uikit.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+                xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
     <ui:define name="head">
 
         <style>

--- a/primefaces-showcase/src/main/webapp/viewExpired.xhtml
+++ b/primefaces-showcase/src/main/webapp/viewExpired.xhtml
@@ -2,7 +2,7 @@
                 xmlns:ui="jakarta.faces.facelets"
                 xmlns:h="jakarta.faces.html"
                 xmlns:f="jakarta.faces.core"
-                xmlns:p="http://primefaces.org/ui"
+                xmlns:p="primefaces"
                 template="/WEB-INF/template.xhtml">
     
     <ui:define name="head">

--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -943,6 +943,9 @@
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
                                             <resource>META-INF/primefaces-p.taglib.xml</resource>
                                         </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
+                                            <resource>META-INF/primefaces-p.urn.taglib.xml</resource>
+                                        </transformer>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                             <resource>META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js</resource>
                                         </transformer>
@@ -1192,6 +1195,31 @@
                         <version>0.0.5</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <!-- Rename the copied XML file -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>rename-xml-file</id>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <target>
+                                <copy  file="${project.build.directory}/classes/META-INF/primefaces-p.taglib.xml"
+                                      tofile="${project.build.directory}/classes/META-INF/primefaces-p.urn.taglib.xml"/>
+                                <!-- Modify the copied file -->
+                                <replace file="${project.build.directory}/classes/META-INF/primefaces-p.urn.taglib.xml">
+                                    <replacefilter token="http://primefaces.org/ui" value="primefaces"/>
+                                </replace>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix #11914: Allow both URN and URI Taglib

@tandraschko this does similar to what OmniFaces is doing to maintain both for a while it basically copies the taglib and renames the namespace so the JAR has both taglibs.

I also tested this is working with our Jakarta JAR as well.