### PR TITLE
Fix #12189: PartialResponseWriter prevent duplicate eval scripts

### DIFF
--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialResponseWriter.java
@@ -23,12 +23,8 @@
  */
 package org.primefaces.context;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.primefaces.util.BeanUtils;
-import org.primefaces.util.EscapeUtils;
-import org.primefaces.util.LangUtils;
+import java.io.IOException;
+import java.util.*;
 
 import javax.faces.component.NamingContainer;
 import javax.faces.component.UINamingContainer;
@@ -36,12 +32,13 @@ import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.faces.context.PartialResponseWriter;
 import javax.faces.event.AbortProcessingException;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.primefaces.util.BeanUtils;
+import org.primefaces.util.EscapeUtils;
+import org.primefaces.util.LangUtils;
 
 public class PrimePartialResponseWriter extends PartialResponseWriter {
 

--- a/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimePartialViewContext.java
@@ -28,9 +28,9 @@ import javax.faces.context.PartialResponseWriter;
 import javax.faces.context.PartialViewContext;
 import javax.faces.context.PartialViewContextWrapper;
 import javax.faces.event.PhaseId;
+
 import org.primefaces.config.PrimeConfiguration;
 import org.primefaces.csp.CspPartialResponseWriter;
-
 import org.primefaces.util.Constants;
 
 public class PrimePartialViewContext extends PartialViewContextWrapper {
@@ -55,12 +55,13 @@ public class PrimePartialViewContext extends PartialViewContextWrapper {
     public PartialResponseWriter getPartialResponseWriter() {
         if (writer == null) {
             PartialResponseWriter parentWriter = getWrapped().getPartialResponseWriter();
-            writer = new PrimePartialResponseWriter(parentWriter);
-
             FacesContext context = FacesContext.getCurrentInstance();
             PrimeConfiguration config = PrimeApplicationContext.getCurrentInstance(context).getConfig();
             if (config.isCsp()) {
-                writer = new CspPartialResponseWriter(writer, context, PrimeFacesContext.getCspState(context));
+                writer = new CspPartialResponseWriter(parentWriter, context, PrimeFacesContext.getCspState(context));
+            }
+            else {
+                writer = new PrimePartialResponseWriter(parentWriter);
             }
         }
 


### PR DESCRIPTION
Fix #12189: PartialResponseWriter prevent duplicate eval scripts

@tandraschko this fixes the Mojarra issue but i am not sure why Mojarra is calling our code twice.  Anyway since this bug is in Mojarra back in the 2.3.X branch which they are no longer touching i would like to implement this defensive fix