### PR TITLE
Fix #12169: Showcase add missing POJO/enums and Tag VDL

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContent.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContent.java
@@ -24,23 +24,17 @@
 package org.primefaces.showcase.util;
 
 import java.io.Serializable;
-import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
-/**
- * FileContentMarkerUtil
- *
- * @author Sébastien Lepage / last modified by $Author$
- * @version $Revision$
- * @since 6.3
- */
 public class FileContent implements Serializable {
 
     private final String title;
     private final String value;
     private final String type;
-    private final List<FileContent> attached;
+    private final Set<FileContent> attached;
 
-    public FileContent(String title, String value, String type, List<FileContent> attached) {
+    public FileContent(String title, String value, String type, Set<FileContent> attached) {
         this.title = title;
         this.value = value;
         this.type = type;
@@ -59,39 +53,21 @@ public class FileContent implements Serializable {
         return type;
     }
 
-    public List<FileContent> getAttached() {
+    public Set<FileContent> getAttached() {
         return attached;
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((title == null) ? 0 : title.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileContent that = (FileContent) o;
+        return Objects.equals(getTitle(), that.getTitle());
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        FileContent other = (FileContent) obj;
-        if (title == null) {
-            if (other.title != null) {
-                return false;
-            }
-        }
-        else if (!title.equals(other.title)) {
-            return false;
-        }
-        return true;
+    public int hashCode() {
+        return Objects.hashCode(getTitle());
     }
 
     @Override

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/util/ShowcaseUtil.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/util/ShowcaseUtil.java
@@ -112,7 +112,7 @@ public class ShowcaseUtil {
     }
 
     private static void flatFileContent(FileContent source, List<FileContent> dest) {
-        dest.add(new FileContent(source.getTitle(), source.getValue(), source.getType(), Collections.<FileContent>emptyList()));
+        dest.add(new FileContent(source.getTitle(), source.getValue(), source.getType(), Collections.<FileContent>emptySet()));
 
         for (FileContent file : source.getAttached()) {
             flatFileContent(file, dest);

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/app/App.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/app/App.java
@@ -24,14 +24,13 @@
 package org.primefaces.showcase.view.app;
 
 import jakarta.enterprise.context.SessionScoped;
+import jakarta.faces.context.FacesContext;
 import jakarta.inject.Named;
-
-import org.primefaces.showcase.domain.Country;
-
 import java.io.Serializable;
 import java.util.Locale;
-import jakarta.faces.context.FacesContext;
+
 import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.showcase.domain.Country;
 
 @Named
 @SessionScoped
@@ -116,5 +115,19 @@ public class App implements Serializable {
 
     public String getPrimeFacesVersion() {
         return PrimeApplicationContext.getCurrentInstance(FacesContext.getCurrentInstance()).getEnvironment().getBuildVersion();
+    }
+
+    public String getTagVdlComponent(String documentationLink) {
+        String separator = "/";
+        if (documentationLink == null || documentationLink.isEmpty()) {
+            return documentationLink;
+        }
+
+        int lastIndex = documentationLink.lastIndexOf(separator);
+        if (lastIndex == -1 || lastIndex == documentationLink.length() - separator.length()) {
+            return "";
+        }
+
+        return documentationLink.substring(lastIndex + separator.length());
     }
 }

--- a/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
@@ -87,6 +87,14 @@
                                     <span>CLIENT API</span>
                                 </a>
                             </ui:fragment>
+                            <ui:fragment rendered="#{not empty documentationLink}">
+                                <a class="documentation-link"
+                                   href="https://primefaces.github.io/primefaces/vdldoc/p/#{app.getTagVdlComponent(documentationLink)}.html"
+                                   target="_blank">
+                                    <i class="pi pi-external-link"></i>
+                                    <span>TAG VDL</span>
+                                </a>
+                            </ui:fragment>
                         </div>
                     </div>
                     <div class="content-section implementation">

--- a/primefaces-showcase/src/main/webapp/ui/input/autoComplete.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/autoComplete.xhtml
@@ -179,10 +179,6 @@
 
     <ui:define name="more-source-tabs">
         <p:tab title="/org/primefaces/showcase/view/data/datatable/LazyCustomerDataModel.java"/>
-        <p:tab title="/org/primefaces/showcase/domain/Customer.java"/>
-        <p:tab title="/org/primefaces/showcase/domain/CustomerStatus.java"/>
-        <p:tab title="/org/primefaces/showcase/domain/Representative.java"/>
-        <p:tab title="/org/primefaces/showcase/convert/CountryConverter.java"/>
         <p:tab title="/org/primefaces/showcase/rest/CountryRestService.java"/>
     </ui:define>
 </ui:composition>


### PR DESCRIPTION
Fix #12169: Showcase add missing POJO/enums

- [x] Finds generics now so `List<Product>` finds `Product` and walks that object
- [x] Finds converters so `#{countryConverter}` was not being picked up by REGEX
- [x] Adds Tag VDL doc link to the pages 