### PR TITLE
Fix #12737: killswitch() widget existence checks

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -1070,11 +1070,11 @@ if (!PrimeFaces.utils) {
             // stop all pollers and idle monitors
             for (var item in PrimeFaces.widgets) {
                 widget = PrimeFaces.widgets[item];
-                if (widget instanceof PrimeFaces.widget.Poll) {
+                if (PrimeFaces.widget.Poll && widget instanceof PrimeFaces.widget.Poll) {
                     PrimeFaces.warn("Stopping Poll");
                     widget.stop();
                 }
-                if (widget instanceof PrimeFaces.widget.IdleMonitor) {
+                if (PrimeFaces.widget.IdleMonitor && widget instanceof PrimeFaces.widget.IdleMonitor) {
                     PrimeFaces.warn("Stopping IdleMonitor");
                     widget.pause();
                 }


### PR DESCRIPTION
Fix #12737: killswitch() widget existence checks