### PR TITLE
Fix #12378: Plain Menu only add ui-state-hover on hover

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.base.js
@@ -307,25 +307,38 @@ PrimeFaces.widget.Menu = PrimeFaces.widget.BaseWidget.extend({
      * Selects the menu item link by making it focused and setting tabindex to "0" for ARIA.
      * 
      * @param {JQuery} menulink - The menu item (`<a>`) to select.
+     * @param {JQuery.TriggeredEvent} [event] - The event that triggered the focus.
      */
-    focus: function(menulink) {
+    focus: function(menulink, event) {
         if (menulink.hasClass('ui-state-disabled')) {
             return;
         }
         this.resetFocus(false);
         var defaultTabIndex = this.tabIndex || "0";
-        menulink.addClass('ui-state-hover ui-state-active').attr('tabindex', defaultTabIndex).trigger('focus');
+        var cssClass = 'ui-state-hover';
+        if (!event || !event.type.startsWith('mouse')) {
+             // only add active class if the event is not a mouse event like a click or keyboard event
+            cssClass = cssClass + ' ui-state-active';
+        }
+        menulink.addClass(cssClass).attr('tabindex', defaultTabIndex).trigger('focus');
     },
 
     /**
      * Unselect the menu item link by removing focus and tabindex=-1 for ARIA.
      * @param {JQuery} menulink Menu item (`A`) to unselect.
+     * @param {JQuery.TriggeredEvent} [event] - The event that triggered the unfocus.
      */
-    unfocus: function(menulink) {
+    unfocus: function(menulink, event) {
         if (menulink.hasClass('ui-state-disabled')) {
             return;
         }
-        menulink.removeClass('ui-state-hover ui-state-active').attr('tabindex', -1);
+
+        var cssClass = 'ui-state-hover';
+        if (!event || !event.type.startsWith('mouse')) {
+            // only remove active class if the event is not a mouse event like a click or keyboard event
+            cssClass = cssClass + ' ui-state-active';
+        }
+        menulink.removeClass(cssClass).attr('tabindex', -1);
     }
 });
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.plainmenu.js
@@ -125,10 +125,10 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
         this.resetFocus(true);
 
         // Bind mouse and click events to focus items
-        this.menuitemLinks.on("mouseenter.menu click.menu", function() {
-            $this.focus($(this));
-        }).on("focusout.menu mouseleave.menu", function() {
-            $this.unfocus($(this));
+        this.menuitemLinks.on("mouseenter.menu click.menu", function(e) {
+            $this.focus($(this), e);
+        }).on("mouseleave.menu", function(e) {
+            $this.unfocus($(this), e);
         });
 
         // Bind keyboard navigation events
@@ -136,11 +136,11 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
             var currentLink = $this.menuitemLinks.filter('.ui-state-hover');
             switch (e.code) {
                 case 'ArrowUp':
-                    $this.navigateMenu(currentLink, 'prev');
+                    $this.navigateMenu(e, currentLink, 'prev');
                     e.preventDefault();
                     break;
                 case 'ArrowDown':
-                    $this.navigateMenu(currentLink, 'next');
+                    $this.navigateMenu(e, currentLink, 'next');
                     e.preventDefault();
                     break;
                 case 'Space':
@@ -161,15 +161,16 @@ PrimeFaces.widget.PlainMenu = PrimeFaces.widget.Menu.extend({
 
     /**
      * Navigates the menu items in the specified direction ('prev' or 'next').
+     * @param {JQuery.TriggeredEvent} event - The event that triggered the focus.
      * @param {JQuery} currentLink The currently focused menu item link.
      * @param {string} direction The direction to navigate ('prev' or 'next').
      * @private
      */
-    navigateMenu: function(currentLink, direction) {
+    navigateMenu: function(event, currentLink, direction) {
         var targetItem = currentLink.parent()[direction + 'All']('.ui-menuitem:first');
         if (targetItem.length) {
-            this.unfocus(currentLink);
-            this.focus(targetItem.children('.ui-menuitem-link'));
+            this.unfocus(currentLink, event);
+            this.focus(targetItem.children('.ui-menuitem-link'), event);
         }
     },
 


### PR DESCRIPTION
Fix #12378: Plain Menu only add ui-state-hover on hover

- [x] If coming from `mouseenter/mouseleave` then only add `ui-state-hover`
- [x] if coming from `click` or `keyup/down` it adds `ui-state-active` as well