### PR TITLE
#13230, #13224 - allowType error message improvements

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -81,6 +81,11 @@ public class FileUploadUtils {
     private static final Pattern INVALID_FILENAME_LINUX = Pattern.compile(".*[/\0:*?\\\"<>|].*");
     private static final Pattern ENCODED_CHARS_PAT = Pattern.compile("(%)([0-9a-fA-F])([0-9a-fA-F])");
 
+    // pattern to format allowedTypes for FileUpload - formats like /.*\.(xls|xlsx|csv|txt)/
+    private static final Pattern ALLOW_TYPES_PATTERN =  Pattern.compile("\\/\\.\\*\\\\.\\(?(.*?)\\)?\\$?\\/");
+    // pattern to format allowedTypes for FileUpload - formats like /(\.|\/)(gif|jpeg|jpg|png)$/
+    private static final Pattern ALLOW_TYPES_PATTERN_2 = Pattern.compile("\\/\\(\\.|\\/\\)\\(?(.*?)\\)?\\$?\\/");
+
     private FileUploadUtils() {
         // private constructor to prevent instantiation
     }
@@ -413,7 +418,30 @@ public class FileUploadUtils {
      * @return The allowTypes formatted in a more human-friendly format.
      */
     public static String formatAllowTypes(String allowTypes) {
-        return allowTypes != null ? allowTypes.replace("/(\\.|\\/)(", "").replace(")$/", "") : null;
+        // emtpy or null
+        if (allowTypes == null || allowTypes.isEmpty()) {
+            return allowTypes;
+        }
+
+        // not a correct regex pattern
+        if (!allowTypes.startsWith("/")) {
+            return allowTypes;
+        }
+
+        // pattern to format allowedTypes for FileUpload - formats like /.*\.(xls|xlsx|csv|txt)/
+        Matcher matcher1 = ALLOW_TYPES_PATTERN.matcher(allowTypes);
+        if (matcher1.find()) {
+            return "." + matcher1.group(1).replace("|", ", .");
+        }
+
+        // pattern to format allowedTypes for FileUpload - formats like /(\.|\/)(gif|jpeg|jpg|png)$/
+        Matcher matcher2 = ALLOW_TYPES_PATTERN_2.matcher(allowTypes);
+        if (matcher2.find()) {
+            return "." + matcher2.group(1).replace("|", ", .");
+        }
+
+        // rest return unchanged
+        return allowTypes;
     }
 
     public static String formatBytes(Long bytes, Locale locale) {

--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -419,7 +419,7 @@ public class FileUploadUtils {
      */
     public static String formatAllowTypes(String allowTypes) {
         // emtpy or null
-        if (allowTypes == null || allowTypes.isEmpty()) {
+        if (LangUtils.isBlank(allowTypes)) {
             return allowTypes;
         }
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -906,7 +906,7 @@ if (!PrimeFaces.utils) {
             }
 
             // formats like /(\.|\/)(gif|jpeg|jpg|png)$/
-            let match = allowTypes.match(/\/\(\.\|\/\)\(?(.*?)\)?\$?\//);
+            let match = allowTypes.match(/\/\(\\\.\|\\\/\)\(?(.*?)\)?\$?\//);
             if (match) {
                 return '.' + match[1].replace(/\|/g, ', .');
             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -905,14 +905,14 @@ if (!PrimeFaces.utils) {
                 return allowTypes;
             }
 
-            // formats like .*\.(xls|xlsx|csv|txt)
-            let match = allowTypes.match(/\/\.\*\\\.\(?(.*?)\)?\$?\//);
+            // formats like /(\.|\/)(gif|jpeg|jpg|png)$/
+            let match = allowTypes.match(/\/\(\.\|\/\)\(?(.*?)\)?\$?\//);
             if (match) {
                 return '.' + match[1].replace(/\|/g, ', .');
             }
 
-            // formats like /(\.|\/)(gif|jpeg|jpg|png)$/
-            match = allowTypes.match(/\/(\.|\/)\(?(.*?)\)?\$?\//);
+            // formats like .*\.(xls|xlsx|csv|txt)
+            match = allowTypes.match(/\/\.\*\\\.\(?(.*?)\)?\$?\//);
             if (match) {
                 return '.' + match[1].replace(/\|/g, ', .');
             }

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -896,7 +896,29 @@ if (!PrimeFaces.utils) {
          * @return {string} The allowTypes formatted in a more human-friendly format.
          */
         formatAllowTypes: function(allowTypes) {
-            return allowTypes === undefined ? '' : allowTypes.replace("/(\\.|\\/)(", "").replace(")$/", "");
+            if (!allowTypes) {
+                return allowTypes;
+            }
+
+            // not a correct regex pattern
+            if (!allowTypes.startsWith('/')) {
+                return allowTypes;
+            }
+
+            // formats like .*\.(xls|xlsx|csv|txt)
+            let match = allowTypes.match(/\/\.\*\\\.\(?(.*?)\)?\$?\//);
+            if (match) {
+                return '.' + match[1].replace(/\|/g, ', .');
+            }
+
+            // formats like /(\.|\/)(gif|jpeg|jpg|png)$/
+            match = allowTypes.match(/\/(\.|\/)\(?(.*?)\)?\$?\//);
+            if (match) {
+                return '.' + match[1].replace(/\|/g, ', .');
+            }
+
+            // others return unchanged
+            return allowTypes;
         },
 
         /**


### PR DESCRIPTION
- ignored regexp flags
- human readable for extensions regexps "zip|xls" -> ".zip, .xls"
- complex regexp returned as-is

Fix https://github.com/primefaces/primefaces/issues/13230
Fix https://github.com/primefaces/primefaces/issues/13224