### PR TITLE
Fix #12463: Signature allow typed text, improve accessibility

### DIFF
--- a/docs/14_0_0/components/signature.md
+++ b/docs/14_0_0/components/signature.md
@@ -23,29 +23,33 @@ devices and legacy browsers without canvas support.
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
-binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
-value | null | Object | Value of the component than can be either an EL expression of a literal text
-converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
-immediate | false | Boolean | Boolean value that specifies the lifecycle phase the valueChangeEvents should be processed, when true the events will be fired at "apply request values", if immediate is set to false, valueChange Events are fired in "process validations" phase
-required | false | Boolean | Marks component as required
-validator | null | MethodExpr | A method binding expression that refers to a method validating the input
-valueChangeListener | null | MethodExpr | A method binding expression that refers to a method for handling a valuchangeevent
-requiredMessage | null | String | Message to be displayed when required field validation fails.
-converterMessage | null | String | Message to be displayed when conversion fails.
-validatorMessage | null | String | Message to be displayed when validation fields.
-widgetVar | null | String | Name of the client side widget
+ariaLabel | "Sign here" | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
 backgroundColor | #ffffff | String | Background color as hex value
+base64Value | null | String | Write-only value used to pass the value in base64 to backing bean
+binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 color | #000000 | String | Foreground color as hex value
-thickness | 2 | Integer | Thickness of the lines
-style | null | String | Inline style of the component
-styleClass | null | String | Style class of the component.
-readonly | false | Boolean | When enabled, signature is used for display purposes only.
+converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
+converterMessage | null | String | Message to be displayed when conversion fails.
+fontFamily | "cursive" | String | Font family for typing in a signature. Default is "Brush Script MT, cursive"
+fontSize |40 | Integer | Font size for typing in a signature. Default is 40.
 guideline | false | Boolean | Adds a guideline when enabled
 guidelineColor | #a0a0a0 | String | Color of the guideline
-guidelineOffset | 25 | String | Offset of guideline from bottom
 guidelineIndent | 10 | Integer | Guide line indent from the edges
+guidelineOffset | 25 | String | Offset of guideline from bottom
+immediate | false | Boolean | Boolean value that specifies the lifecycle phase the valueChangeEvents should be processed, when true the events will be fired at "apply request values", if immediate is set to false, valueChange Events are fired in "process validations" phase
 onchange | null | String | Client side callback to execute when signature changes.
-base64Value | null | String | Write-only value used to pass the value in base64 to backing bean
+readonly | false | Boolean | When enabled, signature is used for display purposes only.
+required | false | Boolean | Marks component as required
+requiredMessage | null | String | Message to be displayed when required field validation fails.
+style | null | String | Inline style of the component
+styleClass | null | String | Style class of the component.
+tabindex | null | Integer | Position of the input element in the tabbing order.
+thickness | 2 | Integer | Thickness of the lines
+validator | null | MethodExpr | A method binding expression that refers to a method validating the input
+validatorMessage | null | String | Message to be displayed when validation fields.
+value | null | Object | Value of the component than can be either an EL expression of a literal text
+valueChangeListener | null | MethodExpr | A method binding expression that refers to a method for handling a valuchangeevent
+widgetVar | null | String | Name of the client side widget
 
 ## Getting started with Signature
 Value is interpreted as JSON so at backing bean should be a string value.
@@ -66,6 +70,61 @@ public class SignatureView {
     }
 }
 ```
+
+## Typing in a Signature
+Instead of drawing a signature, you can also type it in.  Just focus on the signature and type.
+
+```xhtml
+<p:signature style="width:400px;height:200px" value="#{signatureView.value}" textValue="#{signatureView.textValue}" fontSize="50" fontFamily="Brush Script MT, cursive" />
+```
+
+```java
+public class SignatureView {
+    private String value;
+    private String textValue;
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getTextValue() {
+        return textValue;
+    }
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
+    }
+}
+```
+
+## Save as PNG
+Optionally you can save the signature as a PNG image. When submitting the form, the base64 value is passed to the backing bean but this is a "write-only" value so it can only be passed to the backing bean, not read from it.
+
+```xhtml
+<p:signature style="width:400px;height:200px" value="#{signatureView.value}" base64Value="#{signatureView.base64Value}" />
+```
+
+```java
+public class SignatureView {
+    private String value;
+    private String base64Value;
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getBase64Value() {
+        return base64Value;
+    }
+    public void setBase64Value(String base64Value) {
+        this.base64Value = base64Value;
+    }
+}
+```
+
 ## Guideline
 Guideline adds a horizontal line to indicate the area to sign, attributes such as guidelineColor,
 guidelineOffset and guidelineIndent can be used to customize this area.
@@ -172,3 +231,5 @@ Widget: _PrimeFaces.widget.Signature_
 | --- | --- | --- | --- |
 | disable() | - | void | Disables the input field |
 | enable() | - | void | Enables the input field |
+| createSignatureFromText(text) | text | void | Creates an SVG signature from the given text |
+

--- a/docs/15_0_0/components/signature.md
+++ b/docs/15_0_0/components/signature.md
@@ -23,29 +23,33 @@ devices and legacy browsers without canvas support.
 | --- | --- | --- | --- |
 id | null | String | Unique identifier of the component
 rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
-binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
-value | null | Object | Value of the component than can be either an EL expression of a literal text
-converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
-immediate | false | Boolean | Boolean value that specifies the lifecycle phase the valueChangeEvents should be processed, when true the events will be fired at "apply request values", if immediate is set to false, valueChange Events are fired in "process validations" phase
-required | false | Boolean | Marks component as required
-validator | null | MethodExpr | A method binding expression that refers to a method validating the input
-valueChangeListener | null | MethodExpr | A method binding expression that refers to a method for handling a valuchangeevent
-requiredMessage | null | String | Message to be displayed when required field validation fails.
-converterMessage | null | String | Message to be displayed when conversion fails.
-validatorMessage | null | String | Message to be displayed when validation fields.
-widgetVar | null | String | Name of the client side widget
+ariaLabel | "Sign here" | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
 backgroundColor | #ffffff | String | Background color as hex value
+base64Value | null | String | Write-only value used to pass the value in base64 to backing bean
+binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean
 color | #000000 | String | Foreground color as hex value
-thickness | 2 | Integer | Thickness of the lines
-style | null | String | Inline style of the component
-styleClass | null | String | Style class of the component.
-readonly | false | Boolean | When enabled, signature is used for display purposes only.
+converter | null | Converter/String | An el expression or a literal text that defines a converter for the component. When it’s an EL expression, it’s resolved to a converter instance. In case it’s a static text, it must refer to a converter id
+converterMessage | null | String | Message to be displayed when conversion fails.
+fontFamily | "cursive" | String | Font family for typing in a signature. Default is "Brush Script MT, cursive"
+fontSize |40 | Integer | Font size for typing in a signature. Default is 40.
 guideline | false | Boolean | Adds a guideline when enabled
 guidelineColor | #a0a0a0 | String | Color of the guideline
-guidelineOffset | 25 | String | Offset of guideline from bottom
 guidelineIndent | 10 | Integer | Guide line indent from the edges
+guidelineOffset | 25 | String | Offset of guideline from bottom
+immediate | false | Boolean | Boolean value that specifies the lifecycle phase the valueChangeEvents should be processed, when true the events will be fired at "apply request values", if immediate is set to false, valueChange Events are fired in "process validations" phase
 onchange | null | String | Client side callback to execute when signature changes.
-base64Value | null | String | Write-only value used to pass the value in base64 to backing bean
+readonly | false | Boolean | When enabled, signature is used for display purposes only.
+required | false | Boolean | Marks component as required
+requiredMessage | null | String | Message to be displayed when required field validation fails.
+style | null | String | Inline style of the component
+styleClass | null | String | Style class of the component.
+tabindex | null | Integer | Position of the input element in the tabbing order.
+thickness | 2 | Integer | Thickness of the lines
+validator | null | MethodExpr | A method binding expression that refers to a method validating the input
+validatorMessage | null | String | Message to be displayed when validation fields.
+value | null | Object | Value of the component than can be either an EL expression of a literal text
+valueChangeListener | null | MethodExpr | A method binding expression that refers to a method for handling a valuchangeevent
+widgetVar | null | String | Name of the client side widget
 
 ## Getting started with Signature
 Value is interpreted as JSON so at backing bean should be a string value.
@@ -66,6 +70,61 @@ public class SignatureView {
     }
 }
 ```
