### PR TITLE
Fix #12824: 14.0.7 TreeTable CSV export missing headers

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableCSVExporter.java
@@ -23,15 +23,6 @@
  */
 package org.primefaces.component.treetable.export;
 
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import javax.faces.FacesException;
-import javax.faces.context.FacesContext;
-
 import org.primefaces.component.api.UIColumn;
 import org.primefaces.component.export.CSVOptions;
 import org.primefaces.component.export.ColumnValue;
@@ -39,10 +30,20 @@ import org.primefaces.component.treetable.TreeTable;
 import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+
+import javax.faces.FacesException;
+import javax.faces.context.FacesContext;
+
 public class TreeTableCSVExporter extends TreeTableExporter<PrintWriter, CSVOptions> {
 
     public TreeTableCSVExporter() {
-        super(CSVOptions.EXCEL, Collections.emptySet(), false);
+        super(CSVOptions.EXCEL,  EnumSet.of(FacetType.COLUMN), false);
     }
 
     @Override


### PR DESCRIPTION
Fix #12824: 14.0.7 TreeTable CSV export missing headers