### PR TITLE
Fix #11929: ConfirmDialog/Popup yes and no labels and classes

### DIFF
--- a/docs/15_0_0/gettingstarted/whatsnew.md
+++ b/docs/15_0_0/gettingstarted/whatsnew.md
@@ -16,6 +16,12 @@ Look into [migration guide](https://primefaces.github.io/primefaces/15_0_0/#/../
 * Captcha
     * Added [hCaptcha](https://www.hcaptcha.com/) support
     
+* ConfirmDialog/ConfirmPopup
+    * `yesButtonLabel`: overrides label of 'Yes' button (and restores it before the global confirm dialog is reused elsewhere)
+    * `yesButtonClass`: adds given class to 'Yes' button (and removes it before the global confirm dialog is reused elsewhere)
+    * `noButtonLabel`: overrides label of 'No' button (and restores it before the global confirm dialog is reused elsewhere)
+    * `noButtonClass`: adds given class to 'No' button (and removes it before the global confirm dialog is reused elsewhere)
+    
 * FeedReader
     * Added `podcast="true"` property if [Apple Itunes Podcast](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) parsing and specific tags 
     

--- a/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog001.xhtml
@@ -19,8 +19,14 @@
             </p:commandButton>
 
             <p:commandButton id="delete" value="Delete" action="#{confirmDialog001.delete}" update="message" styleClass="ui-button-danger mr-2" icon="pi pi-times">
-                <p:confirm header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
-            </p:commandButton>
+				<p:confirm header="Confirmation"
+					message="Do you want to delete this record?"
+					icon="pi pi-info-circle" 
+					yesButtonLabel="Delete Me!"
+					yesButtonClass="bg-red-500 text-white" 
+					noButtonLabel="Keep this!"
+					noButtonClass="bg-green-500 text-white" />
+			</p:commandButton>
             
             <p:commandButton id="nonAjax" value="Non-Ajax" action="#{confirmDialog001.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
                 <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>

--- a/primefaces-integration-tests/src/main/webapp/confirmpopup/confirmPopup001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmpopup/confirmPopup001.xhtml
@@ -19,7 +19,13 @@
             </p:commandButton>
 
             <p:commandButton id="delete" value="Delete" action="#{confirmPopup001.delete}" update="message" styleClass="ui-button-danger" icon="pi pi-times">
-                <p:confirm type="popup" header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
+                <p:confirm type="popup" header="Confirmation"
+                    message="Do you want to delete this record?"
+                    icon="pi pi-info-circle" 
+                    yesButtonLabel="Delete Me!"
+                    yesButtonClass="bg-red-500 text-white" 
+                    noButtonLabel="Keep this!"
+                    noButtonClass="bg-green-500 text-white" />
             </p:commandButton>
 
             <p:confirmPopup id="confirmpopup" global="true" showEffect="fade" hideEffect="fade">

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
@@ -34,6 +34,7 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeExpectedConditions;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.ConfirmDialog;
@@ -96,9 +97,12 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.confirm.click();
+        CommandButton noButton = dialog.getNoButton();
+        assertEquals("No", noButton.getText());
+        assertCss(noButton, "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirmdialog-no ui-button-flat");
 
         // Act
-        dialog.getNoButton().click();
+        noButton.click();
 
         // Assert
         assertTrue(page.message.isEmpty());
@@ -113,9 +117,12 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         page.confirm.click();
         assertTrue(dialog.isVisible());
+        CommandButton yesButton = dialog.getYesButton();
+        assertEquals("Yes", yesButton.getText());
+        assertCss(yesButton, "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirmdialog-yes");
 
         // Act
-        PrimeSelenium.guardAjax(dialog.getYesButton()).click();
+        PrimeSelenium.guardAjax(yesButton).click();
 
         // Assert
         assertEquals("You have accepted", page.message.getMessage(0).getDetail());
@@ -130,6 +137,10 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.delete.click();
+        CommandButton noButton = dialog.getNoButton();
+        assertEquals("Keep this!", noButton.getText());
+        assertCss(noButton,
+                "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirmdialog-no ui-button-flat bg-green-500 text-white");
 
         // Act
         dialog.getNoButton().click();
@@ -137,6 +148,9 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         // Assert
         assertTrue(page.message.isEmpty());
         assertDialog(page, false);
+
+        // assert the buttons are back to normal
+        confirmNo(page);
     }
 
     @Test
@@ -147,13 +161,18 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.delete.click();
+        CommandButton yesButton = dialog.getYesButton();
+        assertEquals("Delete Me!", yesButton.getText());
+        assertCss(yesButton, "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirmdialog-yes bg-red-500 text-white");
 
         // Act
-        PrimeSelenium.guardAjax(dialog.getYesButton()).click();
+        PrimeSelenium.guardAjax(yesButton).click();
 
         // Assert
         assertEquals("Record deleted", page.message.getMessage(0).getDetail());
         assertDialog(page, false);
+        // assert the buttons are back to normal
+        confirmYes(page);
     }
 
     @Test
