### PR TITLE
Fix #12416: Core.js use crypto.randomUUID if available

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -1305,21 +1305,21 @@
         /**
          * Generate a RFC-4122 compliant UUID to be used as a unique identifier.
          *
+         * Uses crypto.randomUUID() if available, otherwise falls back to a custom implementation.
+         *
          * See https://www.ietf.org/rfc/rfc4122.txt
          *
          * @return {string} A random UUID.
          */
         uuid: function() {
-            var lut = [];
-            for (var i=0; i<256; i++) { lut[i] = (i<16?'0':'')+(i).toString(16); }
-            var d0 = Math.random()*0xffffffff|0;
-            var d1 = Math.random()*0xffffffff|0;
-            var d2 = Math.random()*0xffffffff|0;
-            var d3 = Math.random()*0xffffffff|0;
-            return lut[d0&0xff]+lut[d0>>8&0xff]+lut[d0>>16&0xff]+lut[d0>>24&0xff]+'-'+
-              lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
-              lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
-              lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
+            if (typeof crypto.randomUUID === 'function') {
+                return crypto.randomUUID();
+            }
+            else {
+                return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
+                    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+                );
+            }
         },
 
         /**


### PR DESCRIPTION
Fix #12416: Core.js use crypto.randomUUID if available


According to MDN there are contexts where `crypto` may not be available for the browser so i left the fallback in.