### PR TITLE
Fix #11714: Ajax Resource handling detect already loaded scripts per Faces spec

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -257,6 +257,45 @@ if (!PrimeFaces.ajax) {
 
             /**
              * Updates the HTML `head` element of the current document with the content received from an AJAX request.
+             * This method ensures that any new JavaScript or CSS resources are only added if they are not already present.
+             * If the content does not contain any JavaScript or CSS links, it is directly appended to the head.
+             * 
+             * @param {string} content The content of the changeset that was returned by an AJAX request.
+             */
+            updateResource: function (content) {
+                var $head = $("head");
+                try {
+                    var $content = $(content);
+                    var filteredContent = $content.length > 0 ? $content.filter("link[href], script[src]") : $();
+
+                    if (filteredContent.length === 0) {
+                        PrimeFaces.debug("Adding content to the head because it lacks any JavaScript or CSS links...");
+                        $head.append(content);
+                    } else {
+                        // #11714 Iterate through each script and stylesheet tag in the content
+                        // checking if resource is already attached to the head and adding it if not
+                        filteredContent.each(function () {
+                            var $resource = $(this);
+                            var src = $resource.attr("href") || $resource.attr("src");
+                            var type = this.tagName.toLowerCase();
+                            var $resources = $head.find(type + '[src="' + src + '"], ' + type + '[href="' + src + '"]');
+
+                            // Check if script or stylesheet already exists and add it to head if it does not
+                            if ($resources.length === 0) {
+                                PrimeFaces.debug("Appending " + type + " to head: " + src);
+                                $head.append($resource);
+                            }
+                        });
+                    }
+                } catch (error) {
+                    // MYFACES-4378 is incorrectly sending executable code here in the Resource section
+                    PrimeFaces.debug("Appending content to the head as it contains only raw JavaScript code...");
+                    $head.append(content);
+                }
+            },
+
+            /**
+             * Updates the HTML `head` element of the current document with the content received from an AJAX request.
              * @param {string} content The content of the changeset that was returned by an AJAX request.
              */
             updateHead: function(content) {
@@ -315,7 +354,7 @@ if (!PrimeFaces.ajax) {
                     PrimeFaces.ajax.Utils.updateBody(content);
                 }
                 else if (id === PrimeFaces.ajax.RESOURCE) {
-                    $('head').append(content);
+                    PrimeFaces.ajax.Utils.updateResource(content);
                 }
                 else if (id === $('head')[0].id) {
                     PrimeFaces.ajax.Utils.updateHead(content);


### PR DESCRIPTION
Fix #11714: Ajax Resource handling detect already loaded scripts per Faces spec

> The "jsf.js" script has to append every element from the update section with this new javax.faces.Resource identifier to the head of the HTML document, if that element is not already there
Note that via the condition "if that element is not already there" in the above algorithm the "jsf.js" script now takes upon it a part of deduplicating resource references, a task that was previously done solely server side.


In the comments specifically i call out MYFACES-4378 bug: 
 https://issues.apache.org/jira/browse/MYFACES-4378 

Original OmniFaces report:
https://github.com/omnifaces/omnifaces/issues/804
