### PR TITLE
Fix #13191: ComponentUtils allow flex="false"

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/FlexAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/FlexAware.java
@@ -33,5 +33,5 @@ public interface FlexAware {
      *
      * @return true to use PrimeFlex instead of Grid CSS.
      */
-    boolean isFlex();
+    Boolean getFlex();
 }

--- a/primefaces/src/main/java/org/primefaces/component/datagrid/DataGridBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datagrid/DataGridBase.java
@@ -130,7 +130,7 @@ public abstract class DataGridBase extends UIPageableData
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datagrid/DataGridBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datagrid/DataGridBase.java
@@ -126,8 +126,8 @@ public abstract class DataGridBase extends UIPageableData
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/dataview/DataViewBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/dataview/DataViewBase.java
@@ -144,8 +144,8 @@ public abstract class DataViewBase extends UIPageableData
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/dataview/DataViewBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/dataview/DataViewBase.java
@@ -148,7 +148,7 @@ public abstract class DataViewBase extends UIPageableData
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -539,7 +539,7 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerBase.java
@@ -535,8 +535,8 @@ public abstract class DatePickerBase extends UICalendar implements Widget, Input
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListBase.java
@@ -181,7 +181,7 @@ public abstract class OrderListBase extends UIInput implements Widget, ClientBeh
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/orderlist/OrderListBase.java
@@ -177,8 +177,8 @@ public abstract class OrderListBase extends UIInput implements Widget, ClientBeh
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxBase.java
@@ -67,8 +67,8 @@ public abstract class SelectManyCheckboxBase extends HtmlSelectManyCheckbox impl
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectmanycheckbox/SelectManyCheckboxBase.java
@@ -71,7 +71,7 @@ public abstract class SelectManyCheckboxBase extends HtmlSelectManyCheckbox impl
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
@@ -78,8 +78,8 @@ public abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements W
     }
 
     @Override
-    public boolean isFlex() {
-        return (Boolean) getStateHelper().eval(PropertyKeys.flex, false);
+    public Boolean getFlex() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
     public void setFlex(boolean flex) {

--- a/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectoneradio/SelectOneRadioBase.java
@@ -82,7 +82,7 @@ public abstract class SelectOneRadioBase extends HtmlSelectOneRadio implements W
         return (Boolean) getStateHelper().eval(PropertyKeys.flex, null);
     }
 
-    public void setFlex(boolean flex) {
+    public void setFlex(Boolean flex) {
         getStateHelper().put(PropertyKeys.flex, flex);
     }
 

--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -302,7 +302,10 @@ public class ComponentUtils {
     }
 
     public static boolean isFlex(FacesContext context, FlexAware component) {
-        return component.isFlex() || PrimeRequestContext.getCurrentInstance(context).isFlex();
+        if (component.getFlex() == null) {
+            return PrimeRequestContext.getCurrentInstance(context).isFlex();
+        }
+        return component.getFlex();
     }
 
     public static void processDecodesOfFacetsAndChilds(UIComponent component, FacesContext context) {


### PR DESCRIPTION
Changes the signature of `FlexAware.isFlex()` to return null instead of defaulting to `false`.

Fix #13191: ComponentUtils allow flex="false"