### PR TITLE
Fix #12214: RowExpansion rendered fix

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -28,6 +28,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
@@ -548,7 +549,7 @@ public class DataTable extends DataTableBase {
     }
 
     public RowExpansion getRowExpansion() {
-        return ComponentTraversalUtils.firstChildRendered(RowExpansion.class, this);
+        return ComponentTraversalUtils.firstChild(RowExpansion.class, this);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/RowExpandFeature.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 
@@ -34,6 +35,7 @@ import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.datatable.DataTableRenderer;
 import org.primefaces.component.datatable.DataTableState;
 import org.primefaces.component.rowexpansion.RowExpansion;
+import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.LangUtils;
 
 public class RowExpandFeature implements DataTableFeature {
@@ -70,16 +72,16 @@ public class RowExpandFeature implements DataTableFeature {
     public void encodeExpansion(FacesContext context, DataTableRenderer renderer, DataTable table, int rowIndex) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String rowIndexVar = table.getRowIndexVar();
-        RowExpansion rowExpansion = table.getRowExpansion();
-
-        String styleClass = DataTable.EXPANDED_ROW_CONTENT_CLASS + " ui-widget-content";
-        if (rowExpansion.getStyleClass() != null) {
-            styleClass = styleClass + " " + rowExpansion.getStyleClass();
-        }
-
         table.setRowIndex(rowIndex);
 
-        if (rowExpansion.isRendered()) {
+        RowExpansion rowExpansion = table.getRowExpansion();
+        if (rowExpansion != null && rowExpansion.isRendered()) {
+            String styleClass = PrimeRequestContext.getCurrentInstance(context).getStyleClassBuilder()
+                .add(DataTable.EXPANDED_ROW_CONTENT_CLASS)
+                .add("ui-widget-content")
+                .add(rowExpansion.getStyleClass())
+                .build();
+
             if (rowIndexVar != null) {
                 context.getExternalContext().getRequestMap().put(rowIndexVar, rowIndex);
             }
@@ -90,7 +92,7 @@ public class RowExpandFeature implements DataTableFeature {
             writer.startElement("td", null);
             writer.writeAttribute("colspan", table.getColumnsCount(), null);
 
-            table.getRowExpansion().encodeAll(context);
+            rowExpansion.encodeAll(context);
 
             writer.endElement("td");
 

--- a/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
@@ -23,15 +23,12 @@
  */
 package org.primefaces.util;
 
-import javax.faces.component.ContextCallback;
-import javax.faces.component.NamingContainer;
-import javax.faces.component.UIComponent;
-import javax.faces.component.UIForm;
-import javax.faces.component.UniqueIdVendor;
-import javax.faces.context.FacesContext;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import javax.faces.component.*;
+import javax.faces.context.FacesContext;
 
 public class ComponentTraversalUtils {
 
@@ -194,6 +191,21 @@ public class ComponentTraversalUtils {
         for (int i = 0; i < base.getChildCount(); i++) {
             UIComponent child = base.getChildren().get(i);
             if (childType.isInstance(child) && child.isRendered() ) {
+                return (T) child;
+            }
+        }
+
+        return null;
+    }
+
+    public static <T> T firstChild(Class<T> childType, UIComponent base) {
+        if (base == null || !base.isRendered()) {
+            return null;
+        }
+
+        for (int i = 0; i < base.getChildCount(); i++) {
+            UIComponent child = base.getChildren().get(i);
+            if (childType.isInstance(child)) {
                 return (T) child;
             }
         }


### PR DESCRIPTION
Fix #12214: RowExpansion rendered fix

- [x] It was determing whether row expansion was enabled or not based on if row expansion rendered but really we just want to know if the table has a `<p:rowExpansion>` for determining that as the `rendered` is evaluated inside the feature
- [x] Switched to use our Style Builder