### PR TITLE
Fix #11900: FileUpload (advanced): Multiple FileUpload - regressions when some files do not meet the limits

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.common.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.common.js
@@ -465,7 +465,13 @@ if (window.PrimeFaces) {
                                     ? {summary: validatorMessageStr, detail: validatorMessageStr}
                                     : ve;
 
-                                vc.addMessage(element, validatorMsg);
+                                if (Array.isArray(validatorMsg)) {
+                                    // e.g. PrimeFaces.validator['primefaces.File'] may return an array of messages
+                                    validatorMsg.forEach((msg) => vc.addMessage(element, msg));
+                                }
+                                else {
+                                    vc.addMessage(element, validatorMsg);
+                                }
 
                                 valid = false;
                             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.validators.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.validators.js
@@ -116,7 +116,8 @@ if (window.PrimeFaces) {
                 var filelimit = element.data('p-filelimit'),
                     allowtypes = element.data('p-allowtypes'),
                     sizelimit = element.data('p-sizelimit'),
-                    vc = PrimeFaces.validation.ValidationContext;
+                    vc = PrimeFaces.validation.ValidationContext,
+                    messages = [];
 
                 var allowtypesRegExp = null;
                 if (allowtypes) {
@@ -127,17 +128,21 @@ if (window.PrimeFaces) {
                 }
 
                 if (filelimit && value.length > filelimit) {
-                    throw vc.getMessage(this.FILE_LIMIT_MESSAGE_ID, filelimit);
+                    messages.push(vc.getMessage(this.FILE_LIMIT_MESSAGE_ID, filelimit));
                 }
 
                 for (var file of value) {
                     if (allowtypesRegExp && (!allowtypesRegExp.test(file.type) && !allowtypesRegExp.test(file.name)))  {
-                        throw vc.getMessage(this.ALLOW_TYPES_MESSAGE_ID, file.name, PrimeFaces.utils.formatAllowTypes(allowtypes));
+                        messages.push(vc.getMessage(this.ALLOW_TYPES_MESSAGE_ID, file.name, PrimeFaces.utils.formatAllowTypes(allowtypes)));
                     }
 
                     if (sizelimit && file.size > sizelimit) {
-                        throw vc.getMessage(this.SIZE_LIMIT_MESSAGE_ID, file.name, PrimeFaces.utils.formatBytes(sizelimit));
+                        messages.push(vc.getMessage(this.SIZE_LIMIT_MESSAGE_ID, file.name, PrimeFaces.utils.formatBytes(sizelimit)));
                     }
+                }
+
+                if (messages.length > 0) {
+                    throw messages;
                 }
             }
         },


### PR DESCRIPTION
Fixes the one message per invalid file issue.
Do we think this solution is good enough?

Maybe i´ll add another PR to add a option which controls the behaviour when some files are within the limits and other outside.