### PR TITLE
Fix #13283: CSP Ajax False

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.csp.js
@@ -95,7 +95,7 @@ if (!PrimeFaces.csp) {
 
                 $(element).off(jqEvent)
                     .on(jqEvent, jsWrapper)
-                    .attr('data-ajax', isAjaxified);
+                    .attr('data-ajax', String(isAjaxified));
 
                 //Collect some basic information about registered AJAXified event listeners
                 if (!PrimeFaces.isProductionProjectStage()) {


### PR DESCRIPTION
Fix #13283: CSP Ajax False

It looks like jquery 4.0 when doing `.attr('data-ajax', isAjaxified)` if the value is boolean `false` it removes the data attribute entirely so we need to set it as a String so it puts `data-ajax="false"`  so `.attr('data-ajax', String(isAjaxified))` fixes this.