@@ -210,6 +229,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         else {
             assertClickableOrLoading(page.confirm);
             assertClickableOrLoading(page.delete);
+            PrimeSelenium.waitGui().until(PrimeExpectedConditions.invisibleAndAnimationComplete(dialog));
         }
 
         assertConfiguration(dialog.getWidgetConfiguration());

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001Test.java
@@ -84,9 +84,13 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
         ConfirmPopup popup = page.popup;
         assertFalse(popup.isVisible());
         page.confirm.click();
+        CommandButton noButton = popup.getNoButton();
+        assertEquals("No", noButton.getText());
+        assertCss(noButton,
+                "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirm-popup-no ui-button-flat");
 
         // Act
-        popup.getNoButton().click();
+        noButton.click();
 
         // Assert
         assertFalse(popup.isVisible());
@@ -102,9 +106,12 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
         ConfirmPopup popup = page.popup;
         assertFalse(popup.isVisible());
         page.confirm.click();
+        CommandButton yesButton = popup.getYesButton();
+        assertEquals("Yes", yesButton.getText());
+        assertCss(yesButton, "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirm-popup-yes");
 
         // Act
-        PrimeSelenium.guardAjax(popup.getYesButton()).click();
+        PrimeSelenium.guardAjax(yesButton).click();
 
         // Assert
         assertFalse(popup.isVisible());
@@ -120,14 +127,21 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
         ConfirmPopup popup = page.popup;
         assertFalse(popup.isVisible());
         page.delete.click();
+        CommandButton noButton = popup.getNoButton();
+        assertEquals("Keep this!", noButton.getText());
+        assertCss(noButton,
+                "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirm-popup-no ui-button-flat bg-green-500 text-white");
 
         // Act
-        popup.getNoButton().click();
+        noButton.click();
 
         // Assert
         assertFalse(popup.isVisible());
         assertTrue(page.messages.isEmpty());
         assertConfiguration(popup.getWidgetConfiguration());
+
+        // assert the buttons are back to normal
+        confirmNo(page);
     }
 
     @Test
@@ -138,14 +152,19 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
         ConfirmPopup popup = page.popup;
         assertFalse(popup.isVisible());
         page.delete.click();
+        CommandButton yesButton = popup.getYesButton();
+        assertEquals("Delete Me!", yesButton.getText());
+        assertCss(yesButton, "ui-button ui-widget ui-state-default ui-corner-all ui-button-text-only ui-confirm-popup-yes bg-red-500 text-white");
 
         // Act
-        PrimeSelenium.guardAjax(popup.getYesButton()).click();
+        PrimeSelenium.guardAjax(yesButton).click();
 
         // Assert
         assertFalse(popup.isVisible());
         assertMessage(page, "Record deleted");
         assertConfiguration(popup.getWidgetConfiguration());
