### PR TITLE
Fix #12989: 14.0.9 Cell Editor with SelectOne blocking tab control

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/edit.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/edit.xhtml
@@ -55,10 +55,10 @@
                         <p:cellEditor>
                             <f:facet name="output"><h:outputText value="#{product.inventoryStatus}"/></f:facet>
                             <f:facet name="input">
-                                <h:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
+                                <p:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
                                     <f:selectItems value="#{dtEditView.inventoryStatusList}" var="status"
                                                    itemLabel="#{status.text}" itemValue="#{status}"/>
-                                </h:selectOneMenu>
+                                </p:selectOneMenu>
                             </f:facet>
                         </p:cellEditor>
                     </p:column>
@@ -117,10 +117,10 @@
                                 <h:outputText value="#{product.inventoryStatus}"/>
                             </f:facet>
                             <f:facet name="input">
-                                <h:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
+                                <p:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
                                     <f:selectItems value="#{dtEditView.inventoryStatusList}" var="status"
                                                    itemLabel="#{status.text}" itemValue="#{status}"/>
-                                </h:selectOneMenu>
+                                </p:selectOneMenu>
                             </f:facet>
                         </p:cellEditor>
                     </p:column>
@@ -175,10 +175,10 @@
                                 <h:outputText value="#{product.inventoryStatus}"/>
                             </f:facet>
                             <f:facet name="input">
-                                <h:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
+                                <p:selectOneMenu value="#{product.inventoryStatus}" style="width:100%">
                                     <f:selectItems value="#{dtEditView.inventoryStatusList}" var="status"
                                                    itemLabel="#{status.text}" itemValue="#{status}"/>
-                                </h:selectOneMenu>
+                                </p:selectOneMenu>
                             </f:facet>
                         </p:cellEditor>
                     </p:column>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -3852,7 +3852,11 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             displayContainer = cellEditor.children('div.ui-cell-editor-output'),
             inputContainer = cellEditor.children('div.ui-cell-editor-input');
             this.enableCellEditors(inputContainer);
-            var inputs = inputContainer.find(':input:enabled[type!=hidden]'),
+            // Look for selectonemenu inputs first since they have special DOM structure, otherwise find any enabled visible inputs
+            var inputs = inputContainer.find('.ui-selectonemenu .ui-inputfield');
+            if (!inputs.length) {
+                inputs = inputContainer.find(':input:enabled:not([type="hidden"])');
+            }
             multi = inputs.length > 1;
 
             cell.addClass('ui-state-highlight ui-cell-editing');
@@ -3905,9 +3909,17 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                         }
                         else if(key === 'Tab') {
                             if(multi) {
+                                // Calculate next/prev input index based on shift key
                                 var focusIndex = shiftKey ? input.index() - 1 : input.index() + 1;
 
-                                if(focusIndex < 0 || (focusIndex === inputs.length) || input.parent().hasClass('ui-inputnumber') || input.parent().hasClass('ui-helper-hidden-accessible')) {
+                                var parent = input.parent();
+                                // Move to next/prev cell if:
+                                // - Index out of bounds
+                                // - Parent is special input component that handles its own tab behavior
+                                if(focusIndex < 0 || focusIndex === inputs.length || 
+                                   parent.hasClass('ui-inputnumber') ||
+                                   parent.hasClass('ui-selectonemenu') ||
+                                   parent.hasClass('ui-helper-hidden-accessible')) {
                                     $this.tabCell(cell, !shiftKey);
                                 } else {
                                     inputs.eq(focusIndex).trigger('focus');


### PR DESCRIPTION
Fix #12989: 14.0.9 Cell Editor with SelectOne blocking tab control

This was because of the restructure of SelectOne for ARIA and Keyboard accessibility