### PR TITLE
Fix #12744 - Datatable: supports multiple editableValueHolder in filters

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -762,13 +762,6 @@ public class ComponentUtils {
         return component.getClass().getName().endsWith("UIRepeat");
     }
 
-    public static boolean isVisitable(VisitContext context, UIComponent component) {
-        // Copy from MyFaces
-        Set<VisitHint> hints = context.getHints();
-        return (!hints.contains(VisitHint.SKIP_UNRENDERED) || component.isRendered())
-                && (!hints.contains(VisitHint.SKIP_TRANSIENT) || !component.isTransient());
-    }
-
     public static Object convertToType(Object value, Class<?> valueType, Logger logger) {
         // skip null
         if (value == null) {

--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -34,6 +34,7 @@ import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.csp.CspResponseWriter;
 import org.primefaces.renderkit.RendererUtils;
 
+import java.beans.BeanInfo;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
@@ -59,6 +60,7 @@ import javax.faces.FacesException;
 import javax.faces.FacesWrapper;
 import javax.faces.application.ConfigurableNavigationHandler;
 import javax.faces.application.NavigationCase;
+import javax.faces.component.ContextCallback;
 import javax.faces.component.EditableValueHolder;
 import javax.faces.component.StateHelper;
 import javax.faces.component.UIComponent;
@@ -69,14 +71,18 @@ import javax.faces.component.ValueHolder;
 import javax.faces.component.behavior.ClientBehavior;
 import javax.faces.component.behavior.ClientBehaviorHolder;
 import javax.faces.component.html.HtmlOutputFormat;
+import javax.faces.component.visit.VisitCallback;
 import javax.faces.component.visit.VisitContext;
 import javax.faces.component.visit.VisitHint;
+import javax.faces.component.visit.VisitResult;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.convert.Converter;
 import javax.faces.convert.ConverterException;
 import javax.faces.render.Renderer;
+import javax.faces.view.AttachedObjectTarget;
+import javax.faces.view.EditableValueHolderAttachedObjectTarget;
 
 public class ComponentUtils {
 
@@ -810,6 +816,61 @@ public class ComponentUtils {
         catch (ConverterException e) {
             logger.log(Level.INFO, e, () -> "Could not convert '" + stringValue + "' to " + valueType + " via " + targetConverter.getClass().getName());
             return value;
+        }
+    }
+
+    /**
+     * Invoke callback on the first rendered {@link EditableValueHolder} component
+     */
+    public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite, ContextCallback callback) {
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, ComponentUtils.VISIT_HINTS_SKIP_UNRENDERED);
+        composite.visitTree(visitContext, new EditableValueHolderVisitCallback(callback));
+    }
+
+    private static class EditableValueHolderVisitCallback implements VisitCallback {
+
+        private final ContextCallback callback;
+
+        public EditableValueHolderVisitCallback(ContextCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public VisitResult visit(VisitContext context, UIComponent target) {
+            if (target instanceof EditableValueHolder) {
+                callback.invokeContextCallback(context.getFacesContext(), target);
+                return VisitResult.COMPLETE;
+            }
+            else if (UIComponent.isCompositeComponent(target)) {
+                visitEditableValueHolderTargets(context, target);
+                return VisitResult.COMPLETE;
+            }
+            return VisitResult.ACCEPT;
+        }
+
+        private void visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
+            BeanInfo info = (BeanInfo) component.getAttributes().get(UIComponent.BEANINFO_KEY);
+            List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
+                    .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
+
+            if (targets != null) {
+                for (int i = 0; i < targets.size(); i++) {
+                    AttachedObjectTarget target = targets.get(i);
+                    if (target instanceof EditableValueHolderAttachedObjectTarget) {
+                        List<UIComponent> children = target.getTargets(component);
+                        if (children == null || children.isEmpty()) {
+                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target " +
+                                    "in component with id: \"" + component.getClientId() + "\"");
+                        }
+                        for (int j = 0; j < children.size(); j++) {
+                            final UIComponent child = children.get(j);
+                            if (child.visitTree(visitContext, this)) {
+                                return; // visit over
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -762,6 +762,13 @@ public class ComponentUtils {
         return component.getClass().getName().endsWith("UIRepeat");
     }
 
+    public static boolean isVisitable(VisitContext context, UIComponent component) {
+        // Copy from MyFaces
+        Set<VisitHint> hints = context.getHints();
+        return (!hints.contains(VisitHint.SKIP_UNRENDERED) || component.isRendered())
+                && (!hints.contains(VisitHint.SKIP_TRANSIENT) || !component.isTransient());
+    }
+
     public static Object convertToType(Object value, Class<?> valueType, Logger logger) {
         // skip null
         if (value == null) {

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -39,8 +39,10 @@ public class CompositeUtils {
 
     /**
      * Invoke callback on the first rendered {@link EditableValueHolder} component
+     * Use {@link ComponentUtils#invokeOnDeepestEditableValueHolder(FacesContext, UIComponent, ContextCallback)} instead
      */
+    @Deprecated
     public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite, ContextCallback callback) {
-        FacetUtils.invokeOnEditableValueHolder(context, composite, callback);
+        ComponentUtils.invokeOnDeepestEditableValueHolder(context, composite, callback);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -72,22 +72,22 @@ public class CompositeUtils {
                                 + composite.getClientId() + "\"");
                     }
 
-                    if (children.size() > 1) {
-                        throw new FacesException(
-                                "Only a single editableValueHolder target is supported in composite component with id: \""
-                                + composite.getClientId() + "\"");
+                    for (int j = 0; j < children.size(); j++) {
+                        final UIComponent child = children.get(j);
+
+                        composite.invokeOnComponent(context, child.getClientId(context), (ctxt, comp) -> {
+                            if (!comp.isRendered()) {
+                                return;
+                            }
+
+                            if (isComposite(comp)) {
+                                invokeOnDeepestEditableValueHolder(ctxt, comp, callback);
+                            }
+                            else {
+                                callback.invokeContextCallback(ctxt, comp);
+                            }
+                        });
                     }
-
-                    final UIComponent child = children.get(0);
-
-                    composite.invokeOnComponent(context, composite.getClientId(context), (ctxt, comp) -> {
-                        if (isComposite(child)) {
-                            invokeOnDeepestEditableValueHolder(ctxt, child, callback);
-                        }
-                        else {
-                            callback.invokeContextCallback(ctxt, child);
-                        }
-                    });
                 }
             }
         }

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -23,10 +23,19 @@
  */
 package org.primefaces.util;
 
+import java.beans.BeanInfo;
+import java.util.List;
+
+import javax.faces.FacesException;
 import javax.faces.component.ContextCallback;
 import javax.faces.component.EditableValueHolder;
 import javax.faces.component.UIComponent;
+import javax.faces.component.visit.VisitCallback;
+import javax.faces.component.visit.VisitContext;
+import javax.faces.component.visit.VisitResult;
 import javax.faces.context.FacesContext;
+import javax.faces.view.AttachedObjectTarget;
+import javax.faces.view.EditableValueHolderAttachedObjectTarget;
 
 public class CompositeUtils {
 
@@ -39,10 +48,56 @@ public class CompositeUtils {
 
     /**
      * Invoke callback on the first rendered {@link EditableValueHolder} component
-     * Use {@link ComponentUtils#invokeOnDeepestEditableValueHolder(FacesContext, UIComponent, ContextCallback)} instead
      */
-    @Deprecated
     public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite, ContextCallback callback) {
-        ComponentUtils.invokeOnDeepestEditableValueHolder(context, composite, callback);
+        VisitContext visitContext = VisitContext.createVisitContext(context, null, ComponentUtils.VISIT_HINTS_SKIP_UNRENDERED);
+        composite.visitTree(visitContext, new EditableValueHolderVisitCallback(callback));
+    }
+
+    private static class EditableValueHolderVisitCallback implements VisitCallback {
+
+        private final ContextCallback callback;
+
+        public EditableValueHolderVisitCallback(ContextCallback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public VisitResult visit(VisitContext context, UIComponent target) {
+            if (target instanceof EditableValueHolder) {
+                callback.invokeContextCallback(context.getFacesContext(), target);
+                return VisitResult.COMPLETE;
+            }
+            else if (UIComponent.isCompositeComponent(target)) {
+                visitEditableValueHolderTargets(context, target);
+                return VisitResult.COMPLETE;
+            }
+            return VisitResult.ACCEPT;
+        }
+
+        private void visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
+            BeanInfo info = (BeanInfo) component.getAttributes().get(UIComponent.BEANINFO_KEY);
+            List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
+                    .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
+
+            if (targets != null) {
+                for (int i = 0; i < targets.size(); i++) {
+                    AttachedObjectTarget target = targets.get(i);
+                    if (target instanceof EditableValueHolderAttachedObjectTarget) {
+                        List<UIComponent> children = target.getTargets(component);
+                        if (children == null || children.isEmpty()) {
+                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target " +
+                                    "in component with id: \"" + component.getClientId() + "\"");
+                        }
+                        for (int j = 0; j < children.size(); j++) {
+                            final UIComponent child = children.get(j);
+                            if (child.visitTree(visitContext, this)) {
+                                return; // visit over
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -23,16 +23,10 @@
  */
 package org.primefaces.util;
 
-import java.beans.BeanInfo;
-import java.util.List;
-
-import javax.faces.FacesException;
 import javax.faces.component.ContextCallback;
 import javax.faces.component.EditableValueHolder;
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
-import javax.faces.view.AttachedObjectTarget;
-import javax.faces.view.EditableValueHolderAttachedObjectTarget;
 
 public class CompositeUtils {
 
@@ -44,52 +38,9 @@ public class CompositeUtils {
     }
 
     /**
-     * Attention: This only supports cc:editableValueHolder which target a single component!
-     *
-     * @param context
-     * @param composite
-     * @param callback
+     * Invoke callback on the first rendered {@link EditableValueHolder} component
      */
     public static void invokeOnDeepestEditableValueHolder(FacesContext context, UIComponent composite, ContextCallback callback) {
-        if (composite instanceof EditableValueHolder) {
-            callback.invokeContextCallback(context, composite);
-            return;
-        }
-
-        BeanInfo info = (BeanInfo) composite.getAttributes().get(UIComponent.BEANINFO_KEY);
-        List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
-                .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
-
-        if (targets != null) {
-            for (int i = 0; i < targets.size(); i++) {
-                AttachedObjectTarget target = targets.get(i);
-                if (target instanceof EditableValueHolderAttachedObjectTarget) {
-
-                    List<UIComponent> children = target.getTargets(composite);
-                    if (children == null || children.isEmpty()) {
-                        throw new FacesException(
-                                "Cannot not resolve editableValueHolder target in composite component with id: \""
-                                + composite.getClientId() + "\"");
-                    }
-
-                    for (int j = 0; j < children.size(); j++) {
-                        final UIComponent child = children.get(j);
-
-                        composite.invokeOnComponent(context, child.getClientId(context), (ctxt, comp) -> {
-                            if (!comp.isRendered()) {
-                                return;
-                            }
-
-                            if (isComposite(comp)) {
-                                invokeOnDeepestEditableValueHolder(ctxt, comp, callback);
-                            }
-                            else {
-                                callback.invokeContextCallback(ctxt, comp);
-                            }
-                        });
-                    }
-                }
-            }
-        }
+        FacetUtils.invokeOnEditableValueHolder(context, composite, callback);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CompositeUtils.java
@@ -69,13 +69,12 @@ public class CompositeUtils {
                 return VisitResult.COMPLETE;
             }
             else if (UIComponent.isCompositeComponent(target)) {
-                visitEditableValueHolderTargets(context, target);
-                return VisitResult.COMPLETE;
+                return visitEditableValueHolderTargets(context, target);
             }
             return VisitResult.ACCEPT;
         }
 
-        private void visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
+        private VisitResult visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
             BeanInfo info = (BeanInfo) component.getAttributes().get(UIComponent.BEANINFO_KEY);
             List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
                     .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
@@ -92,12 +91,14 @@ public class CompositeUtils {
                         for (int j = 0; j < children.size(); j++) {
                             final UIComponent child = children.get(j);
                             if (child.visitTree(visitContext, this)) {
-                                return; // visit over
+                                return VisitResult.COMPLETE;
                             }
                         }
                     }
                 }
             }
+
+            return VisitResult.ACCEPT;
         }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -123,8 +123,8 @@ public class FacetUtils {
                     if (target instanceof EditableValueHolderAttachedObjectTarget) {
                         List<UIComponent> children = target.getTargets(component);
                         if (children == null || children.isEmpty()) {
-                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target in component with id: \""
-                                    + component.getClientId() + "\"");
+                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target " +
+                                    "in component with id: \"" + component.getClientId() + "\"");
                         }
                         for (int j = 0; j < children.size(); j++) {
                             final UIComponent child = children.get(j);

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -80,10 +80,10 @@ public class FacetUtils {
 
     /**
      * Invoke callback on the first rendered {@link EditableValueHolder} component
-     * Use {@link ComponentUtils#invokeOnDeepestEditableValueHolder(FacesContext, UIComponent, ContextCallback)} instead
+     * Use {@link CompositeUtils#invokeOnDeepestEditableValueHolder(FacesContext, UIComponent, ContextCallback)} instead
      */
     @Deprecated
     public static void invokeOnEditableValueHolder(FacesContext context, UIComponent facet, ContextCallback callback) {
-        ComponentUtils.invokeOnDeepestEditableValueHolder(context, facet, callback);
+        CompositeUtils.invokeOnDeepestEditableValueHolder(context, facet, callback);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -26,7 +26,6 @@ package org.primefaces.util;
 import java.beans.BeanInfo;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 
 import javax.faces.FacesException;
 import javax.faces.component.ContextCallback;
@@ -41,8 +40,6 @@ import javax.faces.view.AttachedObjectTarget;
 import javax.faces.view.EditableValueHolderAttachedObjectTarget;
 
 public class FacetUtils {
-
-    private static final Logger LOGGER = Logger.getLogger(FacetUtils.class.getName());
 
     private FacetUtils() {
     }

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -127,7 +127,8 @@ public class FacetUtils {
                     if (target instanceof EditableValueHolderAttachedObjectTarget) {
                         List<UIComponent> children = target.getTargets(component);
                         if (children == null || targets.isEmpty()) {
-                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target in component with id: \"" + component.getClientId() + "\"");
+                            throw new FacesException("Cannot resolve <cc:editableValueHolder /> target in component with id: \""
+                                    + component.getClientId() + "\"");
                         }
                         for (int j = 0; j < children.size(); j++) {
                             final UIComponent child = children.get(j);

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -107,12 +107,13 @@ public class FacetUtils {
                 return VisitResult.COMPLETE;
             }
             else if (UIComponent.isCompositeComponent(target)) {
-                return visitEditableValueHolderTargets(context, target);
+                visitEditableValueHolderTargets(context, target);
+                return VisitResult.COMPLETE;
             }
             return VisitResult.ACCEPT;
         }
 
-        private VisitResult visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
+        private void visitEditableValueHolderTargets(VisitContext visitContext, UIComponent component) {
             BeanInfo info = (BeanInfo) component.getAttributes().get(UIComponent.BEANINFO_KEY);
             List<AttachedObjectTarget> targets = (List<AttachedObjectTarget>) info.getBeanDescriptor()
                     .getValue(AttachedObjectTarget.ATTACHED_OBJECT_TARGETS_KEY);
@@ -129,14 +130,12 @@ public class FacetUtils {
                         for (int j = 0; j < children.size(); j++) {
                             final UIComponent child = children.get(j);
                             if (child.visitTree(visitContext, this)) {
-                                return VisitResult.COMPLETE;
+                                return; // visit over
                             }
                         }
                     }
                 }
             }
-
-            return VisitResult.COMPLETE;
         }
     }
 

--- a/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FacetUtils.java
@@ -136,7 +136,7 @@ public class FacetUtils {
                 }
             }
 
-            return VisitResult.ACCEPT;
+            return VisitResult.COMPLETE;
         }
     }
 


### PR DESCRIPTION
I always felt that getting only the first item was some sort of trick but now it feels more compliant with the JSF API