### PR TITLE
Fix #12365: Spinner do not allow ONLY a thousandsSeparator char or any invalid number

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/spinner/Spinner001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/spinner/Spinner001Test.java
@@ -125,6 +125,23 @@ public class Spinner001Test extends AbstractPrimePageTest {
         assertConfiguration(spinner.getWidgetConfiguration());
     }
 
+    @Test
+    @Order(6)
+    @DisplayName("Spinner: GitHub #12365 do not allow only a thousands separator character")
+    void thousandSeparatorOnly(Page page) {
+        // Arrange
+        Spinner spinner = page.spinner;
+        assertEquals("", spinner.getValue());
+
+        // Act
+        sendKeys(spinner, ",");
+        page.button.click();
+
+        // Assert
+        assertEquals("", spinner.getValue());
+        assertConfiguration(spinner.getWidgetConfiguration());
+    }
+
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
         System.out.println("Spinner Config = " + cfg);

--- a/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/spinner/SpinnerRenderer.java
@@ -67,9 +67,17 @@ public class SpinnerRenderer extends InputRenderer {
                 submittedValue = submittedValue.replace(spinner.getDecimalSeparator(), ".");
             }
 
-            // GitHub #11830 prevent value outside of minimum or maximum range
-            double submittedNumber = Double.parseDouble(submittedValue);
-            if (submittedNumber < spinner.getMin() || submittedNumber > spinner.getMax()) {
+            try {
+                // GitHub #11830 prevent value outside of minimum or maximum range
+                double submittedNumber = Double.parseDouble(submittedValue);
+                if (submittedNumber < spinner.getMin() || submittedNumber > spinner.getMax()) {
+                    logDevelopmentWarning(context, this, String.format("Value is outside min/max range: %s", submittedValue));
+                    return;
+                }
+            }
+            catch (NumberFormatException e) {
+                // GitHub #12365 prevent any invalid number like just the thousands separator
+                logDevelopmentWarning(context, this, String.format("Invalid number format: %s", submittedValue));
                 return;
             }
         }


### PR DESCRIPTION
Fix #12365: Spinner do not allow ONLY a thousandsSeparator char or any invalid number

- [x] Integration test added