### PR TITLE
Execute filterEnricher before columnFilters allows multi-field filtering from outside dataTable

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -142,6 +142,10 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
         List<Predicate> predicates = new ArrayList<>();
 
+        if (filterEnricher != null) {
+            filterEnricher.enrich(filterBy, cb, cq, root, predicates);
+        }
+
         if (filterBy != null) {
             FacesContext context = FacesContext.getCurrentInstance();
             Locale locale = LocaleUtils.getCurrentLocale(context);
@@ -168,10 +172,6 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                 Predicate predicate = createPredicate(filter, pd, root, cb, fieldExpression, convertedFilterValue, locale);
                 predicates.add(predicate);
             }
-        }
-
-        if (filterEnricher != null) {
-            filterEnricher.enrich(filterBy, cb, cq, root, predicates);
         }
 
         if (!predicates.isEmpty()) {


### PR DESCRIPTION
Execute filterEnricher before columnFilters (where applyGlobalFilters previously was). It will now be possible to create custom filterMeta without referencing specific field; handle the filterMeta in enricher, create predicates accordingly, and remove the filterMeta