### PR TITLE
Fix #11979: DatePicker/Calendar remove locale examples

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
@@ -42,6 +42,8 @@ import java.util.List;
 @ViewScoped
 public class CalendarJava8View implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private LocalDate date;
     private LocalDate date1;
     @Future
@@ -53,7 +55,6 @@ public class CalendarJava8View implements Serializable {
     private LocalDate date7;
     private LocalDate date8;
     private LocalDate date9;
-    private LocalDate dateDe;
     private LocalDate date10;
     private LocalDate date11;
     private LocalDate date12;
@@ -77,7 +78,6 @@ public class CalendarJava8View implements Serializable {
     private LocalDateTime dateTime5;
     private LocalDateTime dateTime6;
     private LocalDateTime dateTime7;
-    private LocalDateTime dateTimeDe;
     private List<LocalDate> multi;
     private List<LocalDate> range;
     private List<LocalDate> invalidDates;
@@ -120,8 +120,6 @@ public class CalendarJava8View implements Serializable {
         minDateTime = LocalDateTime.now().minusWeeks(1);
         maxDateTime = LocalDateTime.now().plusWeeks(1);
 
-        dateDe = LocalDate.of(2019, 7, 27);
-        dateTimeDe = LocalDateTime.of(2019, 7, 27, 12, 59);
         dateTime4 = LocalDateTime.now();
 
         time4 = LocalTime.of(10, 30);
@@ -224,14 +222,6 @@ public class CalendarJava8View implements Serializable {
         this.date9 = date9;
     }
 
-    public LocalDate getDateDe() {
-        return dateDe;
-    }
-
-    public void setDateDe(LocalDate dateDe) {
-        this.dateDe = dateDe;
-    }
-
     public LocalDate getDate10() {
         return date10;
     }
@@ -326,14 +316,6 @@ public class CalendarJava8View implements Serializable {
 
     public void setMaxDate(LocalDate maxDate) {
         this.maxDate = maxDate;
-    }
-
-    public LocalDateTime getDateTimeDe() {
-        return dateTimeDe;
-    }
-
-    public void setDateTimeDe(LocalDateTime dateTimeDe) {
-        this.dateTimeDe = dateTimeDe;
     }
 
     public LocalTime getTime2() {

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/CalendarView.java
@@ -40,6 +40,8 @@ import java.util.*;
 @ViewScoped
 public class CalendarView implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private Date date;
     private Date date1;
     @Future
@@ -51,7 +53,6 @@ public class CalendarView implements Serializable {
     private Date date7;
     private Date date8;
     private Date date9;
-    private Date dateDe;
     @Future
     private Date date10;
     private Date date11;
@@ -61,7 +62,6 @@ public class CalendarView implements Serializable {
     private Date date15;
     private Date date16;
     private Date date17;
-    private Date dateTimeDe;
     private Date dateTimeMillis;
     private List<Date> multi;
     private List<Date> range;
@@ -116,8 +116,6 @@ public class CalendarView implements Serializable {
         minDateTime = new Date(today.getTime() - (7 * oneDay));
         maxDateTime = new Date(today.getTime() + (7 * oneDay));
 
-        dateDe = GregorianCalendar.getInstance().getTime();
-        dateTimeDe = GregorianCalendar.getInstance().getTime();
         dateTimeMillis = GregorianCalendar.getInstance().getTime();
     }
 
@@ -314,22 +312,6 @@ public class CalendarView implements Serializable {
 
     public void setMaxDate(Date maxDate) {
         this.maxDate = maxDate;
-    }
-
-    public Date getDateTimeDe() {
-        return dateTimeDe;
-    }
-
-    public void setDateTimeDe(Date dateTimeDe) {
-        this.dateTimeDe = dateTimeDe;
-    }
-
-    public Date getDateDe() {
-        return dateDe;
-    }
-
-    public void setDateDe(Date dateDe) {
-        this.dateDe = dateDe;
     }
 
     public Date getDateTimeMillis() {

--- a/primefaces-showcase/src/main/webapp/ui/input/calendar/calendar.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/calendar/calendar.xhtml
@@ -6,37 +6,6 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script>
-            PrimeFaces.locales ['de'] = {
-                monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
-                monthNamesShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-                dayNames: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-                dayNamesShort: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
-                dayNamesMin: ['S', 'M', 'D', 'M ', 'D', 'F ', 'S'],
-                weekHeader: 'Woche',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Nur Zeit',
-                timeText: 'Zeit',
-                hourText: 'Stunde',
-                minuteText: 'Minute',
-                secondText: 'Sekunde',
-                today: 'Aktuelles Datum',
-                ampm: false,
-                month: 'Monat',
-                week: 'Woche',
-                day: 'Tag',
-                allDayText: 'Ganzer Tag',
-                aria: {
-                   close: 'Schließen',
-                   previous: 'Zurück',
-                   next: 'Weiter',
-               }
-            };
-        </script>
-
         <style>
             .value {
                 font-weight: bold;
@@ -75,14 +44,6 @@
                         <p:ajax event="dateSelect" listener="#{calendarView.onDateSelect}" update="msgs"/>
                     </p:calendar>
 
-                    <p:outputLabel for="german" value="German:"/>
-                    <p:calendar id="german" value="#{calendarView.date5}" locale="de" navigator="true"
-                                pattern="yyyy-MMM-dd"/>
-
-                    <p:outputLabel for="germanV2" value="German (other Pattern):"/>
-                    <p:calendar id="germanV2" value="#{calendarView.dateDe}" locale="de" navigator="true"
-                                pattern="dd.MM.yyyy"/>
-
                     <p:outputLabel for="restricted" value="Restricted:"/>
                     <p:calendar id="restricted" value="#{calendarView.date6}" mindate="#{calendarView.minDate}"
                                       maxdate="#{calendarView.maxDate}"/>
@@ -98,10 +59,6 @@
 
                     <p:outputLabel for="datetime" value="Datetime:"/>
                     <p:calendar id="datetime" value="#{calendarView.date10}" pattern="MM/dd/yyyy HH:mm:ss"/>
-
-                    <p:outputLabel for="dateTimeDe" value="Datetime (German):"/>
-                    <p:calendar id="dateTimeDe" value="#{calendarView.dateTimeDe}" locale="de"
-                                pattern="dd.MM.yyyy HH:mm"/>
 
                     <p:outputLabel for="time" value="Time Only:"/>
                     <p:calendar id="time" value="#{calendarView.date11}" pattern="HH:mm" timeOnly="true"/>

--- a/primefaces-showcase/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
@@ -6,37 +6,6 @@
                 template="/WEB-INF/template.xhtml">
 
     <ui:define name="head">
-        <script>
-            PrimeFaces.locales ['de'] = {
-                monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
-                monthNamesShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-                dayNames: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-                dayNamesShort: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
-                dayNamesMin: ['S', 'M', 'D', 'M ', 'D', 'F ', 'S'],
-                weekHeader: 'Woche',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Nur Zeit',
-                timeText: 'Zeit',
-                hourText: 'Stunde',
-                minuteText: 'Minute',
-                secondText: 'Sekunde',
-                today: 'Aktuelles Datum',
-                ampm: false,
-                month: 'Monat',
-                week: 'Woche',
-                day: 'Tag',
-                allDayText: 'Ganzer Tag',
-                aria: {
-                   close: 'Schließen',
-                   previous: 'Zurück',
-                   next: 'Weiter',
-               }
-            };
-        </script>
-
         <style>
             .value {
                 font-weight: bold;
@@ -78,14 +47,6 @@
                         <p:ajax event="dateSelect" listener="#{calendarJava8View.onDateSelect}" update="msgs"/>
                     </p:calendar>
 
-                    <p:outputLabel for="german" value="German:"/>
-                    <p:calendar id="german" value="#{calendarJava8View.date5}" locale="de" navigator="true"
-                                pattern="yyyy-MMM-dd"/>
-
-                    <p:outputLabel for="germanV2" value="German (other Pattern):"/>
-                    <p:calendar id="germanV2" value="#{calendarJava8View.dateDe}" locale="de" navigator="true"
-                                pattern="dd.MM.yyyy"/>
-
                     <p:outputLabel for="restricted" value="Restricted:"/>
                     <p:calendar id="restricted" value="#{calendarJava8View.date6}" mindate="#{calendarJava8View.minDate}"
                                       maxdate="#{calendarJava8View.maxDate}" />
@@ -102,10 +63,6 @@
 
                     <p:outputLabel for="datetime" value="Datetime:"/>
                     <p:calendar id="datetime" value="#{calendarJava8View.dateTime1}" pattern="MM/dd/yyyy HH:mm:ss"/>
-
-                    <p:outputLabel for="dateTimeDe" value="Datetime (German):"/>
-                    <p:calendar id="dateTimeDe" value="#{calendarJava8View.dateTimeDe}" locale="de"
-                                pattern="dd.MM.yyyy HH:mm"/>
 
                     <p:outputLabel for="time" value="Time Only:"/>
                     <p:calendar id="time" value="#{calendarJava8View.time1}" pattern="HH:mm" timeOnly="true"/>

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePicker.xhtml
@@ -6,69 +6,6 @@
 
 	<ui:define name="head">
 		<script>
-            PrimeFaces.locales['es'] = {
-                monthNames: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
-                monthNamesShort: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-                dayNames: ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'],
-                dayNamesShort: ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'],
-                dayNamesMin: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
-                weekHeader: 'Semana',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Sólo hora',
-                timeText: 'Tiempo',
-                hourText: 'Hora',
-                minuteText: 'Minuto',
-                secondText: 'Segundo',
-                millisecondText: 'Milisegundo',
-                ampm: false,
-                month: 'Mes',
-                week: 'Semana',
-                day: 'Día',
-                allDayText: 'Todo el día',
-                today: 'Hoy',
-                now: 'Ahora',
-                clear: 'Limpiar',
-                aria: {
-                   close: 'Cerrar',
-                   previous: 'Anterior',
-                   next: 'Siguiente',
-               }
-            };
-            PrimeFaces.locales ['de'] = {
-                monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
-                monthNamesShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-                dayNames: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-                dayNamesShort: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
-                dayNamesMin: ['S', 'M', 'D', 'M ', 'D', 'F ', 'S'],
-                weekHeader: 'Woche',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Nur Zeit',
-                timeText: 'Zeit',
-                hourText: 'Stunde',
-                minuteText: 'Minute',
-                secondText: 'Sekunde',
-                today: 'Aktuelles Datum',
-                now: 'Jetzt',
-                ampm: false,
-                month: 'Monat',
-                week: 'Woche',
-                day: 'Tag',
-                allDayText: 'Ganzer Tag',
-                aria: {
-                   close: 'Schließen',
-                   previous: 'Zurück',
-                   next: 'Weiter',
-               }
-            };
-        </script>
-
-		<script>
             //<![CDATA[
             function dateTemplateFunc(date) {
                 return '<span style="background-color:' + ((date.day < 21 && date.day > 10) ? '#81C784' : 'inherit') + ';border-radius:50%;width: 2.5rem;height: 2.5rem;line-height: 2.5rem;display: flex;align-items: center;justify-content: center;">' + date.day + '</span>';
@@ -158,16 +95,6 @@
 					</div>
 
 					<div class="field col-12 md:col-4">
-						<p:outputLabel for="spanish" value="Spanish" />
-						<p:datePicker id="spanish" value="#{calendarView.date9}" locale="es" monthNavigator="true" pattern="yyyy-MMM-dd" />
-					</div>
-
-					<div class="field col-12 md:col-4">
-						<p:outputLabel for="german" value="German" />
-						<p:datePicker id="german" value="#{calendarView.dateDe}" locale="de" monthNavigator="true" pattern="dd.MM.yyyy" />
-					</div>
-
-					<div class="field col-12 md:col-4">
 						<p:outputLabel for="buttonbar" value="Button Bar" />
 						<p:datePicker id="buttonbar" value="#{calendarView.date10}"	showButtonBar="true" />
 					</div>
@@ -192,11 +119,6 @@
 						<p:outputLabel for="timeMinMax" value="Time (Min-Max)" />
 						<p:datePicker id="timeMinMax" value="#{calendarView.date16}" showTime="true" mindate="#{calendarView.minDateTime}"
 							maxdate="#{calendarView.maxDateTime}" />
-					</div>
-
-					<div class="field col-12 md:col-4">
-						<p:outputLabel for="timeDe" value="Time (German)" />
-						<p:datePicker id="timeDe" value="#{calendarView.dateTimeDe}" showTime="true" locale="de" pattern="dd.MM.yyyy" />
 					</div>
 
 					<div class="field col-12 md:col-4">

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -7,69 +7,6 @@
 
     <ui:define name="head">
         <script>
-                        PrimeFaces.locales['es'] = {
-                monthNames: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
-                monthNamesShort: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-                dayNames: ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'],
-                dayNamesShort: ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'],
-                dayNamesMin: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
-                weekHeader: 'Semana',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Sólo hora',
-                timeText: 'Tiempo',
-                hourText: 'Hora',
-                minuteText: 'Minuto',
-                secondText: 'Segundo',
-                millisecondText: 'Milisegundo',
-                ampm: false,
-                month: 'Mes',
-                week: 'Semana',
-                day: 'Día',
-                allDayText: 'Todo el día',
-                today: 'Hoy',
-                now: 'Ahora',
-                clear: 'Limpiar',
-                aria: {
-                   close: 'Cerrar',
-                   previous: 'Anterior',
-                   next: 'Siguiente',
-               }
-            };
-            PrimeFaces.locales ['de'] = {
-                monthNames: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
-                monthNamesShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-                dayNames: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-                dayNamesShort: ['Son', 'Mon', 'Die', 'Mit', 'Don', 'Fre', 'Sam'],
-                dayNamesMin: ['S', 'M', 'D', 'M ', 'D', 'F ', 'S'],
-                weekHeader: 'Woche',
-                firstDay: 1,
-                isRTL: false,
-                showMonthAfterYear: false,
-                yearSuffix: '',
-                timeOnlyTitle: 'Nur Zeit',
-                timeText: 'Zeit',
-                hourText: 'Stunde',
-                minuteText: 'Minute',
-                secondText: 'Sekunde',
-                today: 'Aktuelles Datum',
-                now: 'Jetzt',
-                ampm: false,
-                month: 'Monat',
-                week: 'Woche',
-                day: 'Tag',
-                allDayText: 'Ganzer Tag',
-                aria: {
-                   close: 'Schließen',
-                   previous: 'Zurück',
-                   next: 'Weiter',
-               }
-            };
-        </script>
-
-        <script>
             //<![CDATA[
             function dateTemplateFunc(date) {
                 return '<span style="background-color:' + ((date.day < 21 && date.day > 10) ? '#81C784' : 'inherit') + ';border-radius:50%;width: 2.5rem;height: 2.5rem;line-height: 2.5rem;display: flex;align-items: center;justify-content: center;">' + date.day + '</span>';
@@ -185,18 +122,6 @@
                     </div>
 
                     <div class="field col-12 md:col-4">
-                        <p:outputLabel for="spanish" value="Spanish"/>
-                        <p:datePicker id="spanish" value="#{calendarJava8View.date9}" locale="es"
-                                        monthNavigator="true" pattern="yyyy-MMM-dd"/>
-                    </div>
-
-                    <div class="field col-12 md:col-4">
-                        <p:outputLabel for="german" value="German"/>
-                        <p:datePicker id="german" widgetVar="german" value="#{calendarJava8View.dateDe}"
-                                            locale="de" monthNavigator="true" pattern="dd.MM.yyyy"/>
-                    </div>
-
-                    <div class="field col-12 md:col-4">
                         <p:outputLabel for="buttonbar" value="Button Bar"/>
                         <p:datePicker id="buttonbar" value="#{calendarJava8View.date10}" showButtonBar="true"/>
                     </div>
@@ -259,13 +184,6 @@
                         <p:outputLabel for="time5" value="Time (with seconds)"/>
                         <p:datePicker id="time5" value="#{calendarJava8View.dateTime5}"
                                       showSeconds="true"/>
-                    </div>
-
-                    <div class="field col-12 md:col-4">
-                        <p:outputLabel for="timeDe" value="Time (German)"/>
-                        <p:datePicker id="timeDe" value="#{calendarJava8View.dateTimeDe}"
-                                        locale="de" pattern="dd.MM.yyyy"
-                                       />
                     </div>
 
                     <div class="field col-12 md:col-4">


### PR DESCRIPTION
Fix #11979: DatePicker/Calendar remove locale examples