### PR TITLE
Fix #12399: CSP improve NULL checking

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/core/csp/CoreCsp001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/core/csp/CoreCsp001.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.csp;
+
+import java.io.Serializable;
+
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class CoreCsp001 implements Serializable {
+
+    private static final long serialVersionUID = 8797995450720503195L;
+
+    private String firstname;
+    private String lastname;
+
+    public String openInNewPage() {
+        return "coreCsp001-page2.xhtml";
+    }
+
+    public void save() {
+        FacesContext.getCurrentInstance().addMessage(null,
+                new FacesMessage("Welcome " + firstname + " " + lastname));
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/core/csp/coreCsp001-page2.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/csp/coreCsp001-page2.xhtml
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form2">
+            <h1>Page 2</h1>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/core/csp/coreCsp001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/csp/coreCsp001.xhtml
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" />
+        
+            <h:panelGrid columns="3" cellpadding="7" styleClass="mb-3">
+                <p:outputLabel for="firstname" value="Firstname:" />
+                <p:inputText id="firstname" value="#{coreCsp001.firstname}" required="true" label="Firstname">
+                    <f:validateLength minimum="2" />
+                </p:inputText>
+                <p:message for="firstname" display="icon" />
+        
+                <p:outputLabel for="lastname" value="Lastname:" />
+                <p:inputText id="lastname" value="#{coreCsp001.lastname}" label="Lastname" required="true">
+                    <f:validateLength minimum="2" />
+                    <p:ajax update="msgLastname" event="keyup" />
+                </p:inputText>
+                <p:message for="lastname" id="msgLastname" display="icon" />
+        
+            </h:panelGrid>
+        
+            <p:commandButton id="btnSave" value="Save" update="@form" action="#{coreCsp001.save}" icon="pi pi-check" />
+        
+            <h:commandLink id="lnkNewPage" action="#{coreCsp001.openInNewPage()}" value="Open in new page" target="_blank">
+            </h:commandLink>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/csp/CoreCsp001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/csp/CoreCsp001Test.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.csp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.InputText;
+
+public class CoreCsp001Test  extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Core-CSP: open in new page don't break NONCE in current page - https://github.com/primefaces/primefaces/issues/12399")
+    void cspInNewPage(Page page) {
+        // Arrange
+        assertEquals("", page.firstname.getValue());
+        assertEquals("", page.lastname.getValue());
+
+        // Act
+        page.btnSave.click();
+
+        // Assert
+        assertCss(page.firstname, "ui-state-error");
+        assertCss(page.firstname, "ui-state-error");
+        assertNoJavascriptErrors();
+
+        // Act
+        page.lnkNewPage.click();
+
+        // Assert
+        assertCss(page.firstname, "ui-state-error");
+        assertCss(page.firstname, "ui-state-error");
+        assertNoJavascriptErrors();
+
+        // Act
+        page.firstname.setValue("John");
+        page.lastname.setValue("Doe");
+        page.btnSave.click(); //submit on original page was broken with a new nonce
+
+        // Assert
+        assertEquals("John", page.firstname.getValue());
+        assertEquals("Doe", page.lastname.getValue());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:firstname")
+        InputText firstname;
+
+        @FindBy(id = "form:lastname")
+        InputText lastname;
+
+        @FindBy(id = "form:btnSave")
+        CommandButton btnSave;
+
+        @FindBy(id = "form:lnkNewPage")
+        WebElement lnkNewPage;
+
+        @Override
+        public String getLocation() {
+            return "core/csp/coreCsp001.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/csp/CspState.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspState.java
@@ -44,19 +44,24 @@ public class CspState {
     }
 
     /**
-     * For AJAX request validate the nonce, else generate a new nonce for non-AJAX requests.
+     * Retrieves or generates a nonce (number used once) for Content Security Policy (CSP).
      *
-     * @return the nonce Base64 value
+     * For AJAX requests and postbacks, it validates the existing nonce.
+     * For non-AJAX requests, it generates a new nonce.
+     *
+     * @return the nonce as a Base64 encoded string
+     * @throws CspException if there's a nonce mismatch or validation fails
      */
     public String getNonce() {
         if (nonce == null) {
             if (context.isPostback() || context.getPartialViewContext().isAjaxRequest()) {
                 String nonceRequest = context.getExternalContext().getRequestParameterMap().get(Constants.RequestParams.NONCE_PARAM);
+                nonceRequest = Objects.toString(nonceRequest, Constants.EMPTY_STRING);
                 String nonceViewState = Constants.EMPTY_STRING;
                 Map<String, Object> viewMap = context.getViewRoot().getViewMap(false);
                 if (viewMap != null) {
-                    nonceViewState = (String) viewMap.get(Constants.RequestParams.NONCE_PARAM);
-                    if (context.isPostback() && !Objects.equals(nonceViewState, nonceRequest)) {
+                    nonceViewState = Objects.toString(viewMap.get(Constants.RequestParams.NONCE_PARAM), Constants.EMPTY_STRING);
+                    if (context.isPostback() && LangUtils.isNotBlank(nonceViewState) && !Objects.equals(nonceViewState, nonceRequest)) {
                         throw new CspException("CSP nonce mismatch");
                     }
                 }


### PR DESCRIPTION
Fix #12399: CSP improve NULL checking

@tandraschko this prevents in case the map has NULL so `Objects.equals(NULL, "")` would be false we should always be comparing a String to a String with a default of Constants.EMPTY_STRING so `Objects.equals("", "")`