### PR TITLE
Fix #12677: 14.0.6 Schedule tooltip was transparent

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/build/src/main.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/build/src/main.css
@@ -5,7 +5,7 @@ body .fc a {
 }
 
 .ui-tooltip:not([role]) {
-    background: var(--surface-a, '#fff');
+    background: var(--surface-a, #fff);
     padding: 5px;
     font-size: .85em;
 }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/fullcalendar.min.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/fullcalendar.min.css
@@ -1459,7 +1459,7 @@ body .fc a {
 }
 
 .ui-tooltip:not([role]) {
-    background: '#fff';
+    background: #fff;
     padding: 5px;
     font-size: .85em;
 }


### PR DESCRIPTION
Fix #12677: 14.0.6 Schedule tooltip was transparent