### PR TITLE
Fix #12296: SelectOneMenu dynamic loading with advanced rendering

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu004.java
@@ -23,14 +23,15 @@
  */
 package org.primefaces.integrationtests.selectonemenu;
 
-import lombok.Data;
+import java.io.Serializable;
 
 import javax.annotation.PostConstruct;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Named;
-import java.io.Serializable;
+
+import lombok.Data;
 
 @Named
 @ViewScoped
@@ -41,6 +42,7 @@ public class SelectOneMenu004 implements Serializable {
 
     private String console = "";
     private String console2 = "PS4";
+    private int driver1;
 
     @PostConstruct
     public void init() {

--- a/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu004.xhtml
@@ -21,6 +21,7 @@
                 <f:selectItem itemLabel="PS4" itemValue="PS4" itemDescription="Playstation 4" />
                 <f:selectItem itemLabel="PS5" itemValue="PS5" itemDisabled="true" />
                 <f:selectItem itemLabel="Wii U" itemValue="Wii U" />
+                <f:selectItem itemLabel="Switch" itemValue="Switch" />
             </p:selectOneMenu>
 
             <p:selectOneMenu id="selectonemenu2" value="#{selectOneMenu004.console2}" dynamic="true">
@@ -29,6 +30,15 @@
                 <f:selectItem itemLabel="PS4" itemValue="PS4" itemDescription="Playstation 4" />
                 <f:selectItem itemLabel="PS5" itemValue="PS5" itemDisabled="true" />
                 <f:selectItem itemLabel="Wii U" itemValue="Wii U" />
+                <f:selectItem itemLabel="Switch" itemValue="Switch" />
+            </p:selectOneMenu>
+
+            <p:selectOneMenu id="selectonemenu3" value="#{selectOneMenu004.driver1}" dynamic="true" var="d">
+                <f:selectItem itemLabel="Select a driver" itemValue="" noSelectionOption="true" />
+                <f:selectItems value="#{selectOneMenu001.drivers}" var="driver" itemLabel="#{driver.name}" itemValue="#{driver.id}" />
+                <p:column>
+                    <span style="font-weight: bold;">#{d.name}</span> (#{d.id})
+                </p:column>
             </p:selectOneMenu>
 
             <p:commandButton id="button" update="@form" value="Submit" action="#{selectOneMenu004.submit()}" />

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu004Test.java
@@ -23,6 +23,12 @@
  */
 package org.primefaces.integrationtests.selectonemenu;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
 import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
@@ -36,10 +42,6 @@ import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.Messages;
 import org.primefaces.selenium.component.SelectOneMenu;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class SelectOneMenu004Test extends AbstractPrimePageTest {
 
@@ -66,15 +68,15 @@ class SelectOneMenu004Test extends AbstractPrimePageTest {
 
         // Assert
         List<WebElement> options = selectOneMenu.getItems().findElements(By.className("ui-selectonemenu-item"));
-        assertEquals(5, options.size());
+        assertEquals(6, options.size());
 
         assertConfiguration(selectOneMenu.getWidgetConfiguration());
     }
 
     @Test
     @Order(2)
-    @DisplayName("SelectOneMenu: dynamic - don´t loose selection on submit")
-    void dynamic2(Page page) {
+    @DisplayName("SelectOneMenu: dynamic - do NOT lose selection on submit")
+    void dynamicAjaxSunmit(Page page) {
         // Arrange
         SelectOneMenu selectOneMenu = page.selectOneMenu2;
 
@@ -84,6 +86,34 @@ class SelectOneMenu004Test extends AbstractPrimePageTest {
         // Assert
         assertTrue(page.messages.getMessage(0).getSummary().contains("console2"));
         assertTrue(page.messages.getMessage(0).getDetail().contains("PS4"));
+
+        assertConfiguration(selectOneMenu.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("SelectOneMenu: dynamic with advanced rendering- load items on demand")
+    void dynamicAdvancedRendering(Page page) {
+        // Arrange
+        SelectOneMenu selectOneMenu = page.selectOneMenu3;
+
+        // Assert
+        boolean contentPanelExists = false;
+        try {
+            selectOneMenu.getItems().getText();
+            contentPanelExists = true;
+        }
+        catch (NoSuchElementException ex) {
+
+        }
+        assertFalse(contentPanelExists);
+
+        // Act
+        selectOneMenu.toggleDropdown();
+
+        // Assert
+        List<WebElement> options = selectOneMenu.getTable().findElements(By.className("ui-selectonemenu-item"));
+        assertEquals(5, options.size());
 
         assertConfiguration(selectOneMenu.getWidgetConfiguration());
     }
@@ -103,6 +133,9 @@ class SelectOneMenu004Test extends AbstractPrimePageTest {
 
         @FindBy(id = "form:selectonemenu2")
         SelectOneMenu selectOneMenu2;
+
+        @FindBy(id = "form:selectonemenu3")
+        SelectOneMenu selectOneMenu3;
 
         @FindBy(id = "form:button")
         CommandButton button;

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
@@ -23,6 +23,9 @@
  */
 package org.primefaces.selenium.component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.json.JSONObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -31,9 +34,6 @@ import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.base.AbstractInputComponent;
 import org.primefaces.selenium.component.base.ComponentUtils;
 import org.primefaces.selenium.findby.FindByParentPartialId;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Component wrapper for the PrimeFaces {@code p:selectOneMenu}.
@@ -221,8 +221,20 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
         return getRoot().findElement(By.id(getId() + "_label"));
     }
 
+    /**
+     * Gets items when using normal rendering.
+     * @return the WebElement of the items
+     */
     public WebElement getItems() {
         return getWebDriver().findElement(By.id(getId() + "_items"));
+    }
+
+    /**
+     * Gets the table element when using advanced rendering.
+     * @return the WebElement of the table
+     */
+    public WebElement getTable() {
+        return getWebDriver().findElement(By.id(getId() + "_table"));
     }
 
     public WebElement getPanel() {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1417,9 +1417,9 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
                     handle: function(content) {
                         var $content = $($.parseHTML(content));
 
-                        var $ul = $content.filter('ul');
+                        var $itemContent = $content.filter('ul, table');
                         $this.itemsWrapper.empty();
-                        $this.itemsWrapper.append($ul);
+                        $this.itemsWrapper.append($itemContent);
 
                         var $select = $content.filter('select');
                         $this.input.replaceWith($select);


### PR DESCRIPTION
Fix #12296: SelectOneMenu dynamic loading with advanced rendering

Advanced sends a `<table>` back not ` <ul>`