### PR TITLE
Fix #12465: DatePicker always format in EN for conversion

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -3283,7 +3283,16 @@
             var now = new Date();
             if (this.options.timeZone) {
                 var jsTimezone = this.convertTimeZone(this.options.timeZone);
-                now = new Date(now.toLocaleString(undefined, { timeZone: jsTimezone }));
+                var localString = now.toLocaleString('en-GB', { // use English so we can parse it back
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "numeric",
+                    second: "numeric",
+                    timeZone: jsTimezone
+                }).replace(' at ', ', ');
+                now = new Date(localString);
             }
             return now;
         },


### PR DESCRIPTION
Fix #12465: DatePicker always format in EN for conversion

Unfortunately this is just a pain of JS there is no way to parse back a date string into a `new Date()` unless its in one of the standard known formats