### PR TITLE
Showcase: Tree lazy example NPE in Quarkus showcase

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/tree/FileInfo.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/data/tree/FileInfo.java
@@ -25,23 +25,29 @@ package org.primefaces.showcase.view.data.tree;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class FileInfo implements Serializable {
 
-    private String path;
-    private String name;
-    private boolean directory;
+    private final String path;
+    private final String name;
+    private final boolean directory;
 
     public FileInfo(String path, boolean directory) {
-        this.path = path;
-        if (this.path.equals(File.separator)) {
-            this.name = this.path;
+        this.directory = directory;
+        if (path == null) {
+            this.path = File.separator;
+            this.name = File.separator;
+        }
+        else if (path.equals(File.separator)) {
+            this.name = path;
+            this.path = path;
         }
         else {
             String[] parts = path.split(File.separator.equals("\\") ? "\\\\" : File.separator);
             this.name = parts[parts.length - 1];
+            this.path = path;
         }
-        this.directory = directory;
     }
 
     public String getPath() {
@@ -54,6 +60,19 @@ public class FileInfo implements Serializable {
 
     public boolean isDirectory() {
         return directory;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileInfo fileInfo = (FileInfo) o;
+        return isDirectory() == fileInfo.isDirectory() && Objects.equals(getPath(), fileInfo.getPath()) && Objects.equals(getName(), fileInfo.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPath(), getName(), isDirectory());
     }
 
     @Override


### PR DESCRIPTION
Was noticing this log in the Quarkus showcase

```
2024-08-05 00:41:23,631 SEVERE [org.pri.app.exc.PrimeExceptionHandler] (executor-thread-486) Cannot invoke "String.equals(Object)" because "this.path" is null: java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "this.path" is null
	at org.primefaces.showcase.view.data.tree.FileInfo.<init>(FileInfo.java:41)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView.init(LazyLoadingView.java:49)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView_Bean.doCreate(Unknown Source)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView_Bean.create(Unknown Source)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView_Bean.create(Unknown Source)
	at org.apache.myfaces.cdi.util.ContextualStorage.createContextualInstance(ContextualStorage.java:154)
	at org.apache.myfaces.cdi.view.ViewScopeContext.get(ViewScopeContext.java:177)
	at org.apache.myfaces.core.extensions.quarkus.runtime.scopes.QuarkusViewScopeContext.get(QuarkusViewScopeContext.java:70)
	at io.quarkus.arc.InjectableContext.getIfActive(InjectableContext.java:60)
	at io.quarkus.arc.impl.ClientProxies.getSingleContextDelegate(ClientProxies.java:28)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView_ClientProxy.arc$delegate(Unknown Source)
	at org.primefaces.showcase.view.data.tree.LazyLoadingView_ClientProxy.getRoot(Unknown Source)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```