### PR TITLE
Frontend build script: fix resource path when building with Windows

### DIFF
--- a/primefaces/src/main/frontend/build/esbuild-plugin/faces-resource-loader-plugin.mjs
+++ b/primefaces/src/main/frontend/build/esbuild-plugin/faces-resource-loader-plugin.mjs
@@ -102,7 +102,7 @@ function createFacesResourceExpression(file, url, config) {
         throw new Error("File is not in the resource base.");
     }
     const relativePath = path.relative(config.absResourceBase, file);
-    const parts = relativePath.split("/");
+    const parts = relativePath.split(/[\\/]/);
     const params = `${url.search}${url.hash}`;
     if (config.useLibrary && parts.length > 1) {
         const [library, ...pathParts] = parts;


### PR DESCRIPTION
As I suspected, it was fortunately just an issue of `\` in the URL path instead of `/`. So normalize backslash to / when building the relative URL path.