### PR TITLE
Fix #12577: ScreenReader improved fix

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/jquery/jquery.ui.pfextensions.css
@@ -7,18 +7,3 @@
     display: block;
     margin-top: 0px;
 }
-
-/* Modern override for all browsers and screenreaders */
-.ui-helper-hidden-accessible {
-    border: unset;
-    clip: unset;
-    height: unset;
-    margin: unset;
-    overflow: unset;
-    padding: unset;
-    width: unset;
-    position: absolute !important;
-    pointer-events: none !important;
-    opacity: 0 !important;
-    white-space: nowrap !important;
-}


### PR DESCRIPTION
Fix #12577: ScreenReader improved fix

The original Jquery code was OK the real issue was the code below that made the hidden inputs 0x0 and NVDA won't read them.   So removing that was all that was needed so we can go back to the original Jquery ui-hidden-accessible with no other chnages

It used to be this

```css
.ui-helper-hidden-accessible input,
.ui-helper-hidden-accessible select {
    -webkit-transform: scale(0); 
    -moz-transform: scale(0); 
    transform: scale(0);
}
```

to scale them down to 0x0