### PR TITLE
Fix #12097/#12455/#13096: DatePicker yearNavigator allow old select dropdown

### DIFF
--- a/docs/15_0_0/components/datepicker.md
+++ b/docs/15_0_0/components/datepicker.md
@@ -148,7 +148,7 @@ ajax selection and more.
 | view | date | String | Defines the view mode, valid values are "date" for datepicker, "week" for week picker, and "month" for month picker.
 | weekCalculator | false | Boolean | A javascript function that is used to calculate the week number. Uses internal implementation on default when start of week is monday, sunday or saturday.
 | widgetVar | null | String | Name of the client side widget.
-| yearNavigator | false | Boolean | Whether the year should be rendered as an input number instead of text.
+| yearNavigator | false | String | Display the year navigator. When set to 'true' or 'input', the year is shown as a numeric input, which is accessible for visually impaired users. If set to 'select', it appears as a dropdown menu. The default setting is 'false'.
 | yearRange | null | String | The range of years allowed in the year input in (nnnn:nnnn) format such as (1974:2020). Default value is "displayed_date - 1000 : displayed_date + 1000".
 
 ## Getting Started with DatePicker

--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -37,6 +37,10 @@
 
   * `defaultMillisec` was renamed to `defaultMillisecond`.
 
+## DatePicker
+
+  * `yearNavigator` was changed from `Boolean` to `String` to allow more flexibility. Display the year navigator. When set to `'true'` or `'input'`, the year is shown as a numeric input, which is accessible for visually impaired users. If set to `'select'`, it appears as a dropdown menu. The default setting is `'false'`.
+
 ## FeedReader
 
   * Switched from [Rome](https://rometools.github.io/rome/) library which uses XML parsing to non XML very fast [RSS Reader](https://github.com/w3stling/rssreader)

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DatePicker.java
@@ -36,6 +36,7 @@ import java.time.ZoneId;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
@@ -313,8 +314,15 @@ public abstract class DatePicker extends AbstractInputComponent {
      * @param year the year to select
      */
     public void selectYear(int year) {
-        WebElement yearInput = showPanel().findElement(By.cssSelector("input.ui-datepicker-year"));
-        yearInput.sendKeys(Integer.toString(year));
+        WebElement panel = showPanel();
+        try {
+            WebElement yearInput = panel.findElement(By.cssSelector("input.ui-datepicker-year"));
+            yearInput.sendKeys(Integer.toString(year));
+        }
+        catch (NoSuchElementException e) {
+            Select yearDropDown = new Select(showPanel().findElement(By.cssSelector("select.ui-datepicker-year")));
+            yearDropDown.selectByValue(Integer.toString(year));
+        }
     }
 
     /**

--- a/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -59,8 +59,13 @@
                     </div>
 
                     <div class="field col-12 md:col-4">
-                        <p:outputLabel for="navigator" value="Navigator" />
-                        <p:datePicker id="navigator" value="#{calendarJava8View.date2}" monthNavigator="true" yearNavigator="true" showWeek="true" showLongMonthNames="true" />
+                        <p:outputLabel for="navigatorInput" value="Navigator (Year Input)" />
+                        <p:datePicker id="navigatorInput" value="#{calendarJava8View.date2}" monthNavigator="true" yearNavigator="input" showWeek="true" showLongMonthNames="true" />
+                    </div>
+
+                    <div class="field col-12 md:col-4">
+                        <p:outputLabel for="navigatorSelect" value="Navigator (Year Select)" />
+                        <p:datePicker id="navigatorSelect" value="#{calendarJava8View.date1}" monthNavigator="true" yearNavigator="select" showWeek="true" showLongMonthNames="true" />
                     </div>
 
                     <div class="field col-12 md:col-4">

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -233,11 +233,11 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         getStateHelper().put(PropertyKeys.monthNavigator, monthNavigator);
     }
 
-    public boolean isYearNavigator() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.yearNavigator, false);
+    public String getYearNavigator() {
+        return (String) getStateHelper().eval(PropertyKeys.yearNavigator, "false");
     }
 
-    public void setYearNavigator(boolean yearNavigator) {
+    public void setYearNavigator(String yearNavigator) {
         getStateHelper().put(PropertyKeys.yearNavigator, yearNavigator);
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -223,7 +223,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer {
             .attr("showOnFocus", datePicker.isShowOnFocus())
             .attr("shortYearCutoff", datePicker.getShortYearCutoff(), null)
             .attr("monthNavigator", datePicker.isMonthNavigator(), false)
-            .attr("yearNavigator", datePicker.isYearNavigator(), false)
+            .attr("yearNavigator", datePicker.getYearNavigator().toLowerCase(Locale.ROOT), "false")
             .attr("showButtonBar", datePicker.isShowButtonBar(), false)
             .attr("showMinMaxRange", datePicker.isShowMinMaxRange(), true)
             .attr("autoMonthFormat", datePicker.isAutoMonthFormat(), true)

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -32171,11 +32171,11 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Whether the year should be rendered as a dropdown instead of text. Default is false.]]>
+                <![CDATA[Display the year navigator. When set to 'true' or 'input', the year is shown as a numeric input, which is accessible for visually impaired users. If set to 'select', it appears as a dropdown menu. Default is 'false'.]]>
             </description>
             <name>yearNavigator</name>
             <required>false</required>
-            <type>java.lang.Boolean</type>
+            <type>java.lang.String</type>
         </attribute>
         <attribute>
             <description>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -114,7 +114,7 @@
             panelStyle: null,
             panelStyleClass: null,
             monthNavigator: false,
-            yearNavigator: false,
+            yearNavigator: "false",
             dateStyleClasses: null,
             disabledDates: null,
             enabledDates: null,
@@ -1221,7 +1221,7 @@
         },
 
         _setInitOptionValues: function() {
-            if (this.options.yearNavigator) {
+            if (this.isYearNavigator()) {
                 var year = this.viewDate.getFullYear();
                 var month = this.viewDate.getMonth();
                 var yearElts = this.panel.find('.ui-datepicker-header > .ui-datepicker-title > .ui-datepicker-year');
@@ -1491,7 +1491,7 @@
         },
 
         renderTitleYearElement: function(year, index) {
-            if (this.options.yearNavigator && index === 0) {
+            if (this.isYearNavigator() && index === 0) {
                 this.updateYearNavigator();
                 var years = this.options.yearRange.split(':'),
                     yearStart = parseInt(years[0], 10),
@@ -1507,7 +1507,16 @@
                     maxYear = Math.min(maxDate.getFullYear(), yearEnd);
                 }
 
-                return '<input class="ui-datepicker-year" size="6" maxlength="4" tabindex="0" aria-label="' + this.options.locale.year + '" type="number" min="' + minYear + '" max="' + maxYear + '" step="1" value="' + year + '"' + '></input>';
+                if (this.isYearNavigatorInput()) {
+                    return '<input class="ui-datepicker-year" size="6" maxlength="4" tabindex="0" aria-label="' + this.options.locale.year + '" type="number" min="' + minYear + '" max="' + maxYear + '" step="1" value="' + year + '"' + '></input>';
+                }
+                else {
+                    var yearOptions = [];
+                    for (var i = yearStart; i <= yearEnd; i++) {
+                        yearOptions.push(i);
+                    }
+                    return '<select class="ui-datepicker-year" tabindex="0" aria-label="' + this.options.locale.year + '">' + this.renderTitleOptions('year', yearOptions, year) + '</select>';
+                }
             }
             else {
                 return '<span class="ui-datepicker-year">' + year + '</span>';
@@ -2453,7 +2462,7 @@
                 var currentYear = newViewDate.getFullYear(),
                     newYear = currentYear - 1;
 
-                if (this.options.yearNavigator) {
+                if (this.isYearNavigator()) {
                     var minYear = parseInt(this.options.yearRange.split(':')[0], 10);
 
                     if (newYear < minYear) {
@@ -2513,7 +2522,7 @@
                 var currentYear = newViewDate.getFullYear(),
                     newYear = currentYear + 1;
 
-                if (this.options.yearNavigator) {
+                if (this.isYearNavigator()) {
                     var maxYear = parseInt(this.options.yearRange.split(':')[1], 10);
 
                     if (newYear > maxYear) {
@@ -2872,6 +2881,14 @@
 
         isDate: function(value) {
             return value && Object.prototype.toString.call(value) === "[object Date]" && !isNaN(value);
+        },
+
+        isYearNavigator: function() {
+            return ["input", "select", "true"].includes(this.options.yearNavigator);
+        },
+
+        isYearNavigatorInput: function() {
+            return ["input", "true"].includes(this.options.yearNavigator);
         },
 
         alignPanel: function() {
@@ -3465,12 +3482,14 @@
         },
 
         updateYearNavigator: function() {
-            if (this.hasCustomYearRange || this.options.yearRange) {
+            var isYearInput = this.isYearNavigatorInput();
+            if (this.hasCustomYearRange || (isYearInput && this.options.yearRange)) {
                 return;
             }
-            if (this.options.yearNavigator) {
+            if (this.isYearNavigator()) {
                 var viewYear = this.viewDate.getFullYear();
-                this.options.yearRange = (viewYear - 1000) + ':' + (viewYear + 1000);
+                var yearIncrement = isYearInput ? 1000 : 10;
+                this.options.yearRange = (viewYear - yearIncrement) + ':' + (viewYear + yearIncrement);
             }
         },
 


### PR DESCRIPTION
Fix #12097
Fix #12455
Fix #13096

This allows you to put back the old behavior without adding a new property.  Now you can do `yearNavigator="select"` to put it back or use `yearNavigator="true or input"` for input box.  And `yearNavigator="false"` still disables it.