### PR TITLE
Fix windows build for frontend project

### DIFF
--- a/primefaces/src/main/frontend/build/common/build-settings.mjs
+++ b/primefaces/src/main/frontend/build/common/build-settings.mjs
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+
 /**
  * Allows a sub folder to affect the build settings when building the
  * frontend project (via ESBuild).
@@ -18,6 +20,8 @@ const emptyBuildSettings = {};
 
 /**
  * Loads the build settings for the given frontend project (if it has any).
+ * Each directory in packages can have its own build settings in a JSON
+ * file that affect the build process.
  * @param {import("./frontend-project.mjs").FrontendProject} frontendProject
  * @returns {Promise<BuildSettings>}
  */
@@ -26,9 +30,9 @@ export async function loadBuildSettings(frontendProject) {
     if (path === undefined) {
         return emptyBuildSettings;
     }
-    const buildSettingsJson = await import(path, { with: { type: "json" } });
-    if (typeof buildSettingsJson.default !== "object" || buildSettingsJson.default === null) {
+    const buildSettingsJson = JSON.parse(await fs.readFile(path, { encoding: "utf8"} ));
+    if (typeof buildSettingsJson !== "object" || buildSettingsJson === null) {
         throw new Error(`Build settings at ${path} must be a JSON object!`);
     }
-    return buildSettingsJson.default;
+    return buildSettingsJson;
 }


### PR DESCRIPTION
@melloware 

This should fix the Window build. It's pretty late here, need to sleep now : /

Also: I'm open to revert the merge if anybody does not feel comfortable with the build system.  We need to all feel ok and be on the same page.

The issue was that I was trying to read a JSON file via JavaScript's `import`, and that doesn't work with absolute paths. That was just node.js that complained about it. I changed it to reading the JSON file directly via node's `fs` module. The build on he Window device I was using now works.

> study it more and document it

For what it's worth, I wrote a little bit in the readme here https://github.com/primefaces/primefaces/blob/master/primefaces/src/main/frontend/README.md

Very brief summary: 

>The PrimeFaces JAR contains multiple different bundles, such as core.js, components.js, or terminal/terminal.js
>
> For each bundle, there's a folder in `packages/`.
>
> The build script build/bin/bundle.mjs lists all folders and invokes esbuild on each folder, to produce the final
bundled file (core.js, components.js etc.).

