### PR TITLE
Fix PrimeFaces.resources.isExtensionMapping

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.resources.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.resources.js
@@ -74,7 +74,7 @@ if (!PrimeFaces.resources) {
                 PrimeFaces.resources.IS_EXTENSION_MAPPING = scriptURI.charAt(scriptURI.indexOf(scriptName) + scriptName.length) === '.';
              }
 
-             return PrimeFaces.IS_EXTENSION_MAPPING;
+             return PrimeFaces.resources.IS_EXTENSION_MAPPING;
           },
 
           /**


### PR DESCRIPTION
Noticed this while refactoring to classes. Not sure if this method is ever used, but `PrimeFaces.resources.isExtensionMapping` always returned `undefined`. The method sets`PrimeFaces.resources.IS_EXTENSION_MAPPING`, but erroneously returns `PrimeFaces.IS_EXTENSION_MAPPING`, which is never set and thus always `undefined`.