### PR TITLE
Fix #13335: SelectOneMenu respect escape for title

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/forms/forms.selectonemenu.js
@@ -1641,7 +1641,7 @@ PrimeFaces.widget.SelectOneMenu = PrimeFaces.widget.DeferredWidget.extend({
         
         var title = $item.data("title");
         if (title) {
-            content += ' title="' + PrimeFaces.escapeHTML(title) + '"';
+            content += ' title="' + (escape ? PrimeFaces.escapeHTML(title) : title) + '"';
         }
         if ($item.is(':disabled')) {
             content += ' disabled';


### PR DESCRIPTION
Fix #13335: SelectOneMenu respect escape for title