### PR TITLE
Fix #12824: TreeTable CSV export missing headers

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
@@ -35,7 +35,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.EnumSet;
 
 import javax.faces.FacesException;
 import javax.faces.context.FacesContext;
@@ -43,7 +43,7 @@ import javax.faces.context.FacesContext;
 public class TreeTableCSVExporter extends TreeTableExporter<PrintWriter, CSVOptions> {
 
     public TreeTableCSVExporter() {
-        super(CSVOptions.EXCEL, Collections.emptySet(), false);
+        super(CSVOptions.EXCEL,  EnumSet.of(FacetType.COLUMN), false);
     }
 
     @Override


### PR DESCRIPTION
Fix #12824: TreeTable CSV export missing headers