### PR TITLE
Fix #12663: ConfirmDialog/Popup restore original values

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001.java
@@ -51,6 +51,10 @@ public class ConfirmDialog001 implements Serializable {
         addMessage("Non AJAX", "Full page submitted");
     }
 
+    public void question() {
+        addMessage("Question", "Are you sure you want to proceed?");
+    }
+
     public void addMessage(String summary, String detail) {
         TestUtils.addMessage(summary, detail);
     }

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001.java
@@ -47,6 +47,10 @@ public class ConfirmPopup001 implements Serializable {
         addMessage("Deleted", "Record deleted");
     }
 
+    public void question() {
+        addMessage("Question", "Are you sure you want to proceed?");
+    }
+
     public void addMessage(String summary, String detail) {
         TestUtils.addMessage(summary, detail);
     }

--- a/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmdialog/confirmDialog002.xhtml
@@ -25,8 +25,13 @@
             <p:commandLink id="nonAjax" value="Non-Ajax" action="#{confirmDialog001.nonAjax}" styleClass="ui-button-warning" icon="pi pi-question" ajax="false">
                 <p:confirm header="Confirmation" message="Submit this page and reload?" icon="pi pi-question-circle"/>
             </p:commandLink>
+
+            <p:commandButton id="question" value="Question" action="#{confirmDialog001.question}" update="message" styleClass="p-mr-2">
+                <p:confirm type="popup" header="Question" message="Do you like cats?"/>
+            </p:commandButton>
+
             
-            <p:confirmDialog id="confirmdialog" global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350">
+            <p:confirmDialog id="confirmdialog" global="true" showEffect="fade" hideEffect="fade" responsive="true" width="350" severity="alert">
                 <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes"/>
                 <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-flat"/>
             </p:confirmDialog>

--- a/primefaces-integration-tests/src/main/webapp/confirmpopup/confirmPopup001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/confirmpopup/confirmPopup001.xhtml
@@ -30,7 +30,11 @@
                     noButtonIcon="pi pi-heart"/>
             </p:commandButton>
 
-            <p:confirmPopup id="confirmpopup" global="true" showEffect="fade" hideEffect="fade">
+            <p:commandButton id="question" value="Question" action="#{confirmPopup001.question}" update="message" styleClass="p-mr-2">
+                <p:confirm type="popup" header="Question" message="Are you sure you want to proceed?"/>
+            </p:commandButton>
+
+            <p:confirmPopup id="confirmpopup" global="true" showEffect="fade" hideEffect="fade" icon="pi pi-question-circle">
                 <p:commandButton value="Yes" type="button" styleClass="ui-confirm-popup-yes" icon="pi pi-check"/>
                 <p:commandButton value="No" type="button" styleClass="ui-confirm-popup-no ui-button-flat" icon="pi pi-times"/>
             </p:confirmPopup>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
@@ -40,7 +40,10 @@ import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ConfirmDialog001Test extends AbstractPrimePageTest {
 
@@ -58,7 +61,7 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         // Assert
         assertDialog(page, true);
         assertEquals("Are you sure you want to proceed?", dialog.getMessage().getText());
-        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getAttribute("class"));
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getDomAttribute("class"));
     }
 
     @Test

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog002Test.java
@@ -38,7 +38,10 @@ import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ConfirmDialog002Test extends AbstractPrimePageTest {
 
@@ -56,7 +59,7 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         // Assert
         assertDialog(page, true);
         assertEquals("Are you sure you want to proceed?", dialog.getMessage().getText());
-        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getAttribute("class"));
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getDomAttribute("class"));
     }
 
     @Test
@@ -97,6 +100,8 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.confirm.click();
+        assertEquals("Are you sure you want to proceed?", dialog.getMessage().getText());
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getDomAttribute("class"));
 
         // Act
         dialog.getNoButton().click();
@@ -114,6 +119,8 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         page.confirm.click();
         assertTrue(dialog.isVisible());
+        assertEquals("Are you sure you want to proceed?", dialog.getMessage().getText());
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-exclamation-triangle", dialog.getIcon().getDomAttribute("class"));
 
         // Act
         PrimeSelenium.guardAjax(dialog.getYesButton()).click();
