### PR TITLE
Fix #12001: Preserve order of constants

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/importconstants/ConstantsHashMap.java
+++ b/primefaces/src/main/java/org/primefaces/component/importconstants/ConstantsHashMap.java
@@ -23,17 +23,17 @@
  */
 package org.primefaces.component.importconstants;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import javax.faces.FacesException;
 
 /**
- * Custom {@link HashMap} which throws an {@link FacesException} if the key/constant does not exist.
+ * Custom {@link LinkedHashMap} which throws an {@link FacesException} if the key/constant does not exist.
  *
  * @param <K> The key type.
  * @param <V> The value type.
  */
-public class ConstantsHashMap<K, V> extends HashMap<K, V> {
+public class ConstantsHashMap<K, V> extends LinkedHashMap<K, V> {
 
     private static final long serialVersionUID = 1L;
 

--- a/primefaces/src/main/java/org/primefaces/component/importenum/EnumHashMap.java
+++ b/primefaces/src/main/java/org/primefaces/component/importenum/EnumHashMap.java
@@ -23,17 +23,17 @@
  */
 package org.primefaces.component.importenum;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import javax.faces.FacesException;
 
 /**
- * Custom {@link HashMap} which throws an {@link FacesException} if the key/constant does not exist.
+ * Custom {@link LinkedHashMap} which throws an {@link FacesException} if the key/constant does not exist.
  *
  * @param <K> The key type.
  * @param <V> The value type.
  */
-public class EnumHashMap<K, V> extends HashMap<K, V> {
+public class EnumHashMap<K, V> extends LinkedHashMap<K, V> {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Fix #12001: Preserve order of constants

Changes the base class of `ConstantsHashMap` and `EnumHashMap` to be `LinkedHashMap`, to preserve the order of constants.