### PR TITLE
Fix #13274: BlockUI switch to ResizeObserver/MutationObserver

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/misc/blockUI.xhtml
@@ -45,26 +45,11 @@
                         Customers
                     </f:facet>
 
-                    <p:column>
-                        <f:facet name="header">
-                            <h:outputText value="Name"/>
-                        </f:facet>
-                        <h:outputText value="#{customer.name}"/>
-                    </p:column>
+                    <p:column field="name" />
 
-                    <p:column>
-                        <f:facet name="header">
-                            <h:outputText value="Country"/>
-                        </f:facet>
-                        <h:outputText value="#{customer.country.name}"/>
-                    </p:column>
+                    <p:column field="country.name" />
 
-                    <p:column>
-                        <f:facet name="header">
-                            <h:outputText value="Company"/>
-                        </f:facet>
-                        <h:outputText value="#{customer.company}"/>
-                    </p:column>
+                    <p:column field="company" />
 
                     <p:column>
                         <f:facet name="header">

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/blockui/blockui.js
@@ -45,11 +45,11 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             PrimeFaces.queueTask(function() { $this.bindTriggers() }, 1);
         }
 
+        this.bindResizer();
+
         if (this.cfg.blocked) {
             this.show();
         }
-
-        this.bindResizer();
     },
 
     /**
@@ -89,8 +89,10 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
      */
     bindResizer: function() {
         var $this = this;
-        this.resizeHandler = PrimeFaces.utils.registerResizeHandler(this, 'resize.' + this.id + '_resize', this.target, function() {
-            $this.alignOverlay();
+        this.resizeHandler = PrimeFaces.utils.registerMutationObserver(this, this.target, function() {
+            if ($this.isBlocking()) {
+                $this.alignOverlay(false);
+            }
         });
     },
 
@@ -275,14 +277,13 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
     },
 
     /**
-    * Align the overlay so it covers its target component.
-    * @private
-    */
-    alignOverlay: function() {
+     * Align the overlay so it covers its target component. Updates the size and position of the blocker and content elements
+     * to match the target component's dimensions.
+     * @param {boolean} [forceUpdate=true] - Whether to force update the overlay dimensions even if they haven't changed
+     * @private
+     */
+    alignOverlay: function(forceUpdate = true) {
         this.target = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.jq, this.cfg.block);
-        if (this.blocker) {
-            PrimeFaces.nextZindex(this.blocker);
-        }
 
         //center position of content
         for (var i = 0; i < this.target.length; i++) {
@@ -300,34 +301,56 @@ PrimeFaces.widget.BlockUI = PrimeFaces.widget.BaseWidget.extend({
             var height = currentTarget.outerHeight(),
                 width = currentTarget.outerWidth(),
                 offset = currentTarget.offset();
-            var sizeAndPosition = {
-                'height': height + 'px',
-                'width': width + 'px',
-                'left': offset.left + 'px',
-                'top': offset.top + 'px'
-            };
-            blocker.css(sizeAndPosition);
+           
+            // Only update blocker CSS if dimensions changed
+            var currentBlockerHeight = blocker.height();
+            var currentBlockerWidth = blocker.width();
+            var currentBlockerOffset = blocker.offset();
 
-            var contentHeight = content.outerHeight();
-            var contentWidth = content.outerWidth();
-            // #9496 if display:none then we need to clone to get its dimensions
-            if (content.height() <= 0) {
-                var currentWidth = this.content[i].getBoundingClientRect().width;
-                var styleWidth = currentWidth ? 'width: ' + currentWidth + 'px' : '';
-                var clone = this.content[i].cloneNode(true);
-                clone.style.cssText = 'position: fixed; top: 0; left: 0; overflow: auto; visibility: hidden; pointer-events: none; height: unset; max-height: unset;' + styleWidth;
-                document.body.append(clone);
-                var jqClone = $(clone);
-                contentHeight = jqClone.outerHeight();
-                contentWidth = jqClone.outerWidth();
-                jqClone.remove();
+            if (forceUpdate || (height !== currentBlockerHeight ||
+                width !== currentBlockerWidth ||
+                offset.left !== currentBlockerOffset.left ||
+                offset.top !== currentBlockerOffset.top)) {
+
+                blocker.css({
+                    'height': height + 'px',
+                    'width': width + 'px',
+                    'left': offset.left + 'px',
+                    'top': offset.top + 'px',
+                    'z-index': PrimeFaces.nextZindex()
+                });
             }
 
-            content.css({
-                'left': ((blocker.width() - contentWidth) / 2) + 'px',
-                'top': ((blocker.height() - contentHeight) / 2) + 'px',
-                'z-index': PrimeFaces.nextZindex()
-            });
+            if (this.hasContent()) {
+                var contentHeight = content.outerHeight();
+                var contentWidth = content.outerWidth();
+
+                // #9496 if display:none then we need to clone to get its dimensions
+                if (content.height() <= 0) {
+                    var currentWidth = this.content[i].getBoundingClientRect().width;
+                    var styleWidth = currentWidth ? 'width: ' + currentWidth + 'px' : '';
+                    var clone = this.content[i].cloneNode(true);
+                    clone.style.cssText = 'position: fixed; top: 0; left: 0; overflow: auto; visibility: hidden; pointer-events: none; height: unset; max-height: unset;' + styleWidth;
+                    document.body.append(clone);
+                    var jqClone = $(clone);
+                    contentHeight = jqClone.outerHeight();
+                    contentWidth = jqClone.outerWidth();
+                    jqClone.remove();
+                }
+
+                // Only update content CSS if position changed
+                var currentContentLeft = parseFloat(content.css('left')) || 0;
+                var currentContentTop = parseFloat(content.css('top')) || 0;
+                var newContentLeft = ((blocker.width() - contentWidth) / 2);
+                var newContentTop = ((blocker.height() - contentHeight) / 2);
+                if (forceUpdate || (newContentLeft !== currentContentLeft || newContentTop !== currentContentTop)) {
+                    content.css({
+                        'left': newContentLeft + 'px',
+                        'top': newContentTop + 'px',
+                        'z-index': PrimeFaces.nextZindex()
+                    });
+                }
+            }
         }
     },
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -370,6 +370,75 @@ if (!PrimeFaces.utils) {
         },
 
         /**
+         * Registers a MutationObserver/ResizeObserver to watch for DOM changes that may affect element sizing/positioning.
+         * @param {PrimeFaces.widget.BaseWidget} widget The widget instance to register the observer for
+         * @param {JQuery | HTMLElement} element The element to observe for changes
+         * @param {() => void} resizeCallback Callback function to execute when relevant mutations occur
+         * @return {{bind: () => void, unbind: () => void}} Object containing bind and unbind functions for the observer
+         */
+        registerMutationObserver: function (widget, element, resizeCallback) {
+            const domElement = element instanceof jQuery ? element.get(0) : element;
+
+            const resizeObserver = new ResizeObserver(entries => {
+                const $entry = $(entries[0].target);
+                if ($entry && ($entry.is(":hidden") || $entry.css('visibility') === 'hidden')) {
+                    return;
+                }
+                resizeCallback();
+            });
+
+            const mutationObserver = new MutationObserver(mutations => {
+                // Check if mutation involves DOM position changes
+                const shouldCallback = mutations.some(mutation => {
+                    const {type, target, attributeName} = mutation;
+                    return (type === "childList" && target.id === domElement.id) ||
+                           (type === "attributes" && attributeName === "style" && target.id === domElement.id) ||
+                           (type === "attributes" && attributeName === "class");
+                });
+
+                if (shouldCallback) {
+                    // Debounce multiple mutations using requestAnimationFrame
+                    if (mutationObserver.rafId) {
+                        window.cancelAnimationFrame(mutationObserver.rafId);
+                    }
+                    mutationObserver.rafId = window.requestAnimationFrame(() => {
+                        resizeCallback();
+                    });
+                }
+            });
+
+            // Cleanup function to disconnect both observers
+            const unbindMutationObserver = function () {
+                resizeObserver.unobserve(domElement);
+                mutationObserver.disconnect();
+            };
+
+
+            // Add cleanup handlers to widget lifecycle
+            widget.addDestroyListener(unbindMutationObserver);
+            widget.addRefreshListener(unbindMutationObserver);
+
+            // Start observing DOM mutations
+            const bindMutationObserver = function () {
+                mutationObserver.observe(document.body, {
+                    childList: true,
+                    subtree: true,
+                    attributes: true
+                });
+
+                // Start observing the element for resizing
+                resizeObserver.observe(domElement);
+            };
+
+            bindMutationObserver();
+
+            return {
+                bind: bindMutationObserver,
+                unbind: unbindMutationObserver
+            };
+        },
+
+        /**
          * Sets up an overlay widget. Appends the overlay widget to the element as specified by the `appendTo`
          * attribute. Also makes sure the overlay widget is handled properly during AJAX updates.
          * @param {PrimeFaces.widget.DynamicOverlayWidget} widget An overlay widget instance.


### PR DESCRIPTION
Fix #13274: BlockUI switch to ResizeObserver

BlockUI incorrectly watches the browser `window` resize for size changes when it needs to watch its `target` for resize using ResizeObserver: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
