### PR TITLE
Fixed mismatched parentheses in JPALazyDataModel example

### DIFF
--- a/docs/14_0_0/components/datatable.md
+++ b/docs/14_0_0/components/datatable.md
@@ -976,7 +976,7 @@ public class CarBean {
 PrimeFaces provides a OOTB implementation for JPA users, which supports basic features.
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         .entityClass(MyEntity.class)
         .entityManager(() -> entityManager)
         .build();
@@ -987,7 +987,7 @@ It's very likely that this is the mapped JPA `@Id`, so we try to auto-lookup per
 Otherwise you can also define it:
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         ...
         .rowKeyField(MyEntity_.id) // JPA MetaModel
         .rowKeyField("id") // or as String
@@ -997,7 +997,7 @@ JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
 or provide a existing JSF `Converter`:
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         ...
         .rowKeyConverter(myConverter)
         ...
@@ -1007,7 +1007,7 @@ JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
 Per default the filters are case sensitive but you can also disable it:
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         ...
         .caseSensitive(false)
         ...
@@ -1019,7 +1019,7 @@ while `?` and `_` mean replace a single character.  For example `Smith*` would f
 the word `Smith`. For single character replacement like `Te?t` would match words `Tent` and `Test`.
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         ...
         .wildcardSupport(true)
         ...
@@ -1029,7 +1029,7 @@ JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
 You can add global filters or manipulate generated predicates (from the DataTable columns) via:
 
 ```java
-JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder())
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
         ...
         .filterEnricher((filterBy, cb, cq, root, predicates) -> {
             predicates.add(cb.isNull(root.get("id")));


### PR DESCRIPTION
I believe the extra right parentheses after builder() are all incorrect, since every .method() should immediately follow.