### PR TITLE
Fixes #12856 - Timeline: Adding events dynamically not working anymore in when passing a search expression to the TimelineUpdater

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
@@ -58,6 +58,16 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
     private String widgetVar;
     private List<CrudOperationData> crudOperationDatas;
 
+    // serialization
+    public DefaultTimelineUpdater() {
+        super();
+    }
+
+    public DefaultTimelineUpdater(String clientId, String widgetVar) {
+        super(clientId);
+        this.widgetVar = widgetVar;
+    }
+
     enum CrudOperation {
 
         ADD,
@@ -136,7 +146,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
             return;
         }
 
-        context.getViewRoot().invokeOnComponent(context, id, (ctx, component) -> {
+        context.getViewRoot().invokeOnComponent(context, clientId, (ctx, component) -> {
             StringBuilder sb = new StringBuilder();
 
             Timeline timeline = (Timeline) component;
@@ -179,7 +189,8 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
                                 sb.append(timelineRenderer.encodeGroup(context, fsw, fswHtml, timeline, groupFacet, groupsContent, foundGroup, orderGroup));
                             }
                             catch (IOException e) {
-                                LOGGER.log(Level.WARNING, e, () -> "Timeline with id " + id + " could not be updated, at least one CRUD operation failed");
+                                LOGGER.log(Level.WARNING, e,
+                                        () -> "Timeline with clientId " + clientId + " could not be updated, at least one CRUD operation failed");
                             }
                             sb.append(")");
                         }
@@ -250,7 +261,7 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
                 PrimeFaces.current().executeScript(sb.toString());
             }
             catch (IOException e) {
-                LOGGER.log(Level.WARNING, e, () -> "Timeline with id " + id + " could not be updated, at least one CRUD operation failed");
+                LOGGER.log(Level.WARNING, e, () -> "Timeline with id " + clientId + " could not be updated, at least one CRUD operation failed");
             }
         });
     }

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineListener.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineListener.java
@@ -48,8 +48,8 @@ public class TimelineListener implements SystemEventListener {
         }
 
         if (!alreadyRegistred) {
-            DefaultTimelineUpdater timelineUpdater = new DefaultTimelineUpdater();
-            timelineUpdater.setWidgetVar(widgetVar);
+            DefaultTimelineUpdater timelineUpdater = new DefaultTimelineUpdater(
+                    timeline.getClientId(context), widgetVar);
             context.getViewRoot().addPhaseListener(timelineUpdater);
         }
     }

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineUpdater.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineUpdater.java
@@ -25,27 +25,35 @@ package org.primefaces.component.timeline;
 
 import org.primefaces.model.timeline.TimelineEvent;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
-import javax.faces.FacesException;
-import javax.faces.component.UIComponent;
+import javax.faces.component.search.SearchExpressionContext;
+import javax.faces.component.search.SearchExpressionHint;
 import javax.faces.context.FacesContext;
 
 public abstract class TimelineUpdater {
 
-    /**
-     * The same id of the Timeline component in terms of findComponent() as in {@link #getCurrentInstance(String)}
-     */
-    protected String id;
+    protected String clientId;
+
+    // serialization
+    public TimelineUpdater() {
+        super();
+    }
+
+    public TimelineUpdater(String clientId) {
+        this.clientId = clientId;
+    }
 
     /**
-     * Gets the current thread-safe TimelineUpdater instance by Id.
+     * Gets the current thread-safe TimelineUpdater instance.
      *
-     * @param id Id of the Timeline component in terms of findComponent()
+     * @param expression The expression to find the Timeline instance.
      * @return TimelineUpdater instance.
-     * @throws FacesException if the Timeline component can not be found by the given Id
+     * @throws javax.faces.component.search.ComponentNotFoundException if the Timeline component can not be found by the given expression.
      */
-    public static TimelineUpdater getCurrentInstance(String id) {
+    public static TimelineUpdater getCurrentInstance(String expression) {
         FacesContext context = FacesContext.getCurrentInstance();
 
         @SuppressWarnings("unchecked")
@@ -54,17 +62,19 @@ public abstract class TimelineUpdater {
             return null;
         }
 
-        UIComponent timeline = context.getViewRoot().findComponent(id);
-        if (!(timeline instanceof Timeline)) {
-            throw new FacesException("Timeline component with Id " + id + " was not found");
-        }
+        AtomicReference<String> widgetVar = new AtomicReference<>();
 
-        TimelineUpdater timelineUpdater = map.get(((Timeline) timeline).resolveWidgetVar(context));
-        if (timelineUpdater != null) {
-            timelineUpdater.id = id;
-        }
+        SearchExpressionContext sec = SearchExpressionContext.createSearchExpressionContext(context,
+                context.getViewRoot(), EnumSet.of(SearchExpressionHint.RESOLVE_SINGLE_COMPONENT), null);
+        context.getApplication().getSearchExpressionHandler().resolveComponent(
+                sec,
+                expression,
+                (ctx, target) -> {
+                    Timeline timeline = (Timeline) target;
+                    widgetVar.set(timeline.resolveWidgetVar(context));
+                });
 
-        return timelineUpdater;
+        return map.get(widgetVar.get());
     }
 
     public abstract void add(TimelineEvent<?> event);


### PR DESCRIPTION
As requested, this is the same as #12857, but without the extraneous commits. #12857 should be closed in favor of this one.

> Fixes https://github.com/primefaces/primefaces/issues/12856 - Timeline: Adding events dynamically not working anymore in when passing a search expression to the TimelineUpdater

I tested the changes with the showcase, everything seems to be working fine now, include drag&drop, lazy loading, and server editing.