### PR TITLE
Fix #13091: Datatable enable editors after validation failure

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4330,7 +4330,9 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
      */
     invalidateRow: function(index) {
         var i = (this.paginator) ? (index % this.paginator.getRows()) : index;
-        this.tbody.children('tr[data-ri]').eq(i).addClass('ui-widget-content ui-row-editing ui-state-error');
+        var row =  this.tbody.children('tr[data-ri]').eq(i);
+        row.addClass('ui-widget-content ui-row-editing ui-state-error');
+        this.enableCellEditors(row);
     },
 
     /**


### PR DESCRIPTION
Fix #13091: Datatable enable editors after validation failure