### PR TITLE
Fix #12819: 14.0.8 Datatable proper CSS for outline cells

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -165,6 +165,7 @@
   outline: var(--primary-color, #90caf9);
   outline-style: solid;
   outline-width: 2px;
+  outline-offset: -2px;
   border: none;
 }
 


### PR DESCRIPTION
Fix #12819: 14.0.8 Datatable proper CSS for outline cells