### PR TITLE
Fix #12143: MenuButton remove duplicate inherited code

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
@@ -27,7 +27,7 @@
                     <p:menuitem value="Update" action="#{menuView.update}" update="messages" icon="pi pi-refresh"/>
                     <p:menuitem value="Delete" action="#{menuView.delete}" update="messages" icon="pi pi-times"/>
                     <p:divider/>
-                    <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link"/>
+                    <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link" target="_blank"/>
                 </p:menuButton>
 
                 <h5>Button style</h5>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.menubutton.js
@@ -177,67 +177,6 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
     },
 
     /**
-     * Sets up all panel event listeners
-     *
-     * @override
-     */
-    bindPanelEvents: function() {
-        var $this = this;
-
-        if (!$this.cfg.disabled) {
-            this.hideOverlayHandler = PrimeFaces.utils.registerHideOverlayHandler(this, 'mousedown.' + this.id + '_hide', this.menu,
-                function() { return $this.trigger; },
-                function(e, eventTarget) {
-                    if (e && !($this.menu.is(eventTarget) || $this.menu.has(eventTarget).length > 0)) {
-                        $this.trigger.removeClass('ui-state-focus ui-state-hover');
-                        $this.hide();
-                    }
-                });
-        }
-
-        this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_align', this.menu, function() {
-            $this.handleOverlayViewportChange();
-        });
-
-        this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.handleOverlayViewportChange();
-        });
-    },
-
-    /**
-     * Unbind all panel event listeners
-     *
-     * @override
-     */
-    unbindPanelEvents: function() {
-        if (this.hideOverlayHandler) {
-            this.hideOverlayHandler.unbind();
-        }
-
-        if (this.resizeHandler) {
-            this.resizeHandler.unbind();
-        }
-
-        if (this.scrollHandler) {
-            this.scrollHandler.unbind();
-        }
-    },
-
-    /**
-     * Fired when the browser viewport is resized or scrolled.  In Mobile environment we don't want to hider the overlay
-     * we want to re-align it.  This is because on some mobile browser the popup may force the browser to trigger a 
-     * resize immediately and close the overlay. See GitHub #7075.
-     * @private
-     */
-    handleOverlayViewportChange: function() {
-        if (PrimeFaces.env.mobile || PrimeFaces.hideOverlaysOnViewportChange === false) {
-            this.alignPanel();
-        } else {
-            this.hide();
-        }
-    },
-
-    /**
      * Brings up the overlay menu with the menu items, as if the menu button were pressed.
      *
      * @override
@@ -281,7 +220,6 @@ PrimeFaces.widget.MenuButton = PrimeFaces.widget.TieredMenu.extend({
                     $this.resetFocus(false);
                     if ($this.trigger && $this.trigger.is(':button')) {
                         $this.trigger.attr('aria-expanded', 'false');
-                        PrimeFaces.queueTask(() =>  $this.trigger.trigger('focus'));
                     }
                 }
             });


### PR DESCRIPTION
Fix #12143: MenuButton remove duplicate inherited code

All of this code it was overridding was already in `menu.base.js` and was correct.  Simply removed all these overrides and the code is working properly.