### PR TITLE
IT: CSP failing test

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/csp/CoreCsp001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/csp/CoreCsp001Test.java
@@ -46,29 +46,21 @@ public class CoreCsp001Test  extends AbstractPrimePageTest {
         assertEquals("", page.lastname.getValue());
 
         // Act
-        page.btnSave.click();
-
-        // Assert
-        assertCss(page.firstname, "ui-state-error");
-        assertCss(page.firstname, "ui-state-error");
-        assertNoJavascriptErrors();
-
-        // Act
-        page.lnkNewPage.click();
-
-        // Assert
-        assertCss(page.firstname, "ui-state-error");
-        assertCss(page.firstname, "ui-state-error");
-        assertNoJavascriptErrors();
-
-        // Act
         page.firstname.setValue("John");
         page.lastname.setValue("Doe");
-        page.btnSave.click(); //submit on original page was broken with a new nonce
+        page.lnkNewPage.click();
 
         // Assert
         assertEquals("John", page.firstname.getValue());
         assertEquals("Doe", page.lastname.getValue());
+        assertNoJavascriptErrors();
+
+        // Act
+        page.firstname.setValue("");
+        page.lastname.setValue(""); // AJAX update triggers CSP nonce mismatch
+
+        // Assert
+        assertPresent(page.firstname);
         assertNoJavascriptErrors();
     }
 

--- a/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
+++ b/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
@@ -45,11 +45,12 @@ import javax.faces.event.ExceptionQueuedEvent;
 import javax.faces.event.PhaseId;
 import javax.faces.lifecycle.ClientWindow;
 import javax.faces.view.ViewDeclarationLanguage;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -264,8 +265,8 @@ public class PrimeExceptionHandler extends ExceptionHandlerWrapper {
             info.setFormattedStackTrace(EscapeUtils.forXml(sw.toString()).replaceAll("(\r\n|\n)", "<br/>"));
         }
 
-        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT_PATTERN);
-        info.setFormattedTimestamp(format.format(info.getTimestamp()));
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN);
+        info.setFormattedTimestamp(info.getTimestamp().format(formatter));
 
         return info;
     }


### PR DESCRIPTION
@tandraschko this definitely fails now if you remove that `Langutils.isNotBlank`

Also fixed an error where it was trying to use a SimpleDateFormat on the LocalDateTime now.