### PR TITLE
Fix #12481: 14.0.5 Tree allow filter event to override node state

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -251,7 +251,9 @@ public class TreeRenderer extends CoreRenderer {
             Locale filterLocale = LocaleUtils.getCurrentLocale(context);
 
             tree.getFilteredRowKeys().clear();
-            encodeFilteredNodes(context, tree, tree.getValue(), filteredValue, filterLocale);
+            if (LangUtils.isNotBlank(filteredValue)) {
+                encodeFilteredNodes(context, tree, tree.getValue(), filteredValue, filterLocale);
+            }
 
             if (root != null && root.getRowKey() == null) {
                 root.setRowKey(ROOT_ROW_KEY);
@@ -259,7 +261,7 @@ public class TreeRenderer extends CoreRenderer {
                 tree.initPreselection();
             }
 
-            if (root != null && (LangUtils.isBlank(filteredValue) || !tree.getFilteredRowKeys().isEmpty())) {
+            if (root != null) {
                 encodeTreeNodeChildren(context, tree, root, root, clientId, tree.isDynamic(), tree.isCheckboxSelectionMode(), tree.isDroppable());
             }
         }


### PR DESCRIPTION
Fix #12481: 14.0.5 Tree allow filter event to override node state