### PR TITLE
Fix #12008: CascadeSelect do not register scrollhandler for large lists

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
@@ -251,9 +251,12 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.DynamicOverlayWidget.extend(
             $this.handleViewportChange();
         });
 
-        this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.handleViewportChange();
-        });
+        // #12008 - Only register scroll handler if there is a small number of items
+        if (this.items.length < 10) {
+            this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
+                $this.handleViewportChange();
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
Fix #12008: CascadeSelect do not register scrollhandler for large lists

Hey guys I tried to add a `max-height` and `overflow: scroll` so the panel would scroll but it then breaks the submenu rendering. This component would need to be changed significantly so for now I am doing what SelectCheckBoxMenu does...

https://github.com/primefaces/primefaces/blob/08d5fe0d93e7ad1c068b7a848f8bbb017542823f/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectcheckboxmenu.js#L220-L222

If there are more than 10 items I will disable this scroll handler automatically.