### PR TITLE
Fix #11850: SelectCheckBoxMenu ARIA accessibility updates

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectcheckboxmenu/SelectCheckboxMenu001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectcheckboxmenu/SelectCheckboxMenu001Test.java
@@ -23,7 +23,9 @@
  */
 package org.primefaces.integrationtests.selectcheckboxmenu;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -159,7 +161,6 @@ class SelectCheckboxMenu001Test extends AbstractPrimePageTest {
 
     private void assertValue(WebElement checkbox, String value) {
         assertEquals(value, checkbox.getAttribute("value"));
-        assertEquals("aria-checked", checkbox.getDomAttribute("aria-checked"));
     }
 
     private void assertConfiguration(JSONObject cfg) {

--- a/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/checkboxMenu.xhtml
@@ -28,7 +28,7 @@
                                       dynamic="true"
                                       filter="true" filterMatchMode="startsWith"
                                       label="Cities" updateLabel="true"
-                                      selectedLabel="Item(s) Selected"
+                                      selectedLabel="Cities Selected"
                                       style="width: 15rem" panelStyle="width: 15rem" scrollHeight="250"
                                       value="#{checkboxView.selectedCities}">
                     <f:selectItems value="#{checkboxView.cities}"/>
@@ -42,7 +42,6 @@
 
                 <h5>Multiple</h5>
                 <p:selectCheckboxMenu id="multiple"
-                                      filter="true" filterMatchMode="startsWith"
                                       multiple="true" emptyLabel="Please select..." updateLabel="true"
                                       style="min-width: 15rem" panelStyle="width: 30rem" scrollHeight="250"
                                       value="#{checkboxView.selectedCities2}">

--- a/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenu.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectcheckboxmenu/SelectCheckboxMenu.java
@@ -73,6 +73,7 @@ public class SelectCheckboxMenu extends SelectCheckboxMenuBase {
     public static final String TOKEN_DISPLAY_CLASS = "ui-selectcheckboxmenu-token ui-state-active ui-corner-all";
     public static final String TOKEN_LABEL_CLASS = "ui-selectcheckboxmenu-token-label";
     public static final String TOKEN_ICON_CLASS = "ui-selectcheckboxmenu-token-icon ui-icon ui-icon-close";
+    public static final String CHECKBOX_INPUT_CLASS = "ui-selectcheckboxmenu-item-input";
 
     private static final String DEFAULT_EVENT = "change";
     private static final Map<String, Class<? extends BehaviorEvent>> BEHAVIOR_EVENT_MAPPING = MapBuilder.<String, Class<? extends BehaviorEvent>>builder()

--- a/primefaces/src/main/java/org/primefaces/util/HTML.java
+++ b/primefaces/src/main/java/org/primefaces/util/HTML.java
@@ -291,6 +291,8 @@ public class HTML {
     public static final String ARIA_READONLY = "aria-readonly";
     public static final String ARIA_REQUIRED = "aria-required";
     public static final String ARIA_SELECTED = "aria-selected";
+    public static final String ARIA_SET_SIZE = "aria-setsize";
+    public static final String ARIA_SET_POSITION = "aria-posinset";
     public static final String ARIA_ORIENTATION = "aria-orientation";
     public static final String ARIA_ORIENTATION_HORIZONTAL = "horizontal";
     public static final String ARIA_ORIENTATION_VERTICAL = "vertical";


### PR DESCRIPTION
Fix #11850: SelectCheckBoxMenu ARIA accessibility updates

Live Test: http://20.161.11.140/showcase/ui/input/checkboxMenu.xhtml

- [x] Removed `readonly` and `aria-hidden` from keyboard target so screenreader can read it
- [x] Adds keyboard handling per Combobox spec
- [x] Adds ARIA roles for `option` so its read "Miami Unselected option 1 of 9"
- [x] Tested basic and advanced mode
- [x] NVDA screenreader
- [x] JAWS screenreader
