### PR TITLE
Fix #12855: 14.0.7 HeadRenderer check for already loaded resource

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -35,6 +35,7 @@ import javax.el.ValueExpression;
 import javax.faces.FacesException;
 import javax.faces.application.ProjectStage;
 import javax.faces.application.Resource;
+import javax.faces.application.ResourceHandler;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.ExternalContext;
@@ -171,10 +172,16 @@ public class HeadRenderer extends Renderer {
     }
 
     protected void encodeCSS(FacesContext context, String library, String resource) throws IOException {
+        ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
+        if (resourceHandler.isResourceRendered(context, resource, library)) {
+            // resource already rendered, skip
+            return;
+        }
+
         ResponseWriter writer = context.getResponseWriter();
         ExternalContext externalContext = context.getExternalContext();
 
-        Resource cssResource = context.getApplication().getResourceHandler().createResource(resource, library);
+        Resource cssResource = resourceHandler.createResource(resource, library);
         if (cssResource == null) {
             throw new FacesException("Error loading CSS, cannot find \"" + resource + "\" resource of \"" + library + "\" library");
         }
@@ -188,9 +195,15 @@ public class HeadRenderer extends Renderer {
     }
 
     protected void encodeJS(FacesContext context, String library, String script) throws IOException {
+        ResourceHandler resourceHandler = context.getApplication().getResourceHandler();
+        if (resourceHandler.isResourceRendered(context, script, library)) {
+            // resource already rendered, skip
+            return;
+        }
+
         ResponseWriter writer = context.getResponseWriter();
         ExternalContext externalContext = context.getExternalContext();
-        Resource resource = context.getApplication().getResourceHandler().createResource(script, library);
+        Resource resource = resourceHandler.createResource(script, library);
 
         if (resource == null) {
             throw new FacesException("Error loading JavaScript, cannot find \"" + script + "\" resource of \"" + library + "\" library");


### PR DESCRIPTION
Fix #12855: 14.0.7 HeadRenderer check for already loaded resource