### PR TITLE
Fix #11783: Datatable keyboard/screen reader support for cells

### DIFF
--- a/docs/14_0_0/components/datatable.md
+++ b/docs/14_0_0/components/datatable.md
@@ -23,6 +23,7 @@ DataTable displays data in tabular format.
 | ariaRowLabel              | null               | String           | Label to read by screen readers on checkbox selection.
 | binding                   | null               | Object           | An el expression that maps to a server side UIComponent instance in a backing bean
 | cellEditMode              | eager              | String           | Defines the cell edit behavior, valid values are "eager" (default) and "lazy".
+| cellNavigation            | true               | Boolean          | Enables cell navigation with the keyboard for WCAG and screen reader compliance.
 | cellSeparator             | null               | String           | Separator text to use in output mode of editable cells with multiple components.
 | clientCache               | false              | Boolean          | Caches the next page asynchronously, default is false.
 | currentPageReportTemplate | null               | String           | Template of the currentPageReport UI.

--- a/docs/14_0_0/gettingstarted/whatsnew.md
+++ b/docs/14_0_0/gettingstarted/whatsnew.md
@@ -48,6 +48,7 @@ Look into [migration guide](https://primefaces.github.io/primefaces/14_0_0/#/../
     * JPALazyDataModel now supports post load data enricher with `JPALazyDataModel.Builder#resultEnricher()` .
     * Added `filterPlaceholder` for `Column` and `Columns`
     * Added `rowData` to `CellEditEvent` which contains the entire row from the cell being edited.
+    * Added `cellNavigation` property which defaults to true to enable WCAG keyboard navigation of table cells.
 
 * Dashboard
     * Added `var` to allow dynamic panels in `DashboardWidget.setValue(obj)` per panel

--- a/docs/15_0_0/components/datatable.md
+++ b/docs/15_0_0/components/datatable.md
@@ -23,6 +23,7 @@ DataTable displays data in tabular format.
 | ariaRowLabel              | null               | String           | Label to read by screen readers on checkbox selection.
 | binding                   | null               | Object           | An el expression that maps to a server side UIComponent instance in a backing bean
 | cellEditMode              | eager              | String           | Defines the cell edit behavior, valid values are "eager" (default) and "lazy".
+| cellNavigation            | true               | Boolean          | Enables cell navigation with the keyboard for WCAG and screen reader compliance.
 | cellSeparator             | null               | String           | Separator text to use in output mode of editable cells with multiple components.
 | clientCache               | false              | Boolean          | Caches the next page asynchronously, default is false.
 | currentPageReportTemplate | null               | String           | Template of the currentPageReport UI.

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -44,6 +44,7 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
         ariaRowLabel,
         caseSensitiveSort,
         cellEditMode,
+        cellNavigation,
         cellSeparator,
         clientCache,
         dataLocale,
@@ -439,7 +440,7 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
         getStateHelper().put(PropertyKeys.rowExpandMode, rowExpandMode);
     }
 
-    public Object getDataLocale() {
+    @Override public Object getDataLocale() {
         return getStateHelper().eval(PropertyKeys.dataLocale, null);
     }
 
@@ -768,4 +769,11 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
         getStateHelper().put(PropertyKeys.selectAllFilteredOnly, selectAllFilteredOnly);
     }
 
+    public boolean isCellNavigation() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.cellNavigation, true);
+    }
+
+    public void setCellNavigation(boolean cellNavigation) {
+        getStateHelper().put(PropertyKeys.cellNavigation, cellNavigation);
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -249,6 +249,7 @@ public class DataTableRenderer extends DataRenderer {
                 .attr("rowHover", table.isRowHover(), false)
                 .attr("clientCache", table.isClientCache(), false)
                 .attr("multiViewState", table.isMultiViewState(), false)
+                .attr("cellNavigation", table.isCellNavigation(), true)
                 .attr("partialUpdate", table.isPartialUpdate(), true)
                 .nativeAttr("groupColumnIndexes", table.getGroupedColumnIndexes(), null)
                 .callback("onRowClick", "function(row)", table.getOnRowClick());

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -9006,6 +9006,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Enables cell navigation with the keyboard for WCAG and screen reader compliance. Default is true.]]>
+            </description>
+            <name>cellNavigation</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Loads data on demand as the scrollbar gets close to the bottom. Default is false.]]>
             </description>
             <name>virtualScroll</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -156,7 +156,17 @@
     top: 0px;
     left: 0px;
     position: absolute;
-} 
+}
+
+/** Accessibility **/
+.ui-datatable-data td[role="gridcell"]:focus,
+.ui-datatable-data td[role="gridcell"] *:focus,
+.ui-datatable-data td[role="grid"] [tabindex="0"]:focus {
+  outline: var(--primary-color, #90caf9);
+  outline-style: solid;
+  outline-width: 2px;
+  border: none;
+}
 
 /* InCell Editing */
 .ui-datatable .ui-cell-editor-input {


### PR DESCRIPTION
Fix #11783: Datatable keyboard/screen reader support for cells

**Financially Sponsored by PRO User ** @Rene-Stoeckel

- [x] Enables keyboard navigation and screen reader support for cells
- [x] new property `cellNavigation` true by default but can be disabled if someone runs into issues
- [x] `cellNavigation` is set to false on Row Selection and Cell Edit because they have their own keyboard handling.


![image](https://github.com/primefaces/primefaces/assets/4399574/22af45e7-c641-4622-ac73-34de1a38a6b1)



![datatable-navigation](https://github.com/primefaces/primefaces/assets/4399574/50fb2ce4-c065-4f97-bbfc-5d090fcf4eaa)

