### PR TITLE
Fix #13029: ColumnToggler cast to UITable not DataTable

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
+++ b/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
@@ -24,7 +24,7 @@
 package org.primefaces.component.columntoggler;
 
 import org.primefaces.component.api.UIColumn;
-import org.primefaces.component.datatable.DataTable;
+import org.primefaces.component.api.UITable;
 import org.primefaces.event.ColumnToggleEvent;
 import org.primefaces.event.ToggleCloseEvent;
 import org.primefaces.event.ToggleEvent;
@@ -90,7 +90,7 @@ public class ColumnToggler extends ColumnTogglerBase {
             Visibility visibility = Visibility.valueOf(params.get(clientId + "_visibility"));
             int index = Integer.parseInt(params.get(clientId + "_index"));
 
-            UIColumn column = ((DataTable) getDataSourceComponent()).getColumns().get(index);
+            UIColumn column = ((UITable) getDataSourceComponent()).getColumns().get(index);
             super.queueEvent(new ColumnToggleEvent(this, ((AjaxBehaviorEvent) event).getBehavior(), column, visibility, index));
         }
         else if (event instanceof AjaxBehaviorEvent && "close".equals(eventName)) {


### PR DESCRIPTION
Fix #13029: ColumnToggler cast to UITable not DataTable