### PR TITLE
Fix #13236: 14.0.11 DataTable ignore non selectable rows during selection

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -2814,7 +2814,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
      * otherwise.
      */
     selectRowsInRange: function(row, silent) {
-        var rows = this.tbody.children(),
+        var rows = this.tbody.children('.ui-datatable-selectable'),
             rowMeta = this.getRowMeta(row),
             offset = (this.cfg.paginator && this.cfg.paginator.page >= 0) ? this.cfg.paginator.rows * this.cfg.paginator.page : 0,
             newCursorIndex = offset > this.originRowMeta.index ? this.originRowMeta.index : this.originRowMeta.index - offset,


### PR DESCRIPTION
Fix #13236: 14.0.11 DataTable ignore non selectable rows during selection