### PR TITLE
Fix #12128: 14.0.2 Datatable updateExpansionAria called on wrong this

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3477,7 +3477,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             for(var i = 0; i < columns.length; i++) {
                 var column = columns.eq(i),
                 toggler = column.children('.ui-row-toggler');
-                this.updateExpansionAria(toggler);
+                $this.updateExpansionAria(toggler);
 
                 if(toggler.length > 0) {
                     if(toggler.hasClass('ui-icon')) {


### PR DESCRIPTION
Fix #12128: 14.0.2 Datatable updateExpansionAria called on wrong this