### PR TITLE
Fix #13182: DatePicker allow CTRL+Z in time input

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/0-datepicker.js
@@ -2221,6 +2221,7 @@
                 "c",
                 "v",
                 "x",
+                "z"
             ];
             if (event.ctrlKey && allowedControlKeys.includes(event.key)) {
                 return true;


### PR DESCRIPTION
Fix #13182: DatePicker allow CTRL+Z in time input

cc @BalusC