### PR TITLE
Fix #11773: UIData handle exception determining lazy attribute

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/UIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIData.java
@@ -25,11 +25,13 @@ package org.primefaces.component.api;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.faces.FacesException;
 import javax.faces.application.Application;
 import javax.faces.application.FacesMessage;
+import javax.faces.application.ProjectStage;
 import javax.faces.application.StateManager;
 import javax.faces.component.*;
 import javax.faces.component.visit.VisitCallback;
@@ -39,7 +41,7 @@ import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseId;
 import javax.faces.event.PostValidateEvent;
 import javax.faces.event.PreValidateEvent;
-import javax.faces.model.*;
+import javax.faces.model.DataModel;
 import javax.faces.render.Renderer;
 
 import org.primefaces.component.column.Column;
@@ -80,18 +82,28 @@ public class UIData extends javax.faces.component.UIData {
     public boolean isLazy() {
         return ComponentUtils.eval(getStateHelper(), PropertyKeys.lazy, () -> {
             boolean lazy = false;
+            FacesContext context = getFacesContext();
 
-            // if not set by xhtml, we need to check the type of the value binding
-            Class<?> type = ELUtils.getType(getFacesContext(),
-                    getValueExpression("value"),
-                    () -> getValue());
-            if (type == null) {
-                LOGGER.warning("Unable to automatically determine the `lazy` attribute, fallback to false. "
-                        + "Either define the `lazy` attribute on the component or make sure the `value` attribute doesn't resolve to `null`. "
-                        + "clientId: " + this.getClientId());
+            try {
+                // if not set by xhtml, we need to check the type of the value binding
+                Class<?> type = ELUtils.getType(context, getValueExpression("value"), () -> getValue());
+
+                if (type == null) {
+                    if (LOGGER.isLoggable(Level.WARNING) && context.isProjectStage(ProjectStage.Development)) {
+                        LOGGER.warning("Unable to automatically determine the `lazy` attribute, fallback to false. "
+                                + "Either define the `lazy` attribute on the component or make sure the `value` attribute doesn't resolve to `null`. "
+                                + "clientId: " + this.getClientId());
+                    }
+                }
+                else {
+                    lazy = LazyDataModel.class.isAssignableFrom(type);
+                }
             }
-            else {
-                lazy = LazyDataModel.class.isAssignableFrom(type);
+            catch (Exception e) {
+                if (LOGGER.isLoggable(Level.WARNING) && context.isProjectStage(ProjectStage.Development)) {
+                    LOGGER.warning("Exception occurred while determining the `lazy` attribute, fallback to false. Error: " + e.getMessage()
+                            + ". clientId: " + this.getClientId());
+                }
             }
 
             // remember in ViewState, to not do the same check again


### PR DESCRIPTION
Fix #11773: UIData handle exception determining lazy attribute

- [x] Switches WARNINGS to development mode only
- [x] Handles an exception being thrown while trying to evaluate the value for `lazy`

Example from reproducer in the ticket:

```
Jun 21, 2024 11:04:58 AM org.primefaces.component.api.UIData lambda$isLazy$1
WARNING: Exception occurred while determining the `lazy` attribute, fallback to false. Error: /test.xhtml @38,12 value="#{testView.outerMap.get(row)}": java.lang.IllegalArgumentException: No bean specified. clientId: frmTest:tblOuter:tblInner
```