### PR TITLE
Fix #11969: Facelets 4.0 Tag Library

### DIFF
--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -955,10 +955,10 @@
                                             <resource>META-INF/faces-config.xml</resource>
                                         </transformer>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
-                                            <resource>META-INF/primefaces-p.taglib.xml</resource>
+                                            <resource>META-INF/primefaces.taglib.xml</resource>
                                         </transformer>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
-                                            <resource>META-INF/primefaces-p.urn.taglib.xml</resource>
+                                            <resource>META-INF/primefaces.urn.taglib.xml</resource>
                                         </transformer>
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                             <resource>META-INF/resources/primefaces/ajaxstatus/ajaxstatus.js</resource>
@@ -1221,11 +1221,14 @@
                         <phase>process-resources</phase>
                         <configuration>
                             <target>
-                                <copy  file="${project.build.directory}/classes/META-INF/primefaces-p.taglib.xml"
-                                      tofile="${project.build.directory}/classes/META-INF/primefaces-p.urn.taglib.xml"/>
+                                <copy  file="${project.build.directory}/classes/META-INF/primefaces.taglib.xml"
+                                      tofile="${project.build.directory}/classes/META-INF/primefaces.urn.taglib.xml"/>
                                 <!-- Modify the copied file -->
-                                <replace file="${project.build.directory}/classes/META-INF/primefaces-p.urn.taglib.xml">
+                                <replace file="${project.build.directory}/classes/META-INF/primefaces.urn.taglib.xml">
                                     <replacefilter token="http://primefaces.org/ui" value="primefaces"/>
+                                    <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd" value="https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_4_0.xsd"/>
+                                    <replacefilter token="http://xmlns.jcp.org/xml/ns/javaee" value="https://jakarta.ee/xml/ns/jakartaee"/>
+                                    <replacefilter token="version=&quot;2.3&quot;" value="version=&quot;4.0&quot;"/>
                                 </replace>
                             </target>
                         </configuration>

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<facelet-taglib xmlns="http://java.sun.com/xml/ns/javaee"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facelettaglibrary_2_0.xsd"
-                version="2.0">
+<facelet-taglib xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_3.xsd" 
+    version="2.3">
 
     <namespace>http://primefaces.org/ui</namespace>
 


### PR DESCRIPTION
Fix #11969: Facelets 4.0 Tag Library

- Removes `-p` from `primefaces.taglib.xml`
- Updates to JSF 2.3 
- `primefaces.urn.taglib.xml` is the Faces 4.0+ version of the taglibrary which will be activated when you use `xmlns:p="primefaces"` in your XHTML files 