### PR TITLE
Fix #12958 : ColorPicker popup not working in Sidebar

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/colorpicker/1-colorpicker.js
@@ -274,7 +274,7 @@ PrimeFaces.widget.ColorPicker = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     setupDialogSupport: function() {
-        var dialog = this.input[0].closest('.ui-dialog');
+        var dialog = this.input[0].closest('.ui-dialog, .ui-sidebar');
         if (dialog) {
             this.cfg.parent = PrimeFaces.escapeClientId(dialog.id);
         }


### PR DESCRIPTION
Fix #12958 : ColorPicker popup not working in Sidebar