### PR TITLE
Fix prefix check in PrimeFaces.ajax.Request.addParams

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -1165,7 +1165,7 @@ if (!PrimeFaces.ajax) {
 
                 for (const param of paramsToAdd) {
                     // add namespace if not available
-                    if (parameterPrefix && !param.name.indexOf(parameterPrefix) === 0) {
+                    if (parameterPrefix && !param.name.startsWith(parameterPrefix)) {
                         param.name = parameterPrefix + param.name;
                     }
 


### PR DESCRIPTION
Fix prefix check in PrimeFaces.ajax.Request.addParams

See #13313

The reason why I wanted to ask is that right now, the prefix never got added; and somehow nobody noticed that something wasn't working.