### PR TITLE
VSCode IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target/
 **/target/**
+**/target-ide/**
 .settings/
 nbactions.xml
 **/dynamichart

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <build.output>target</build.output>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
         <junit.version>5.10.3</junit.version>
@@ -100,6 +101,7 @@
     </modules>
 
     <build>
+        <directory>${build.output}</directory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -306,6 +308,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>vscode-ide</id>
+            <activation>
+                <property><name>m2e.version</name></property>
+            </activation>
+            <properties>
+                <build.output>target-ide</build.output>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
@tandraschko @Rapster 

@FlipWarthog and myself have been using VSCode for all my PF development.  I like it because its so fast and easy.  However there is one annoying bug where Maven builds like `mvn clean jetty:run` performed outside of VSCode cause VSCode to start running its compile and the collide.

You can read the issue here but this fix seems to be the only one that makes both VSCode and command line play nicely: https://github.com/redhat-developer/vscode-java/issues/1381#issuecomment-846578339

This change should affect ABSOLUTELY nothing except anyone building PrimeFaces in either VSCode or Eclipse.   

> [!IMPORTANT]  
> IntelliJ and NetBeans are completely unaffected by this change.