### PR TITLE
Fix #12454: DatePicker increase default year range to 2000

### DIFF
--- a/docs/14_0_0/components/datepicker.md
+++ b/docs/14_0_0/components/datepicker.md
@@ -144,7 +144,7 @@ ajax selection and more.
 | weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
 | widgetVar | null | String | Name of the client side widget.
 | yearNavigator | false | Boolean | Whether the year should be rendered as an input number instead of text.
-| yearRange | null | String | The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020). Default value is "displayed_date - 10 : displayed_date + 10".
+| yearRange | null | String | The range of years allowed in the year input in (nnnn:nnnn) format such as (1974:2020). Default value is "displayed_date - 1000 : displayed_date + 1000".
 
 ## Getting Started with DatePicker
 Value of the DatePicker should be a java.time.LocalDate in single selection mode which is the default.

--- a/docs/15_0_0/components/datepicker.md
+++ b/docs/15_0_0/components/datepicker.md
@@ -144,7 +144,7 @@ ajax selection and more.
 | weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
 | widgetVar | null | String | Name of the client side widget.
 | yearNavigator | false | Boolean | Whether the year should be rendered as an input number instead of text.
-| yearRange | null | String | The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020). Default value is "displayed_date - 10 : displayed_date + 10".
+| yearRange | null | String | The range of years allowed in the year input in (nnnn:nnnn) format such as (1974:2020). Default value is "displayed_date - 1000 : displayed_date + 1000".
 
 ## Getting Started with DatePicker
 Value of the DatePicker should be a java.time.LocalDate in single selection mode which is the default.

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -31993,7 +31993,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020).]]>
+                <![CDATA[The range of years allowed in the year input in (nnnn:nnnn) format such as (1974:2020). Default value is "displayed_date - 1000 : displayed_date + 1000"..]]>
             </description>
             <name>yearRange</name>
             <required>false</required>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -3376,7 +3376,7 @@
             }
             if (this.options.yearNavigator) {
                 var viewYear = this.viewDate.getFullYear();
-                this.options.yearRange = (viewYear - 10) + ':' + (viewYear + 10);
+                this.options.yearRange = (viewYear - 1000) + ':' + (viewYear + 1000);
             }
         },
 


### PR DESCRIPTION
Fix #12454: DatePicker increase default year range to 2000

@tandraschko @jepsar @lprimak i picked +/- 1000 years because the component checks so many places for `min` and `max` year that it wasn't worth trying to go find every place and add null checks.  So I just gave it a really wide range by default to prevent issues like @lprimak 

it seemed the safer fix.