+        // assert the buttons are back to normal
+        confirmYes(page);
     }
 
     private void assertMessage(Page page, String message) {

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageTest.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageTest.java
@@ -184,7 +184,7 @@ public abstract class AbstractPrimePageTest {
     protected void assertIsAt(Class<? extends AbstractPrimePage> pageClass) {
         String location;
         try {
-            location = PrimeSelenium.getUrl((AbstractPrimePage) pageClass.getDeclaredConstructor().newInstance());
+            location = PrimeSelenium.getUrl(pageClass.getDeclaredConstructor().newInstance());
         }
         catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
@@ -305,19 +305,20 @@ public abstract class AbstractPrimePageTest {
 
         String[] elementClasses = elementClass.split(" ");
 
-        boolean result = true;
-        for (String expected : cssClasses) {
-            boolean found = false;
-            for (String actual : elementClasses) {
-                if (actual.equalsIgnoreCase(expected)) {
-                    found = true;
+        for (String expectedClass : cssClasses) {
+            for (String expected : expectedClass.split(" ")) {
+                boolean found = false;
+                for (String actual : elementClasses) {
+                    if (actual.equalsIgnoreCase(expected)) {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found) {
+                    fail("Element expected CSS class '" + expected + "' but was not found in '" + elementClass + "'.");
                     break;
                 }
-            }
-
-            if (!found) {
-                fail("Element expected CSS class '" + expected + "' but was not found in '" + elementClass + "'.");
-                break;
             }
         }
 

--- a/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/confirmDialog.xhtml
@@ -25,11 +25,17 @@
                     <p:confirm header="Confirmation" message="Are you sure you want to proceed?" icon="pi pi-exclamation-triangle"/>
                 </p:commandButton>
 
-                <p:commandButton value="Delete" action="#{confirmView.delete}" update="message" styleClass="ui-button-danger mr-2" icon="pi pi-times">
-                    <p:confirm header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
-                </p:commandButton>
-                
-                <p:commandButton value="Non-Ajax" action="#{confirmView.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
+				<p:commandButton value="Delete" action="#{confirmView.delete}"	update="message" styleClass="ui-button-danger mr-2" icon="pi pi-times">
+					<p:confirm header="Confirmation"
+						message="Do you want to delete this record?"
+						icon="pi pi-info-circle" 
+						yesButtonLabel="Delete Me!"
+						yesButtonClass="bg-red-500 text-white" 
+						noButtonLabel="Keep this!"
+						noButtonClass="bg-green-500 text-white" />
+				</p:commandButton>
+
+				<p:commandButton value="Non-Ajax" action="#{confirmView.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
                     <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>
                 </p:commandButton>
 

--- a/primefaces-showcase/src/main/webapp/ui/overlay/confirmPopup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/confirmPopup.xhtml
@@ -26,8 +26,14 @@
                 </p:commandButton>
 
                 <p:commandButton value="Delete" action="#{confirmView.delete}" update="message" styleClass="ui-button-danger mr-2" icon="pi pi-times">
-                    <p:confirm type="popup" header="Confirmation" message="Do you want to delete this record?" icon="pi pi-info-circle"/>
-                </p:commandButton>
+					<p:confirm type="popup" header="Confirmation"
+						message="Do you want to delete this record?"
+						icon="pi pi-info-circle" 
+						yesButtonLabel="Delete Me!"
+						yesButtonClass="bg-red-500 text-white" 
+						noButtonLabel="Keep this!"
+						noButtonClass="bg-green-500 text-white" />
+				</p:commandButton>
                 
                 <p:commandButton value="Non-Ajax" action="#{confirmView.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
                     <p:confirm type="popup" header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>

--- a/primefaces/src/main/java/org/primefaces/behavior/confirm/ConfirmBehavior.java
+++ b/primefaces/src/main/java/org/primefaces/behavior/confirm/ConfirmBehavior.java
@@ -42,6 +42,10 @@ public class ConfirmBehavior extends AbstractBehavior {
         header(String.class),
         message(String.class),
         icon(String.class),
+        yesButtonLabel(String.class),
+        yesButtonClass(String.class),
+        noButtonLabel(String.class),
+        noButtonClass(String.class),
         disabled(Boolean.class),
         beforeShow(String.class),
         escape(Boolean.class);
@@ -76,6 +80,10 @@ public class ConfirmBehavior extends AbstractBehavior {
         String headerText = JSONObject.quote(getHeader());
         String messageText = JSONObject.quote(getMessage());
         String beforeShow = JSONObject.quote(getBeforeShow());
+        String yesButtonClass = JSONObject.quote(getYesButtonClass());
+        String yesButtonLabel = JSONObject.quote(getYesButtonLabel());
+        String noButtonClass = JSONObject.quote(getNoButtonClass());
+        String noButtonLabel = JSONObject.quote(getNoButtonLabel());
 
         source = (source == null) ? component.getClientId(context) : source;
 
@@ -88,6 +96,10 @@ public class ConfirmBehavior extends AbstractBehavior {
                                                    + ",escape:" + isEscape()
                                                    + ",header:" + headerText
                                                    + ",message:" + messageText
+                                                   + ",yesButtonClass:" + yesButtonClass
+                                                   + ",yesButtonLabel:" + yesButtonLabel
+                                                   + ",noButtonClass:" + noButtonClass
+                                                   + ",noButtonLabel:" + noButtonLabel
                                                    + ",icon:\"" + (icon == null ? "" : icon)
                                                    + "\",beforeShow:" + beforeShow
                                                    + "});return false;";
@@ -168,5 +180,37 @@ public class ConfirmBehavior extends AbstractBehavior {
 
     public void setEscape(boolean escape) {
         put(PropertyKeys.escape, escape);
+    }
+
+    public String getYesButtonLabel() {
+        return eval(PropertyKeys.yesButtonLabel, null);
+    }
+
+    public void setYesButtonLabel(String yesButtonLabel) {
+        put(PropertyKeys.yesButtonLabel, yesButtonLabel);
+    }
+
+    public String getYesButtonClass() {
+        return eval(PropertyKeys.yesButtonClass, null);
+    }
+
+    public void setYesButtonClass(String yesButtonClass) {
+        put(PropertyKeys.yesButtonClass, yesButtonClass);
+    }
+
+    public String getNoButtonLabel() {
+        return eval(PropertyKeys.noButtonLabel, null);
+    }
+
+    public void setNoButtonLabel(String noButtonLabel) {
+        put(PropertyKeys.noButtonLabel, noButtonLabel);
+    }
+
+    public String getNoButtonClass() {
+        return eval(PropertyKeys.noButtonClass, null);
+    }
+
+    public void setNoButtonClass(String noButtonClass) {
+        put(PropertyKeys.noButtonClass, noButtonClass);
     }
 }

--- a/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces-p.taglib.xml
@@ -534,6 +534,30 @@
             <type>java.lang.Boolean</type>
         </attribute>
         <attribute>
+            <description><![CDATA[Overrides label of 'Yes' button (and restores it before the global confirm dialog is reused elsewhere)]]></description>
+            <name>yesButtonLabel</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description><![CDATA[Adds given style class to 'Yes' button (and removes it before the global confirm dialog is reused elsewhere)]]></description>
+            <name>yesButtonClass</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description><![CDATA[Overrides label of 'No' button (and restores it before the global confirm dialog is reused elsewhere)]]></description>
+            <name>noButtonLabel</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description><![CDATA[Adds given style class to 'No' button (and removes it before the global confirm dialog is reused elsewhere)]]></description>
+            <name>noButtonClass</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
             <description>
                 <![CDATA[Callback to execute before displaying confirmation dialog. Return false to prevent dialog from appearing.]]>
             </description>


### PR DESCRIPTION
Fix #11929: ConfirmDialog/Popup yes and no labels and classes

![image](https://github.com/primefaces/primefaces/assets/4399574/22ba5775-d06f-4f37-87c9-697d9dea467d)
