### PR TITLE
Fix #12178: JPALazyDataModel use getId not getDeclaredId

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -29,6 +29,7 @@ import java.util.*;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
 import javax.faces.FacesException;
 import javax.faces.context.FacesContext;
 import javax.faces.convert.Converter;
@@ -431,7 +432,7 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                         }
                     }
 
-                    SingularAttribute<?, ?> idAttribute = entityType.getDeclaredId(idType.getJavaType());
+                    SingularAttribute<?, ?> idAttribute = entityType.getId(idType.getJavaType());
                     model.rowKeyField = idAttribute.getName();
                     if (model.rowKeyType == null) {
                         model.rowKeyType = idType.getJavaType();


### PR DESCRIPTION
Fix #12178: JPALazyDataModel use getId not getDeclaredId

cc @FlipWarthog 