### PR TITLE
JPALazyDataModel: add possibilty to inject own/custom FilterMeta

### DIFF
--- a/docs/15_0_0/components/datatable.md
+++ b/docs/15_0_0/components/datatable.md
@@ -1053,6 +1053,18 @@ JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity> builder()
         ...
 ```
 
+#### Add additional filters
+You can add your own/custom FilterMeta to manipulate generated predicates:
+```java
+JPALazyDataModel<MyEntity> lazyDataModel = JPALazyDataModel.<MyEntity>builder()
+        ...
+        .additionalFilterMeta(() -> {
+            return new ArrayList<FilterMeta>(...);
+        })
+        ...
+```
+
+
 #### `Iterator` and performance considerations
 `JPALazyDataModel`, being an extension of `DataModel`, is iterable over the JPA values. This is accomplished lazily by paging through, and therefore querying, the data as needed (calls to `hasNext()` and `next()` from `Iterator` in turn call `load(first, pageSize, sortBy, filterBy)`).
 

--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -161,7 +161,7 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
     protected void applyFiltersFromFilterMeta(Class<T> entityClass, Collection<FilterMeta> filterBy, CriteriaBuilder cb,
                                               CriteriaQuery<?> cq,
-                                              Root<T> root, List<Predicate>predicates) {
+                                              Root<T> root, List<Predicate> predicates) {
         if (filterBy != null) {
             FacesContext context = FacesContext.getCurrentInstance();
             Locale locale = LocaleUtils.getCurrentLocale(context);

--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -143,14 +143,14 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
         List<Predicate> predicates = new ArrayList<>();
 
-        applyPredicatesFromFilterMetaMap(entityClass, filterBy, cb, cq, root, predicates);
+        applyFiltersFromFilterMeta(entityClass, filterBy.values(), cb, cq, root, predicates);
 
         if (filterEnricher != null) {
             filterEnricher.enrich(filterBy, cb, cq, root, predicates);
         }
 
         if (additionalFilterMeta != null) {
-            applyPredicatesFromFilterMetaMap(entityClass, additionalFilterMeta.process(), cb, cq, root, predicates);
+            applyFiltersFromFilterMeta(entityClass, additionalFilterMeta.process(), cb, cq, root, predicates);
         }
 
         if (!predicates.isEmpty()) {
@@ -159,14 +159,14 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
         }
     }
 
-    protected void applyPredicatesFromFilterMetaMap(Class<T> entityClass, Map<String, FilterMeta> filterBy, CriteriaBuilder cb,
-                                                      CriteriaQuery<?> cq,
-                                                      Root<T> root, List<Predicate>predicates) {
+    protected void applyFiltersFromFilterMeta(Class<T> entityClass, Collection<FilterMeta> filterBy, CriteriaBuilder cb,
+                                              CriteriaQuery<?> cq,
+                                              Root<T> root, List<Predicate>predicates) {
         if (filterBy != null) {
             FacesContext context = FacesContext.getCurrentInstance();
             Locale locale = LocaleUtils.getCurrentLocale(context);
             PropertyDescriptorResolver propResolver = PrimeApplicationContext.getCurrentInstance(context).getPropertyDescriptorResolver();
-            for (FilterMeta filter : filterBy.values()) {
+            for (FilterMeta filter : filterBy) {
                 if (filter.getField() == null || filter.getFilterValue() == null || filter.isGlobalFilter()) {
                     continue;
                 }
@@ -518,6 +518,6 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
     @FunctionalInterface
     public interface AdditionalFilterMeta extends Serializable {
 
-        Map<String, FilterMeta> process();
+        Collection<FilterMeta> process();
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -81,6 +81,7 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
     protected Class<?> rowKeyType;
     protected QueryEnricher<T> queryEnricher;
     protected FilterEnricher<T> filterEnricher;
+    protected AdditionalFilterMeta additionalFilterMeta;
     protected SortEnricher<T> sortEnricher;
     protected Callbacks.SerializableSupplier<EntityManager> entityManager;
     protected Callbacks.SerializableFunction<T, Object> rowKeyProvider;
@@ -146,6 +147,10 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
         if (filterEnricher != null) {
             filterEnricher.enrich(filterBy, cb, cq, root, predicates);
+        }
+
+        if (additionalFilterMeta != null) {
+            applyPredicatesFromFilterMetaMap(entityClass, additionalFilterMeta.process(), cb, cq, root, predicates);
         }
 
         if (!predicates.isEmpty()) {
@@ -407,6 +412,11 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
             return this;
         }
 
+        public Builder<T> additionalFilterMeta(AdditionalFilterMeta additionalFilterMeta) {
+            model.additionalFilterMeta = additionalFilterMeta;
+            return this;
+        }
+
         public Builder<T> sortEnricher(SortEnricher<T> sortEnricher) {
             model.sortEnricher = sortEnricher;
             return this;
@@ -503,5 +513,11 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
     public interface FilterEnricher<T> extends Serializable {
 
         void enrich(Map<String, FilterMeta> filterBy, CriteriaBuilder cb, CriteriaQuery<?> cq, Root<T> root, List<Predicate> predicates);
+    }
+
+    @FunctionalInterface
+    public interface AdditionalFilterMeta extends Serializable {
+
+        Map<String, FilterMeta> process();
     }
 }

--- a/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/JPALazyDataModel.java
@@ -142,6 +142,21 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
 
         List<Predicate> predicates = new ArrayList<>();
 
+        applyPredicatesFromFilterMetaMap(entityClass, filterBy, cb, cq, root, predicates);
+
+        if (filterEnricher != null) {
+            filterEnricher.enrich(filterBy, cb, cq, root, predicates);
+        }
+
+        if (!predicates.isEmpty()) {
+            cq.where(
+                cb.and(predicates.toArray(new Predicate[0])));
+        }
+    }
+
+    protected void applyPredicatesFromFilterMetaMap(Class<T> entityClass, Map<String, FilterMeta> filterBy, CriteriaBuilder cb,
+                                                      CriteriaQuery<?> cq,
+                                                      Root<T> root, List<Predicate>predicates) {
         if (filterBy != null) {
             FacesContext context = FacesContext.getCurrentInstance();
             Locale locale = LocaleUtils.getCurrentLocale(context);
@@ -168,15 +183,6 @@ public class JPALazyDataModel<T> extends LazyDataModel<T> implements Serializabl
                 Predicate predicate = createPredicate(filter, pd, root, cb, fieldExpression, convertedFilterValue, locale);
                 predicates.add(predicate);
             }
-        }
-
-        if (filterEnricher != null) {
-            filterEnricher.enrich(filterBy, cb, cq, root, predicates);
-        }
-
-        if (!predicates.isEmpty()) {
-            cq.where(
-                cb.and(predicates.toArray(new Predicate[0])));
         }
     }
 


### PR DESCRIPTION
Fix #12864

This PR introduces an enhancement to the `JPALazyDataModel` class, allowing developers to apply custom predicates within the `filterEnricher` by leveraging the existing `createPredicate` method. With this change, users can pass a custom `FilterMeta` map directly into the `filterEnricher`, enabling flexible and reusable predicate creation for dynamic filtering.

```java
JPALazyDataModel.<MyEntity>builder()
        .entityClass(MyEntity.class)
        .entityManager(() -> entityManager)
         .filterEnricher((myFilterMetaMap, cb, cq, root, predicates, createPredicateFunc) -> {
                createPredicateFunc.apply(myFilterMetaMap);
              // Custom enrichment logic here, if any
            })
            .build();
```