### PR TITLE
Fix #12570: InputNumber change padControl from boolean to string for flexibility

### DIFF
--- a/docs/15_0_0/components/inputnumber.md
+++ b/docs/15_0_0/components/inputnumber.md
@@ -93,7 +93,7 @@ maxValue | 10000000000000 | String | Maximum values allowed. Warning: SEE BELOW!
 minValue | -10000000000000 | String | Minimum value. Warning: SEE BELOW!!!
 modifyValueOnWheel | true | Boolean | Allows the user to increment or decrement the element value with the mouse wheel.
 modifyValueOnUpDownArrow | true | Boolean | Allows the user to increment or decrement the element value with the up and down arrow keys.
-padControl | true | Boolean | Controls padding of the decimal places. If true, always pads the decimal with zeros.
+padControl | true | String | Allow padding the decimal places with zeros. If set to 'floats', padding is only done when there are some decimals (up to the number of decimal places from the decimalPlaces variable). If set to an integer, padding will use that number for adding the zeros. If set to "true" it will always pad the decimal places with zeroes, and never if set to "false". Default is "true"
 roundMethod | Round-Half-Up-Symmetric | String | Controls the rounding method.
 selectOnFocus | true | Boolean | Defines if the element value should be selected on focu.
 signPosition | null | String | Placement of the negative/positive sign relative to the symbolPosition option The sign is placed on either side of the symbolPosition, which can be placed on either side of the numbers. 'p' for prefix 's' for suffix 'l' for left 'r' for right

--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -18,9 +18,14 @@
   * Class `org.primefaces.component.api.UIData` was renamed `org.primefaces.component.api.PrimeUIData`.
   * Context param `primefaces.HTML5_COMPLIANCE` now defaults to `auto`.
 
-## Showcase
-  * Was migrated to Jakarta EE 10. Requires e.g. Jetty 12 and Java 17 to run stand-alone.
-
 ## FeedReader
 
   * Switched from [Rome](https://rometools.github.io/rome/) library which uses XML parsing to non XML very fast [RSS Reader](https://github.com/w3stling/rssreader)
+
+## InputNumber
+
+  * `padControl` attribute was changed from `Boolean` to `String` to allow more flexibility. Allow padding the decimal places with zeros. If set to 'floats', padding is only done when there are some decimals (up to the number of decimal places from the decimalPlaces variable). If set to an integer, padding will use that number for adding the zeros. If set to "true" it will always pad the decimal places with zeroes, and never if set to "false". Default is "true"
+
+## Showcase
+  * Was migrated to Jakarta EE 10. Requires e.g. Jetty 12 and Java 17 to run stand-alone.
+

--- a/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
@@ -36,28 +36,28 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
     public static final String DEFAULT_RENDERER = "org.primefaces.component.InputNumberRenderer";
 
     public enum PropertyKeys {
-        placeholder,
-        widgetVar,
-        type,
-        symbol,
-        symbolPosition,
-        signPosition,
-        minValue,
-        maxValue,
-        roundMethod,
+        caretPositionOnFocus,
         decimalPlaces,
         decimalSeparator,
-        thousandSeparator,
+        decimalSeparatorAlternative,
         emptyValue,
         inputStyle,
         inputStyleClass,
-        padControl,
         leadingZero,
-        decimalSeparatorAlternative,
-        modifyValueOnWheel,
+        maxValue,
+        minValue,
         modifyValueOnUpDownArrow,
-        caretPositionOnFocus,
-        selectOnFocus
+        modifyValueOnWheel,
+        padControl,
+        placeholder,
+        roundMethod,
+        selectOnFocus,
+        signPosition,
+        symbol,
+        symbolPosition,
+        thousandSeparator,
+        type,
+        widgetVar
     }
 
     public InputNumberBase() {
@@ -191,11 +191,11 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
         getStateHelper().put(PropertyKeys.inputStyleClass, inputStyleClass);
     }
 
-    public boolean isPadControl() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.padControl, true);
+    public String getPadControl() {
+        return (String) getStateHelper().eval(PropertyKeys.padControl, "true");
     }
 
-    public void setPadControl(boolean padControl) {
+    public void setPadControl(String padControl) {
         getStateHelper().put(PropertyKeys.padControl, padControl);
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -239,7 +239,7 @@ public class InputNumberRenderer extends InputRenderer {
             .attr("decimalPlaces", getDecimalPlaces(isIntegral, inputNumber))
             .attr("emptyInputBehavior", emptyValue, "focus")
             .attr("leadingZero", inputNumber.getLeadingZero(), "deny")
-            .attr("allowDecimalPadding", inputNumber.isPadControl(), true)
+            .attr("allowDecimalPadding", inputNumber.getPadControl(), "true")
             .attr("modifyValueOnWheel", inputNumber.isModifyValueOnWheel(), true)
             .attr("modifyValueOnUpDownArrow", inputNumber.isModifyValueOnUpDownArrow(), true)
             .attr("roundingMethod", inputNumber.getRoundMethod(), "S")

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -14197,11 +14197,11 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Controls padding of the decimal places. If true, always pads the decimal with zeros.]]>
+                <![CDATA[Allow padding the decimal places with zeros. If set to 'floats', padding is only done when there are some decimals (up to the number of decimal places from the decimalPlaces variable). If set to an integer, padding will use that number for adding the zeros. If set to "true" it will always pad the decimal places with zeroes, and never if set to "false". Default is "true"]]>
             </description>
             <name>padControl</name>
             <required>false</required>
-            <type>java.lang.Boolean</type>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>


### PR DESCRIPTION
Fix #12570: InputNumber change padControl from boolean to string for flexibility