### PR TITLE
#12085 Core: Ajax performance (cleanseDomElement): No need to cleanse options elements

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1122,7 +1122,7 @@ if (!PrimeFaces.utils) {
                 return;
             }
 
-            if (jq.prop("tagName") !== 'SELECT') { //No need to cleanse <option>s tag
+            if (!jq.is("select")) { //No need to cleanse <option> tags
                 // Recursively remove events from children elements
                 jq.children().each(function() {
                     PrimeFaces.utils.cleanseDomElement($(this), clearData, removeElement);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1121,11 +1121,13 @@ if (!PrimeFaces.utils) {
             if (!jq || !jq.length) {
                 return;
             }
-            // Recursively remove events from children elements
-            jq.children().each(function() {
-                PrimeFaces.utils.cleanseDomElement($(this), clearData, removeElement);
-            });
 
+            if (jq.prop("tagName") !== 'SELECT') { //No need to cleanse <option>s tag
+                // Recursively remove events from children elements
+                jq.children().each(function() {
+                    PrimeFaces.utils.cleanseDomElement($(this), clearData, removeElement);
+                });
+            }
             // Remove inline event attributes
             var attributes = jq[0].attributes;
             for (var i = 0; i < attributes.length; i++) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1122,7 +1122,8 @@ if (!PrimeFaces.utils) {
                 return;
             }
 
-            if (!jq.is("select")) { //No need to cleanse <option> tags
+            //Skip cleanse of select and svg tags, it can impact performance if a lot of tags are present. They don't have PF listeners attached, so cleanse it's unnecesary.
+            if (!jq.is("select, svg, svg *")) {
                 // Recursively remove events from children elements
                 jq.children().each(function() {
                     PrimeFaces.utils.cleanseDomElement($(this), clearData, removeElement);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1138,7 +1138,7 @@ if (!PrimeFaces.utils) {
                 }
             }
 
-            // Trigger onRemove events for widget.destroy and remove the element from the DOM and
+            // Trigger onRemove events for widget.destroy and remove the element from the DOM
             // IMPORTANT: This must occur before jq.off() to ensure the on("remove") events remain registered.
             if (removeElement) {
                 jq.triggerHandler("remove");

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1140,7 +1140,8 @@ if (!PrimeFaces.utils) {
             // Remove the element from the DOM and trigger onRemove events for widget.destroy.
             // IMPORTANT: This must occur before jq.off() to ensure the on("remove") events remain registered.
             if (removeElement) {
-                jq.remove();
+                jq.triggerHandler("remove");
+                jq.get(0).remove()
             }
 
             // Remove event listeners

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1137,7 +1137,7 @@ if (!PrimeFaces.utils) {
                 }
             }
 
-            // Remove the element from the DOM and trigger onRemove events for widget.destroy.
+            // Trigger onRemove events for widget.destroy and remove the element from the DOM and
             // IMPORTANT: This must occur before jq.off() to ensure the on("remove") events remain registered.
             if (removeElement) {
                 jq.triggerHandler("remove");


### PR DESCRIPTION
Fix #12085 In my test, with the performance measurement script provided in https://github.com/primefaces/primefaces/issues/12085

Without the patch:

```
AJAX updateElement : 104.026123046875 ms
common.js:751 Removed 269 DOM elements
common.js:750 AJAX updateElement : 1.4541015625 ms
common.js:751 Removed 1 DOM elements
common.js:750 AJAX updateElement : 1908.331787109375 ms
common.js:751 Removed 33193 DOM elements
```
With the patch:

```
AJAX updateElement : 99.87109375 ms
common.js:41 Removed 22 DOM elements
common.js:40 AJAX updateElement : 2.444091796875 ms
common.js:41 Removed 1 DOM elements
common.js:40 AJAX updateElement : 390.40087890625 ms
common.js:41 Removed 2413 DOM elements
```
Numbers are still way worse than the ones @melloware posted in https://github.com/primefaces/primefaces/issues/12085#issuecomment-2155018334, but this is an improvement