### PR TITLE
Fix #12098: Tooltip autoHide="false" hidden when not crossing arrow

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -301,7 +301,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         else {
             var mouseTarget = $(e.relatedTarget);
             var previousElement = this.target;
-            this.allowHide = !(mouseTarget.is(this.target) ||
+            this.allowHide = !(mouseTarget.is(previousElement) ||
                                previousElement.attr('aria-describedby') === mouseTarget.closest('#' + this.id).attr('id'));
         }
         if (this.allowHide) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -300,10 +300,9 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
         }
         else {
             var mouseTarget = $(e.relatedTarget);
-            this.allowHide = !(mouseTarget.is(this.target) || 
-                               mouseTarget.hasClass('ui-tooltip-arrow') ||
-                               mouseTarget.attr('aria-describedby') === this.id || 
-                               mouseTarget.parent().attr('aria-describedby') === this.id);
+            var previousElement = this.target;
+            this.allowHide = !(mouseTarget.is(this.target) ||
+                               previousElement.attr('aria-describedby') === mouseTarget.closest('#' + this.id).attr('id'));
         }
         if (this.allowHide) {
             this.hide();


### PR DESCRIPTION
Complements #12102 on 
Fix #12098

This fixes the check for allowHide by checking if the previous element's (the one that the mouse is leaving from) "aria-describedby" value is the same as the target element's (tooltip) or any of its parents' id (because if there is any child elements on the tooltip, the event may refer to it as the target instead of the tooltip itself). This includes the "ui-tooltip-arrow" element.