### PR TITLE
Fix #12891: 14.0.8 Revert datatable CSS border-collapse

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -1,6 +1,7 @@
 .ui-datatable table {
     width: 100%;
     table-layout: fixed;
+    border-collapse: collapse;
 }
 
 .ui-datatable-tablewrapper {


### PR DESCRIPTION
Fix #12891: Revert datatable CSS border-collapse
Fix #12819 

cc @stolp 