### PR TITLE
Fix #13209: Improve formatBytes for localization

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -416,6 +416,13 @@ public class FileUploadUtils {
         return allowTypes != null ? allowTypes.replace("/(\\.|\\/)(", "").replace(")$/", "") : null;
     }
 
+    /**
+     * Formats the given data size in a more human-friendly format, e.g., `1.5 MB` etc.
+     * @param bytes File size in bytes to format
+     * @param locale The locale to use for number formatting
+     * @return The given file size, formatted in a more human-friendly format. Returns empty string if bytes is null,
+     *         or "N/A" if bytes is 0.
+     */
     public static String formatBytes(Long bytes, Locale locale) {
         if (bytes == null) {
             return "";
@@ -425,7 +432,7 @@ public class FileUploadUtils {
             return "N/A";
         }
 
-        String[] sizes = new String[] {"Bytes", "KB", "MB", "GB", "TB"};
+        String[] sizes = new String[] {"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
         int i = (int) Math.floor(Math.log(bytes) / Math.log(1024));
         if (i == 0) {
             return bytes + " " + sizes[i];

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -911,7 +911,7 @@ if (!PrimeFaces.utils) {
             if (bytes === 0)
                 return 'N/A';
 
-            var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+            var sizes = PrimeFaces.getLocaleLabel('fileSizeTypes');
             var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
             if (i === 0)
                 return bytes + ' ' + sizes[i];

--- a/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -426,8 +426,8 @@ class FileUploadUtilsTest {
 
     @Test
     void formatBytes() {
-        assertEquals("1000 Bytes", FileUploadUtils.formatBytes(1000L, Locale.US));
-        assertEquals("1.0 KB", FileUploadUtils.formatBytes(1025L, Locale.US));
+        assertEquals("1000 B", FileUploadUtils.formatBytes(1000L, Locale.US));
+        assertEquals("1.0 kB", FileUploadUtils.formatBytes(1025L, Locale.US));
     }
 
     @Test


### PR DESCRIPTION
Fix #13209: CSV FormatBytes use locale value

cc @milansie this fixes the CSV side of the locale labels.