### PR TITLE
Fix #12887: Widget callBehavior fall back to DOM `on` if no behaviors

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -84,8 +84,6 @@ public class InputTextRenderer extends InputRenderer {
             }
         }
 
-        encodeClientBehaviors(context, inputText);
-
         wb.finish();
     }
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -505,6 +505,10 @@ if (!PrimeFaces.widget) {
             if(this.hasBehavior(event)) {
                 this.cfg.behaviors[event].call(this, ext);
             }
+            else if (this.cfg.behaviors === undefined && this.jq.length > 0) {
+                // #12887 if no behavior is defined, try to call the DOM event
+                this.jq.trigger(event, ext);
+            }
         },
 
         /**


### PR DESCRIPTION
Fix #12887: Widget callBehavior fall back to DOM `on` if no behaviors

@tandraschko this works if NO behaviors found we check the `this.jq` for an `on` event and call it if found.