### PR TITLE
IT - ubuntu-latest with firefox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+#on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
 
 env:
     MAVEN_OPTS: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: CI
 
-#on: [push, pull_request, workflow_dispatch]
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *'
+on: [push, pull_request, workflow_dispatch]
 
 env:
     MAVEN_OPTS: >-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,10 @@
 name: IT
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 6 * * *'
+on: [push, pull_request, workflow_dispatch]
+#on:
+#  workflow_dispatch:
+#  schedule:
+#    - cron: '0 6 * * *'
 
 env:
   SCREENSHOT_DIRECTORY: '/tmp/pf_it/'
@@ -14,7 +15,7 @@ permissions:
 jobs:
   nightly:
     if: github.repository == 'primefaces/primefaces' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Java ${{ matrix.java }}, ${{ matrix.profile }}
     strategy:
       fail-fast: false
@@ -24,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Setup firefox
+        uses: browser-actions/setup-firefox@v1
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   nightly:
-    if: github.repository == 'primefaces/primefaces' && github.ref == 'refs/heads/master'
+#    if: github.repository == 'primefaces/primefaces' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     name: Java ${{ matrix.java }}, ${{ matrix.profile }}
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,9 @@
 name: IT
 
-on: [push, pull_request, workflow_dispatch]
-#on:
-#  workflow_dispatch:
-#  schedule:
-#    - cron: '0 6 * * *'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
 
 env:
   SCREENSHOT_DIRECTORY: '/tmp/pf_it/'
@@ -14,7 +13,7 @@ permissions:
 
 jobs:
   nightly:
-#    if: github.repository == 'primefaces/primefaces' && github.ref == 'refs/heads/master'
+    if: github.repository == 'primefaces/primefaces' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     name: Java ${{ matrix.java }}, ${{ matrix.profile }}
     strategy:


### PR DESCRIPTION
Until now we were hanging on ubuntu-20.04 for nightly IT because this was the last version comming with Firefox OOTB.
Was running by concidence into a solution how the install Firefox into a runner. So we can use ubuntu-latest also for nightly IT.