### PR TITLE
Fixes #9254 - Treetable: clearFilters() API make table breaks table when filtering is enabled

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTable.java
@@ -86,7 +86,6 @@ public class TreeTable extends TreeTableBase {
     public static final String SORTABLE_COLUMN_HEADER_CLASS = "ui-state-default ui-sortable-column";
     public static final String ROW_CLASS = "ui-widget-content";
     public static final String SELECTED_ROW_CLASS = "ui-widget-content ui-state-highlight ui-selected";
-    public static final String COLUMN_CONTENT_WRAPPER = "ui-tt-c";
     public static final String EXPAND_ICON = "ui-treetable-toggler ui-icon ui-icon-triangle-1-e ui-c";
     public static final String COLLAPSE_ICON = "ui-treetable-toggler ui-icon ui-icon-triangle-1-s ui-c";
     public static final String SCROLLABLE_CONTAINER_CLASS = "ui-treetable-scrollable";
@@ -268,13 +267,26 @@ public class TreeTable extends TreeTableBase {
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         super.processEvent(event);
 
-        // restore "value" from "filteredValue"
+        // restored filter-state if it was filtered in the previous request
         if (event instanceof PostRestoreStateEvent
+                && this == event.getComponent()
                 && isFilteringEnabled()
-                && this == event.getComponent()) {
-            TreeNode<?> filteredValue = getFilteredValue();
-            if (filteredValue != null) {
-                setValue(filteredValue);
+                && isFilteringCurrentlyActive()) {
+
+            // restore "value" from "filteredValue" - we must work on filtered data
+            // in future we might remember filtered rowKeys and skip them while rendering instead of doing it this way
+            ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
+            if (ve != null) {
+                TreeNode filteredValue = getFilteredValue();
+                if (filteredValue != null) {
+                    setValue(filteredValue);
+                }
+            }
+            else {
+                // trigger filter as previous requests were filtered
+                // in older PF versions, we stored the filtered data in the viewstate but this blows up memory
+                // and caused bugs with editing and serialization like #7999
+                filterAndSort();
             }
         }
     }
@@ -460,17 +472,6 @@ public class TreeTable extends TreeTableBase {
         }
     }
 
-    public void updateFilteredValue(FacesContext context, TreeNode node) {
-        ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
-
-        if (ve != null) {
-            ve.setValue(context.getELContext(), node);
-        }
-        else {
-            setFilteredValue(node);
-        }
-    }
-
     public List<String> getFilteredRowKeys() {
         return filteredRowKeys;
     }
@@ -634,4 +635,18 @@ public class TreeTable extends TreeTableBase {
         }
     }
 
+    public TreeNode getFilteredValue() {
+        ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
+        if (ve != null) {
+            return (TreeNode) ve.getValue(getFacesContext().getELContext());
+        }
+        return null;
+    }
+
+    public void setFilteredValue(TreeNode filteredValue) {
+        ValueExpression ve = getValueExpression(PropertyKeys.filteredValue.name());
+        if (ve != null) {
+            ve.setValue(getFacesContext().getELContext(), filteredValue);
+        }
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -29,7 +29,6 @@ import org.primefaces.component.api.UIPageableData;
 import org.primefaces.component.api.UITable;
 import org.primefaces.component.api.UITree;
 import org.primefaces.component.api.Widget;
-import org.primefaces.model.TreeNode;
 import org.primefaces.util.MessageFactory;
 
 import javax.el.MethodExpression;
@@ -378,14 +377,6 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
 
     public void setFirst(int first) {
         getStateHelper().put(PropertyKeys.first, first);
-    }
-
-    public TreeNode<?> getFilteredValue() {
-        return (TreeNode<?>) getStateHelper().eval(PropertyKeys.filteredValue, null);
-    }
-
-    public void setFilteredValue(TreeNode<?> filteredValue) {
-        getStateHelper().put(PropertyKeys.filteredValue, filteredValue);
     }
 
     public String getFilterEvent() {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -60,7 +60,7 @@ public class FilterFeature implements TreeTableFeature {
         table.updateFilterByValuesWithFilterRequest(context, filterBy);
 
         // reset state
-        table.updateFilteredValue(context, null);
+        table.setFilteredValue(null);
         table.setValue(null);
         table.setFirst(0);
 
@@ -111,7 +111,7 @@ public class FilterFeature implements TreeTableFeature {
         TreeNode filteredValue = cloneTreeNode(root, root.getParent());
         createFilteredValueFromRowKeys(tt, root, filteredValue, filteredRowKeys);
 
-        tt.updateFilteredValue(context, filteredValue);
+        tt.setFilteredValue( filteredValue);
         tt.setValue(filteredValue);
         tt.setRowKey(root, null);
 


### PR DESCRIPTION
I think it should also fix #8073

i aligned it with DataTable now, to not store the filtered stuff memory and just refilter each request