### PR TITLE
Fix #13012/#12754/#12837: 14.0.10 DatePicker mask with blur

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -88,6 +88,8 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
 
         //Client behaviors, input skinning and z-index
         if(!this.cfg.inline) {
+            this.applyMask(); // must be before datepicker and skinInput #6445/#7176/#13012
+
             PrimeFaces.skinInput(this.jqEl);
 
             if(this.cfg.behaviors) {
@@ -158,7 +160,7 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
         }
         
 
-        this.applyMask(); // must be before datepicker see #6445 and #7176
+        
         this.jq.datePicker(this.cfg);
 
         //extensions


### PR DESCRIPTION
Fix #13012
Fix #12754 
Fix #12837 

PR submitted...Finally got to the bottom of this. We need to Apply Mask and remove its InputMask "blur" before we call `Primefaces.skinInput` which adds the proper blur.