### PR TITLE
Fixes primefaces/primefaces#12614, include allSuffix in cache key for importEnum tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ What is the first step to be taken?
 -----------------------------------
 
 First of all, **Discuss with the [project members](http://forum.primefaces.org/)** (a new thread should do) about
-your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let we
+your ideas: new features, fixes, documentation... whatever you would like to contribute to the project. Let us
 discuss the possibilities with you so that we make sure your contribution goes in the right direction and aligns
 with the project's standards, intentions and roadmap.
 

--- a/docs/15_0_0/components/importenum.md
+++ b/docs/15_0_0/components/importenum.md
@@ -2,12 +2,11 @@
 
 In older EL versions (< 3.0), it's not possible to use enum constants or any other static
 fields/methods in an EL expression. As it is not really a good practice to create beans with
-getter/setter for each constants class, we provide an utils tag which allows to import enum values in
+getter/setter for each constants class, we provide a utils tag which allows to import enum values in
 a page.
 
 The enum values can be accessed via the name of the class (default setting) or via a custom name
-(var attribute). It also possible to get all enum values of the class with the "ALL_VALUES" suffix
-or a custom prefix via the "allSuffix" attribute.
+(var attribute). It is also possible to get all enum values of the class with the "ALL_VALUES" key.
 
 ## Info
 
@@ -22,20 +21,20 @@ or a custom prefix via the "allSuffix" attribute.
 | --- | --- | --- | --- |
 type | null | String | Name of the class containing the constants.
 var | null | String | Variable name to expose to EL.
-allSuffix | null | String | Suffix name to retrieve all values.
+~~allSuffix~~ | null | String | **Deprecated**: Use the special key `ALL_VALUES` to access all values, which is and was always available. Suffix name to retrieve all values.
 
 ## Getting Started with ImportEnum
 Class whose enums would be imported is defined with type property and the var property specifies
 the variable name to use via EL.
 
 ```xhtml
-<p:importEnum type="jakarta.faces.application.ProjectStage" var="JsfProjectStages" allSuffix="ALL_ENUM_VALUES" />
+<p:importEnum type="jakarta.faces.application.ProjectStage" var="JsfProjectStages" />
 Development: \#{JsfProjectStages.Development}
 ```
 ```xhtml
-ALL:
-<ui:repeat var="current" value="#{JsfProjectStages.ALL_ENUM_VALUES}">
+ALL
+<ui:repeat var="current" value="#{JsfProjectStages.ALL_VALUES}">
     <h:outputText value="#{current}" />
-</ui:repeat>>
+</ui:repeat>
 ```
 

--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -12,6 +12,8 @@
 
   * `Separator` component is deprecated since 15.0.0, please switch to `Divider`.
   * `Spacer` component is deprecated since 15.0.0, please use any of the modern CSS methods of spacing.
+  * The `allSuffix` attribute of the `importEnum` is deprecated since 15.0.0. Please use the special key `ALL_VALUES` to
+    access all values, which is and was always available.
 
 ## Core
 

--- a/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
@@ -21,12 +21,20 @@
         <div class="card">
             <p:importEnum type="jakarta.faces.application.ProjectStage" var="JsfProjectStages"
                           allSuffix="ALL_ENUM_VALUES"/>
+            <p:importEnum type="jakarta.faces.application.ProjectStage" var="Stages"
+                          allSuffix="ALL_STAGES"/>
 
             <h5 class="mt-0">Development</h5>
             <h:outputText value="#{JsfProjectStages.Development}" />
 
             <h5>ALL</h5>
             <ui:repeat var="current" value="#{JsfProjectStages.ALL_ENUM_VALUES}">
+                <h:outputText value="#{current}" styleClass="mb-2 block"/>
+            </ui:repeat>
+
+            <h5>ALL_STAGES</h5>
+            <p>You can use the same enum with different variable names and suffix for all enums, if necessary.</p>
+            <ui:repeat var="current" value="#{Stages.ALL_STAGES}">
                 <h:outputText value="#{current}" styleClass="mb-2 block"/>
             </ui:repeat>
         </div>

--- a/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/importEnum.xhtml
@@ -12,29 +12,21 @@
     <ui:define name="description">
         In older EL versions (&lt; 3.0), it's not possible to use enum constants or any other static fields/methods in an EL expression as it is not really a good practive to create beans with getter/setter for each constants class, we provide an utils tag which allows to import enum values in a page.<br/>
         The enum values can be accessed via the name of the class (default setting) or via a custom name (var attribute).
-        It also possible to get all enum values of the class with the "ALL_VALUES" suffix or a custom prefix via the "allSuffix" attribute.
+        It also possible to get all enum values of the class with the key "ALL_VALUES".
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/importenum"/>
 
     <ui:define name="implementation">
         <div class="card">
-            <p:importEnum type="jakarta.faces.application.ProjectStage" var="JsfProjectStages"
-                          allSuffix="ALL_ENUM_VALUES"/>
-            <p:importEnum type="jakarta.faces.application.ProjectStage" var="Stages"
-                          allSuffix="ALL_STAGES"/>
+            <p:importEnum type="jakarta.faces.application.ProjectStage" var="JsfProjectStages" />
 
             <h5 class="mt-0">Development</h5>
             <h:outputText value="#{JsfProjectStages.Development}" />
 
-            <h5>ALL</h5>
-            <ui:repeat var="current" value="#{JsfProjectStages.ALL_ENUM_VALUES}">
-                <h:outputText value="#{current}" styleClass="mb-2 block"/>
-            </ui:repeat>
-
-            <h5>ALL_STAGES</h5>
-            <p>You can use the same enum with different variable names and suffix for all enums, if necessary.</p>
-            <ui:repeat var="current" value="#{Stages.ALL_STAGES}">
+            <h5>ALL_VALUES</h5>
+            <p>You can use the special key ALL_VALUES to access all enum values.</p>
+            <ui:repeat var="current" value="#{JsfProjectStages.ALL_VALUES}">
                 <h:outputText value="#{current}" styleClass="mb-2 block"/>
             </ui:repeat>
         </div>

--- a/primefaces/src/main/java/org/primefaces/component/importenum/ImportEnumTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/importenum/ImportEnumTagHandler.java
@@ -110,13 +110,14 @@ public class ImportEnumTagHandler extends TagHandler {
         if (type.isEnum()) {
 
             boolean cacheEnabled = facesContext.isProjectStage(ProjectStage.Production);
-            Map<Class<?>, Map<String, Object>> cache
+            Map<Map.Entry<Class<?>, String>, Map<String, Object>> cache
                     = PrimeApplicationContext.getCurrentInstance(FacesContext.getCurrentInstance()).getEnumCacheMap();
+            Map.Entry<Class<?>, String> cacheKey = Map.entry(type, allSuffix != null ? allSuffix : "");
 
             Map<String, Object> enums;
 
-            if (cacheEnabled && cache.containsKey(type)) {
-                enums = cache.get(type);
+            if (cacheEnabled && cache.containsKey(cacheKey)) {
+                enums = cache.get(cacheKey);
             }
             else {
                 enums = new EnumHashMap<>(type);
@@ -135,7 +136,7 @@ public class ImportEnumTagHandler extends TagHandler {
                 enums = Collections.unmodifiableMap(enums);
 
                 if (cacheEnabled) {
-                    cache.put(type, enums);
+                    cache.put(cacheKey, enums);
                 }
             }
 

--- a/primefaces/src/main/java/org/primefaces/component/importenum/ImportEnumTagHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/importenum/ImportEnumTagHandler.java
@@ -129,6 +129,8 @@ public class ImportEnumTagHandler extends TagHandler {
             else {
                 enums = new EnumHashMap<>(type);
 
+                enums.put(DEFAULT_ALL_SUFFIX, type.getEnumConstants());
+
                 for (Object value : type.getEnumConstants()) {
                     Enum<?> currentEnum = (Enum<?>) value;
                     enums.put(currentEnum.name(), currentEnum);
@@ -137,8 +139,6 @@ public class ImportEnumTagHandler extends TagHandler {
                 if (allSuffix != null) {
                     enums.put(allSuffix, type.getEnumConstants());
                 }
-
-                enums.put(DEFAULT_ALL_SUFFIX, type.getEnumConstants());
 
                 enums = Collections.unmodifiableMap(enums);
 

--- a/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
@@ -81,7 +81,7 @@ public class PrimeApplicationContext {
     private final PrimeEnvironment environment;
     private final PrimeConfiguration config;
     private final ClassLoader applicationClassLoader;
-    private final Map<Class<?>, Map<String, Object>> enumCacheMap;
+    private final Map<Map.Entry<Class<?>, String>, Map<String, Object>> enumCacheMap;
     private final Map<Class<?>, Map<String, Object>> constantsCacheMap;
     private final Map<Class<? extends UIComponent>, Map<String, Class<? extends Exporter<?>>>> exporters;
     private final Map<String, ClientValidationConstraint> beanValidationClientConstraintMapping;
@@ -304,7 +304,7 @@ public class PrimeApplicationContext {
         return cacheProvider.get();
     }
 
-    public Map<Class<?>, Map<String, Object>> getEnumCacheMap() {
+    public Map<Map.Entry<Class<?>, String>, Map<String, Object>> getEnumCacheMap() {
         return enumCacheMap;
     }
 

--- a/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeApplicationContext.java
@@ -81,7 +81,7 @@ public class PrimeApplicationContext {
     private final PrimeEnvironment environment;
     private final PrimeConfiguration config;
     private final ClassLoader applicationClassLoader;
-    private final Map<Map.Entry<Class<?>, String>, Map<String, Object>> enumCacheMap;
+    private final Map<Class<?>, Map<String, Object>> enumCacheMap;
     private final Map<Class<?>, Map<String, Object>> constantsCacheMap;
     private final Map<Class<? extends UIComponent>, Map<String, Class<? extends Exporter<?>>>> exporters;
     private final Map<String, ClientValidationConstraint> beanValidationClientConstraintMapping;
@@ -304,7 +304,7 @@ public class PrimeApplicationContext {
         return cacheProvider.get();
     }
 
-    public Map<Map.Entry<Class<?>, String>, Map<String, Object>> getEnumCacheMap() {
+    public Map<Class<?>, Map<String, Object>> getEnumCacheMap() {
         return enumCacheMap;
     }
 

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -674,7 +674,7 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[The suffix mapping for a array with all enum values. Default value: ALL_VALUES.]]>
+                <![CDATA[Deprecated. Use the key ALL_VALUES to access all values, which is and was always available. The suffix mapping for an array with all enum values. Default value: ALL_VALUES.]]>
             </description>
             <name>allSuffix</name>
             <required>false</required>


### PR DESCRIPTION
Fixes #12614. As mentioned there, this includes the `allSuffix` in the cache key when getting the map with the enum constant for the `importEnum` tag.

I added another `importEnum` tag to the show case with another variable name and allSuffix. Without this fix, this will result in an error if the faces stages is not set to development.