### PR TITLE
Fix #12969: DatePicker allow showLongMonthNames

### DIFF
--- a/docs/15_0_0/components/datepicker.md
+++ b/docs/15_0_0/components/datepicker.md
@@ -123,6 +123,7 @@ ajax selection and more.
 | showMinMaxRange | true | Boolean | Only display valid dates within the min/max range.
 | autoMonthFormat | true | Boolean | Whether to format the month. Default is true.
 | showOtherMonths | false | Boolean | Displays days belonging to other months.
+| showLongMonthNames | false | Boolean | Displays long month names instead of short names in month picker and month navigator.. Default is false.
 | showSeconds | false | Boolean | Whether to show the seconds in time picker. Default is false.
 | showTime | false * | Boolean | Specifies if the timepicker should be displayed.  (* Defaults to true, when value is bound to java.time.LocalDateTime)
 | showWeek | false | Boolean | Displays the week number next to each week.

--- a/docs/15_0_0/gettingstarted/whatsnew.md
+++ b/docs/15_0_0/gettingstarted/whatsnew.md
@@ -40,7 +40,8 @@ Look into [migration guide](https://primefaces.github.io/primefaces/15_0_0/#/../
 
 * DatePicker
     * Added `defaultHour`, `defaultMinute`, `defaultSecond`, `defaultMillisec` attributes to match legacy `Calendar` component
-    * Added ability to pick weeks by view="week"
+    * Added ability to pick weeks by `view="week"`
+    * Added `showLongMonthNames` attribute to display long month names instead of short names in month picker and month navigator
 
 * FeedReader
     * Added `podcast="true"` property if [Apple Itunes Podcast](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) parsing and specific tags 

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -60,7 +60,7 @@
 
                     <div class="field col-12 md:col-4">
                         <p:outputLabel for="navigator" value="Navigator" />
-                        <p:datePicker id="navigator" value="#{calendarJava8View.date2}" monthNavigator="true" yearNavigator="true" showWeek="true" />
+                        <p:datePicker id="navigator" value="#{calendarJava8View.date2}" monthNavigator="true" yearNavigator="true" showWeek="true" showLongMonthNames="true" />
                     </div>
 
                     <div class="field col-12 md:col-4">
@@ -69,12 +69,12 @@
                     </div>
 
                     <div class="field col-12 md:col-4">
-                        <p:outputLabel for="month" value="Month Picker" />
-                        <p:datePicker id="month" view="month" value="#{calendarJava8View.date3}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" />
+                        <p:outputLabel for="month" value="Month Picker (Long Month Names)" />
+                        <p:datePicker id="month" view="month" value="#{calendarJava8View.date3}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" showLongMonthNames="true" />
                     </div>
 
                     <div class="field col-12 md:col-4">
-                        <p:outputLabel for="yearMonth" value="Month Picker (java.time.YearMonth)" />
+                        <p:outputLabel for="yearMonth" value="Month Picker (java.time.YearMonth with Short Month Names)" />
                         <p:datePicker id="yearMonth" view="month" value="#{calendarJava8View.yearMonth}" pattern="MM/yyyy" yearNavigator="true"
                             yearRange="2000:2030" />
                     </div>
@@ -114,12 +114,12 @@
 
                     <div class="field col-12 md:col-4">
                         <p:outputLabel for="spanish" value="Spanish" />
-                        <p:datePicker id="spanish" value="#{calendarJava8View.date9}" locale="es" monthNavigator="true" pattern="yyyy-MMM-dd" />
+                        <p:datePicker id="spanish" value="#{calendarJava8View.date9}" locale="es" monthNavigator="true" showLongMonthNames="true" pattern="yyyy-MMM-dd" />
                     </div>
 
                     <div class="field col-12 md:col-4">
                         <p:outputLabel for="german" value="German" />
-                        <p:datePicker id="german" widgetVar="german" value="#{calendarJava8View.dateDe}" locale="de" monthNavigator="true"
+                        <p:datePicker id="german" widgetVar="german" value="#{calendarJava8View.dateDe}" locale="de" monthNavigator="true" showLongMonthNames="true"
                             pattern="dd.MM.yyyy" />
                     </div>
 

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -91,6 +91,7 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         showMinMaxRange,
         showOnFocus,
         showOtherMonths,
+        showLongMonthNames,
         showSeconds,
         showTime,
         showWeek,
@@ -523,6 +524,14 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
 
     public void setAutoMonthFormat(boolean autoMonthFormat) {
         getStateHelper().put(PropertyKeys.autoMonthFormat, autoMonthFormat);
+    }
+
+    public boolean isShowLongMonthNames() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.showLongMonthNames, false);
+    }
+
+    public void setShowLongMonthNames(boolean showLongMonthNames) {
+        getStateHelper().put(PropertyKeys.showLongMonthNames, showLongMonthNames);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -237,6 +237,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("responsiveBreakpoint", datePicker.getResponsiveBreakpoint(), DatePicker.RESPONSIVE_BREAKPOINT_SMALL)
             .attr("touchUI", datePicker.isTouchUI(), false)
             .attr("showWeek", datePicker.isShowWeek(), false)
+            .attr("showLongMonthNames", datePicker.isShowLongMonthNames(), false)
             .attr("appendTo", SearchExpressionUtils.resolveOptionalClientIdForClientSide(context, datePicker, datePicker.getAppendTo()))
             .attr("icon", datePicker.getTriggerButtonIcon(), null)
             .attr("rangeSeparator", datePicker.getRangeSeparator(), "-")

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -3466,6 +3466,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Displays long month names instead of short names in month picker and month navigator. Default is false.]]>
+            </description>
+            <name>showLongMonthNames</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Enables selection of days belonging to other months. Default is false.]]>
             </description>
             <name>selectOtherMonths</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -124,6 +124,7 @@
             maxDateCount: null,
             showMinMaxRange: true,
             showOtherMonths: false,
