### PR TITLE
Fix #12118: 14.0.2 Tooltip: escape selector for mouseTarget.closest

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tooltip/tooltip.js
@@ -302,7 +302,9 @@ PrimeFaces.widget.Tooltip = PrimeFaces.widget.BaseWidget.extend({
             var mouseTarget = $(e.relatedTarget);
             var previousElement = this.target;
             this.allowHide = !(mouseTarget.is(previousElement) ||
-                               previousElement.attr('aria-describedby') === mouseTarget.closest('#' + this.id).attr('id'));
+                               previousElement.attr('aria-describedby') === mouseTarget.closest(PrimeFaces.escapeClientId(this.id)).attr('id') ||
+                               mouseTarget.attr('aria-describedby') === this.id ||
+                               mouseTarget.parent().attr('aria-describedby') === this.id);
         }
         if (this.allowHide) {
             this.hide();


### PR DESCRIPTION
Fix #12118: 14.0.2 Tooltip: escape selector for mouseTarget.closest