### PR TITLE
Update 13_0_0.md -> About chartOptions new features that are enabled by default

### DIFF
--- a/docs/migrationguide/13_0_0.md
+++ b/docs/migrationguide/13_0_0.md
@@ -64,3 +64,6 @@
 
 ## TextEditor
   * `height` is now a String. So please change `height=200` to `height=200px`
+
+## ChartOptions
+  * New features `responsive` and `maintainAspectRatio` are enabled by default. If you use the options Java object directly, you may want to call `ChartOptions::setMaintainAspectRatio(false)` as a workaround to get the same display as 12.0.X. This concerns all Java classes, from the `org.primefaces.model.charts` package, whose name ends with `ChartOptions`.


### PR DESCRIPTION
Fix #12173 (documentation)

New features `responsive` and `maintainAspectRatio` are enabled by default. This changes generated pages' layout. Here is a proposed entry for the migration guide.