### PR TITLE
Fix #12819: Datatable proper CSS for outline cells

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -164,6 +164,7 @@
   outline: var(--primary-color, #90caf9);
   outline-style: solid;
   outline-width: 2px;
+  outline-offset: -2px;
   border: none;
 }
 


### PR DESCRIPTION
Fix #12819: Datatable proper CSS for outline cells