+
+## Typing in a Signature
+Instead of drawing a signature, you can also type it in.  Just focus on the signature and type.
+
+```xhtml
+<p:signature style="width:400px;height:200px" value="#{signatureView.value}" textValue="#{signatureView.textValue}" fontSize="50" fontFamily="Brush Script MT, cursive" />
+```
+
+```java
+public class SignatureView {
+    private String value;
+    private String textValue;
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getTextValue() {
+        return textValue;
+    }
+    public void setTextValue(String textValue) {
+        this.textValue = textValue;
+    }
+}
+```
+
+## Save as PNG
+Optionally you can save the signature as a PNG image. When submitting the form, the base64 value is passed to the backing bean but this is a "write-only" value so it can only be passed to the backing bean, not read from it.
+
+```xhtml
+<p:signature style="width:400px;height:200px" value="#{signatureView.value}" base64Value="#{signatureView.base64Value}" />
+```
+
+```java
+public class SignatureView {
+    private String value;
+    private String base64Value;
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getBase64Value() {
+        return base64Value;
+    }
+    public void setBase64Value(String base64Value) {
+        this.base64Value = base64Value;
+    }
+}
+```
+
 ## Guideline
 Guideline adds a horizontal line to indicate the area to sign, attributes such as guidelineColor,
 guidelineOffset and guidelineIndent can be used to customize this area.
@@ -172,3 +231,5 @@ Widget: _PrimeFaces.widget.Signature_
 | --- | --- | --- | --- |
 | disable() | - | void | Disables the input field |
 | enable() | - | void | Enables the input field |
+| createSignatureFromText(text) | text | void | Creates an SVG signature from the given text |
+

