### PR TITLE
Fix ##12908: 14.0.8 Datatable scrollable height must be 0px

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.css
@@ -131,7 +131,7 @@
 }
 
 .ui-datatable-scrollable-theadclone th.ui-state-default {
-    height:0px;
+    height:0px !important; /* #12908 */
     border-bottom-width: 0px;
     border-top-width: 0px;
     padding-top: 0px;


### PR DESCRIPTION
Fix ##12908: 14.0.8 Datatable scrollable height must be 0px