### PR TITLE
Fix #12507 - DataTable: default input facet filter not working with dynamic columns

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -25,6 +25,7 @@ package org.primefaces.component.api;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -251,12 +252,13 @@ public interface UIColumn {
     default EditableValueHolderState getFilterValueHolder(FacesContext context) {
         UIComponent filterFacet = getFacet("filter");
         if (filterFacet != null) {
-            EditableValueHolderState state = new EditableValueHolderState();
+            AtomicReference<EditableValueHolderState> stateRef = new AtomicReference<>(null);
             FacetUtils.invokeOnEditableValueHolder(context, filterFacet, (fc, target) -> {
-                state.setComponent((EditableValueHolder) target);
+                EditableValueHolderState state = new EditableValueHolderState();
                 state.setValue(((EditableValueHolder) target).getValue());
+                stateRef.set(state);
             });
-            return state;
+            return stateRef.get();
         }
 
         return null;

--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -264,10 +264,10 @@ public interface UIColumn {
         return null;
     }
 
-    default void setFilterValueToValueHolder(Object value) {
+    default void setFilterValueToValueHolder(FacesContext context, Object value) {
         UIComponent filterFacet = getFacet("filter");
 
-        FacetUtils.invokeOnEditableValueHolder(FacesContext.getCurrentInstance(), filterFacet, (ctx, component) -> {
+        FacetUtils.invokeOnEditableValueHolder(context, filterFacet, (ctx, component) -> {
             ((EditableValueHolder) component).setValue(value);
         });
     }

--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -23,10 +23,11 @@
  */
 package org.primefaces.component.api;
 
-import org.primefaces.component.celleditor.CellEditor;
-import org.primefaces.model.MatchMode;
-import org.primefaces.util.FacetUtils;
-import org.primefaces.util.LangUtils;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.el.ELContext;
 import javax.el.MethodExpression;
@@ -36,11 +37,12 @@ import javax.faces.component.EditableValueHolder;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIData;
 import javax.faces.context.FacesContext;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import org.primefaces.component.celleditor.CellEditor;
+import org.primefaces.model.MatchMode;
+import org.primefaces.util.ComponentTraversalUtils;
+import org.primefaces.util.FacetUtils;
+import org.primefaces.util.LangUtils;
 
 public interface UIColumn {
 
@@ -247,14 +249,19 @@ public interface UIColumn {
 
     Object getConverter();
 
-    default Object getFilterValueFromValueHolder() {
+    default EditableValueHolder getFilterValueHolder() {
+        UIComponent filterFacet = getFacet("filter");
+        return ComponentTraversalUtils.firstChildRenderedOrSelf(EditableValueHolder.class, filterFacet);
+    }
+
+    default Object getFilterValueFromValueHolder(FacesContext context) {
         UIComponent filterFacet = getFacet("filter");
         if (filterFacet == null) {
             return null;
         }
         AtomicReference<Object> filterValue = new AtomicReference<>(null);
 
-        FacetUtils.invokeOnEditableValueHolder(FacesContext.getCurrentInstance(), filterFacet, (ctx, component) -> {
+        FacetUtils.invokeOnEditableValueHolder(context, filterFacet, (ctx, component) -> {
             filterValue.set(((EditableValueHolder) component).getValue());
         });
 

--- a/primefaces/src/main/java/org/primefaces/component/api/UITable.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITable.java
@@ -23,6 +23,22 @@
  */
 package org.primefaces.component.api;
 
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+import javax.faces.FacesException;
+import javax.faces.component.EditableValueHolder;
+import javax.faces.component.UIComponent;
+import javax.faces.component.UINamingContainer;
+import javax.faces.component.ValueHolder;
+import javax.faces.component.search.SearchExpressionHint;
+import javax.faces.context.FacesContext;
+import javax.faces.convert.ConverterException;
+
 import org.primefaces.component.column.ColumnBase;
 import org.primefaces.component.headerrow.HeaderRow;
 import org.primefaces.expression.SearchExpressionUtils;
@@ -33,20 +49,6 @@ import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.FacetUtils;
 import org.primefaces.util.LangUtils;
 import org.primefaces.util.LocaleUtils;
-
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
-import javax.faces.FacesException;
-import javax.faces.component.UIComponent;
-import javax.faces.component.UINamingContainer;
-import javax.faces.component.ValueHolder;
-import javax.faces.component.search.SearchExpressionHint;
-import javax.faces.context.FacesContext;
-import javax.faces.convert.ConverterException;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public interface UITable<T extends UITableState> extends ColumnAware, MultiViewStateAware<T> {
 
@@ -195,11 +197,11 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 ((DynamicColumn) column).applyModel();
             }
 
-            boolean hasCustomFilter = column.getFacet("filter") != null;
+            EditableValueHolder hasCustomFilter = column.getFilterValueHolder();
 
             Object filterValue;
-            if (hasCustomFilter) {
-                filterValue = column.getFilterValueFromValueHolder();
+            if (hasCustomFilter != null) {
+                filterValue = column.getFilterValueFromValueHolder(context);
             }
             else {
                 String valueHolderClientId = column instanceof DynamicColumn

--- a/primefaces/src/main/java/org/primefaces/component/api/UITable.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITable.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import javax.el.MethodExpression;
 import javax.el.ValueExpression;
 import javax.faces.FacesException;
-import javax.faces.component.EditableValueHolder;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UINamingContainer;
 import javax.faces.component.ValueHolder;
@@ -45,10 +44,7 @@ import org.primefaces.expression.SearchExpressionUtils;
 import org.primefaces.model.ColumnMeta;
 import org.primefaces.model.FilterMeta;
 import org.primefaces.model.SortMeta;
-import org.primefaces.util.ComponentUtils;
-import org.primefaces.util.FacetUtils;
-import org.primefaces.util.LangUtils;
-import org.primefaces.util.LocaleUtils;
+import org.primefaces.util.*;
 
 public interface UITable<T extends UITableState> extends ColumnAware, MultiViewStateAware<T> {
 
@@ -197,11 +193,11 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 ((DynamicColumn) column).applyModel();
             }
 
-            EditableValueHolder hasCustomFilter = column.getFilterValueHolder();
+            EditableValueHolderState editableValueHolderState = column.getFilterValueHolder(context);
 
             Object filterValue;
-            if (hasCustomFilter != null) {
-                filterValue = column.getFilterValueFromValueHolder(context);
+            if (editableValueHolderState != null) {
+                filterValue = editableValueHolderState.getValue();
             }
             else {
                 String valueHolderClientId = column instanceof DynamicColumn

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -800,7 +800,7 @@ public class DataTableRenderer extends DataRenderer {
         }
         else {
             Object filterValue = table.getFilterValue(column);
-            column.setFilterValueToValueHolder(filterValue);
+            column.setFilterValueToValueHolder(context, filterValue);
 
             writer.startElement("div", null);
             writer.writeAttribute("class", DataTable.COLUMN_CUSTOM_FILTER_CLASS, null);

--- a/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -62,74 +62,16 @@ public class OutputLabelRenderer extends CoreRenderer {
                 .add(ComponentUtils.isRTL(context, label), OutputLabel.RTL_CLASS)
                 .add(label.getStyleClass());
 
-        final EditableValueHolderState state = new EditableValueHolderState();
+        EditableValueHolderState forState = null;
 
         final String indicateRequired = label.getIndicateRequired();
         boolean isAuto = "auto".equals(indicateRequired) || "autoSkipDisabled".equals(indicateRequired);
 
         String _for = label.getFor();
         if (!isValueBlank(_for)) {
-            ContextCallback callback = (ctxt, target) -> {
-                if (target instanceof InputHolder) {
-                    InputHolder inputHolder = ((InputHolder) target);
-                    state.setClientId(inputHolder.getInputClientId());
-
-                    inputHolder.setLabelledBy(clientId);
-                }
-                else {
-                    state.setClientId(target.getClientId(ctxt));
-                }
-
-                if (target instanceof UIInput) {
-                    UIInput input = (UIInput) target;
-
-                    if (value != null && (input.getAttributes().get("label") == null || input.getValueExpression("label") == null)) {
-                        ValueExpression ve = label.getValueExpression("value");
-
-                        if (ve != null) {
-                            input.setValueExpression("label", ve);
-                        }
-                        else {
-                            String labelString = value;
-                            char separatorChar = UINamingContainer.getSeparatorChar(ctxt);
-                            int separatorCharPos = labelString.lastIndexOf(separatorChar);
-
-                            if (separatorCharPos != -1) {
-                                labelString = labelString.substring(0, separatorCharPos);
-                            }
-
-                            input.getAttributes().put("label", labelString);
-                        }
-                    }
-
-                    if (!input.isValid()) {
-                        styleClassBuilder.add("ui-state-error");
-                    }
-
-                    if (isAuto) {
-                        boolean disabled = false;
-                        if ("autoSkipDisabled".equals(indicateRequired)) {
-                            disabled = ComponentUtils.isDisabledOrReadonly(input);
-                        }
-
-                        if (disabled) {
-                            state.setRequired(false);
-                        }
-                        else {
-                            state.setRequired(input.isRequired());
-                            // fallback if required=false
-                            if (!state.isRequired()) {
-                                PrimeApplicationContext applicationContext = PrimeApplicationContext.getCurrentInstance(ctxt);
-                                if (applicationContext.getConfig().isBeanValidationEnabled() && isBeanValidationDefined(input, ctxt)) {
-                                    state.setRequired(true);
-                                }
-                            }
-                        }
-                    }
-                }
-            };
-
             UIComponent forComponent = SearchExpressionUtils.contextlessResolveComponent(context, label, _for);
+            ContextCallbackFor callback = new ContextCallbackFor(clientId, indicateRequired, isAuto, label, styleClassBuilder, value);
+            forState = callback.getState();
 
             if (CompositeUtils.isComposite(forComponent)) {
                 CompositeUtils.invokeOnDeepestEditableValueHolder(context, forComponent, callback);
@@ -140,7 +82,7 @@ public class OutputLabelRenderer extends CoreRenderer {
         }
 
         boolean withRequiredIndicator = "true".equals(indicateRequired)
-                || (isAuto && !isValueBlank(_for) && state.isRequired());
+                || (isAuto && forState != null && forState.isRequired());
         if (withRequiredIndicator) {
             styleClassBuilder.add("ui-required");
         }
@@ -153,7 +95,7 @@ public class OutputLabelRenderer extends CoreRenderer {
         renderRTLDirection(context, label);
 
         if (!isValueBlank(_for)) {
-            writer.writeAttribute("for", state.getClientId(), "for");
+            writer.writeAttribute("for", forState.getClientId(), "for");
         }
 
         if (value != null) {
@@ -233,5 +175,90 @@ public class OutputLabelRenderer extends CoreRenderer {
     @Override
     public boolean getRendersChildren() {
         return true;
+    }
+
+    private class ContextCallbackFor implements ContextCallback {
+
+        private final EditableValueHolderState state = new EditableValueHolderState();
+        private final UIComponent label;
+        private final String indicateRequired;
+        private final String clientId;
+        private final String value;
+        private final StyleClassBuilder styleClassBuilder;
+        private final boolean isAuto;
+
+        public ContextCallbackFor(String clientId, String indicateRequired, boolean isAuto, UIComponent label,
+                                  StyleClassBuilder styleClassBuilder, String value) {
+            this.clientId = clientId;
+            this.indicateRequired = indicateRequired;
+            this.isAuto = isAuto;
+            this.label = label;
+            this.styleClassBuilder = styleClassBuilder;
+            this.value = value;
+        }
+
+        @Override
+        public void invokeContextCallback(FacesContext context, UIComponent target) {
+            if (target instanceof InputHolder) {
+                InputHolder inputHolder = ((InputHolder) target);
+                state.setClientId(inputHolder.getInputClientId());
+                inputHolder.setLabelledBy(clientId);
+            }
+            else {
+                state.setClientId(target.getClientId(context));
+            }
+
+            if (target instanceof UIInput) {
+                UIInput input = (UIInput) target;
+
+                if (value != null && (input.getAttributes().get("label") == null || input.getValueExpression("label") == null)) {
+                    ValueExpression ve = label.getValueExpression("value");
+
+                    if (ve != null) {
+                        input.setValueExpression("label", ve);
+                    }
+                    else {
+                        String labelString = value;
+                        char separatorChar = UINamingContainer.getSeparatorChar(context);
+                        int separatorCharPos = labelString.lastIndexOf(separatorChar);
+
+                        if (separatorCharPos != -1) {
+                            labelString = labelString.substring(0, separatorCharPos);
+                        }
+
+                        input.getAttributes().put("label", labelString);
+                    }
+                }
+
+                if (!input.isValid()) {
+                    styleClassBuilder.add("ui-state-error");
+                }
+
+                if (isAuto) {
+                    boolean disabled = false;
+                    if ("autoSkipDisabled".equals(indicateRequired)) {
+                        disabled = ComponentUtils.isDisabledOrReadonly(input);
+                    }
+
+                    if (disabled) {
+                        state.setRequired(false);
+                    }
+                    else {
+                        state.setRequired(input.isRequired());
+                        // fallback if required=false
+                        if (!state.isRequired()) {
+                            PrimeApplicationContext applicationContext = PrimeApplicationContext.getCurrentInstance(context);
+                            if (applicationContext.getConfig().isBeanValidationEnabled() && isBeanValidationDefined(input, context)) {
+                                state.setRequired(true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public EditableValueHolderState getState() {
+            return state;
+        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/event/CellEditEvent.java
+++ b/primefaces/src/main/java/org/primefaces/event/CellEditEvent.java
@@ -23,6 +23,15 @@
  */
 package org.primefaces.event;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.faces.FacesException;
+import javax.faces.component.EditableValueHolder;
+import javax.faces.component.UIComponent;
+import javax.faces.component.behavior.Behavior;
+import javax.faces.context.FacesContext;
+
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.api.UIData;
@@ -31,15 +40,6 @@ import org.primefaces.component.celleditor.CellEditor;
 import org.primefaces.component.datatable.DataTable;
 import org.primefaces.component.treetable.TreeTable;
 import org.primefaces.util.FacetUtils;
-
-import javax.faces.FacesException;
-import javax.faces.component.EditableValueHolder;
-import javax.faces.component.UIComponent;
-import javax.faces.component.behavior.Behavior;
-import javax.faces.context.FacesContext;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CellEditEvent<T> extends AbstractAjaxBehaviorEvent {
 
@@ -159,21 +159,17 @@ public class CellEditEvent<T> extends AbstractAjaxBehaviorEvent {
             if (child instanceof CellEditor) {
                 UIComponent inputFacet = child.getFacet("input");
 
-                AtomicBoolean invoked = new AtomicBoolean(false);
                 List<Object> values = new ArrayList<>(1);
 
                 FacetUtils.invokeOnEditableValueHolder(FacesContext.getCurrentInstance(), inputFacet, (ctx, component) -> {
                     values.add(((EditableValueHolder) component).getValue());
-                    invoked.set(true);
                 });
 
-                if (!invoked.get()) {
+                if (values.isEmpty()) {
                     throw new FacesException("No ValueHolder found inside the 'input' facet of the CellEditor!");
                 }
 
-                if (!values.isEmpty()) {
-                    value = values.size() > 1 ? (T) values : (T) values.get(0);
-                }
+                value = values.size() > 1 ? (T) values : (T) values.get(0);
             }
         }
 

--- a/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
@@ -40,6 +40,7 @@ import org.primefaces.model.filter.FilterConstraint;
 import org.primefaces.model.filter.FilterConstraints;
 import org.primefaces.model.filter.FunctionFilterConstraint;
 import org.primefaces.model.filter.GlobalFilterConstraint;
+import org.primefaces.util.EditableValueHolderState;
 import org.primefaces.util.LangUtils;
 
 public class FilterMeta implements Serializable {
@@ -100,7 +101,10 @@ public class FilterMeta implements Serializable {
 
         Object filterValue = column.getFilterValue();
         if (filterValue == null) {
-            filterValue = column.getFilterValueFromValueHolder(context);
+            EditableValueHolderState state = column.getFilterValueHolder(context);
+            if (state != null) {
+                filterValue = state.getValue();
+            }
         }
 
         return new FilterMeta(column.getColumnKey(),

--- a/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
+++ b/primefaces/src/main/java/org/primefaces/model/FilterMeta.java
@@ -23,6 +23,16 @@
  */
 package org.primefaces.model;
 
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.el.ELContext;
+import javax.el.MethodExpression;
+import javax.el.ValueExpression;
+import javax.faces.context.FacesContext;
+
 import org.primefaces.component.api.DynamicColumn;
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.column.ColumnBase;
@@ -31,15 +41,6 @@ import org.primefaces.model.filter.FilterConstraints;
 import org.primefaces.model.filter.FunctionFilterConstraint;
 import org.primefaces.model.filter.GlobalFilterConstraint;
 import org.primefaces.util.LangUtils;
-
-import javax.el.ELContext;
-import javax.el.MethodExpression;
-import javax.el.ValueExpression;
-import javax.faces.context.FacesContext;
-import java.io.Serializable;
-import java.lang.reflect.Array;
-import java.util.Collection;
-import java.util.Objects;
 
 public class FilterMeta implements Serializable {
 
@@ -99,7 +100,7 @@ public class FilterMeta implements Serializable {
 
         Object filterValue = column.getFilterValue();
         if (filterValue == null) {
-            filterValue = column.getFilterValueFromValueHolder();
+            filterValue = column.getFilterValueFromValueHolder(context);
         }
 
         return new FilterMeta(column.getColumnKey(),

--- a/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
@@ -183,6 +183,17 @@ public class ComponentTraversalUtils {
         return (UIComponent) closest(NamingContainer.class, component);
     }
 
+    public static <T> T firstChildRenderedOrSelf(Class<T> childType, UIComponent base) {
+        if (base == null || !base.isRendered()) {
+            return null;
+        }
+        else if (childType.isInstance(base)) {
+            return (T) base;
+        }
+
+        return firstChildRendered(childType, base);
+    }
+
     public static <T> T firstChildRendered(Class<T> childType, UIComponent base) {
         if (base == null || !base.isRendered()) {
             return null;

--- a/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentTraversalUtils.java
@@ -183,17 +183,6 @@ public class ComponentTraversalUtils {
         return (UIComponent) closest(NamingContainer.class, component);
     }
 
-    public static <T> T firstChildRenderedOrSelf(Class<T> childType, UIComponent base) {
-        if (base == null || !base.isRendered()) {
-            return null;
-        }
-        else if (childType.isInstance(base)) {
-            return (T) base;
-        }
-
-        return firstChildRendered(childType, base);
-    }
-
     public static <T> T firstChildRendered(Class<T> childType, UIComponent base) {
         if (base == null || !base.isRendered()) {
             return null;

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -80,7 +80,7 @@ public class CompositeUtils {
 
                     final UIComponent child = children.get(0);
 
-                    composite.invokeOnComponent(context, composite.getClientId(context), (ctxt, target1) -> {
+                    composite.invokeOnComponent(context, composite.getClientId(context), (ctxt, comp) -> {
                         if (isComposite(child)) {
                             invokeOnDeepestEditableValueHolder(ctxt, child, callback);
                         }

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -25,6 +25,7 @@ package org.primefaces.util;
 
 import java.beans.BeanInfo;
 import java.util.List;
+
 import javax.faces.FacesException;
 import javax.faces.component.ContextCallback;
 import javax.faces.component.EditableValueHolder;
@@ -49,9 +50,7 @@ public class CompositeUtils {
      * @param composite
      * @param callback
      */
-    public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite,
-            final ContextCallback callback) {
-
+    public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite, ContextCallback callback) {
         if (composite instanceof EditableValueHolder) {
             callback.invokeContextCallback(context, composite);
             return;
@@ -81,16 +80,12 @@ public class CompositeUtils {
 
                     final UIComponent child = children.get(0);
 
-                    composite.invokeOnComponent(context, composite.getClientId(context), new ContextCallback() {
-
-                        @Override
-                        public void invokeContextCallback(FacesContext context, UIComponent target) {
-                            if (isComposite(child)) {
-                                invokeOnDeepestEditableValueHolder(context, child, callback);
-                            }
-                            else {
-                                callback.invokeContextCallback(context, child);
-                            }
+                    composite.invokeOnComponent(context, composite.getClientId(context), (ctxt, target1) -> {
+                        if (isComposite(child)) {
+                            invokeOnDeepestEditableValueHolder(ctxt, child, callback);
+                        }
+                        else {
+                            callback.invokeContextCallback(ctxt, child);
                         }
                     });
                 }

--- a/primefaces/src/main/java/org/primefaces/util/EditableValueHolderState.java
+++ b/primefaces/src/main/java/org/primefaces/util/EditableValueHolderState.java
@@ -23,8 +23,12 @@
  */
 package org.primefaces.util;
 
+import javax.faces.component.EditableValueHolder;
+
 public class EditableValueHolderState {
 
+    private EditableValueHolder component;
+    private Object value;
     private String clientId;
     private boolean valid;
     private boolean required;
@@ -51,5 +55,21 @@ public class EditableValueHolderState {
 
     public void setRequired(boolean required) {
         this.required = required;
+    }
+
+    public EditableValueHolder getComponent() {
+        return component;
+    }
+
+    public void setComponent(EditableValueHolder component) {
+        this.component = component;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/EditableValueHolderState.java
+++ b/primefaces/src/main/java/org/primefaces/util/EditableValueHolderState.java
@@ -23,11 +23,8 @@
  */
 package org.primefaces.util;
 
-import javax.faces.component.EditableValueHolder;
-
 public class EditableValueHolderState {
 
-    private EditableValueHolder component;
     private Object value;
     private String clientId;
     private boolean valid;
@@ -55,14 +52,6 @@ public class EditableValueHolderState {
 
     public void setRequired(boolean required) {
         this.required = required;
-    }
-
-    public EditableValueHolder getComponent() {
-        return component;
-    }
-
-    public void setComponent(EditableValueHolder component) {
-        this.component = component;
     }
 
     public Object getValue() {


### PR DESCRIPTION
Fix #12507

Regression by #11135 

@tandraschko Why do we need a FacetUtils? All methods are not related to facet, but can be used on any UIComponent. IMO, that util should be removed, and everything  should go back to ComponentUtils