--- a/docs/15_0_0/core/thirdpartylibs.md
+++ b/docs/15_0_0/core/thirdpartylibs.md
@@ -34,7 +34,7 @@ are many other third party libraries and plugins used to support features.
 | [Moment Timezone](../jsdocs/modules/node_modules_moment_ts3_1_typings_moment.html#tz) | 0.5.45 | https://github.com/moment/moment-timezone |
 | [Quill Editor](../jsdocs/modules/node_modules__types_quill.html) | 2.0.2 | https://quilljs.com/ |
 | [Raphaël](../jsdocs/interfaces/node_modules__types_raphael.RaphaelStatic.html) | 2.3.0 | http://raphaeljs.com |
-| [Signature](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#signature) | 1.2.0 | http://keith-wood.name/signature.html |
+| [Signature](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#signature) | 1.2.1 | http://keith-wood.name/signature.html |
 | [Timeline](../jsdocs/modules/node_modules_vis_timeline_declarations.html) | 7.7.2 | https://github.com/visjs/vis-timeline |
 | [TouchSwipe](../jsdocs/interfaces/src_PrimeFaces.JQuery-1.html#swipe) | 1.6.19 | https://github.com/mattbryson/TouchSwipe-Jquery-Plugin |
 | [WebcamJS](../jsdocs/modules/src_PrimeFaces.Webcam.html) | 1.0.26 | https://github.com/jhuckaby/webcamjs |

--- a/docs/15_0_0/gettingstarted/whatsnew.md
+++ b/docs/15_0_0/gettingstarted/whatsnew.md
@@ -42,6 +42,11 @@ Look into [migration guide](https://primefaces.github.io/primefaces/15_0_0/#/../
 * SelectOneMenu
     * Added `clear` AJAX event when in `editable="true"` and you clear out a value with BACKSPACE/DELETE
 
+* Signature
+    * Ability to type your signature
+    * Added `textValue`, `fontSize`, `fontFamily` attributes to support typing of signature
+    * ARIA accessibility support with `role="img"` and `aria-label`
+
 * StaticMessage
     * Added `severity="success"` to align with React/Vue/Angular
 

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/SignatureView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/input/SignatureView.java
@@ -31,6 +31,8 @@ import jakarta.inject.Named;
 public class SignatureView {
 
     private String value;
+    private String text;
+    private String base64;
 
     public String getValue() {
         return value;
@@ -38,5 +40,21 @@ public class SignatureView {
 
     public void setValue(String value) {
         this.value = value;
+    }
+
+    public String getBase64() {
+        return base64;
+    }
+
+    public void setBase64(String base64) {
+        this.base64 = base64;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
     }
 }

--- a/primefaces-showcase/src/main/webapp/ui/input/signature.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/signature.xhtml
@@ -1,9 +1,5 @@
-<ui:composition xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:ui="jakarta.faces.facelets"
-                xmlns:h="jakarta.faces.html"
-                xmlns:f="jakarta.faces.core"
-                xmlns:p="primefaces"
-                template="/WEB-INF/template.xhtml">
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="jakarta.faces.facelets" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core"
+    xmlns:p="primefaces" template="/WEB-INF/template.xhtml">
 
     <ui:define name="title">
         Signature
@@ -11,32 +7,35 @@
 
     <ui:define name="description">
         Signature is used to draw a signature as an input. Various options such as background color, foreground color, thickness are available
-        for customization. Signature also supports touch enabled devices and legacy browsers without canvas support.
+        for customization. Signature also supports touch enabled devices as well as typeable text.
     </ui:define>
 
-    <ui:param name="documentationLink" value="/components/signature"/>
-    <ui:param name="widgetLink" value="Signature-1"/>
+    <ui:param name="documentationLink" value="/components/signature" />
+    <ui:param name="widgetLink" value="Signature-1" />
 
     <ui:define name="implementation">
         <div class="card">
             <h:form>
                 <p:growl>
-                    <p:autoUpdate/>
+                    <p:autoUpdate />
                 </p:growl>
 
-                <p:signature style="width:400px;height:200px" widgetVar="sig" value="#{signatureView.value}"
-                             required="true" guideline="true"/>
+                <p:outputPanel id="input">
+                    <p:outputLabel for="@next" value="Signature:" style="font-size:1.5rem" styleClass="block mb-2" />
+                    <p:signature id="signature" widgetVar="sig" style="width:400px;height:200px" value="#{signatureView.value}" required="true" guideline="true"
+                         textValue="#{signatureView.text}" base64Value="#{signatureView.base64}" />
+                </p:outputPanel>
 
                 <div style="margin:20px 0">
-                    <p:commandButton value="Submit" icon="pi pi-check" update="output"/>
-                    <p:commandButton value="Clear" icon="pi pi-times" type="button" onclick="PF('sig').clear()" styleClass="ui-button-flat ml-2"/>
+                    <p:commandButton value="Submit" icon="pi pi-check" update="output signature" />
+                    <p:commandButton value="Clear" icon="pi pi-times" type="button" onclick="PF('sig').clear()" styleClass="ui-button-flat ml-2" />
                 </div>
 
                 <p:outputPanel id="output">
-                    <h:outputText rendered="#{not empty signatureView.value}" style="font-size:1.5rem" styleClass="block mb-2"
-                                  value="Your Signature" />
-                    <p:signature style="width:400px;height:200px;" value="#{signatureView.value}" readonly="true"
-                                 rendered="#{not empty signatureView.value}" backgroundColor="#eaeaea" color="#03a9f4"/>
+                    <h:outputText rendered="#{not empty signatureView.value}" style="font-size:1.5rem" styleClass="block mb-2" value="Your Signature" />
+                    <p:signature id="signed" widgetVar="signed" style="width:400px;height:200px;" value="#{signatureView.value}"
+                        textValue="#{signatureView.text}" readonly="true" rendered="#{not empty signatureView.value}" backgroundColor="#eaeaea"
+                        color="#1769aa" />
                 </p:outputPanel>
             </h:form>
         </div>

--- a/primefaces/src/main/java/org/primefaces/component/signature/Signature.java
+++ b/primefaces/src/main/java/org/primefaces/component/signature/Signature.java
@@ -37,7 +37,7 @@ public class Signature extends SignatureBase {
 
     public static final String COMPONENT_TYPE = "org.primefaces.component.Signature";
 
-    public static final String STYLE_CLASS = "ui-inputfield ui-widget ui-state-default ui-corner-all";
+    public static final String STYLE_CLASS = "ui-inputfield ui-inputtextarea ui-widget ui-state-default ui-corner-all";
     public static final String READONLY_STYLE_CLASS = "ui-widget ui-widget-content ui-corner-all";
 
     @Override
@@ -52,15 +52,34 @@ public class Signature extends SignatureBase {
                 getStateHelper().put(PropertyKeys.base64Value, null);
             }
         }
+
+        String textValue = this.getTextValue();
+        if (textValue != null) {
+            ValueExpression ve = this.getValueExpression(PropertyKeys.textValue.toString());
+            if (ve != null) {
+                ve.setValue(context.getELContext(), textValue);
+                getStateHelper().put(PropertyKeys.textValue, null);
+            }
+        }
     }
 
-    public String resolveStyleClass() {
-        String styleClass = STYLE_CLASS;
+    @Override
+    public String getInputClientId() {
+        return getClientId(getFacesContext()) + "_canvas";
+    }
 
-        if (isReadonly()) {
-            styleClass = READONLY_STYLE_CLASS;
-        }
+    @Override
+    public String getValidatableInputClientId() {
+        return getClientId(getFacesContext()) + "_value";
+    }
 
-        return styleClass;
+    @Override
+    public String getLabelledBy() {
+        return (String) getStateHelper().get("labelledby");
+    }
+
+    @Override
+    public void setLabelledBy(String labelledBy) {
+        getStateHelper().put("labelledby", labelledBy);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/signature/SignatureBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/signature/SignatureBase.java
@@ -23,31 +23,32 @@
  */
 package org.primefaces.component.signature;
 
-import javax.faces.component.UIInput;
 
+import org.primefaces.component.api.AbstractPrimeHtmlInputText;
+import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.Widget;
 
-public abstract class SignatureBase extends UIInput implements Widget {
+public abstract class SignatureBase extends AbstractPrimeHtmlInputText implements InputHolder, Widget {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
     public static final String DEFAULT_RENDERER = "org.primefaces.component.SignatureRenderer";
 
     public enum PropertyKeys {
-
-        widgetVar,
+        ariaLabel,
         backgroundColor,
+        base64Value,
         color,
-        thickness,
-        style,
-        styleClass,
-        readonly,
+        fontFamily,
+        fontSize,
         guideline,
         guidelineColor,
-        guidelineOffset,
         guidelineIndent,
+        guidelineOffset,
         onchange,
-        base64Value
+        thickness,
+        textValue,
+        widgetVar,
     }
 
     public SignatureBase() {
@@ -91,30 +92,6 @@ public abstract class SignatureBase extends UIInput implements Widget {
         getStateHelper().put(PropertyKeys.thickness, thickness);
     }
 
-    public String getStyle() {
-        return (String) getStateHelper().eval(PropertyKeys.style, null);
-    }
-
-    public void setStyle(String style) {
-        getStateHelper().put(PropertyKeys.style, style);
-    }
-
-    public String getStyleClass() {
-        return (String) getStateHelper().eval(PropertyKeys.styleClass, null);
-    }
-
-    public void setStyleClass(String styleClass) {
-        getStateHelper().put(PropertyKeys.styleClass, styleClass);
-    }
-
-    public boolean isReadonly() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.readonly, false);
-    }
-
-    public void setReadonly(boolean readonly) {
-        getStateHelper().put(PropertyKeys.readonly, readonly);
-    }
-
     public boolean isGuideline() {
         return (Boolean) getStateHelper().eval(PropertyKeys.guideline, false);
     }
@@ -147,19 +124,43 @@ public abstract class SignatureBase extends UIInput implements Widget {
         getStateHelper().put(PropertyKeys.guidelineIndent, guidelineIndent);
     }
 
-    public String getOnchange() {
-        return (String) getStateHelper().eval(PropertyKeys.onchange, null);
-    }
-
-    public void setOnchange(String onchange) {
-        getStateHelper().put(PropertyKeys.onchange, onchange);
-    }
-
     public String getBase64Value() {
         return (String) getStateHelper().eval(PropertyKeys.base64Value, null);
     }
 
     public void setBase64Value(String base64Value) {
         getStateHelper().put(PropertyKeys.base64Value, base64Value);
+    }
+
+    public String getFontFamily() {
+        return (String) getStateHelper().eval(PropertyKeys.fontFamily, null);
+    }
+
+    public void setFontFamily(String fontFamily) {
+        getStateHelper().put(PropertyKeys.fontFamily, fontFamily);
+    }
+
+    public int getFontSize() {
+        return (Integer) getStateHelper().eval(PropertyKeys.fontSize, 40);
+    }
+
+    public void setFontSize(int fontSize) {
+        getStateHelper().put(PropertyKeys.fontSize, fontSize);
+    }
+
+    public String getAriaLabel() {
+        return (String) getStateHelper().eval(PropertyKeys.ariaLabel, null);
+    }
+
+    public void setAriaLabel(String ariaLabel) {
+        getStateHelper().put(PropertyKeys.ariaLabel, ariaLabel);
+    }
+
+    public String getTextValue() {
+        return (String) getStateHelper().eval(PropertyKeys.textValue, null);
+    }
+
+    public void setTextValue(String textValue) {
+        getStateHelper().put(PropertyKeys.textValue, textValue);
     }
 }

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -25682,6 +25682,54 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[The typed text of this signature if the user chose to type instead of draw the signature.]]>
+            </description>
+            <name>textValue</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Position of the element in the tabbing order. Default to "0".]]>
+            </description>
+            <name>tabindex</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Position of the element in the tabbing order.]]>
+            </description>
+            <name>tabindex</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[The aria-label attribute is used to define a string that labels the current element for accessibility.]]>
+            </description>
+            <name>ariaLabel</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Font size for typing in a signature. Default is 40.]]>
+            </description>
+            <name>fontSize</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Font family for typing in a signature. Default is "Brush Script MT, cursive"]]>
+            </description>
+            <name>fontFamily</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/signature/0-signature.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/signature/0-signature.js
@@ -1,51 +1,52 @@
 /* http://keith-wood.name/signature.html
-	Signature plugin for jQuery UI v1.2.0.
-	Requires excanvas.js in IE.
-	Written by Keith Wood (wood.keith{at}optusnet.com.au) April 2012.
-	Available under the MIT (http://keith-wood.name/licence.html) license.
-	Please attribute the author if you use it. */
+    Signature plugin for jQuery UI v1.2.1.
+    Requires excanvas.js in IE.
+    Written by Keith Wood (wood.keith{at}optusnet.com.au) April 2012.
+    Available under the MIT (http://keith-wood.name/licence.html) license. 
+    Please attribute the author if you use it. */
 
 /* globals G_vmlCanvasManager */
 
-(function($) { // Hide scope, no $ conflict
+(function ($) { // Hide scope, no $ conflict
     'use strict';
 
     /** Signature capture and display.
-     <p>Depends on <code>jquery.ui.widget</code>, <code>jquery.ui.mouse</code>.</p>
-     <p>Expects HTML like:</p>
-     <pre>&lt;div>&lt;/div></pre>
-     @namespace Signature
-     @augments $.Widget
-     @example $(selector).signature()
-     $(selector).signature({color: 'blue', guideline: true}) */
+        <p>Depends on <code>jquery.ui.widget</code>, <code>jquery.ui.mouse</code>.</p>
+        <p>Expects HTML like:</p>
+        <pre>&lt;div>&lt;/div></pre>
+        @namespace Signature
+        @augments $.Widget
+        @example $(selector).signature()
+$(selector).signature({color: 'blue', guideline: true}) */
     var signatureOverrides = {
 
         /** Be notified when a signature changes.
-         @callback SignatureChange
-         @global
-         @this Signature
-         @example change: function() {
+            @callback SignatureChange
+            @global
+            @this Signature
+            @example change: function() {
   console.log('Signature changed');
 } */
 
         /** Global defaults for signature.
-         @memberof Signature
-         @property {number} [distance=0] The minimum distance to start a drag.
-         @property {string} [background='#fff'] The background colour.
-         @property {string} [color='#000'] The colour of the signature.
-         @property {number} [thickness=2] The thickness of the lines.
-         @property {boolean} [guideline=false] <code>true</code> to add a guideline.
-         @property {string} [guidelineColor='#a0a0a0'] The guideline colour.
-         @property {number} [guidelineOffset=50] The guideline offset (pixels) from the bottom.
-         @property {number} [guidelineIndex=10] The guideline indent (pixels) from the edges.
-         @property {string} [notAvailable='Your browser doesn\'t support signing']
-         The error message to show when no canvas is available.
-         @property {string|Element|jQuery} [syncField=null] The selector, DOM element, or jQuery object
-         for a field to automatically synchronise with a text version of the signature.
-         @property {string} [syncFormat='JSON'] The output representation: 'JSON', 'SVG', 'PNG', 'JPEG'.
-         @property {boolean} [svgStyles=false] <code>true</code> to use the <code>style</code> attribute in SVG.
-         @property {SignatureChange} [change=null] A callback triggered when the signature changes.
-         @example $.extend($.kbw.signature.options, {guideline: true}) */
+            @memberof Signature
+            @property {number} [distance=0] The minimum distance to start a drag.
+            @property {string} [background='#fff'] The background colour.
+            @property {string} [color='#000'] The colour of the signature.
+            @property {number} [thickness=2] The thickness of the lines.
+            @property {boolean} [guideline=false] <code>true</code> to add a guideline.
+            @property {string} [guidelineColor='#a0a0a0'] The guideline colour.
+            @property {number} [guidelineOffset=50] The guideline offset (pixels) from the bottom.
+            @property {number} [guidelineIndex=10] The guideline indent (pixels) from the edges.
+            @property {string} [notAvailable='Your browser doesn\'t support signing']
+                                The error message to show when no canvas is available.
+            @property {number} [scale=1] A scaling factor for rendering the signature (only applies to redraws).
+            @property {string|Element|jQuery} [syncField=null] The selector, DOM element, or jQuery object
+                                for a field to automatically synchronise with a text version of the signature.
+            @property {string} [syncFormat='JSON'] The output representation: 'JSON', 'SVG', 'PNG', 'JPEG'.
+            @property {boolean} [svgStyles=false] <code>true</code> to use the <code>style</code> attribute in SVG.
+            @property {SignatureChange} [change=null] A callback triggered when the signature changes.
+            @example $.extend($.kbw.signature.options, {guideline: true}) */
         options: {
             distance: 0,
             background: '#fff',
@@ -56,6 +57,7 @@
             guidelineOffset: 50,
             guidelineIndent: 10,
             notAvailable: 'Your browser doesn\'t support signing',
+            scale: 1,
             syncField: null,
             syncFormat: 'JSON',
             svgStyles: false,
@@ -63,9 +65,9 @@
         },
 
         /** Initialise a new signature area.
-         @memberof Signature
-         @private */
-        _create: function() {
+            @memberof Signature
+            @private */
+        _create: function () {
             this.element.addClass(this.widgetFullName || this.widgetBaseClass);
             try {
                 this.canvas = $('<canvas width="' + this.element.width() + '" height="' +
@@ -80,11 +82,6 @@
                 this.canvas.setAttribute('height', this.element.height());
                 this.canvas.innerHTML = this.options.notAvailable;
                 this.element.append(this.canvas);
-                /* jshint -W106 */
-                if (G_vmlCanvasManager) { // Requires excanvas.js
-                    G_vmlCanvasManager.initElement(this.canvas);
-                }
-                /* jshint +W106 */
             }
             this.ctx = this.canvas.getContext('2d');
             this._refresh(true);
@@ -92,13 +89,13 @@
         },
 
         /** Refresh the appearance of the signature area.
-         @memberof Signature
-         @private
-         @param {boolean} init <code>true</code> if initialising. */
-        _refresh: function(init) {
+            @memberof Signature
+            @private
+            @param {boolean} init <code>true</code> if initialising. */
+        _refresh: function (init) {
             if (this.resize) {
                 var parent = $(this.canvas);
-                $('div', this.canvas).css({width: parent.width() + 'px', height: parent.height() + 'px'});
+                $('div', this.canvas).css({ width: parent.width(), height: parent.height() });
             }
             this.ctx.fillStyle = this.options.background;
             this.ctx.strokeStyle = this.options.color;
@@ -109,13 +106,14 @@
         },
 
         /** Clear the signature area.
-         @memberof Signature
-         @param {boolean} init <code>true</code> if initialising - internal use only.
-         @example $(selector).signature('clear') */
-        clear: function(init) {
+            @memberof Signature
+            @param {boolean} init <code>true</code> if initialising - internal use only.
+            @example $(selector).signature('clear') */
+        clear: function (init) {
             if (this.options.disabled) {
                 return;
             }
+            this.ctx.clearRect(0, 0, this.element.width(), this.element.height());
             this.ctx.fillRect(0, 0, this.element.width(), this.element.height());
             if (this.options.guideline) {
                 this.ctx.save();
@@ -136,10 +134,10 @@
         },
 
         /** Synchronise changes and trigger a change event.
-         @memberof Signature
-         @private
-         @param {Event} event The triggering event. */
-        _changed: function(event) {
+            @memberof Signature
+            @private
+            @param {Event} event The triggering event. */
+        _changed: function (event) {
             if (this.options.syncField) {
                 var output = '';
                 switch (this.options.syncFormat) {
@@ -161,10 +159,10 @@
         },
 
         /** Refresh the signature when options change.
-         @memberof Signature
-         @private
-         @param {object} options The new option values. */
-        _setOptions: function(/* options */) {
+            @memberof Signature
+            @private
+            @param {object} options The new option values. */
+        _setOptions: function (/* options */) {
             if (this._superApply) {
                 this._superApply(arguments); // Base widget handling
             }
@@ -185,35 +183,35 @@
         },
 
         /** Determine if dragging can start.
-         @memberof Signature
-         @private
-         @param {Event} event The triggering mouse event.
-         @return {boolean} <code>true</code> if allowed, <code>false</code> if not */
-        _mouseCapture: function(/* event */) {
+            @memberof Signature
+            @private
+            @param {Event} event The triggering mouse event.
+            @return {boolean} <code>true</code> if allowed, <code>false</code> if not */
+        _mouseCapture: function (/* event */) {
             return !this.options.disabled;
         },
 
         /** Start a new line.
-         @memberof Signature
-         @private
-         @param {Event} event The triggering mouse event. */
-        _mouseStart: function(event) {
+            @memberof Signature
+            @private
+            @param {Event} event The triggering mouse event. */
+        _mouseStart: function (event) {
             this.offset = this.element.offset();
             this.offset.left -= document.documentElement.scrollLeft || document.body.scrollLeft;
             this.offset.top -= document.documentElement.scrollTop || document.body.scrollTop;
             this.lastPoint = [this._round(event.clientX - this.offset.left),
-                this._round(event.clientY - this.offset.top)];
+            this._round(event.clientY - this.offset.top)];
             this.curLine = [this.lastPoint];
             this.lines.push(this.curLine);
         },
 
         /** Track the mouse.
-         @memberof Signature
-         @private
-         @param {Event} event The triggering mouse event. */
-        _mouseDrag: function(event) {
+            @memberof Signature
+            @private
+            @param {Event} event The triggering mouse event. */
+        _mouseDrag: function (event) {
             var point = [this._round(event.clientX - this.offset.left),
-                this._round(event.clientY - this.offset.top)];
+            this._round(event.clientY - this.offset.top)];
             this.curLine.push(point);
             this.ctx.beginPath();
             this.ctx.moveTo(this.lastPoint[0], this.lastPoint[1]);
@@ -223,10 +221,10 @@
         },
 
         /** End a line.
-         @memberof Signature
-         @private
-         @param {Event} event The triggering mouse event. */
-        _mouseStop: function(event) {
+            @memberof Signature
+            @private
+            @param {Event} event The triggering mouse event. */
+        _mouseStop: function (event) {
             if (this.curLine.length === 1) {
                 event.clientY += this.options.thickness;
                 this._mouseDrag(event);
@@ -237,31 +235,31 @@
         },
 
         /** Round to two decimal points.
-         @memberof Signature
-         @private
-         @param {number} value The value to round.
-         @return {number} The rounded value. */
-        _round: function(value) {
+            @memberof Signature
+            @private
+            @param {number} value The value to round.
+            @return {number} The rounded value. */
+        _round: function (value) {
             return Math.round(value * 100) / 100;
         },
 
         /** Convert the captured lines to JSON text.
-         @memberof Signature
-         @return {string} The JSON text version of the lines.
-         @example var json = $(selector).signature('toJSON') */
-        toJSON: function() {
-            return '{"lines":[' + $.map(this.lines, function(line) {
-                return '[' + $.map(line, function(point) {
+            @memberof Signature
+            @return {string} The JSON text version of the lines.
+            @example var json = $(selector).signature('toJSON') */
+        toJSON: function () {
+            return '{"lines":[' + $.map(this.lines, function (line) {
+                return '[' + $.map(line, function (point) {
                     return '[' + point + ']';
                 }) + ']';
             }) + ']}';
         },
 
         /** Convert the captured lines to SVG text.
-         @memberof Signature
-         @return {string} The SVG text version of the lines.
-         @example var svg = $(selector).signature('toSVG') */
-        toSVG: function() {
+            @memberof Signature
+            @return {string} The SVG text version of the lines.
+            @example var svg = $(selector).signature('toSVG') */
+        toSVG: function () {
             var attrs1 = (this.options.svgStyles ? 'style="fill: ' + this.options.background + ';"' :
                 'fill="' + this.options.background + '"');
             var attrs2 = (this.options.svgStyles ?
@@ -272,115 +270,118 @@
                 '<svg xmlns="http://www.w3.org/2000/svg" width="15cm" height="15cm">\n' +
                 '	<g ' + attrs1 + '>\n' +
                 '		<rect x="0" y="0" width="' + this.canvas.width + '" height="' + this.canvas.height + '"/>\n' +
-                '		<g ' + attrs2 +	'>\n'+
-                $.map(this.lines, function(line) {
+                '		<g ' + attrs2 + '>\n' +
+                $.map(this.lines, function (line) {
                     return '			<polyline points="' +
-                        $.map(line, function(point) { return point + ''; }).join(' ') + '"/>\n';
+                        $.map(line, function (point) { return point + ''; }).join(' ') + '"/>\n';
                 }).join('') +
                 '		</g>\n	</g>\n</svg>\n';
         },
 
         /** Convert the captured lines to an image encoded in a <code>data:</code> URL.
-         @memberof Signature
-         @param {string} [type='image/png'] The MIME type of the image.
-         @param {number} [quality=0.92] The image quality, between 0 and 1.
-         @return {string} The signature as a data: URL image.
-         @example var data = $(selector).signature('toDataURL', 'image/jpeg') */
-        toDataURL: function(type, quality) {
+            @memberof Signature
+            @param {string} [type='image/png'] The MIME type of the image.
+            @param {number} [quality=0.92] The image quality, between 0 and 1.
+            @return {string} The signature as a data: URL image.
+            @example var data = $(selector).signature('toDataURL', 'image/jpeg') */
+        toDataURL: function (type, quality) {
             return this.canvas.toDataURL(type, quality);
         },
 
         /** Draw a signature from its JSON or SVG description or <code>data:</code> URL.
-         <p>Note that drawing a <code>data:</code> URL does not reconstruct the internal representation!</p>
-         @memberof Signature
-         @param {object|string} sig An object with attribute <code>lines</code> being an array of arrays of points
-         or the text version of the JSON or SVG or a <code>data:</code> URL containing an image.
-         @example $(selector).signature('draw', sigAsJSON) */
-        draw: function(sig) {
+            <p>Note that drawing a <code>data:</code> URL does not reconstruct the internal representation!</p>
+            @memberof Signature
+            @param {object|string} sig An object with attribute <code>lines</code> being an array of arrays of points
+                            or the text version of the JSON or SVG or a <code>data:</code> URL containing an image.
+            @example $(selector).signature('draw', sigAsJSON) */
+        draw: function (sig) {
             if (this.options.disabled) {
                 return;
             }
             this.clear(true);
             if (typeof sig === 'string' && sig.indexOf('data:') === 0) { // Data URL
-                this._drawDataURL(sig);
+                this._drawDataURL(sig, this.options.scale);
             } else if (typeof sig === 'string' && sig.indexOf('<svg') > -1) { // SVG
-                this._drawSVG(sig);
+                this._drawSVG(sig, this.options.scale);
             } else {
-                this._drawJSON(sig);
+                this._drawJSON(sig, this.options.scale);
             }
             this._changed();
         },
 
         /** Draw a signature from its JSON description.
-         @memberof Signature
-         @private
-         @param {object|string} sig An object with attribute <code>lines</code> being an array of arrays of points
-         or the text version of the JSON. */
-        _drawJSON: function(sig) {
+            @memberof Signature
+            @private
+            @param {object|string} sig An object with attribute <code>lines</code> being an array of arrays of points
+                            or the text version of the JSON.
+            @param {number} scale A scaling factor. */
+        _drawJSON: function (sig, scale) {
             if (typeof sig === 'string') {
-                sig = $.parseJSON(sig);
+                sig = JSON.parse(sig);
             }
             this.lines = sig.lines || [];
             var ctx = this.ctx;
-            $.each(this.lines, function() {
+            $.each(this.lines, function () {
                 ctx.beginPath();
-                $.each(this, function(i) {
-                    ctx[i === 0 ? 'moveTo' : 'lineTo'](this[0], this[1]);
+                $.each(this, function (i) {
+                    ctx[i === 0 ? 'moveTo' : 'lineTo'](this[0] * scale, this[1] * scale);
                 });
                 ctx.stroke();
             });
         },
 
         /** Draw a signature from its SVG description.
-         @memberof Signature
-         @private
-         @param {string} sig The text version of the SVG. */
-        _drawSVG: function(sig) {
+            @memberof Signature
+            @private
+            @param {string} sig The text version of the SVG.
+            @param {number} scale A scaling factor. */
+        _drawSVG: function (sig, scale) {
             var lines = this.lines = [];
-            $(sig).find('polyline').each(function() {
+            $(sig).find('polyline').each(function () {
                 var line = [];
-                $.each($(this).attr('points').split(' '), function(i, point) {
+                $.each($(this).attr('points').split(' '), function (i, point) {
                     var xy = point.split(',');
                     line.push([parseFloat(xy[0]), parseFloat(xy[1])]);
                 });
                 lines.push(line);
             });
             var ctx = this.ctx;
-            $.each(this.lines, function() {
+            $.each(this.lines, function () {
                 ctx.beginPath();
-                $.each(this, function(i) {
-                    ctx[i === 0 ? 'moveTo' : 'lineTo'](this[0], this[1]);
+                $.each(this, function (i) {
+                    ctx[i === 0 ? 'moveTo' : 'lineTo'](this[0] * scale, this[1] * scale);
                 });
                 ctx.stroke();
             });
         },
 
         /** Draw a signature from its <code>data:</code> URL.
-         <p>Note that this does not reconstruct the internal representation!</p>
-         @memberof Signature
-         @private
-         @param {string} sig The <code>data:</code> URL containing an image. */
-        _drawDataURL: function(sig) {
+            <p>Note that this does not reconstruct the internal representation!</p>
+            @memberof Signature
+            @private
+            @param {string} sig The <code>data:</code> URL containing an image.
+            @param {number} scale A scaling factor. */
+        _drawDataURL: function (sig, scale) {
             var image = new Image();
             var context = this.ctx;
-            image.onload = function() {
-                context.drawImage(this, 0, 0);
+            image.onload = function () {
+                context.drawImage(this, 0, 0, image.width * scale, image.height * scale);
             };
             image.src = sig;
         },
 
         /** Determine whether or not any drawing has occurred.
-         @memberof Signature
-         @return {boolean} <code>true</code> if not signed, <code>false</code> if signed.
-         @example if ($(selector).signature('isEmpty')) ... */
-        isEmpty: function() {
+            @memberof Signature
+            @return {boolean} <code>true</code> if not signed, <code>false</code> if signed.
+            @example if ($(selector).signature('isEmpty')) ... */
+        isEmpty: function () {
             return this.lines.length === 0;
         },
 
         /** Remove the signature functionality.
-         @memberof Signature
-         @private */
-        _destroy: function() {
+            @memberof Signature
+            @private */
+        _destroy: function () {
             this.element.removeClass(this.widgetFullName || this.widgetBaseClass);
             $(this.canvas).remove();
             this.canvas = this.ctx = this.lines = null;
@@ -391,7 +392,7 @@
     if (!$.Widget.prototype._destroy) {
         $.extend(signatureOverrides, {
             /* Remove the signature functionality. */
-            destroy: function() {
+            destroy: function () {
                 this._destroy();
                 $.Widget.prototype.destroy.call(this); // Base widget handling
             }
@@ -401,7 +402,7 @@
     if ($.Widget.prototype._getCreateOptions === $.noop) {
         $.extend(signatureOverrides, {
             /* Restore the metadata functionality. */
-            _getCreateOptions: function() {
+            _getCreateOptions: function () {
                 return $.metadata && $.metadata.get(this.element[0])[this.widgetName];
             }
         });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/signature/1-widget.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/signature/1-widget.js
@@ -9,9 +9,10 @@
  * {@link SignatureCfg.onchange}.
  * @this {PrimeFaces.widget.Signature} PrimeFaces.widget.Signature.OnChangeCallback
  *
- * @prop {JQuery} base64Input The DOM element for the hidden input element storing the base 64 value.
- * @prop {HTMLCanvasElement} canvasEL The canvas element where the signature is drawn.
- * @prop {JQuery} input The DOM element for the hidden input storing the value of this widget.
+ * @prop {JQuery} canvas The canvas element where the signature is drawn.
+ * @prop {JQuery} inputBase64 The DOM element for the hidden input element storing the base 64 value.
+ * @prop {JQuery} inputJson The DOM element for the hidden input storing the value of this widget.
+ * @prop {JQuery} inputText The DOM element for the hidden input storing the printed text value of this widget.
  *
  * @interface {PrimeFaces.widget.SignatureCfg} cfg The configuration for the {@link  Signature| Signature widget}.
  * You can access this configuration via {@link PrimeFaces.widget.BaseWidget.cfg|BaseWidget.cfg}. Please note that this
@@ -31,57 +32,169 @@ PrimeFaces.widget.Signature = PrimeFaces.widget.BaseWidget.extend({
      * @inheritdoc
      * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
      */
-    init: function(cfg) {
+    init: function (cfg) {
         this._super(cfg);
-        this.input = this.jq.children(this.jqId + '_value');
-        this.base64Input = this.jq.children(this.jqId + '_base64');
-        this.cfg.syncField = this.input;
-
-        var $this = this;
-        this.cfg.change = function() {
-            $this.handleChange();
-        };
+        this.inputJson = this.jq.children(this.jqId + '_value');
+        this.inputText = this.jq.children(this.jqId + '_text');
+        this.cfg.notAvailable = '<p>Your browser does NOT support signing</p>';
+        this.cfg.syncField = this.inputJson;
+        this.cfg.tabindex = this.cfg.tabindex || '0';
+        this.cfg.fontSize = this.cfg.fontSize || 40;
+        this.cfg.fontFamily = this.cfg.fontFamily || 'Brush Script MT, cursive';
 
         this.render();
-
-        //disable the signature
-        if(this.cfg.readonly){
-            this.jq.signature("disable");
-        }
     },
 
     /**
-     * Clears this signature widget, removing all drawn lines.
+     * @override
+     * @inheritdoc
      */
-    clear: function() {
-        this.jq.signature('clear');
-        this.input.val('');
-        this.base64Input.val('');
-    },
-
-    /**
-     * Draws the given line data to this signature widget viewport.
-     * @param {string | JQuerySignature.SignatureJson} value The signatue data to draw.
-     */
-    draw: function(value) {
-        this.jq.signature('draw', value);
-        if(this.cfg.base64) {
-            this.base64Input.val(this.canvasEL.toDataURL());
-        }
+    destroy: function () {
+        this._super();
+        this.clear();
+        this.jq.signature('destroy');
     },
 
     /**
      * Renders the client-side parts of this widget.
      * @private
      */
-    render: function() {
+    render: function () {
+        var $this = this;
+        this.setupBase64();
+
+        this.cfg.change = function () {
+            $this.handleChange();
+        };
+
+        // create the signature 
         this.jq.signature(this.cfg);
 
-        this.canvasEL = this.jq.children('canvas').get(0);
+        //disable the signature
+        if (this.cfg.readonly) {
+            this.disable();
+        }
 
-        var value = this.input.val();
-        if(value) {
-            this.draw(value);
+        // bind accessibility events
+        this.setupCanvas();
+        this.bindEvents();
+
+        // attempt to draw the signature from the JSON value
+        const json = this.inputJson.val();
+        if (json) {
+            this.draw(json);
+            if (!this.jq.signature('isEmpty')) {
+                return;
+            }
+        }
+
+        // if the JSON load fails, attempt to draw the signature from the text value
+        const textValue = this.inputText.val();
+        if (textValue) {
+            this.createSignatureFromText(textValue);
+        }
+    },
+
+    /**
+     * Sets up the base64 configuration for the signature widget.
+     * @private
+     */
+    setupBase64: function () {
+        if (this.cfg.base64) {
+            this.cfg.svgStyles = true;
+            this.inputBase64 = this.jq.children(this.jqId + '_base64');
+        }
+    },
+
+    /**
+     * Sets up the base64 configuration for the signature widget.
+     * @private
+     */
+    setupCanvas: function () {
+        this.canvas = this.jq.children('canvas');
+
+        // accessibility
+        this.canvas.attr({
+            'aria-label': PrimeFaces.getAriaLabel('signatureLabel', this.cfg.ariaLabel || 'Sign here'),
+            'aria-labelledby': this.cfg.ariaLabelledBy,
+            'id': this.id + '_canvas',
+            'role': 'img',
+            'tabindex': this.cfg.readonly ? "-1" : (this.cfg.tabindex || '0'),
+        });
+    },
+
+    /**
+     * Binds event handlers to the signature canvas.
+     * @private
+     */
+    bindEvents: function () {
+        var $this = this;
+        if (this.cfg.readonly) {
+            return;
+        }
+
+        // focus from label
+        if (this.cfg.ariaLabelledBy) {
+            $(PrimeFaces.escapeClientId(this.cfg.ariaLabelledBy)).on('click', () => $this.canvas.trigger('focus'));
+        }
+
+        // events
+        this.canvas.off('mouseenter mouseleave mousedown focus blur keydown')
+            .on('mouseenter', () => $this.jq.addClass('ui-state-hover'))
+            .on('mouseleave', () => $this.jq.removeClass('ui-state-hover'))
+            .on('mousedown', () => $this.canvas.trigger('focus'))
+            .on('focus', () => $this.jq.addClass('ui-state-focus'))
+            .on('blur', () => $this.jq.removeClass('ui-state-hover ui-state-focus'))
+            .on('keydown', (event) => {
+                let printedText = $this.inputText.val() || '';
+                switch (event.code) {
+                    case 'Backspace':
+                    case 'Delete':
+                        if (printedText.length > 1) {
+                            printedText = printedText.slice(0, -1);
+                        } else {
+                            printedText = '';
+                            $this.clear();
+                        }
+                        break;
+                    case 'Escape':
+                        $this.clear();
+                        break;
+                    default:
+                        if (PrimeFaces.utils.isPrintableKey(event)) {
+                            printedText += event.key;
+                        } else {
+                            return;
+                        }
+                }
+
+                event.preventDefault();
+                if (printedText) {
+                    $this.inputText.val(printedText);
+                    $this.createSignatureFromText(printedText);
+                }
+            });
+    },
+
+    /**
+     * Clears this signature widget, removing all drawn lines.
+     */
+    clear: function () {
+        this.jq.signature('clear');
+        this.inputJson.val('');
+        this.inputText.val('');
+        if (this.cfg.base64) {
+            this.inputBase64.val('');
+        }
+    },
+
+    /**
+     * Draws the given line data to this signature widget viewport.
+     * @param {string | JQuerySignature.SignatureJson} value The signatue data to draw.
+     */
+    draw: function (value) {
+        if (value) {
+            this.jq.signature('draw', value);
         }
     },
 
@@ -89,28 +202,45 @@ PrimeFaces.widget.Signature = PrimeFaces.widget.BaseWidget.extend({
      * Callback for when the signature has changed.
      * @private
      */
-    handleChange: function() {
-        if(this.cfg.base64) {
-            this.base64Input.val(this.canvasEL.toDataURL());
+    handleChange: function () {
+        if (this.cfg.base64) {
+            this.inputBase64.val(this.canvas[0].toDataURL());
         }
 
-        if(this.cfg.onchange) {
+        if (this.cfg.onchange) {
             this.cfg.onchange.call(this);
         }
     },
 
     /**
+     * Creates a signature from the given text using SVG.
+     * @param {string} text - The text to convert into a signature.
+     */
+    createSignatureFromText: function (text) {
+        const width = this.canvas[0].width;
+        const height = this.canvas[0].height;
+        let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+           <g fill="${this.cfg.background || 'white'}">
+           <text x="10" y="50" font-family="${this.cfg.fontFamily}" font-size="${this.cfg.fontSize}" fill="${this.cfg.color || 'black'}">${text}</text>
+           </g>
+        </svg>`;
+        svg = svg.replace(/\n/g, '');
+        svg = `data:image/svg+xml;base64,${btoa(svg)}`;
+        this.draw(svg);
+    },
+
+    /**
      * Disables this input so that the user cannot enter a value anymore.
      */
-    disable: function() {
-        PrimeFaces.utils.disableInputWidget(this.jq, this.input);
+    disable: function () {
+        PrimeFaces.utils.disableInputWidget(this.jq, this.inputJson);
     },
 
     /**
      * Enables this input so that the user can enter a value.
      */
-    enable: function() {
-        PrimeFaces.utils.enableInputWidget(this.jq, this.input);
+    enable: function () {
+        PrimeFaces.utils.enableInputWidget(this.jq, this.inputJson);
     }
 
 });

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/signature/signature.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/signature/signature.css
@@ -1,12 +1,11 @@
-/* Styles for signature plugin v1.2.0. */
+/* Styles for signature plugin v1.2.1. */
 .kbw-signature {
     display: inline-block;
     border: 1px solid #a0a0a0;
 }
 .kbw-signature-disabled {
-    opacity: 0.35;
+    opacity: 0.6;
 }
-
 .ui-inputfield.kbw-signature {
     padding: 0 !important;
 }


### PR DESCRIPTION
Fix #12463: Signature allow typed text, improve accessibility

- [x] ARIA and WCAG accessibility
- [x] `ESC` to clear signature
- [x] Updated to standards we use in other components
- [x] Allow typing of signature

![signature](https://github.com/user-attachments/assets/7807d19d-e753-499c-a920-2cb649594e72)
