### PR TITLE
Fix #11885 14.0.1 DataTable: Select/unselect all with selectionPageOnly="false" does not work properly

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable006.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable006.xhtml
@@ -39,7 +39,10 @@
             </p:dataTable>
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable006.submit}"/>
-            <p:commandButton id="toggleSelectPageOnly" value="Selection Page Only" update="@form" action="#{dataTable006.toggleSelectPageOnly}"/>
+            <p:selectBooleanButton id="toggleSelectPageOnly" value="#{dataTable006.selectionPageOnly}"
+                                   onLabel="Page only" offLabel="All pages">
+                <p:ajax update="@form"/>
+            </p:selectBooleanButton>
             <p:commandButton id="toggleLazyMode" value="Lazy Mode" update="@form" action="#{dataTable006.toggleLazyMode}"/>
             <p:commandButton id="togglePaginator" value="Paginator" update="@form" action="#{dataTable006.togglePaginator}"/>
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable006Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable006Test.java
@@ -23,9 +23,6 @@
  */
 package org.primefaces.integrationtests.datatable;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
@@ -37,8 +34,12 @@ import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.DataTable;
 import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.SelectBooleanButton;
 import org.primefaces.selenium.component.model.Msg;
 import org.primefaces.selenium.component.model.datatable.Row;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataTable006Test extends AbstractDataTableTest {
 
@@ -338,6 +339,32 @@ class DataTable006Test extends AbstractDataTableTest {
         assertConfiguration(dataTable.getWidgetConfiguration(), true);
     }
 
+    @Test
+    @Order(9)
+    @DisplayName("DataTable: selection - unselect all for page with selectionPageOnly='false'")
+    void unselectAllRows(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+
+        // Act - select all items on all pages
+        page.toggleSelectPageOnly.click();
+        dataTable.toggleSelectAllCheckBox();
+        page.submit.click();
+
+        // Assert
+        assertSelectAllCheckbox(dataTable, true);
+        assertSelections(page.messages, "1,2,3,4,5");
+
+        // Act - unselect all
+        dataTable.toggleSelectAllCheckBox();
+        page.submit.click();
+
+        // Assert
+        assertSelections(page.messages, "");
+        assertSelectAllCheckbox(dataTable, false);
+        assertConfiguration(dataTable.getWidgetConfiguration(), false);
+    }
+
     private void assertConfiguration(JSONObject cfg, boolean selectionPageOnly) {
         assertNoJavascriptErrors();
         System.out.println("DataTable Config = " + cfg);
@@ -372,7 +399,7 @@ class DataTable006Test extends AbstractDataTableTest {
         CommandButton buttonUnselect;
 
         @FindBy(id = "form:toggleSelectPageOnly")
-        CommandButton toggleSelectPageOnly;
+        SelectBooleanButton toggleSelectPageOnly;
 
         @FindBy(id = "form:toggleLazyMode")
         CommandButton toggleLazyMode;

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2980,7 +2980,6 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             else {
                 this.checkAllToggler.addClass('ui-state-active').children('span.ui-chkbox-icon').removeClass('ui-icon-blank').addClass('ui-icon-check');
                 this.checkAllToggler.attr('aria-checked', true);
-                
 
                 checkboxes.each(function() {
                     $this.selectRowWithCheckbox($(this), null, true);
@@ -2991,8 +2990,13 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         this.configureSelectAllAria();
 
         // GitHub #6730 user wants all rows not just displayed rows
-        if(!this.cfg.selectionPageOnly && shouldCheckAll) {
-            this.selectAllRows();
+        if(!this.cfg.selectionPageOnly) {
+            if (shouldCheckAll) {
+                this.selectAllRows();
+            }
+            else {
+                this.unselectAllRows();
+            }
         }
 
         //save state


### PR DESCRIPTION
Fix #11885 14.0.1 DataTable: Select/unselect all with selectionPageOnly="false" does not work properly