### PR TITLE
Fix prefix check in PrimeFaces.ajax.Request.addFormData/addParam/addParams

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1123,7 +1123,7 @@ if (!PrimeFaces.ajax) {
              */
             addParam: function(params, name, value, parameterPrefix) {
                 // add namespace if not available
-                if (parameterPrefix || !name.indexOf(parameterPrefix) === 0) {
+                if (parameterPrefix && !name.startsWith(parameterPrefix)) {
                     params.push({ name: parameterPrefix + name, value: value });
                 }
                 else {

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1142,7 +1142,7 @@ if (!PrimeFaces.ajax) {
              */
             addFormData: function(formData, name, value, parameterPrefix) {
                 // add namespace if not available
-                if (parameterPrefix || !name.indexOf(parameterPrefix) === 0) {
+                if (parameterPrefix && !name.startsWith(parameterPrefix)) {
                     formData.append(parameterPrefix + name, value);
                 }
                 else {


### PR DESCRIPTION
TypeScript complained about this line from `PrimeFaces.ajax.Request.addFormData`

https://github.com/primefaces/primefaces/blob/2e05a7ac4cb73ea916cec75abc86e34c5c3cd93e/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js#L1145

If you think about it, the check `!name.indexOf(parameterPrefix) === 0` makes no sense:

- `indexOf` always returns a number,
- `!number` always evaluates to a boolean
- triple-equal (`===`) comparing a boolean to the number 0 always evaluates `false`

Therefore, `(parameterPrefix || !name.indexOf(parameterPrefix) === 0)` is equivalent to just `(parameterPrefix)`.

Considering the context, I assume the intention was to not add the prefix when the name already starts with the prefix, so I changed it to `(parameterPrefix && !name.startsWith(parameterPrefix))` ?

Same goes for the function [PrimeFaces.ajax.Request.addParam](https://github.com/primefaces/primefaces/blob/2e05a7ac4cb73ea916cec75abc86e34c5c3cd93e/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js#L1126) directly above.