### PR TITLE
Fix #12985: 14.0.9 DatePicker prevent ESC from bubbling up when panel open

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2324,6 +2324,8 @@
 
         onPanelKeyDown: function(event) {
             if (event.key === 'Escape') {
+                event.preventDefault();
+                event.stopPropagation();
                 this.onEscapeKey(event);
             }
         },


### PR DESCRIPTION
Fix #12985: 14.0.9 DatePicker prevent ESC from bubbling up when panel open