### PR TITLE
Fix #12819: 14.0.7 Datatable remove legacy CSS border-collapse

### DIFF
--- a/docs/migrationguide/14_0_0.md
+++ b/docs/migrationguide/14_0_0.md
@@ -56,6 +56,7 @@
   * Using Column custom `sortFunction` signature change now requires a third parameter `SortMeta` like `public int sortByModel(Object car1, Object car2, SortMeta sortMeta)`
   * `JpaLazyDataModel` renamed to `JPALazyDataModel`, and initialization by constructors removed _(no backward compatibility)_, use `JPALazyDataModel.builder()` instead
   * `LazyDataModel#getRowData(rowIndex, sortBy, filterBy)` has been renamed `loadOne()` to load a single row
+  * Added `cellNavigation` property which defaults to `true` to enable WCAG keyboard navigation of table cells.
 
 ### DataTable selection
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -1,5 +1,4 @@
 .ui-datatable table {
-	border-collapse:collapse;
     width: 100%;
     table-layout: fixed;
 }


### PR DESCRIPTION
Fix #12819: 14.0.7 Datatable remove legacy CSS border-collapse