### PR TITLE
Fix #12953: SelectOneRadio proper identification by label

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/selectoneradio/selectOneRadio001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectoneradio/selectOneRadio001.xhtml
@@ -12,6 +12,7 @@
     <h:body>
 
         <h:form id="form">
+            <p:outputLabel id="outputlabel" value="Drivers Label" for="selectoneradio"/>
             <p:selectOneRadio id="selectoneradio" value="#{selectOneRadio001.value}">
                 <f:selectItems value="#{selectOneRadio001.drivers}" var="driver" itemLabel="#{driver.name}" itemValue="#{driver.id}"/>
                 <p:ajax process="@this"/>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectoneradio/SelectOneRadio001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectoneradio/SelectOneRadio001Test.java
@@ -26,6 +26,7 @@ package org.primefaces.integrationtests.selectoneradio;
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.OutputLabel;
 import org.primefaces.selenium.component.SelectOneRadio;
 
 import org.json.JSONObject;
@@ -164,6 +165,24 @@ class SelectOneRadio001Test extends AbstractPrimePageTest {
         assertConfiguration(selectOneRadio.getWidgetConfiguration());
     }
 
+    @Test
+    @Order(1)
+    @DisplayName("SelectOneRadio: ensure aria-labelledby is set from OutputLabel")
+    void ariaLabelledBy(Page page) {
+        // Arrange
+        SelectOneRadio selectOneRadio = page.selectOneRadio;
+        OutputLabel outputLabel = page.outputLabel;
+        assertEquals(4, selectOneRadio.getItemsSize());
+        assertEquals("Lewis", selectOneRadio.getSelectedLabel());
+
+        // Act
+
+
+        // Assert
+        assertEquals(outputLabel.getId(), selectOneRadio.getDomAttribute("aria-labelledby"));
+        assertConfiguration(selectOneRadio.getWidgetConfiguration());
+    }
+
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
         System.out.println("SelectOneRadio Config = " + cfg);
@@ -171,6 +190,9 @@ class SelectOneRadio001Test extends AbstractPrimePageTest {
     }
 
     public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:outputlabel")
+        OutputLabel outputLabel;
+
         @FindBy(id = "form:selectoneradio")
         SelectOneRadio selectOneRadio;
 

--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadio.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadio.java
@@ -47,4 +47,24 @@ public class SelectOneRadio extends SelectOneRadioBase {
     public String getRadioButtonId(FacesContext context, int index) {
         return this.getClientId(context) + UINamingContainer.getSeparatorChar(context) + index;
     }
+
+    @Override
+    public String getInputClientId() {
+        return getRadioButtonId(getFacesContext(), 0);
+    }
+
+    @Override
+    public String getValidatableInputClientId() {
+        return getRadioButtonId(getFacesContext(), 0);
+    }
+
+    @Override
+    public String getLabelledBy() {
+        return (String) getStateHelper().get("labelledby");
+    }
+
+    @Override
+    public void setLabelledBy(String labelledBy) {
+        getStateHelper().put("labelledby", labelledBy);
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
@@ -24,11 +24,12 @@
 package org.primefaces.component.selectoneradio;
 
 import org.primefaces.component.api.FlexAware;
+import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.Widget;
 
 import javax.faces.component.html.HtmlSelectOneRadio;
 
-public abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements Widget, FlexAware {
+public abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements Widget, FlexAware, InputHolder {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 

--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioRenderer.java
@@ -116,7 +116,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
                 .add(SelectOneRadio.STYLE_CLASS)
                 .add(radio.isReadonly(), "ui-state-readonly")
                 .build();
-        String labelledBy = radio.getLabel();
+        String labelledBy = radio.getLabelledBy();
 
         writer.startElement("div", radio);
         writer.writeAttribute("id", clientId, "id");
@@ -200,7 +200,7 @@ public class SelectOneRadioRenderer extends SelectOneRenderer {
                     .add(SelectOneRadio.STYLE_CLASS)
                     .add(radio.isReadonly(), "ui-state-readonly")
                     .build();
-            String labelledBy = radio.getLabel();
+            String labelledBy = radio.getLabelledBy();
             writer.startElement("span", radio);
             writer.writeAttribute("id", radio.getClientId(context), "id");
             writer.writeAttribute("role", "radiogroup", null);


### PR DESCRIPTION
Fix #12953: SelectOneRadio proper identification by label

This was incorrectly just pointing to text instead of the ID of the `p:outputLabel`.  That is what `InputHolder` is for so `p:outputLabel` can set the corrected `LabelledBy` element.