### PR TITLE
Fix #12379 14.0.4 DataTable: dont try to write filterValue back to EL if its read-only

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -314,7 +314,7 @@ public class DataTable extends DataTableBase {
                 continue;
             }
             ValueExpression columnFilterValueVE = column.getValueExpression(Column.PropertyKeys.filterValue.toString());
-            if (columnFilterValueVE == null) {
+            if (columnFilterValueVE == null || columnFilterValueVE.isReadOnly(elContext)) {
                 continue;
             }
             if (column.isDynamic()) {


### PR DESCRIPTION
Fix #12379 14.0.4 DataTable: dont try to write filterValue back to EL if its read-only