### PR TITLE
Fixes #13310 14.0.12 Datatable: Draggable Rows with input component not working correctly

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -5049,7 +5049,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                         {name: $this.id + '_rowreorder', value: true},
                         {name: $this.id + '_fromIndex', value: fromIndex},
                         {name: $this.id + '_toIndex', value: toIndex},
-                        {name: this.id + '_skipChildren', value: true}
+                        {name: $this.id + '_skipChildren', value: true}
                     ]
                 }
 


### PR DESCRIPTION
Fixes #13310 14.0.12 Datatable: Draggable Rows with input component not working correctly