### PR TITLE
Fix #12887: 14.0.8 Widget callBehavior fall back to DOM `on` if no behaviors

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputtext/InputTextRenderer.java
@@ -84,8 +84,6 @@ public class InputTextRenderer extends InputRenderer {
             }
         }
 
-        encodeClientBehaviors(context, inputText);
-
         wb.finish();
     }
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.widget.js
@@ -499,6 +499,10 @@ if (!PrimeFaces.widget) {
             if(this.hasBehavior(event)) {
                 this.cfg.behaviors[event].call(this, ext);
             }
+            else if (this.cfg.behaviors === undefined && this.jq.length > 0) {
+                // #12887 if no behavior is defined, try to call the DOM event
+                this.jq.trigger(event, ext);
+            }
         },
 
         /**


### PR DESCRIPTION
Fix #12887: 14.0.8 Widget callBehavior fall back to DOM `on` if no behaviors