### PR TITLE
Fix #12597: 14.0.6 Datatable CSS selector too broad

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -161,7 +161,6 @@
 
 /** Accessibility **/
 .ui-datatable-data td[role="gridcell"]:focus,
-.ui-datatable-data td[role="gridcell"] *:focus,
 .ui-datatable-data td[role="grid"] [tabindex="0"]:focus {
   outline: var(--primary-color, #90caf9);
   outline-style: solid;


### PR DESCRIPTION
Fix #12597: 14.0.6 Datatable CSS selector too broad