### PR TITLE
Fix #12008: 14.0.7 CascadeSelect do not register scrollhandler for large lists

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.cascadeselect.js
@@ -251,9 +251,12 @@ PrimeFaces.widget.CascadeSelect = PrimeFaces.widget.DynamicOverlayWidget.extend(
             $this.handleViewportChange();
         });
 
-        this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
-            $this.handleViewportChange();
-        });
+        // #12008 - Only register scroll handler if there is a small number of items
+        if (this.items.length < 10) {
+            this.scrollHandler = PrimeFaces.utils.registerConnectedOverlayScrollHandler(this, 'scroll.' + this.id + '_hide', this.jq, function() {
+                $this.handleViewportChange();
+            });
+        }
     },
 
     /**


### PR DESCRIPTION
Fix #12008: 14.0.7 CascadeSelect do not register scrollhandler for large lists