### PR TITLE
#12587 DatePicker fluid input width

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -1006,7 +1006,7 @@ body .ui-cascadeselect-item-content .ui-cascadeselect-group-icon {
 }
 
 /** Calendar **/
-.ui-fluid .ui-calendar, .ui-fluid .ui-calendar input {
+.ui-fluid .ui-calendar, .ui-fluid .ui-calendar > input {
     width: 100%;
 }
 


### PR DESCRIPTION
Prevent navigator year input to be 100%.

Fixes #12587