### PR TITLE
Fix #12604: 14.0.6 JPA do not UPPERCASE numeric columns

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -178,7 +178,8 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                                         Object filterValue,
                                         Locale locale) {
 
-        Supplier<Expression<String>> fieldExpressionAsString = () -> caseSensitive
+        boolean isCaseSensitive = caseSensitive || !(CharSequence.class.isAssignableFrom(pd.getPropertyType()) || pd.getPropertyType() == char.class);
+        Supplier<Expression<String>> fieldExpressionAsString = () -> isCaseSensitive
                 ? fieldExpression.as(String.class)
                 : cb.upper(fieldExpression.as(String.class));
         Supplier<Collection<Object>> filterValueAsCollection = () -> filterValue.getClass().isArray()


### PR DESCRIPTION
Fix #12604: 14.0.6 JPA do not UPPERCASE numeric columns