### PR TITLE
Fix #12144: ARIA label null checking

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1233,7 +1233,7 @@
          * @returns {string} - The localized ARIA label, with placeholders replaced by their corresponding values from `options` if provided.
          */
         getAriaLabel: function(key, defaultValue, options) {
-            var ariaLocaleSettings = this.getLocaleSettings()['aria'];
+            var ariaLocaleSettings = this.getLocaleSettings()['aria'] || {};
             var label = ariaLocaleSettings[key] || PrimeFaces.locales['en_US']['aria'][key] || defaultValue || "???" + key + "???";
             if (options) {
                 for (const valKey in options) {


### PR DESCRIPTION
Fix #12144: ARIA label null checking

I realized there was an error if the user had NO `aria` section at all it would throw an error.   it was throwing an error because on this line its getting the `aria` section

`this.getLocaleSettings()['aria']`


### Missing Label

`PrimeFaces.getAriaLabel('pageLabel') = '???pageLabel???'`

### Found Label

`PrimeFaces.getAriaLabel('pageLabel') = "Page {page}" 