### PR TITLE
Fix #13321: AutoComplete reinstate `emptyMessage` property

### DIFF
--- a/docs/15_0_0/components/autocomplete.md
+++ b/docs/15_0_0/components/autocomplete.md
@@ -40,6 +40,7 @@ AutoComplete provides live suggestions while an input is being typed.
 | dropdownTabindex | null | String | Position of the dropdown button in the tabbing order.
 | dynamic | false | Boolean | Defines if dynamic loading is enabled for the element's panel. If the value is "true", the overlay is not rendered on page load to improve performance.
 | escape | true | Boolean | Defines if autocomplete results are escaped or not.
+| emptyMessage | null | String | Text to display when there is no data to display. Default "No records found."
 | forceSelection | false | Boolean | When enabled, autoComplete only accepts input from the selection list.
 | groupByTooltip | null | String | Tooltip to display on group headers.
 | highlightSelector | span | String | jQuery selector specifies what content to identify for highlighting in search results. By default, it targets `<span>` elements.

--- a/docs/migrationguide/15_0_0.md
+++ b/docs/migrationguide/15_0_0.md
@@ -27,6 +27,10 @@
     access all values, which is and was always available.
   * The themes saga, arya and vela are now called saga-blue, arya-blue and vela-blue. The old names are still supported but will removed in the next version.
 
+## AutoComplete
+
+  * `emptyMessage` attribute is reinstated and defaults to `No records found.` from Messages_{locale}.properties to control the message when there is no data to display.
+
 ## Barcode
 
   * Barcode component now uses the **Okapi** library for barcode generation instead of `barcode4j` and `qrcodegen`. Simply update your dependency to use **Okapi** instead.

--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteBase.java
@@ -26,8 +26,10 @@ package org.primefaces.component.autocomplete;
 import org.primefaces.component.api.AbstractPrimeHtmlInputText;
 import org.primefaces.component.api.InputHolder;
 import org.primefaces.component.api.MixedClientBehaviorHolder;
+import org.primefaces.component.api.UIPageableData;
 import org.primefaces.component.api.Widget;
 import org.primefaces.model.LazyDataModel;
+import org.primefaces.util.MessageFactory;
 
 public abstract class AutoCompleteBase extends AbstractPrimeHtmlInputText implements Widget, InputHolder, MixedClientBehaviorHolder {
 
@@ -37,51 +39,52 @@ public abstract class AutoCompleteBase extends AbstractPrimeHtmlInputText implem
 
     public enum PropertyKeys {
 
-        placeholder,
-        widgetVar,
-        completeMethod,
-        var,
-        itemLabel,
-        itemValue,
-        itemStyleClass,
-        maxResults,
-        minQueryLength,
-        queryDelay,
-        forceSelection,
-        scrollHeight,
-        dropdown,
-        panelStyle,
-        panelStyleClass,
-        multiple,
-        itemtipMyPosition,
-        itemtipAtPosition,
+        active,
+        appendTo,
+        at,
+        autoHighlight,
+        autoSelection,
         cache,
         cacheTimeout,
-        appendTo,
-        groupBy,
-        queryEvent,
+        completeEndpoint,
+        completeMethod,
+        dropdown,
         dropdownMode,
-        autoHighlight,
-        selectLimit,
+        dropdownTabindex,
+        dynamic,
+        emptyMessage,
+        escape,
+        forceSelection,
+        groupBy,
+        groupByTooltip,
+        highlightSelector,
         inputStyle,
         inputStyleClass,
-        groupByTooltip,
-        my,
-        at,
-        active,
-        type,
-        moreText,
-        unique,
-        dynamic,
-        autoSelection,
-        escape,
-        queryMode,
-        dropdownTabindex,
-        completeEndpoint,
-        lazyModel,
+        itemLabel,
+        itemStyleClass,
+        itemtipAtPosition,
+        itemtipMyPosition,
+        itemValue,
         lazyField,
+        lazyModel,
+        maxResults,
+        minQueryLength,
+        moreText,
+        multiple,
+        my,
+        panelStyle,
+        panelStyleClass,
+        placeholder,
+        queryDelay,
+        queryEvent,
+        queryMode,
+        scrollHeight,
+        selectLimit,
         showEmptyMessage,
-        highlightSelector
+        type,
+        unique,
+        var,
+        widgetVar,
     }
 
     public AutoCompleteBase() {
@@ -451,5 +454,13 @@ public abstract class AutoCompleteBase extends AbstractPrimeHtmlInputText implem
 
     public void setHighlightSelector(String highlightSelector) {
         getStateHelper().put(PropertyKeys.highlightSelector, highlightSelector);
+    }
+
+    public String getEmptyMessage() {
+        return (String) getStateHelper().eval(PropertyKeys.emptyMessage, MessageFactory.getMessage(getFacesContext(), UIPageableData.EMPTY_MESSAGE));
+    }
+
+    public void setEmptyMessage(String emptyMessage) {
+        getStateHelper().put(PropertyKeys.emptyMessage, emptyMessage);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/autocomplete/AutoCompleteRenderer.java
@@ -793,6 +793,7 @@ public class AutoCompleteRenderer extends InputRenderer {
                 .attr("highlightSelector", ac.getHighlightSelector(), null)
                 .attr("autoHighlight", ac.isAutoHighlight(), true)
                 .attr("showEmptyMessage", ac.isShowEmptyMessage(), true)
+                .attr("emptyMessage", ac.getEmptyMessage(), null)
                 .attr("myPos", ac.getMy(), null)
                 .attr("atPos", ac.getAt(), null)
                 .attr("active", ac.isActive(), true)

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -1870,6 +1870,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Text to display when there is no data to display. Default is "No records found."]]>
+            </description>
+            <name>emptyMessage</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Should the empty message be displayed when no items are found? Default is true.]]>
             </description>
             <name>showEmptyMessage</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -82,6 +82,7 @@
  * @prop {boolean} cfg.dynamic Defines if dynamic loading is enabled for the element's panel. If the value is `true`,
  * the overlay is not rendered on page load to improve performance.
  * @prop {boolean} cfg.escape Whether the text of the suggestion items is escaped for HTML.
+ * @prop {string} cfg.emptyMessage Text to display when there is no data to display.
  * @prop {boolean} cfg.hasFooter Whether a footer facet is present.
  * @prop {boolean} cfg.forceSelection Whether one of the available suggestion items is forced to be preselected.
  * @prop {boolean} cfg.grouping Whether suggestion items are grouped.
@@ -219,7 +220,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
      * @private
      */
     configureLocale: function() {
-        this.emptyMessage = this.getLabel('emptySearchMessage');
+        this.emptyMessage = this.cfg.emptyMessage || this.getLabel('emptySearchMessage');
         this.resultsMessage = this.getLabel('searchMessage');
         if (this.dropdown) {
             this.dropdown.attr('aria-label', this.getLabel('choose'));


### PR DESCRIPTION
Fix #13321: AutoComplete reinstate emptyMessage property