@@ -131,6 +138,8 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.delete.click();
+        assertEquals("Do you want to delete this record?", dialog.getMessage().getText());
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-info-circle", dialog.getIcon().getDomAttribute("class"));
 
         // Act
         dialog.getNoButton().click();
@@ -148,6 +157,8 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         ConfirmDialog dialog = page.dialog;
         assertFalse(dialog.isVisible());
         page.delete.click();
+        assertEquals("Do you want to delete this record?", dialog.getMessage().getText());
+        assertEquals("ui-icon ui-confirm-dialog-severity pi pi-info-circle", dialog.getIcon().getDomAttribute("class"));
 
         // Act
         PrimeSelenium.guardAjax(dialog.getYesButton()).click();
@@ -189,6 +200,24 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
         // Assert
         assertEquals("Full page submitted", page.message.getMessage(0).getDetail());
         assertDialog(page, false);
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("ConfirmDialog: Default icon to the one set on the global")
+    void defaultIcon(Page page) {
+        // Arrange
+        ConfirmDialog dialog = page.dialog;
+        assertFalse(dialog.isVisible());
+
+        // Act
+        page.question.click();
+
+        // Assert
+        assertDialog(page, true);
+        assertEquals("Do you like cats?", dialog.getMessage().getText());
+        assertEquals("ui-icon ui-confirm-dialog-severity ui-icon-alert", dialog.getIcon().getDomAttribute("class"));
+        assertConfiguration(dialog.getWidgetConfiguration());
     }
 
     private void assertDialog(Page page, boolean visible) {
@@ -246,6 +275,9 @@ class ConfirmDialog002Test extends AbstractPrimePageTest {
 
         @FindBy(id = "form:nonAjax")
         CommandLink nonAjax;
+
+        @FindBy(id = "form:question")
+        CommandLink question;
 
         @Override
         public String getLocation() {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmpopup/ConfirmPopup001Test.java
@@ -39,7 +39,9 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.FindBy;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ConfirmPopup001Test extends AbstractPrimePageTest {
 
@@ -151,6 +153,25 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(6)
+    @DisplayName("ConfirmPopup: Default icon to the one set on the global")
+    void defaultIcon(Page page) {
+        // Arrange
+        ConfirmPopup popup = page.popup;
+        assertFalse(popup.isVisible());
+
+
+        // Act
+        page.question.click();
+
+        // Assert
+        assertTrue(popup.isVisible());
+        assertTrue(page.messages.isEmpty());
+        assertCss(popup.getIcon(), "ui-confirm-popup-icon pi pi-question-circle");
+        assertConfiguration(popup.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(6)
     @DisplayName("ConfirmPopup: Delete button pressing YES")
     void deleteYes(Page page) {
         // Arrange
@@ -202,6 +223,9 @@ class ConfirmPopup001Test extends AbstractPrimePageTest {
 
         @FindBy(id = "form:delete")
         CommandButton delete;
+
+        @FindBy(id = "form:question")
+        CommandButton question;
 
         @Override
         public String getLocation() {

--- a/primefaces/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/confirmdialog/ConfirmDialogRenderer.java
@@ -130,7 +130,7 @@ public class ConfirmDialogRenderer extends CoreRenderer {
         ResponseWriter writer = context.getResponseWriter();
         String messageText = dialog.getMessage();
         UIComponent messageFacet = dialog.getFacet("message");
-        String defaultIcon = dialog.isGlobal() ? "ui-icon" : "ui-icon ui-icon-" + dialog.getSeverity();
+        String defaultIcon = "ui-icon ui-icon-" + dialog.getSeverity();
         String severityIcon = defaultIcon + " " + ConfirmDialog.SEVERITY_ICON_CLASS;
 
         writer.startElement("div", null);

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/confirmpopup/confirmpopup.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/confirmpopup/confirmpopup.js
@@ -57,6 +57,9 @@ PrimeFaces.widget.ConfirmPopup = PrimeFaces.widget.DynamicOverlayWidget.extend({
         this.message = this.content.children('.ui-confirm-popup-message');
         this.icon = this.content.children('.ui-confirm-popup-icon');
         if (this.cfg.global) {
+            this.content.data('p-text', this.content.text());
+            this.message.data('p-text', this.message.text());
+            this.icon.data('p-icon', this.icon.removeClass('ui-confirm-popup-icon').attr('class'));
             this.yesButton = this.jq.find('.ui-confirm-popup-yes');
             this.noButton = this.jq.find('.ui-confirm-popup-no');
             this.yesButton.data('p-text', this.yesButton.children('.ui-button-text').text());
@@ -251,6 +254,15 @@ PrimeFaces.widget.ConfirmPopup = PrimeFaces.widget.DynamicOverlayWidget.extend({
     restoreButtons: function() {
         var $this = this;
         if ($this.cfg.global) {
+            if ($this.content.data('p-text')) {
+                $this.content.text($this.content.data('p-text'));
+            }
+            if ($this.message.data('p-text')) { 
+                $this.message.text($this.message.data('p-text'));
+            }
+            if ($this.icon.data('p-icon')) {
+                $this.icon.attr('class', 'ui-confirm-popup-icon ' + $this.icon.data('p-icon'));
+            }
             $this.yesButton.removeClass($this.yesButton.data('p-class'));
             $this.noButton.removeClass($this.noButton.data('p-class'));
             $this.yesButton.children('.ui-button-text').text($this.yesButton.data('p-text'));
@@ -340,9 +352,12 @@ PrimeFaces.widget.ConfirmPopup = PrimeFaces.widget.DynamicOverlayWidget.extend({
                 PrimeFaces.csp.eval(msg.beforeShow);
             }
 
-            $this.icon.removeClass().addClass('ui-confirm-popup-icon');
-            if (msg.icon !== 'null') {
-                $this.icon.addClass(msg.icon);
+            var iconClass = msg.icon || $this.icon.data('p-icon');
+            if (iconClass) {
+                $this.icon.removeClass().addClass('ui-confirm-popup-icon ' + iconClass);
+                $this.icon.show();
+            } else {
+                $this.icon.hide();
             }
 
             if (msg.message) {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/dialog/dialog.js
@@ -951,6 +951,9 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
         if(this.cfg.global) {
             PrimeFaces.confirmDialog = this;
             
+            this.title.data('p-text', this.title.text());
+            this.message.data('p-text', this.message.text());
+            this.icon.data('p-icon', this.icon.removeClass('ui-icon ui-confirm-dialog-severity').attr('class'));
             this.yesButton = this.jq.find('.ui-confirmdialog-yes');
             this.noButton = this.jq.find('.ui-confirmdialog-no');
             this.yesButton.data('p-text', this.yesButton.children('.ui-button-text').text());
@@ -1029,6 +1032,15 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
 
         // Remove added classes and reset button labels to their original values
         if (this.cfg.global) {
+            if (this.title.data('p-text')) {
+                this.title.text(this.title.data('p-text'));
+            }
+            if (this.message.data('p-text')) {
+                this.message.text(this.message.data('p-text'));
+            }
+            if (this.icon.data('p-icon')) {
+                this.icon.attr('class', 'ui-icon ui-confirm-dialog-severity ' + this.icon.data('p-icon'));
+            }
             this.yesButton.removeClass(this.yesButton.data('p-class'));
             this.noButton.removeClass(this.noButton.data('p-class'));
             this.yesButton.children('.ui-button-text').text(this.yesButton.data('p-text'));
@@ -1049,8 +1061,9 @@ PrimeFaces.widget.ConfirmDialog = PrimeFaces.widget.Dialog.extend({
         }
 
         // Set icon if provided, or hide it otherwise
-        if (msg.icon) {
-            this.icon.removeClass().addClass('ui-icon ui-confirm-dialog-severity ' + msg.icon);
+        var iconClass = msg.icon || this.icon.data('p-icon');
+        if (iconClass) {
+            this.icon.removeClass().addClass('ui-icon ui-confirm-dialog-severity ' + iconClass);
             this.icon.show();
         } else {
             this.icon.hide();


### PR DESCRIPTION
Fix #12663: ConfirmDialog/Popup restore original values

Similar to what was already being done for Yes and No buttons and icons must store original value in `.data` and restore it upon hide.

Added integration tests