+            showLongMonthNames: false,
             selectOtherMonths: false,
             autoMonthFormat: true,
             showButtonBar: false,
@@ -1407,7 +1408,7 @@
         },
 
         renderMonthViewMonth: function(index) {
-            var monthName = this.options.locale.monthNamesShort[index],
+            var monthName = this.options.showLongMonthNames ? this.options.locale.monthNames[index] : this.options.locale.monthNamesShort[index],
                 content = this.options.dateTemplate ? this.options.dateTemplate.call(this, monthName) : this.escapeHTML(monthName),
                 compareDate = new Date(this.viewDate.getFullYear(), index, 1),
                 minDate = this.options.minDate,
@@ -1481,7 +1482,8 @@
 
         renderTitleMonthElement: function(month, index) {
             if (this.options.monthNavigator && this.options.view !== 'month' && index === 0) {
-                return '<select class="ui-datepicker-month" tabindex="0" aria-label="' + this.options.locale.month + '">' + this.renderTitleOptions('month', this.options.locale.monthNamesShort, month) + '</select>';
+                const monthNames = this.options.showLongMonthNames ? this.options.locale.monthNames : this.options.locale.monthNamesShort;
+                return '<select class="ui-datepicker-month" tabindex="0" aria-label="' + this.options.locale.month + '">' + this.renderTitleOptions('month', monthNames, month) + '</select>';
             }
             else {
                 return '<span class="ui-datepicker-month">' + this.escapeHTML(this.options.locale.monthNames[month]) + '</span>';


### PR DESCRIPTION
Fix #12969: DatePicker allow showLongMonthNames

![image](https://github.com/user-attachments/assets/dd46bf24-2f93-4b89-8cb0-e34c38d31aec)

![image](https://github.com/user-attachments/assets/095bf76c-fa2b-462e-a733-b8886f12b7fb)

Attribute is `showLongMonthNames="true"`