### PR TITLE
Fix #12274: CellEditor update cell editors after any AJAX update

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -257,6 +257,11 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
         if(this.cfg.editable) {
             this.bindEditEvents();
+            // ensure DOM memory is cleaned up by releasing document event handlers
+            this.addDestroyListener(function () {
+                $(document).off(namespace);
+                $(document).off('mouseup.datatable-cell-blur' + this.id);
+            });
         }
 
         if(this.cfg.draggableRows) {
@@ -379,6 +384,10 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
      * @private
      */
     postUpdateData: function() {
+        if (this.cfg.editable) {
+            this.bindEditEvents();
+        }
+
         if(this.cfg.draggableRows) {
             this.makeRowsDraggable();
         }
@@ -3563,12 +3572,6 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         // #3571 Set all fields to disabled by default
         this.disableCellEditors();
         
-        // ensure DOM memory is cleaned up by releasing document event handlers
-        this.addDestroyListener(function() {
-            $(document).off(namespace);
-            $(document).off('mouseup.datatable-cell-blur' + this.id);
-        });
-
         if(this.cfg.editMode === 'row') {
             var rowEditorSelector = '> tr > td > div.ui-row-editor > a';
             


### PR DESCRIPTION
Fix #12274: CellEditor update cell editors after any AJAX update

After any sort, filter, page etc we need to reset the `disabled` state of the cell editors.