### PR TITLE
Fix #13295: RemoteCommand treat object like h:commandScript

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/ajax/remoteCommand.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/ajax/remoteCommand.xhtml
@@ -35,9 +35,11 @@
                 <p:commandButton type="button" value="Send" icon="pi pi-refresh" onclick="rc()"/>
 
                 <h5>Parameters</h5>
-                <p>Passing parameters to the remote method as a javascript object.</p>
-                <p:commandButton type="button" value="Send" icon="pi pi-refresh"
+                <p>Passing parameters to the remote method as a javascript object or array of objects.</p>
+                <p:commandButton type="button" value="Send Array" icon="pi pi-refresh" styleClass="mr-2"
                         onclick="rc([{name: 'param1', value: 'foo'}, {name: 'param2', value: 'bar'}])"/>
+                <p:commandButton type="button" value="Send Object" icon="pi pi-refresh"
+                        onclick="rc({param1: 'foo', param2: 'bar'})"/>
 
                 <h5>Receive Values Back</h5>
                 <p>Receiving values form the server as a serialized json object.</p>

--- a/primefaces/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
+++ b/primefaces/src/main/java/org/primefaces/util/AjaxRequestBuilder.java
@@ -357,9 +357,17 @@ public class AjaxRequestBuilder {
         return this;
     }
 
+    /**
+     * Passes parameters to the ajax request. If the first argument is a plain object, it will be converted to an array of name-value pairs.
+     * Otherwise, the argument will be passed as-is.
+     *
+     * @return The current instance of AjaxRequestBuilder
+     */
     public AjaxRequestBuilder passParams() {
-        buffer.append(",pa:arguments[0]");
-
+        buffer.append(",pa:");
+        buffer.append("(typeof arguments[0] === 'object' && !Array.isArray(arguments[0]) ");
+        buffer.append("? Object.entries(arguments[0]).map(([key, value]) => ({ name: key, value })) ");
+        buffer.append(": arguments[0])");
         return this;
     }
 


### PR DESCRIPTION
Fix #13295: RemoteCommand treat object like h:commandScript