### PR TITLE
Fix #12949: HeadRenderer use resources not links

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/core/head/CoreHead003.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/core/head/CoreHead003.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.head;
+
+import java.io.Serializable;
+
+import javax.annotation.PostConstruct;
+import javax.faces.view.ViewScoped;
+import javax.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class CoreHead003 implements Serializable {
+
+    private static final long serialVersionUID = 8797995450720503195L;
+
+    private boolean visible;
+
+    @PostConstruct
+    public void init() {
+        visible = false;
+    }
+
+    public void doShow() {
+        visible = true;
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/WEB-INF/web.xml
+++ b/primefaces-integration-tests/src/main/webapp/WEB-INF/web.xml
@@ -27,10 +27,6 @@
         <param-value>${primefaces.THEME}</param-value>
     </context-param>
     <context-param>
-        <param-name>primefaces.FONT_AWESOME</param-name>
-        <param-value>true</param-value>
-    </context-param>
-    <context-param>
         <param-name>primefaces.MOVE_SCRIPTS_TO_BOTTOM</param-name>
         <param-value>true</param-value>
     </context-param>

--- a/primefaces-integration-tests/src/main/webapp/core/head/head001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head001.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head id="head">
+         <f:facet name="first">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        </f:facet>
+        <f:facet name="last">
+            <meta name="apple-mobile-web-app-capable" content="yes"/>
+        </f:facet>
+        <title>PrimeFaces Selenium</title>
+
+        <h:outputScript name="jquery/jquery.js" library="primefaces"/> <!-- duplicate  -->
+        <h:outputScript name="jquery/jquery-plugins.js" library="primefaces"/> <!-- duplicate  -->
+        <h:outputScript id="jquery" name="jquery/jquery.js" library="primefaces"/> <!-- duplicate  -->
+        <h:outputScript id="jquery-ui" name="jquery/jquery-plugins.js" library="primefaces"/> <!-- duplicate  -->
+        <h:outputScript name="locales/locale-fr.js" library="primefaces"/> <!-- check order -->
+    </h:head>
+    <h:body>
+        <h:outputScript name="locales/locale-de.js" library="primefaces" target="head"/> <!-- added to head from body -->
+        <h:form id="form">
+            <p:datePicker /> 
+        </h:form>
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/core/head/head002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head002.xhtml
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head id="head">
+         <f:facet name="first">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        </f:facet>
+        <f:facet name="last">
+            <meta name="apple-mobile-web-app-capable" content="yes"/>
+        </f:facet>
+        <title>PrimeFaces Selenium</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+            <p:chart style="width: 100%; height: 500px;"> <!-- was loading moment.js twice on page load-->
+                <f:facet name="value">
+                {
+                  type: 'bar',
+                  data: {
+                    labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+                    datasets: [{
+                      label: '# of Votes',
+                      data: [12, 19, 3, 5, 2, 3],
+                      borderWidth: 1,
+                      backgroundColor: ['DarkRed', 'CornflowerBlue', 'Gold', 'Lime', 'BlueViolet', 'DarkOrange']
+                    }]
+                  },
+                  options: {
+                    scales: {
+                      y: {
+                        beginAtZero: true
+                      }
+                    }
+                  }
+                }
+                </f:facet>
+     </p:chart>
+        </h:form>
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/core/head/head003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head003.xhtml
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head id="head">
+         <f:facet name="first">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        </f:facet>
+        <f:facet name="last">
+            <meta name="apple-mobile-web-app-capable" content="yes"/>
+        </f:facet>
+        <title>PrimeFaces Selenium</title>
+    </h:head>
+    <h:body>
+        <h:form id="form">
+          <c:if test="#{coreHead003.visible}">
+            <p:chart style="width: 100%; height: 500px;"> <!-- was loading moment.js twice on component load-->
+            <f:facet name="value">
+            {
+              type: 'bar',
+              data: {
+                labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+                datasets: [{
+                  label: '# of Votes',
+                  data: [12, 19, 3, 5, 2, 3],
+                  borderWidth: 1,
+                  backgroundColor: ['DarkRed', 'CornflowerBlue', 'Gold', 'Lime', 'BlueViolet', 'DarkOrange']
+                }]
+              },
+              options: {
+                scales: {
+                  y: {
+                    beginAtZero: true
+                  }
+                }
+              }
+                }
+                </f:facet>
+            </p:chart>
+          </c:if>
+          <p:commandButton id="button" actionListener="#{coreHead003.doShow()}" update="@form" />
+            
+        </h:form>
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
@@ -97,17 +97,16 @@ public class CoreHead001Test extends AbstractPrimePageTest {
         // Scripts in order
         assertEquals(11, scriptElements.size());
         assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
-
-        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
-        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
         assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
         assertTrue(scriptElements.get(4).getDomAttribute("src").contains("inputmask/inputmask.js"));
         assertTrue(scriptElements.get(5).getDomAttribute("src").contains("datepicker/datepicker.js"));
         assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-de.js"));
-        assertTrue(scriptElements.get(7).getDomAttribute("src").contains("locales/locale-fr.js"));
-        assertTrue(scriptElements.get(8).getDomAttribute("src").contains("moment/moment.js"));
-        assertTrue(scriptElements.get(9).getDomAttribute("src").contains("validation/validation.bv.js"));
-        assertTrue(scriptElements.get(10).getDomAttribute("src").contains("locales/locale-en.js"));
+        assertTrue(scriptElements.get(7).getDomAttribute("src").contains("moment/moment.js"));
+        assertTrue(scriptElements.get(8).getDomAttribute("src").contains("validation/validation.bv.js"));
+        assertTrue(scriptElements.get(9).getDomAttribute("src").contains("locales/locale-en.js"));
+        assertTrue(scriptElements.get(10).getDomAttribute("src").contains("locales/locale-fr.js"));
         assertNoJavascriptErrors();
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.head;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoreHead001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Core: HeadRenderer ensure order of scripts and prevent duplicates")
+    void headRendererOrdering(Page page) {
+        // Arrange
+        WebElement head = page.head;
+        WebElement body = page.body;
+        List<WebElement> headElements = head.findElements(By.tagName("*"));
+        List<WebElement> scriptElements = body.findElements(By.tagName("script"));
+
+        // Act & Assert
+
+        // <f:facet name="first">
+        WebElement viewportMeta = headElements.get(0);
+        assertEquals(viewportMeta.getTagName(), "meta");
+        assertEquals(viewportMeta.getDomAttribute("name"), "viewport");
+        assertEquals(viewportMeta.getDomAttribute("content"), "width=device-width, initial-scale=1.0");
+
+        // CSS in order
+        WebElement themeCss = headElements.get(1);
+        assertEquals(themeCss.getTagName(), "link");
+        assertTrue(themeCss.getDomAttribute("href").contains("theme.css"));
+
+        WebElement primeiconsCss = headElements.get(2);
+        assertEquals(primeiconsCss.getTagName(), "link");
+        assertTrue(primeiconsCss.getDomAttribute("href").contains("primeicons.css"));
+
+        WebElement componentsCss = headElements.get(3);
+        assertEquals(componentsCss.getTagName(), "link");
+        assertTrue(componentsCss.getDomAttribute("href").contains("components.css"));
+
+        // Title
+        WebElement titleTag =  headElements.get(4);
+        assertEquals(titleTag.getTagName(), "title");
+
+        // <f:facet name="last">
+        WebElement webMeta = headElements.get(5);
+        assertEquals(webMeta.getTagName(), "meta");
+        assertEquals(webMeta.getDomAttribute("name"), "apple-mobile-web-app-capable");
+        assertEquals(webMeta.getDomAttribute("content"), "yes");
+
+        // Scripts in order
+        assertEquals(11, scriptElements.size());
+        assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
+        assertTrue(scriptElements.get(4).getDomAttribute("src").contains("inputmask/inputmask.js"));
+        assertTrue(scriptElements.get(5).getDomAttribute("src").contains("datepicker/datepicker.js"));
+        assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-de.js"));
+        assertTrue(scriptElements.get(7).getDomAttribute("src").contains("moment/moment.js"));
+        assertTrue(scriptElements.get(8).getDomAttribute("src").contains("validation/validation.bv.js"));
+        assertTrue(scriptElements.get(9).getDomAttribute("src").contains("locales/locale-en.js"));
+        assertTrue(scriptElements.get(10).getDomAttribute("src").contains("locales/locale-fr.js"));
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(tagName = "head")
+        WebElement head;
+
+        @FindBy(tagName = "body")
+        WebElement body;
+
+        @Override
+        public String getLocation() {
+            return "core/head/head001.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
@@ -48,9 +48,22 @@ public class CoreHead001Test extends AbstractPrimePageTest {
         WebElement head = page.head;
         WebElement body = page.body;
         List<WebElement> headElements = head.findElements(By.tagName("*"));
+        List<WebElement> headScriptElements = head.findElements(By.tagName("script"));
         List<WebElement> scriptElements = body.findElements(By.tagName("script"));
 
         // Act & Assert
+        System.out.println("Head sources: " + headElements.size());
+        for (WebElement elem : headElements) {
+            System.out.println(elem.getTagName() + " " + elem.getDomAttribute("href"));
+        }
+        System.out.println("Head Script sources: " + headScriptElements.size());
+        for (WebElement script : headScriptElements) {
+            System.out.println(script.getDomAttribute("href"));
+        }
+        System.out.println("Body Script sources: " + scriptElements.size());
+        for (WebElement script : scriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
 
         // <f:facet name="first">
         WebElement viewportMeta = headElements.get(0);
@@ -84,16 +97,17 @@ public class CoreHead001Test extends AbstractPrimePageTest {
         // Scripts in order
         assertEquals(11, scriptElements.size());
         assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
-        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
-        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
+
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
         assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
         assertTrue(scriptElements.get(4).getDomAttribute("src").contains("inputmask/inputmask.js"));
         assertTrue(scriptElements.get(5).getDomAttribute("src").contains("datepicker/datepicker.js"));
         assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-de.js"));
-        assertTrue(scriptElements.get(7).getDomAttribute("src").contains("moment/moment.js"));
-        assertTrue(scriptElements.get(8).getDomAttribute("src").contains("validation/validation.bv.js"));
-        assertTrue(scriptElements.get(9).getDomAttribute("src").contains("locales/locale-en.js"));
-        assertTrue(scriptElements.get(10).getDomAttribute("src").contains("locales/locale-fr.js"));
+        assertTrue(scriptElements.get(7).getDomAttribute("src").contains("locales/locale-fr.js"));
+        assertTrue(scriptElements.get(8).getDomAttribute("src").contains("moment/moment.js"));
+        assertTrue(scriptElements.get(9).getDomAttribute("src").contains("validation/validation.bv.js"));
+        assertTrue(scriptElements.get(10).getDomAttribute("src").contains("locales/locale-en.js"));
         assertNoJavascriptErrors();
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.head;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoreHead002Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Core: HeadRenderer ensure moment.js is not loaded twice on page load")
+    void headRendererInitalPageLoad(Page page) {
+        // Arrange
+        WebElement head = page.head;
+        WebElement body = page.body;
+        List<WebElement> headElements = head.findElements(By.tagName("*"));
+        List<WebElement> scriptElements = body.findElements(By.tagName("script"));
+
+        // Act & Assert
+        assertEquals(6, headElements.size());
+        // <f:facet name="first">
+        WebElement viewportMeta = headElements.get(0);
+        assertEquals("meta", viewportMeta.getTagName());
+        assertEquals("viewport", viewportMeta.getDomAttribute("name"));
+        assertEquals("width=device-width, initial-scale=1.0", viewportMeta.getDomAttribute("content"));
+
+        // CSS in order
+        WebElement themeCss = headElements.get(1);
+        assertEquals("link", themeCss.getTagName());
+        assertTrue(themeCss.getDomAttribute("href").contains("theme.css"));
+
+        WebElement primeiconsCss = headElements.get(2);
+        assertEquals("link", primeiconsCss.getTagName());
+        assertTrue(primeiconsCss.getDomAttribute("href").contains("primeicons.css"));
+
+        // Title
+        WebElement titleTag = headElements.get(3);
+        assertEquals("title", titleTag.getTagName());
+
+
+        // <f:facet name="last">
+        WebElement webMeta = headElements.get(4);
+        assertEquals("meta", webMeta.getTagName());
+        assertEquals("apple-mobile-web-app-capable", webMeta.getDomAttribute("name"));
+        assertEquals("yes", webMeta.getDomAttribute("content"));
+
+        // Scripts in order
+        assertEquals(7, scriptElements.size());
+        assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("components.js"));
+        assertTrue(scriptElements.get(3).getDomAttribute("src").contains("moment/moment.js"));
+        assertTrue(scriptElements.get(4).getDomAttribute("src").contains("chart/chart.js"));
+        assertTrue(scriptElements.get(5).getDomAttribute("src").contains("validation/validation.bv.js"));
+        assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-en.js"));
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(tagName = "head")
+        WebElement head;
+
+        @FindBy(tagName = "body")
+        WebElement body;
+
+        @Override
+        public String getLocation() {
+            return "core/head/head002.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
@@ -48,7 +48,21 @@ public class CoreHead002Test extends AbstractPrimePageTest {
         WebElement head = page.head;
         WebElement body = page.body;
         List<WebElement> headElements = head.findElements(By.tagName("*"));
+        List<WebElement> headScriptElements = head.findElements(By.tagName("script"));
         List<WebElement> scriptElements = body.findElements(By.tagName("script"));
+
+        System.out.println("Head sources: " + headElements.size());
+        for (WebElement elem : headElements) {
+            System.out.println(elem.getTagName() + " " + elem.getDomAttribute("href"));
+        }
+        System.out.println("Head Script sources: " + headScriptElements.size());
+        for (WebElement script : headScriptElements) {
+            System.out.println(script.getDomAttribute("href"));
+        }
+        System.out.println("Body Script sources: " + scriptElements.size());
+        for (WebElement script : scriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
 
         // Act & Assert
         assertEquals(6, headElements.size());
@@ -80,6 +94,7 @@ public class CoreHead002Test extends AbstractPrimePageTest {
 
         // Scripts in order
         assertEquals(7, scriptElements.size());
+
         assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
         assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
         assertTrue(scriptElements.get(2).getDomAttribute("src").contains("components.js"));
@@ -87,6 +102,7 @@ public class CoreHead002Test extends AbstractPrimePageTest {
         assertTrue(scriptElements.get(4).getDomAttribute("src").contains("chart/chart.js"));
         assertTrue(scriptElements.get(5).getDomAttribute("src").contains("validation/validation.bv.js"));
         assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-en.js"));
+
         assertNoJavascriptErrors();
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.core.head;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoreHead003Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Core: HeadRenderer ensure moment.js is not loaded twice on component load")
+    void headRendererOnDynamicComponentLoad(Page page) {
+        // Arrange
+        WebElement head = page.head;
+        WebElement body = page.body;
+
+        // Chart.js is not included on page load because the component doesn't exist
+        // Moment.js is included on page load because of CSV enabled
+        boolean isChartJsIncluded = false;
+        assertHeader(head, body, isChartJsIncluded);
+
+        // Act
+        page.button.click();
+
+        // Assert
+        // Chart.js is included on page load because the component exists
+        // Moment.js is not duplicated because it's already loaded
+        isChartJsIncluded = true;
+        assertHeader(head, body, isChartJsIncluded);
+    }
+
+    private void assertHeader(WebElement head, WebElement body, boolean isChartJsIncluded) {
+        List<WebElement> headElements = head.findElements(By.tagName("*"));
+        List<WebElement> headScriptElements = head.findElements(By.tagName("script"));
+        List<WebElement> scriptElements = body.findElements(By.tagName("script"));
+        int expectedHeadElementsSize = isChartJsIncluded ? 8 : 7;
+        assertEquals(expectedHeadElementsSize, headElements.size(), "Header elements not expected size");
+
+        // <f:facet name="first">
+        WebElement viewportMeta = headElements.get(0);
+        assertEquals("meta", viewportMeta.getTagName());
+        assertEquals("viewport", viewportMeta.getDomAttribute("name"));
+        assertEquals("width=device-width, initial-scale=1.0", viewportMeta.getDomAttribute("content"));
+
+        // CSS in order
+        WebElement themeCss = headElements.get(1);
+        assertEquals("link", themeCss.getTagName());
+        assertTrue(themeCss.getDomAttribute("href").contains("theme.css"));
+
+        WebElement primeiconsCss = headElements.get(2);
+        assertEquals("link", primeiconsCss.getTagName());
+        assertTrue(primeiconsCss.getDomAttribute("href").contains("primeicons.css"));
+
+        WebElement componentsCss = headElements.get(3);
+        assertEquals(componentsCss.getTagName(), "link");
+        assertTrue(componentsCss.getDomAttribute("href").contains("components.css"));
+
+        // Title
+        WebElement titleTag = headElements.get(4);
+        assertEquals("title", titleTag.getTagName());
+
+         // <f:facet name="last">
+        WebElement webMeta = headElements.get(5);
+        assertEquals(webMeta.getTagName(), "meta");
+        assertEquals(webMeta.getDomAttribute("name"), "apple-mobile-web-app-capable");
+        assertEquals(webMeta.getDomAttribute("content"), "yes");
+
+        WebElement inlineStyle = headElements.get(6);
+        assertEquals("style", inlineStyle.getTagName());
+
+        if (isChartJsIncluded) {
+            WebElement chartJs = headElements.get(7);
+            assertEquals("script", chartJs.getTagName());
+            assertTrue(chartJs.getDomAttribute("src").contains("chart/chart.js"));
+        }
+
+        // Scripts in order
+        System.out.println("Head Script sources: " + headScriptElements.size());
+        for (WebElement script : headScriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
+        System.out.println("Body Script sources: " + scriptElements.size());
+        for (WebElement script : scriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
+        assertTrue(scriptElements.size() >= 7, "Script elements not expected size");
+        assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
+        assertTrue(scriptElements.get(4).getDomAttribute("src").contains("moment/moment.js"));
+        assertTrue(scriptElements.get(5).getDomAttribute("src").contains("validation/validation.bv.js"));
+        assertTrue(scriptElements.get(6).getDomAttribute("src").contains("locales/locale-en.js"));
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(tagName = "head")
+        WebElement head;
+
+        @FindBy(tagName = "body")
+        WebElement body;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "core/head/head003.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
@@ -68,6 +68,19 @@ public class CoreHead003Test extends AbstractPrimePageTest {
         List<WebElement> headElements = head.findElements(By.tagName("*"));
         List<WebElement> headScriptElements = head.findElements(By.tagName("script"));
         List<WebElement> scriptElements = body.findElements(By.tagName("script"));
+
+        System.out.println("Head sources: " + headElements.size());
+        for (WebElement elem : headElements) {
+            System.out.println(elem.getTagName() + " " + elem.getDomAttribute("href"));
+        }
+        System.out.println("Head Script sources: " + headScriptElements.size());
+        for (WebElement script : headScriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
+        System.out.println("Body Script sources: " + scriptElements.size());
+        for (WebElement script : scriptElements) {
+            System.out.println(script.getDomAttribute("src"));
+        }
         int expectedHeadElementsSize = isChartJsIncluded ? 8 : 7;
         assertEquals(expectedHeadElementsSize, headElements.size(), "Header elements not expected size");
 
@@ -110,18 +123,10 @@ public class CoreHead003Test extends AbstractPrimePageTest {
         }
 
         // Scripts in order
-        System.out.println("Head Script sources: " + headScriptElements.size());
-        for (WebElement script : headScriptElements) {
-            System.out.println(script.getDomAttribute("src"));
-        }
-        System.out.println("Body Script sources: " + scriptElements.size());
-        for (WebElement script : scriptElements) {
-            System.out.println(script.getDomAttribute("src"));
-        }
         assertTrue(scriptElements.size() >= 7, "Script elements not expected size");
         assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
-        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
-        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
         assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
         assertTrue(scriptElements.get(4).getDomAttribute("src").contains("moment/moment.js"));
         assertTrue(scriptElements.get(5).getDomAttribute("src").contains("validation/validation.bv.js"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
@@ -125,8 +125,8 @@ public class CoreHead003Test extends AbstractPrimePageTest {
         // Scripts in order
         assertTrue(scriptElements.size() >= 7, "Script elements not expected size");
         assertTrue(scriptElements.get(0).getDomAttribute("src").contains("jquery/jquery.js"));
-        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("core.js"));
-        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(1).getDomAttribute("src").contains("jquery/jquery-plugins.js"));
+        assertTrue(scriptElements.get(2).getDomAttribute("src").contains("core.js"));
         assertTrue(scriptElements.get(3).getDomAttribute("src").contains("components.js"));
         assertTrue(scriptElements.get(4).getDomAttribute("src").contains("moment/moment.js"));
         assertTrue(scriptElements.get(5).getDomAttribute("src").contains("validation/validation.bv.js"));

--- a/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
@@ -28,9 +28,9 @@
         <h:outputStylesheet name="css/primeflex3.css" library="showcase"/><!-- latest primeflex -->
         <h:outputStylesheet name="css/flags/flags.css" library="showcase"/>
 
-        <h:outputScript name="jquery/jquery.js" library="primefaces"/>
-        <h:outputScript name="jquery/jquery-plugins.js" library="primefaces"/>
-        <h:outputScript name="locales/locale-#{app.locale.language}.js" library="primefaces"/>
+        <h:outputScript name="jquery/jquery.js" library="primefaces" target="head"/>
+        <h:outputScript name="jquery/jquery-plugins.js" library="primefaces" target="head"/>
+        <h:outputScript name="locales/locale-#{app.locale.language}.js" library="primefaces" target="head"/>
 
         <ui:insert name="head"/>
         

--- a/primefaces/src/main/java/org/primefaces/application/resource/HeadResourceProcessor.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/HeadResourceProcessor.java
@@ -1,0 +1,182 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2024 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.application.resource;
+
+import org.primefaces.config.PrimeConfiguration;
+import org.primefaces.context.PrimeApplicationContext;
+import org.primefaces.context.PrimeRequestContext;
+import org.primefaces.util.Constants;
+import org.primefaces.util.LocaleUtils;
+import org.primefaces.util.MapBuilder;
+import org.primefaces.util.ResourceUtils;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.el.ELContext;
+import javax.el.ExpressionFactory;
+import javax.el.ValueExpression;
+import javax.faces.FacesException;
+import javax.faces.application.ProjectStage;
+import javax.faces.context.FacesContext;
+import javax.faces.event.PhaseEvent;
+import javax.faces.event.PhaseId;
+import javax.faces.event.PhaseListener;
+
+/**
+ * PhaseListener implementation that processes and adds required PrimeFaces resources to the head section during the RENDER_RESPONSE phase.
+ * This ensures core resources like themes, icons, and validation/localization scripts are added before component-specific resources.
+ *
+ * @since 15.0.0
+ */
+public class HeadResourceProcessor implements PhaseListener {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(HeadResourceProcessor.class.getName());
+    private static final Map<String, String> THEME_MAPPING = MapBuilder.<String, String>builder()
+            .put("saga", "saga-blue")
+            .put("arya", "arya-blue")
+            .put("vela", "vela-blue")
+            .build();
+
+    @Override
+    public PhaseId getPhaseId() {
+        return PhaseId.RENDER_RESPONSE;
+    }
+
+    @Override
+    public void beforePhase(PhaseEvent event) {
+        FacesContext context = event.getFacesContext();
+
+        /*
+         * Check if this is an AJAX request by checking postback or partial view context.
+         * For AJAX requests, we skip loading core resources since they should already be loaded.
+         */
+        if (context.getPartialViewContext().isAjaxRequest()) {
+            return;
+        }
+
+        PrimeRequestContext requestContext = PrimeRequestContext.getCurrentInstance(context);
+        PrimeApplicationContext applicationContext = requestContext.getApplicationContext();
+        PrimeConfiguration configuration = applicationContext.getConfig();
+
+        //Theme
+        String theme;
+        String themeParamValue = applicationContext.getConfig().getTheme();
+
+        if (themeParamValue != null) {
+            ELContext elContext = context.getELContext();
+            ExpressionFactory expressionFactory = context.getApplication().getExpressionFactory();
+            ValueExpression ve = expressionFactory.createValueExpression(elContext, themeParamValue, String.class);
+
+            theme = (String) ve.getValue(elContext);
+        }
+        else {
+            theme = "saga-blue";     //default
+        }
+
+        if (theme != null && !"none".equals(theme)) {
+            if (THEME_MAPPING.containsKey(theme)) {
+                theme = THEME_MAPPING.get(theme);
+            }
+
+            ResourceUtils.addStyleSheetResource(context, Constants.LIBRARY + "-" + theme, "theme.css");
+        }
+
+        // Icons
+        if (configuration.isPrimeIconsEnabled()) {
+            ResourceUtils.addStyleSheetResource(context, "primeicons/primeicons.css");
+        }
+
+        /*
+         * Core resources (jQuery + core.js) are only needed for non-AJAX requests when validation
+         * or localization is enabled. This prevents duplicate loading of resources and optimizes
+         * page load time.
+         */
+        if (configuration.isClientSideValidationEnabled() || configuration.isClientSideLocalizationEnabled()) {
+            /*
+             * jQuery must be loaded before core.js and any validation/localization resources
+             * to ensure proper dependency loading order
+             */
+            ResourceUtils.addJavascriptResource(context, "jquery/jquery.js");
+            ResourceUtils.addJavascriptResource(context, "core.js");
+        }
+
+        /*
+         * For non-AJAX requests, load validation and localization resources if configured.
+         * These depend on core resources being loaded first to function properly.
+         */
+        encodeValidationResources(context, configuration);
+        encodeLocalizationResources(context, configuration);
+    }
+
+    @Override
+    public void afterPhase(PhaseEvent event) {
+       // no-op
+    }
+
+    /**
+     * Encodes validation resources if client side validation is enabled.
+     * Adds moment.js for date validation and bean validation resources if enabled.
+     *
+     * @param context The FacesContext instance
+     * @param configuration The PrimeConfiguration instance containing validation settings
+     */
+    protected void encodeValidationResources(FacesContext context, PrimeConfiguration configuration) {
+        if (configuration.isClientSideValidationEnabled()) {
+            // moment is needed for Date validation
+            ResourceUtils.addJavascriptResourceToBody(context,  "moment/moment.js");
+
+            // BV CSV is optional and must be enabled by config
+            if (configuration.isBeanValidationEnabled()) {
+                ResourceUtils.addJavascriptResourceToBody(context, "validation/validation.bv.js");
+            }
+        }
+    }
+
+    /**
+     * Encodes localization resources if client side localization is enabled.
+     * Attempts to load the appropriate locale JavaScript file based on the current locale.
+     * Logs a warning in Development stage if locale file fails to load.
+     *
+     * @param context The FacesContext instance
+     * @param configuration The PrimeConfiguration instance containing localization settings
+     */
+    private void encodeLocalizationResources(FacesContext context, PrimeConfiguration configuration) {
+        if (configuration.isClientSideLocalizationEnabled()) {
+            try {
+                Locale locale = LocaleUtils.getCurrentLocale(context);
+                ResourceUtils.addJavascriptResourceToBody(context, "locales/locale-" + locale.getLanguage() + ".js");
+            }
+            catch (FacesException e) {
+                if (context.isProjectStage(ProjectStage.Development)) {
+                    LOGGER.log(Level.WARNING,
+                                "Failed to load client side locale.js. {0}", e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/application/resource/HeadResourceProcessor.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/HeadResourceProcessor.java
@@ -27,20 +27,14 @@ import org.primefaces.config.PrimeConfiguration;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.Constants;
-import org.primefaces.util.LocaleUtils;
 import org.primefaces.util.MapBuilder;
 import org.primefaces.util.ResourceUtils;
 
-import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.el.ELContext;
 import javax.el.ExpressionFactory;
 import javax.el.ValueExpression;
-import javax.faces.FacesException;
-import javax.faces.application.ProjectStage;
 import javax.faces.context.FacesContext;
 import javax.faces.event.PhaseEvent;
 import javax.faces.event.PhaseId;
@@ -55,7 +49,6 @@ import javax.faces.event.PhaseListener;
 public class HeadResourceProcessor implements PhaseListener {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger LOGGER = Logger.getLogger(HeadResourceProcessor.class.getName());
     private static final Map<String, String> THEME_MAPPING = MapBuilder.<String, String>builder()
             .put("saga", "saga-blue")
             .put("arya", "arya-blue")
@@ -110,73 +103,10 @@ public class HeadResourceProcessor implements PhaseListener {
         if (configuration.isPrimeIconsEnabled()) {
             ResourceUtils.addStyleSheetResource(context, "primeicons/primeicons.css");
         }
-
-        /*
-         * Core resources (jQuery + core.js) are only needed for non-AJAX requests when validation
-         * or localization is enabled. This prevents duplicate loading of resources and optimizes
-         * page load time.
-         */
-        if (configuration.isClientSideValidationEnabled() || configuration.isClientSideLocalizationEnabled()) {
-            /*
-             * jQuery must be loaded before core.js and any validation/localization resources
-             * to ensure proper dependency loading order
-             */
-            ResourceUtils.addJavascriptResource(context, "jquery/jquery.js");
-            ResourceUtils.addJavascriptResource(context, "core.js");
-        }
-
-        /*
-         * For non-AJAX requests, load validation and localization resources if configured.
-         * These depend on core resources being loaded first to function properly.
-         */
-        encodeValidationResources(context, configuration);
-        encodeLocalizationResources(context, configuration);
     }
 
     @Override
     public void afterPhase(PhaseEvent event) {
        // no-op
-    }
-
-    /**
-     * Encodes validation resources if client side validation is enabled.
-     * Adds moment.js for date validation and bean validation resources if enabled.
-     *
-     * @param context The FacesContext instance
-     * @param configuration The PrimeConfiguration instance containing validation settings
-     */
-    protected void encodeValidationResources(FacesContext context, PrimeConfiguration configuration) {
-        if (configuration.isClientSideValidationEnabled()) {
-            // moment is needed for Date validation
-            ResourceUtils.addJavascriptResourceToBody(context,  "moment/moment.js");
-
-            // BV CSV is optional and must be enabled by config
-            if (configuration.isBeanValidationEnabled()) {
-                ResourceUtils.addJavascriptResourceToBody(context, "validation/validation.bv.js");
-            }
-        }
-    }
-
-    /**
-     * Encodes localization resources if client side localization is enabled.
-     * Attempts to load the appropriate locale JavaScript file based on the current locale.
-     * Logs a warning in Development stage if locale file fails to load.
-     *
-     * @param context The FacesContext instance
-     * @param configuration The PrimeConfiguration instance containing localization settings
-     */
-    private void encodeLocalizationResources(FacesContext context, PrimeConfiguration configuration) {
-        if (configuration.isClientSideLocalizationEnabled()) {
-            try {
-                Locale locale = LocaleUtils.getCurrentLocale(context);
-                ResourceUtils.addJavascriptResourceToBody(context, "locales/locale-" + locale.getLanguage() + ".js");
-            }
-            catch (FacesException e) {
-                if (context.isProjectStage(ProjectStage.Development)) {
-                    LOGGER.log(Level.WARNING,
-                                "Failed to load client side locale.js. {0}", e.getMessage());
-                }
-            }
-        }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/export/DataExporter.java
@@ -69,7 +69,7 @@ public class DataExporter implements ActionListener, StateHolder {
     private ValueExpression bufferSize;
 
     public DataExporter() {
-        ResourceUtils.addComponentResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
+        ResourceUtils.addJavascriptResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
+++ b/primefaces/src/main/java/org/primefaces/component/filedownload/FileDownloadActionListener.java
@@ -59,7 +59,7 @@ public class FileDownloadActionListener implements ActionListener, StateHolder {
     private ValueExpression store;
 
     public FileDownloadActionListener() {
-        ResourceUtils.addComponentResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
+        ResourceUtils.addJavascriptResource(FacesContext.getCurrentInstance(), "filedownload/filedownload.js");
     }
 
     public FileDownloadActionListener(ValueExpression value, ValueExpression contentDisposition, ValueExpression monitorKey, ValueExpression store) {

--- a/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/HeadRenderer.java
@@ -29,13 +29,16 @@ import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.util.FacetUtils;
 import org.primefaces.util.LocaleUtils;
+import org.primefaces.util.ResourceUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.faces.FacesException;
 import javax.faces.application.ProjectStage;
 import javax.faces.component.UIComponent;
 import javax.faces.component.UIViewRoot;
@@ -84,6 +87,29 @@ public class HeadRenderer extends Renderer {
         UIComponent middle = component.getFacet("middle");
         if (FacetUtils.shouldRenderFacet(middle)) {
             middle.encodeAll(context);
+        }
+
+        if (applicationContext.getConfig().isClientSideValidationEnabled()) {
+            // moment is needed for Date validation
+            ResourceUtils.addJavascriptResource(context,  "moment/moment.js");
+
+            // BV CSV is optional and must be enabled by config
+            if (applicationContext.getConfig().isBeanValidationEnabled()) {
+                ResourceUtils.addJavascriptResource(context, "validation/validation.bv.js");
+            }
+        }
+
+        if (applicationContext.getConfig().isClientSideLocalizationEnabled()) {
+            try {
+                Locale locale = LocaleUtils.getCurrentLocale(context);
+                ResourceUtils.addJavascriptResource(context, "locales/locale-" + locale.getLanguage() + ".js");
+            }
+            catch (FacesException e) {
+                if (context.isProjectStage(ProjectStage.Development)) {
+                    LOGGER.log(Level.WARNING,
+                                "Failed to load client side locale.js. {0}", e.getMessage());
+                }
+            }
         }
 
         //Registered Resources

--- a/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
@@ -324,8 +324,9 @@ public class ResourceUtils {
      * @param resourceName The name of the JavaScript resource
      */
     public static void addJavascriptResource(FacesContext context, String libraryName, String resourceName) {
-        addResource(context, RENDERER_SCRIPT, libraryName, resourceName);
+        addResource(context, RENDERER_SCRIPT, libraryName, resourceName, "head");
     }
+
     /**
      * Adds a JavaScript resource from the default PrimeFaces library to the view.
      *
@@ -337,6 +338,16 @@ public class ResourceUtils {
     }
 
     /**
+     * Adds a JavaScript resource from the default PrimeFaces library to the view.
+     *
+     * @param context The FacesContext
+     * @param resourceName The name of the JavaScript resource
+     */
+    public static void addJavascriptResourceToBody(FacesContext context, String resourceName) {
+        addResource(context, RENDERER_SCRIPT, Constants.LIBRARY, resourceName, "body");
+    }
+
+    /**
      * Adds a CSS resource to the view.
      *
      * @param context The FacesContext
@@ -344,7 +355,7 @@ public class ResourceUtils {
      * @param resourceName The name of the CSS resource
      */
     public static void addStyleSheetResource(FacesContext context, String libraryName, String resourceName) {
-        addResource(context, RENDERER_STYLESHEET, libraryName, resourceName);
+        addResource(context, RENDERER_STYLESHEET, libraryName, resourceName, "head");
     }
 
     /**
@@ -364,11 +375,17 @@ public class ResourceUtils {
      * @param type The renderer type (CSS or JS)
      * @param libraryName The library name containing the resource
      * @param resourceName The name of the resource
+     * @param target The target location ("head" or "body")
      */
-    public static void addResource(FacesContext context, String type, String libraryName, String resourceName) {
+    public static void addResource(FacesContext context, String type, String libraryName, String resourceName, String target) {
         boolean isRendered = context.getApplication().getResourceHandler().isResourceRendered(context, resourceName, libraryName);
         if (!isRendered) {
-            addResourceToHead(context, type, libraryName, resourceName);
+            if ("head".equals(target)) {
+                addResourceToHead(context, type, libraryName, resourceName);
+            }
+            else {
+                addResourceToBody(context, type, libraryName, resourceName);
+            }
         }
     }
 

--- a/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ResourceUtils.java
@@ -60,6 +60,7 @@ public class ResourceUtils {
     private static final Pattern RESOURCE_PATTERN = Pattern.compile("^#\\{resource\\['(.+)']}$");
 
     private ResourceUtils() {
+        // prevent instantiation
     }
 
     public static String getResourceURL(FacesContext context, String value) {
@@ -233,27 +234,6 @@ public class ResourceUtils {
         return resource.getRequestPath();
     }
 
-    public static void addComponentResource(FacesContext context, String name, String library, String target) {
-
-        Application application = context.getApplication();
-
-        UIComponent componentResource = application.createComponent(UIOutput.COMPONENT_TYPE);
-        componentResource.setRendererType(application.getResourceHandler().getRendererTypeForResourceName(name));
-        componentResource.getAttributes().put("name", name);
-        componentResource.getAttributes().put("library", library);
-        componentResource.getAttributes().put("target", target);
-
-        context.getViewRoot().addComponentResource(context, componentResource, target);
-    }
-
-    public static void addComponentResource(FacesContext context, String name, String library) {
-        addComponentResource(context, name, library, "head");
-    }
-
-    public static void addComponentResource(FacesContext context, String name) {
-        addComponentResource(context, name, Constants.LIBRARY, "head");
-    }
-
     public static boolean isScript(UIComponent component) {
         return RENDERER_SCRIPT.equals(component.getRendererType());
     }
@@ -334,5 +314,109 @@ public class ResourceUtils {
         }
 
         return !isResourceNotFound(resource) ? resource : null;
+    }
+
+    /**
+     * Adds a JavaScript resource to the view.
+     *
+     * @param context The FacesContext
+     * @param libraryName The library name containing the resource
+     * @param resourceName The name of the JavaScript resource
+     */
+    public static void addJavascriptResource(FacesContext context, String libraryName, String resourceName) {
+        addResource(context, RENDERER_SCRIPT, libraryName, resourceName);
+    }
+    /**
+     * Adds a JavaScript resource from the default PrimeFaces library to the view.
+     *
+     * @param context The FacesContext
+     * @param resourceName The name of the JavaScript resource
+     */
+    public static void addJavascriptResource(FacesContext context, String resourceName) {
+        addJavascriptResource(context, Constants.LIBRARY, resourceName);
+    }
+
+    /**
+     * Adds a CSS resource to the view.
+     *
+     * @param context The FacesContext
+     * @param libraryName The library name containing the resource
+     * @param resourceName The name of the CSS resource
+     */
+    public static void addStyleSheetResource(FacesContext context, String libraryName, String resourceName) {
+        addResource(context, RENDERER_STYLESHEET, libraryName, resourceName);
+    }
+
+    /**
+     * Adds a CSS resource from the default PrimeFaces library to the view.
+     *
+     * @param context The FacesContext
+     * @param resourceName The name of the CSS resource
+     */
+    public static void addStyleSheetResource(FacesContext context, String resourceName) {
+        addStyleSheetResource(context, Constants.LIBRARY, resourceName);
+    }
+
+    /**
+     * Adds a resource to the view if it hasn't been rendered yet.
+     *
+     * @param context The FacesContext
+     * @param type The renderer type (CSS or JS)
+     * @param libraryName The library name containing the resource
+     * @param resourceName The name of the resource
+     */
+    public static void addResource(FacesContext context, String type, String libraryName, String resourceName) {
+        boolean isRendered = context.getApplication().getResourceHandler().isResourceRendered(context, resourceName, libraryName);
+        if (!isRendered) {
+            addResourceToHead(context, type, libraryName, resourceName);
+        }
+    }
+
+    /**
+     * Adds a resource component to the specified target, avoiding duplicates based on ID.
+     *
+     * @param context The FacesContext
+     * @param type The renderer type
+     * @param libraryName The library name
+     * @param resourceName The resource name
+     * @param target The target location ("head" or "body")
+     * @return The added or existing UIComponent
+     */
+    public static UIComponent addScriptResourceToTarget(FacesContext context, String type, String libraryName, String resourceName, String target) {
+        UIOutput outputResource = createResource(type);
+
+        if (libraryName != null) {
+            outputResource.getAttributes().put("library", libraryName);
+        }
+
+        outputResource.getAttributes().put("name", resourceName);
+        context.getViewRoot().addComponentResource(context, outputResource, target);
+        return outputResource;
+    }
+
+    /**
+     * Creates a new UIOutput component with the specified renderer type.
+     *
+     * @param type The renderer type
+     * @return New UIOutput component
+     */
+    public static UIOutput createResource(String type) {
+        UIOutput outputScript = new UIOutput();
+        outputScript.setRendererType(type);
+        return outputScript;
+    }
+
+    /**
+     * Adds a resource to the head section.
+     */
+    public static void addResourceToHead(FacesContext context, String type, String libraryName, String resourceName) {
+        addScriptResourceToTarget(context, type, libraryName, resourceName, "head");
+    }
+
+    /**
+     * Adds a resource to the body section.
+     */
+    public static void addResourceToBody(FacesContext context, String type, String libraryName, String resourceName) {
+        addScriptResourceToTarget(context, type, libraryName, resourceName, "body");
     }
 }

--- a/primefaces/src/main/resources/META-INF/faces-config.xml
+++ b/primefaces/src/main/resources/META-INF/faces-config.xml
@@ -11,6 +11,7 @@
     </factory>
 
     <lifecycle>
+        <phase-listener>org.primefaces.application.resource.HeadResourceProcessor</phase-listener>
         <phase-listener>org.primefaces.component.autoupdate.AutoUpdatePhaseListener</phase-listener>
         <phase-listener>org.primefaces.csp.CspPhaseListener</phase-listener>
         <phase-listener>org.primefaces.application.DialogKeepFlashPhaseListener</phase-listener>


### PR DESCRIPTION
Fix #12949: HeadRenderer use resources not links

Opened this as draft for discussion:

1. Replace links with resources.
2. Now that resources are pulled we need to ensure the order so use an ArrayList so we can sort things to top or later bottom if we need to before applying.   
3. Currently adding the CSS needs to be moved back to the top of the list
4. Adding the JS adds it properly to the bottom of the list so I just had to move the code up before processing
5. Took ideas from `OmniFaces` how it adds resources to `head` or `body` etc and its got some nice features like uniquely giving ID's to components if missing and ensuring no duplicates are added.