### PR TITLE
Fix #13288: SelectOneRadio prevent unclickable gap

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.css
@@ -184,7 +184,8 @@
 .ui-selectoneradio label {
     cursor: pointer;
     display: inline-block;
-    margin: 0 16px 0 8px;
+    margin: 0 16px 0 -8px;
+    padding-left: 16px;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
Fix #13288: SelectOneRadio prevent unclickable gap