### PR TITLE
Dependency Manage Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,15 @@
                 </exclusions>
             </dependency>
 
+            <!-- Jackson for Integration Tests / Selenium -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>2.18.2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>   
+
             <!-- JUnit -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -148,13 +148,6 @@
            <version>2.6.0</version>
         </dependency>
 
-        <!-- Conflict with resteasy-jackson2-provider -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
-        </dependency>
-
         <!-- Cache -->
         <dependency>
             <groupId>org.ehcache</groupId>


### PR DESCRIPTION
It looks like WebDriverManager uses `com.github.docker-java` which I am pretty sure we don't even use and it brings in vulnerable jackson.