### PR TITLE
Selenium: deprecated getAttribute

### DIFF
--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/AccordionPanel.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/AccordionPanel.java
@@ -102,7 +102,7 @@ public abstract class AccordionPanel extends AbstractComponent {
      */
     public void expandTab(int index) {
         WebElement tab = getHeaders().get(index);
-        if (tab.getAttribute("aria-expanded").equalsIgnoreCase("false")) {
+        if (tab.getDomAttribute("aria-expanded").equalsIgnoreCase("false")) {
             toggleTab(index);
         }
     }
@@ -114,7 +114,7 @@ public abstract class AccordionPanel extends AbstractComponent {
      */
     public void collapseTab(int index) {
         WebElement tab = getHeaders().get(index);
-        if (tab.getAttribute("aria-expanded").equalsIgnoreCase("true")) {
+        if (tab.getDomAttribute("aria-expanded").equalsIgnoreCase("true")) {
             toggleTab(index);
         }
     }
@@ -126,7 +126,7 @@ public abstract class AccordionPanel extends AbstractComponent {
      */
     public List<Tab> getSelectedTabs() {
         return getTabs().stream()
-                    .filter(tab -> tab.getHeader().getAttribute("class").contains("ui-state-active"))
+                    .filter(tab -> tab.getHeader().getDomAttribute("class").contains("ui-state-active"))
                     .collect(Collectors.toList());
     }
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/AutoComplete.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/AutoComplete.java
@@ -71,7 +71,7 @@ public abstract class AutoComplete extends AbstractInputComponent {
     }
 
     public String getValue() {
-        return getInput().getAttribute("value");
+        return getInput().getDomProperty("value");
     }
 
     /**

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Button.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Button.java
@@ -41,13 +41,13 @@ public abstract class Button extends AbstractComponent {
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(button));
         PrimeSelenium.waitGui().until(ExpectedConditions.elementToBeClickable(button));
 
-        if (button.getAttribute("data-pfconfirmcommand") != null) {
+        if (button.getDomAttribute("data-pfconfirmcommand") != null) {
             // Confirm Dialog/Popup we don't want to guard for AJAX
         }
         else if (isAjaxified("onclick")) {
             button = PrimeSelenium.guardAjax(button);
         }
-        else if ("submit".equals(button.getAttribute("type"))) {
+        else if ("submit".equals(button.getDomAttribute("type"))) {
             button = PrimeSelenium.guardHttp(button);
         }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CascadeSelect.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CascadeSelect.java
@@ -98,10 +98,8 @@ public abstract class CascadeSelect extends AbstractInputComponent {
             toggleDropdown();
         }
 
-        boolean isLeaf = false;
         for (WebElement element : getItems()) {
-            if (element.getAttribute("data-label").equalsIgnoreCase(label)) {
-                isLeaf = !PrimeSelenium.hasCssClass(element, "ui-cascadeselect-item-group");
+            if (element.getDomAttribute("data-label").equalsIgnoreCase(label)) {
                 click(element);
                 break;
             }
@@ -125,13 +123,13 @@ public abstract class CascadeSelect extends AbstractInputComponent {
 
     public List<String> getLabels() {
         return getItems().stream()
-                    .map(e -> e.getAttribute("data-label"))
+                    .map(e -> e.getDomAttribute("data-label"))
                     .collect(Collectors.toList());
     }
 
     public List<String> getValues() {
         return getItems().stream()
-                    .map(e -> e.getAttribute("data-value"))
+                    .map(e -> e.getDomAttribute("data-value"))
                     .collect(Collectors.toList());
     }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandLink.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/CommandLink.java
@@ -41,13 +41,13 @@ public abstract class CommandLink extends Link {
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleAndAnimationComplete(link));
         PrimeSelenium.waitGui().until(ExpectedConditions.elementToBeClickable(link));
 
-        if (link.getAttribute("data-pfconfirmcommand") != null) {
+        if (link.getDomAttribute("data-pfconfirmcommand") != null) {
             // Confirm Dialog/Popup we don't want to guard for AJAX
         }
         else if (isAjaxified("onclick")) {
             link = PrimeSelenium.guardAjax(link);
         }
-        else if ("_blank".equals(link.getAttribute("target"))) {
+        else if ("_blank".equals(link.getDomAttribute("target"))) {
             link = PrimeSelenium.guardHttp(link);
         }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DataView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/DataView.java
@@ -70,8 +70,8 @@ public abstract class DataView extends AbstractPageableData {
         List<WebElement> layoutButtons = getLayoutOptionsWebElement().findElements(By.className("ui-button"));
         for (WebElement layoutButton: layoutButtons) {
             WebElement layoutButtonInputHidden = layoutButton.findElement(By.tagName("input"));
-            if ("true".equals(layoutButtonInputHidden.getAttribute("checked"))) {
-                if ("list".equals(layoutButtonInputHidden.getAttribute("value"))) {
+            if ("true".equals(layoutButtonInputHidden.getDomProperty("checked"))) {
+                if ("list".equals(layoutButtonInputHidden.getDomProperty("value"))) {
                     return Layout.LIST;
                 }
                 else {
@@ -87,10 +87,10 @@ public abstract class DataView extends AbstractPageableData {
         List<WebElement> layoutButtons = getLayoutOptionsWebElement().findElements(By.className("ui-button"));
         for (WebElement layoutButton: layoutButtons) {
             WebElement layoutButtonInputHidden = layoutButton.findElement(By.tagName("input"));
-            if (layout == Layout.LIST && "list".equals(layoutButtonInputHidden.getAttribute("value"))) {
+            if (layout == Layout.LIST && "list".equals(layoutButtonInputHidden.getDomProperty("value"))) {
                 PrimeSelenium.guardAjax(layoutButton).click();
             }
-            else if (layout == Layout.GRID && "grid".equals(layoutButtonInputHidden.getAttribute("value"))) {
+            else if (layout == Layout.GRID && "grid".equals(layoutButtonInputHidden.getDomProperty("value"))) {
                 PrimeSelenium.guardAjax(layoutButton).click();
             }
         }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/FileUpload.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/FileUpload.java
@@ -47,7 +47,7 @@ public abstract class FileUpload extends AbstractInputComponent {
     @Override
     public WebElement getInput() {
         // in case of mode=simple skinSimple=false the input element is this element
-        boolean isInputFile = "input".equals(getTagName()) && "file".equals(getAttribute("type"));
+        boolean isInputFile = "input".equals(getTagName()) && "file".equals(getDomAttribute("type"));
         return isInputFile ? this : findElement(By.id(getId() + "_input"));
     }
 
@@ -56,7 +56,7 @@ public abstract class FileUpload extends AbstractInputComponent {
      * @return the file name
      */
     public String getValue() {
-        return getInput().getAttribute("value");
+        return getInput().getDomProperty("value");
     }
 
     /**

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Messages.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Messages.java
@@ -56,7 +56,7 @@ public abstract class Messages extends AbstractComponent {
         List<WebElement> messagesSeverities = findElements(By.tagName("div"));
         for (WebElement messageSeverity : messagesSeverities) {
 
-            Severity severity = Severity.toSeverity(messageSeverity.getAttribute("class"));
+            Severity severity = Severity.toSeverity(messageSeverity.getDomAttribute("class"));
 
             for (WebElement message : messageSeverity.findElements(By.cssSelector("li"))) {
                 Msg msg = new Msg();

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/OutputLabel.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/OutputLabel.java
@@ -57,7 +57,7 @@ public abstract class OutputLabel extends AbstractComponent {
      */
     public WebElement getFor() {
         try {
-            return getWebDriver().findElement(By.id(getAttribute("for")));
+            return getWebDriver().findElement(By.id(getDomAttribute("for")));
         }
         catch (NoSuchElementException | StaleElementReferenceException e) {
             return null;

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/PickList.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/PickList.java
@@ -288,7 +288,7 @@ public abstract class PickList extends AbstractComponent {
      */
     public List<String> getSourceListValues() {
         return getSourceListElements().stream()
-                    .map(e -> e.getAttribute(ITEM_VALUE_ATTR)).collect(Collectors.toList());
+                    .map(e -> e.getDomAttribute(ITEM_VALUE_ATTR)).collect(Collectors.toList());
     }
 
     /**
@@ -298,7 +298,7 @@ public abstract class PickList extends AbstractComponent {
      */
     public List<String> getSourceListLabels() {
         return getSourceListElements().stream()
-                    .map(e -> e.getAttribute(ITEM_LABEL_ATTR)).collect(Collectors.toList());
+                    .map(e -> e.getDomAttribute(ITEM_LABEL_ATTR)).collect(Collectors.toList());
     }
 
     /**
@@ -318,7 +318,7 @@ public abstract class PickList extends AbstractComponent {
      */
     public List<String> getTargetListValues() {
         return getTargetListElements().stream()
-                    .map(e -> e.getAttribute(ITEM_VALUE_ATTR)).collect(Collectors.toList());
+                    .map(e -> e.getDomAttribute(ITEM_VALUE_ATTR)).collect(Collectors.toList());
     }
 
     /**
@@ -328,7 +328,7 @@ public abstract class PickList extends AbstractComponent {
      */
     public List<String> getTargetListLabels() {
         return getTargetListElements().stream()
-                    .map(e -> e.getAttribute(ITEM_LABEL_ATTR)).collect(Collectors.toList());
+                    .map(e -> e.getDomAttribute(ITEM_LABEL_ATTR)).collect(Collectors.toList());
     }
 
     /**
@@ -457,8 +457,8 @@ public abstract class PickList extends AbstractComponent {
      */
     private WebElement findListItem(final WebElement listElement, final String item) {
         final Optional<WebElement> listItem = listElement.findElements(By.tagName("li")).stream().filter(e -> {
-            final String value = e.getAttribute(ITEM_VALUE_ATTR);
-            final String label = e.getAttribute(ITEM_LABEL_ATTR);
+            final String value = e.getDomAttribute(ITEM_VALUE_ATTR);
+            final String label = e.getDomAttribute(ITEM_LABEL_ATTR);
             return value.equals(item) || label.equals(item);
         }).findFirst();
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectBooleanButton.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectBooleanButton.java
@@ -44,7 +44,7 @@ public abstract class SelectBooleanButton extends AbstractToggleComponent {
         if (PrimeSelenium.isElementDisplayed(label)) {
             return label.getText();
         }
-        return label.getAttribute("textContent");
+        return label.getDomProperty("textContent");
     }
 
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectManyCheckbox.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectManyCheckbox.java
@@ -123,13 +123,13 @@ public abstract class SelectManyCheckbox extends AbstractComponent {
         int idx = 0;
         for (WebElement checkbox : getCheckboxes()) {
             WebElement input = checkbox.findElement(By.tagName("input"));
-            WebElement label = getRoot().findElement(By.cssSelector("label[for='" + input.getAttribute("id") + "']"));
+            WebElement label = getRoot().findElement(By.cssSelector("label[for='" + input.getDomAttribute("id") + "']"));
             WebElement box = checkbox.findElement(By.className("ui-chkbox-box"));
 
             SelectItem item = new SelectItem();
             item.setIndex(idx);
             item.setLabel(label.getText());
-            item.setValue(input.getAttribute("value"));
+            item.setValue(input.getDomProperty("value"));
             item.setSelected(PrimeSelenium.hasCssClass(box, "ui-state-active"));
             items.add(item);
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectManyMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectManyMenu.java
@@ -152,12 +152,12 @@ public abstract class SelectManyMenu extends AbstractInputComponent {
         if (widgetConfiguration.has("filter") && widgetConfiguration.getBoolean("filter")) {
             return getSelectlistbox().findElements(By.cssSelector("li.ui-selectlistbox-item")).stream()
                     .filter(listElt -> listElt.isDisplayed())
-                    .map(e -> e.getAttribute("innerHTML"))
+                    .map(e -> e.getDomProperty("innerHTML"))
                     .collect(Collectors.toList());
         }
         else {
             return getInput().findElements(By.tagName("option")).stream()
-                    .map(e -> e.getAttribute("innerHTML"))
+                    .map(e -> e.getDomProperty("innerHTML"))
                     .collect(Collectors.toList());
         }
     }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneButton.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneButton.java
@@ -64,7 +64,7 @@ public abstract class SelectOneButton extends AbstractInputComponent {
         if (PrimeSelenium.isElementDisplayed(label)) {
             return label.getText();
         }
-        return label.getAttribute("textContent");
+        return label.getDomProperty("textContent");
     }
 
     public boolean isSelected(String label) {

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
@@ -140,7 +140,7 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
         if (PrimeSelenium.isElementDisplayed(label)) {
             return label.getText();
         }
-        return label.getAttribute("textContent");
+        return label.getDomProperty("textContent");
     }
 
     public boolean isSelected(String label) {
@@ -166,12 +166,12 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
 
             return getItems().findElements(By.cssSelector("li.ui-selectonemenu-item")).stream()
                     .filter(listElt -> listElt.isDisplayed())
-                    .map(e -> e.getAttribute("innerHTML"))
+                    .map(e -> e.getDomProperty("innerHTML"))
                     .collect(Collectors.toList());
         }
         else {
             return getInput().findElements(By.tagName("option")).stream()
-                    .map(e -> e.getAttribute("innerHTML"))
+                    .map(e -> e.getDomProperty("innerHTML"))
                     .collect(Collectors.toList());
         }
     }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneRadio.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneRadio.java
@@ -124,13 +124,13 @@ public abstract class SelectOneRadio extends AbstractComponent {
         int idx = 0;
         for (WebElement radiobutton : getRadioButtons()) {
             WebElement input = radiobutton.findElement(By.tagName("input"));
-            WebElement label = getRoot().findElement(By.cssSelector("label[for='" + input.getAttribute("id") + "']"));
+            WebElement label = getRoot().findElement(By.cssSelector("label[for='" + input.getDomAttribute("id") + "']"));
             WebElement box = radiobutton.findElement(By.className("ui-radiobutton-box"));
 
             SelectItem item = new SelectItem();
             item.setIndex(idx);
             item.setLabel(label.getText());
-            item.setValue(input.getAttribute("value"));
+            item.setValue(input.getDomProperty("value"));
             item.setSelected(PrimeSelenium.hasCssClass(box, "ui-state-active"));
             items.add(item);
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TabView.java
@@ -97,6 +97,6 @@ public abstract class TabView extends AbstractComponent {
     }
 
     private Integer getIndexOfHeader(WebElement headerElt) {
-        return Integer.parseInt(headerElt.getAttribute("data-index"));
+        return Integer.parseInt(headerElt.getDomAttribute("data-index"));
     }
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Tree.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/Tree.java
@@ -50,7 +50,7 @@ public abstract class Tree extends AbstractComponent {
 
     public List<TreeNode> getChildren() {
         return findElements(By.cssSelector(CHILD_SELECTOR)).stream()
-                .map(e -> new TreeNode(this, e.getAttribute("data-rowkey"), null))
+                .map(e -> new TreeNode(this, e.getDomAttribute("data-rowkey"), null))
                 .collect(Collectors.toList());
     }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TriStateCheckbox.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/TriStateCheckbox.java
@@ -67,7 +67,7 @@ public abstract class TriStateCheckbox extends AbstractInputComponent {
     }
 
     public String getValue() {
-        return input.getAttribute("value");
+        return input.getDomProperty("value");
     }
 
     /**

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractComponent.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractComponent.java
@@ -90,13 +90,13 @@ public abstract class AbstractComponent extends AbstractPrimePageFragment {
         }
 
         // first check normal path if component is AJAXified
-        boolean isAjaxScript = ComponentUtils.isAjaxScript(element.getAttribute(event));
+        boolean isAjaxScript = ComponentUtils.isAjaxScript(element.getDomProperty(event));
         if (isAjaxScript) {
             return true;
         }
 
         // now check for CSP events
-        String id = element.getAttribute("id");
+        String id = element.getDomAttribute("id");
         String cspScript = String.format(CSP_SCRIPT, id, event);
         Boolean csp = PrimeSelenium.executeScript(cspScript);
         return csp != null && csp;

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractInputComponent.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractInputComponent.java
@@ -66,7 +66,7 @@ public abstract class AbstractInputComponent extends AbstractComponent {
      * @return the {@link WebElement} representing the label.
      */
     public WebElement getAssignedLabel() {
-        return getWebDriver().findElement(By.cssSelector("label[for='" + getInput().getAttribute("id") + "']"));
+        return getWebDriver().findElement(By.cssSelector("label[for='" + getInput().getDomAttribute("id") + "']"));
     }
 
     /**
@@ -88,7 +88,7 @@ public abstract class AbstractInputComponent extends AbstractComponent {
         Keys command = PrimeSelenium.isMacOs() ? Keys.COMMAND : Keys.CONTROL;
         input.sendKeys(Keys.chord(command, "a")); // select everything
         input.sendKeys(Keys.chord(command, "c")); // copy
-        return input.getAttribute("value");
+        return input.getDomAttribute("value");
     }
 
     /**
@@ -101,7 +101,7 @@ public abstract class AbstractInputComponent extends AbstractComponent {
         Keys command = PrimeSelenium.isMacOs() ? Keys.COMMAND : Keys.CONTROL;
         input.sendKeys(Keys.chord(command, "a")); // select everything
         input.sendKeys(Keys.chord(command, "v")); // paste
-        return input.getAttribute("value");
+        return input.getDomAttribute("value");
     }
 
     /**

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractToggleComponent.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/AbstractToggleComponent.java
@@ -87,7 +87,8 @@ public abstract class AbstractToggleComponent extends AbstractInputComponent {
      * @return true for checked, false for unchecked
      */
     public boolean getValue() {
-        return getInput().getAttribute("checked") != null;
+        WebElement input = getInput();
+        return "true".equals(input.getDomProperty("checked")) || "true".equals(input.getDomAttribute("checked"));
     }
 
     /**

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/ComponentUtils.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/base/ComponentUtils.java
@@ -38,7 +38,7 @@ public final class ComponentUtils {
             return false;
         }
 
-        String id = element.getAttribute("id");
+        String id = element.getDomAttribute("id");
         String result = PrimeSelenium.executeScript("return " + getWidgetByIdScript(id) + ".getBehavior('" + behavior + "').toString();");
         return isAjaxScript(result);
     }
@@ -48,12 +48,12 @@ public final class ComponentUtils {
             return false;
         }
 
-        String id = element.getAttribute("id");
+        String id = element.getDomAttribute("id");
         return PrimeSelenium.executeScript("return " + getWidgetByIdScript(id) + ".hasBehavior('" + behavior + "');");
     }
 
     public static boolean isWidget(WebElement element) {
-        String id = element.getAttribute("id");
+        String id = element.getDomAttribute("id");
         if (id == null || id.isEmpty()) {
             return false;
         }
@@ -73,7 +73,7 @@ public final class ComponentUtils {
     }
 
     public static String getWidgetConfiguration(WebElement element) {
-        String id = element.getAttribute("id");
+        String id = element.getDomAttribute("id");
         return PrimeSelenium.executeScript("return JSON.stringify(" + getWidgetByIdScript(id) + ".cfg, function(key, value) {\n" +
                     "  if (typeof value === 'function') {\n" +
                     "    return value.toString();\n" +

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/html/Link.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/html/Link.java
@@ -42,10 +42,10 @@ public abstract class Link extends AbstractComponent {
     }
 
     public String getHref() {
-        return getRoot().getAttribute("href");
+        return getRoot().getDomAttribute("href");
     }
 
     public String getTarget() {
-        return getRoot().getAttribute("target");
+        return getRoot().getDomAttribute("target");
     }
 }

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/html/SelectOneMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/html/SelectOneMenu.java
@@ -44,7 +44,7 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
         }
 
         WebElement option = getOptions().stream()
-                .filter(e -> Objects.equals(e.getAttribute("innerHTML"), label) && e.isSelected())
+                .filter(e -> Objects.equals(e.getDomProperty("innerHTML"), label) && e.isSelected())
                 .findFirst()
                 .orElse(null);
         if (option != null) {
@@ -61,7 +61,7 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
         }
 
         WebElement option = getOptions().stream()
-                .filter(e -> Objects.equals(e.getAttribute("innerHTML"), label) && !e.isSelected())
+                .filter(e -> Objects.equals(e.getDomProperty("innerHTML"), label) && !e.isSelected())
                 .findFirst()
                 .orElse(null);
         if (option != null) {
@@ -77,7 +77,7 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
                 .filter(e -> e.isSelected())
                 .findFirst()
                 .orElse(null);
-        return option == null ? null : option.getAttribute("innerHTML");
+        return option == null ? null : option.getDomProperty("innerHTML");
     }
 
     public boolean isSelected(String label) {
@@ -97,7 +97,7 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
      */
     public List<String> getLabels() {
         return getOptions().stream()
-                .map(e -> e.getAttribute("innerHTML"))
+                .map(e -> e.getDomProperty("innerHTML"))
                 .collect(Collectors.toList());
     }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/datatable/Row.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/datatable/Row.java
@@ -60,7 +60,7 @@ public class Row {
     }
 
     public boolean isExpanded() {
-        return Boolean.parseBoolean(getToggler().getAttribute("aria-expanded"));
+        return Boolean.parseBoolean(getToggler().getDomAttribute("aria-expanded"));
     }
 
     public void expand() {

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/tree/TreeNode.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/tree/TreeNode.java
@@ -85,7 +85,7 @@ public class TreeNode {
         // we need a xpath selector as selenium doesnt support direct child selector like #findElements(">...")
         return getWebElement()
                 .findElements(By.xpath("./ul/li[contains(@class, 'ui-treenode')]")).stream()
-                .map(e -> new TreeNode(tree, e.getAttribute("data-rowkey"), this))
+                .map(e -> new TreeNode(tree, e.getDomAttribute("data-rowkey"), this))
                 .collect(Collectors.toList());
     }
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/treetable/Row.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/model/treetable/Row.java
@@ -43,7 +43,7 @@ public class Row extends org.primefaces.selenium.component.model.datatable.Row {
     }
 
     public int getLevel() {
-        String cssClasses = getWebElement().getAttribute("class");
+        String cssClasses = getWebElement().getDomAttribute("class");
         Optional<String> levelClassOpt = Arrays.stream(cssClasses.split(" ")).filter(c -> c.startsWith("ui-node-level")).findFirst();
         if (levelClassOpt.isPresent()) {
             String levelClass = levelClassOpt.get();

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageFragment.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageFragment.java
@@ -59,7 +59,7 @@ public abstract class AbstractPrimePageFragment implements WebElement, WrapsElem
     }
 
     public String getId() {
-        return getRoot().getAttribute("id");
+        return getRoot().getDomAttribute("id");
     }
 
 }

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageTest.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/AbstractPrimePageTest.java
@@ -299,7 +299,7 @@ public abstract class AbstractPrimePageTest {
      * @param cssClasses the CSS class or classes to look for
      */
     protected void assertCss(WebElement element, String... cssClasses) {
-        String elementClass = element.getAttribute("class");
+        String elementClass = element.getDomAttribute("class");
         if (elementClass == null) {
             Assertions.fail("Element did not have CSS 'class' attribute.");
             return;

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/PrimeSelenium.java
@@ -214,7 +214,7 @@ public final class PrimeSelenium {
      * @return true if this element has the CSS class
      */
     public static boolean hasCssClass(WebElement element, String... cssClass) {
-        String elementClass = element.getAttribute("class");
+        String elementClass = element.getDomAttribute("class");
         if (elementClass == null) {
             return false;
         }
@@ -364,7 +364,7 @@ public final class PrimeSelenium {
         return isElementDisplayed(element) &&
                     isElementEnabled(element) &&
                     !hasCssClass(element, "ui-state-disabled") &&
-                    !Boolean.parseBoolean(element.getAttribute("aria-busy"));
+                    !Boolean.parseBoolean(element.getDomAttribute("aria-busy"));
     }
 
     /**
@@ -502,7 +502,7 @@ public final class PrimeSelenium {
      * @see <a href="https://stackoverflow.com/questions/11858366/how-to-type-some-text-in-hidden-field-in-selenium-webdriver-using-java">Stack Overflow</a>
      */
     public static void setHiddenInput(WebElement input, String value) {
-        executeScript(" document.getElementById('" + input.getAttribute("id") + "').value='" + value + "'");
+        executeScript(" document.getElementById('" + input.getDomAttribute("id") + "').value='" + value + "'");
     }
 
     /**
@@ -515,7 +515,7 @@ public final class PrimeSelenium {
     public static void clearInput(WebElement input, boolean isAjaxified) {
         if (PrimeSelenium.isSafari()) {
             // Safari hack https://stackoverflow.com/a/64067604/502366
-            String inputText = input.getAttribute("value");
+            String inputText = input.getDomProperty("value");
             if (inputText != null && inputText.length() > 0) {
                 CharSequence[] clearText = new CharSequence[inputText.length()];
                 for (int i = 0; i < inputText.length(); i++) {

--- a/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/findby/FindByParentPartialIdElementLocator.java
+++ b/primefaces-selenium/primefaces-selenium-core/src/main/java/org/primefaces/selenium/findby/FindByParentPartialIdElementLocator.java
@@ -57,7 +57,7 @@ public class FindByParentPartialIdElementLocator implements ElementLocator {
     public List<WebElement> findElements() {
         WebElement parent = parentLocator.findElement();
 
-        String parentId = parent.getAttribute("id");
+        String parentId = parent.getDomAttribute("id");
         if (parentId == null || parentId.trim().isEmpty()) {
             throw new WebDriverException("Id of parent element is null or empty!");
         }


### PR DESCRIPTION
```java
/**
   * Get the value of the given attribute of the element. Will return the current value, even if
   * this has been modified after the page has been loaded.
   *
   * <p>More exactly, this method will return the value of the property with the given name, if it
   * exists. If it does not, then the value of the attribute with the given name is returned. If
   * neither exists, null is returned.
   *
   * <p>The "style" attribute is converted as best can be to a text representation with a trailing
   * semicolon.
   *
   * <p>The following are deemed to be "boolean" attributes, and will return either "true" or null:
   *
   * <p>async, autofocus, autoplay, checked, compact, complete, controls, declare, defaultchecked,
   * defaultselected, defer, disabled, draggable, ended, formnovalidate, hidden, indeterminate,
   * iscontenteditable, ismap, itemscope, loop, multiple, muted, nohref, noresize, noshade,
   * novalidate, nowrap, open, paused, pubdate, readonly, required, reversed, scoped, seamless,
   * seeking, selected, truespeed, willvalidate
   *
   * <p>Finally, the following commonly mis-capitalized attribute/property names are evaluated as
   * expected:
   *
   * <ul>
   *   <li>If the given name is "class", the "className" property is returned.
   *   <li>If the given name is "readonly", the "readOnly" property is returned.
   * </ul>
   *
   * <i>Note:</i> The reason for this behavior is that users frequently confuse attributes and
   * properties. If you need to do something more precise, use {@link #getDomAttribute(String)} or
   * {@link #getDomProperty(String)} to obtain the result you desire.
   *
   * <p>See <a href="https://w3c.github.io/webdriver/#get-element-attribute">W3C WebDriver
   * specification</a> for more details.
   *
   * @param name The name of the attribute.
   * @return The attribute/property's current value or null if the value is not set.
   * @deprecated This method is deprecated. Use {@link #getDomProperty(String)} or {@link
   *     #getDomAttribute(String)} for more precise attribute retrieval.
   */
```