### PR TITLE
Fix #12698: Ensure row edited is visible after AJAX

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -4314,13 +4314,14 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     },
 
     /**
-     * Updates a row with the given content
+     * Updates a row with the given content and ensures it is visible.
      * @protected
      * @param {JQuery} row Row to update.
      * @param {string} content HTML string to set on the row.
      */
     updateRow: function(row, content) {
-        row.replaceWith(content);
+        const $content = $(content).show();
+        row.replaceWith($content);
     },
 
     /**


### PR DESCRIPTION
Fix #12698: Ensure row edited is visible after AJAX

When we added #6325 `expanded` to HeaderRow its evaluated serverside and there is no AJAX its purely an EL evaluation.  So if the value is `false` it think the row should not be displayed and `display:none` is always added.

However using RowEditing inside of it when a row is being edited it by default HAS to be visible.