### PR TITLE
Remove PrimeFaces.setCaretToEnd JS method

### DIFF
--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -10,6 +10,7 @@
   * Deleted `autocomplete="off"` from any hidden inputs as is recommended by w3c spec
   * Deleted long time deprecated `primefaces.LEGACY_WIDGET_NAMESPACE`
   * Removed additional themes from primefaces.jar (only saga is still there), you now need to include `primefaces-themes.jar`. Please check the docs. 
+  * Deleted legacy client-side JavaScript method `PrimeFaces.setCaretToEnd`, which did not work and was unused. Use `element.setSelectionRange(0, element.value.length)` on an `HTMLInputElement` or `HTMLTextAreaElement` if you need that functionality.
 
 ## Deprecated
 

--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -10,7 +10,10 @@
   * Deleted `autocomplete="off"` from any hidden inputs as is recommended by w3c spec
   * Deleted long time deprecated `primefaces.LEGACY_WIDGET_NAMESPACE`
   * Removed additional themes from primefaces.jar (only saga is still there), you now need to include `primefaces-themes.jar`. Please check the docs. 
-  * Deleted legacy client-side JavaScript method `PrimeFaces.setCaretToEnd`, which did not work and was unused. Use `element.setSelectionRange(0, element.value.length)` on an `HTMLInputElement` or `HTMLTextAreaElement` if you need that functionality.
+  * Deleted legacy client-side JavaScript methods that were unused and sometimes did not even work properly anymore. Affects:
+    * `PrimeFaces.setCaretToEnd`. Unused and did not work. Use `element.setSelectionRange(0, element.value.length)` on an `HTMLInputElement` or `HTMLTextAreaElement` if you need that functionality.
+    * `PrimeFaces.getSelection`. Worked, but returned a string or Selection object, whereas it was meant to always return a string.
+    * `PrimeFaces.hasSelection`. Did not work and always returned `false`.
 
 ## Deprecated
 

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -710,31 +710,6 @@
         },
 
         /**
-         * Finds the text currently selected by the user on the current page.
-         * @return {string | Selection} The text currently selected by the user on the current page.
-         */
-        getSelection: function() {
-            var text = '';
-            if (window.getSelection) {
-                text = window.getSelection();
-            } else if (document.getSelection) {
-                text = document.getSelection();
-            } else if (document.selection) {
-                text = document.selection.createRange().text;
-            }
-
-            return text;
-        },
-
-        /**
-         * Checks whether any text on the current page is selected by the user.
-         * @return {boolean} `true` if text is selected, `false` otherwise.
-         */
-        hasSelection: function() {
-            return this.getSelection().length > 0;
-        },
-
-        /**
          * A shortcut for {@link createWidget}.
          * @param {string} widgetName Name of the widget class, as registered in {@link PrimeFaces.widget}.
          * @param {string} widgetVar Widget variable of the widget

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -629,24 +629,15 @@
 
         /**
          * Takes an input or textarea element and sets the caret (text cursor) position to the end of the the text.
-         * @param {JQuery} element An input or textarea element.
+         * @param {HTMLInputElement | HTMLTextAreaElement} element An input or textarea element.
          */
         setCaretToEnd: function(element) {
-            if(element) {
-                element.trigger('focus');
+            if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+                element.focus();
                 var length = element.value.length;
 
-                if(length > 0) {
-                    if(element.setSelectionRange) {
-                        element.setSelectionRange(0, length);
-                    }
-                    else if (element.createTextRange) {
-                      var range = element.createTextRange();
-                      range.collapse(true);
-                      range.moveEnd('character', 1);
-                      range.moveStart('character', 1);
-                      range.select();
-                    }
+                if(length > 0 && element.setSelectionRange) {
+                    element.setSelectionRange(0, length);
                 }
             }
         },

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js
@@ -628,21 +628,6 @@
         },
 
         /**
-         * Takes an input or textarea element and sets the caret (text cursor) position to the end of the the text.
-         * @param {HTMLInputElement | HTMLTextAreaElement} element An input or textarea element.
-         */
-        setCaretToEnd: function(element) {
-            if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
-                element.focus();
-                var length = element.value.length;
-
-                if(length > 0 && element.setSelectionRange) {
-                    element.setSelectionRange(0, length);
-                }
-            }
-        },
-
-        /**
          * Gets the currently loaded PrimeFaces theme CSS link.
          * @return {string} The full URL to the theme CSS
          */


### PR DESCRIPTION
`PrimeFaces.setCaretToEnd` is broken. It takes a parameter `element`. Then it calls `element.trigger(...)`, which only works if `element` is a JQuery instance. Afterwards, it calls `element.setSelectionRange(...)`, which only works if `element` is an `HTMLInputElement` or `HTMLTextAreaElement`. No matter what you pass the method, one of these is going to fail.

Fortunately, that method does not seem to be used, at least I did not find any usages.

The intention of the method seems to have been to take a raw `HTMLInputElement` or `HTMLTextAreaElement`, I suppose. I changed that to use `element.focus()` instead, and removed `element.createTextRange` since that is an Internet Explorer-only method and we don't support IE anymore.

https://github.com/primefaces/primefaces/blob/081c590fa19efceddcb2ec98aaba0f9da60cd35e/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.js#L634-L652