### PR TITLE
Fix #12666: Datatable: filtering with BigDecimal

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
@@ -25,12 +25,12 @@ package org.primefaces.model.filter;
 
 import java.util.function.BiPredicate;
 
-public class EqualsFilterConstraint extends StringFilterConstraint {
+public class EqualsFilterConstraint extends ComparableFilterConstraint {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected BiPredicate<String, String> getPredicate() {
-        return String::equals;
+    protected BiPredicate<Comparable, Comparable> getPredicate() {
+        return (o1, o2) -> o1.compareTo(o2) == 0;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
@@ -23,14 +23,32 @@
  */
 package org.primefaces.model.filter;
 
-import java.util.function.BiPredicate;
+import java.util.Locale;
 
-public class EqualsFilterConstraint extends ComparableFilterConstraint {
+import javax.faces.context.FacesContext;
+
+public class EqualsFilterConstraint implements FilterConstraint {
 
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected BiPredicate<Comparable, Comparable> getPredicate() {
-        return (o1, o2) -> o1.compareTo(o2) == 0;
+    public boolean isMatching(FacesContext ctxt, Object value, Object filter, Locale locale) {
+        if (value == filter) {
+            return true;
+        }
+        if (value == null || filter == null) {
+            return false;
+        }
+        // If Comparable, prefer compareTo to handle BigDecimal, etc.
+        if (value instanceof Comparable) {
+            ComparableFilterConstraint.assertAssignable(filter, value);
+            return compareToEquals((Comparable) value, (Comparable) filter);
+        }
+        return value.equals(filter);
     }
+
+    protected boolean compareToEquals(Comparable value, Comparable filter) {
+        return value.compareTo(filter) == 0;
+    }
+
 }

--- a/primefaces/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/ExactFilterConstraint.java
@@ -31,6 +31,6 @@ public class ExactFilterConstraint extends StringFilterConstraint {
 
     @Override
     protected BiPredicate<String, String> getPredicate() {
-        return String::equalsIgnoreCase;
+        return String::equals;
     }
 }


### PR DESCRIPTION

Fix #12666

As mentioned in https://github.com/primefaces/primefaces/issues/12666#issuecomment-2389177712 I think the implementation of this filter constraint was not entirely correct. With this rework, it now properly uses `Object.equals` rather than a `String` conversion comparison, like `ExactFilterConstraint` should. It also makes use of `compareTo`, where available, to address the original issue with BigDecimal (and any other similar cases) by setting the filter with:

```xml
<p:column field="price" filterMatchMode="equals" converter="jakarta.faces.BigDecimal">
    <h:outputText value="#{customer.price}" >
        <f:convertNumber minFractionDigits="0" maxFractionDigits="2"/>
    </h:outputText>
</p:column>
```

@melloware @Rapster take a look and let me know what you think.