### PR TITLE
Fix #12118: Tooltip: escape selector for mouseTarget.closest

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -302,7 +302,7 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
             var mouseTarget = $(e.relatedTarget);
             var previousElement = this.target;
             this.allowHide = !(mouseTarget.is(previousElement) ||
-                               previousElement.attr('aria-describedby') === mouseTarget.closest('#' + this.id).attr('id'));
+                               previousElement.attr('aria-describedby') === mouseTarget.closest('#' + $.escapeSelector(this.id)).attr('id'));
         }
         if (this.allowHide) {
             this.hide();

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -302,7 +302,9 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
             var mouseTarget = $(e.relatedTarget);
             var previousElement = this.target;
             this.allowHide = !(mouseTarget.is(previousElement) ||
-                               previousElement.attr('aria-describedby') === mouseTarget.closest('#' + $.escapeSelector(this.id)).attr('id'));
+                               previousElement.attr('aria-describedby') === mouseTarget.closest(PrimeFaces.escapeClientId(this.id)).attr('id') ||
+                               mouseTarget.attr('aria-describedby') === this.id ||
+                               mouseTarget.parent().attr('aria-describedby') === this.id);
         }
         if (this.allowHide) {
             this.hide();


### PR DESCRIPTION
Fix #12118

This PR fixes an issue that happens when the tooltip's ID has characters that should be escaped, like the colon, something that happens frequently on Faces.