### PR TITLE
Fix #13346: Schedule events must be called after the viewChange event is fired

### DIFF
--- a/primefaces/src/main/frontend/packages/schedule/schedule/src/schedule.widget.js
+++ b/primefaces/src/main/frontend/packages/schedule/schedule/src/schedule.widget.js
@@ -318,29 +318,31 @@ PrimeFaces.widget.Schedule = class Schedule extends PrimeFaces.widget.DeferredWi
         var $this = this;
 
         this.cfg.options.events = function(fetchInfo, successCallback) {
-            var options = {
-                source: $this.id,
-                process: $this.id,
-                update: $this.id,
-                formId: $this.getParentFormId(),
-                params: [
-                    {name: $this.id + '_event', value: true},
-                    {name: $this.id + '_start', value: fetchInfo.start.toISOString()},
-                    {name: $this.id + '_end', value:  fetchInfo.end.toISOString()}
-                ],
-                onsuccess: function(responseXML, status, xhr) {
-                    PrimeFaces.ajax.Response.handle(responseXML, status, xhr, {
-                        widget: $this,
-                        handle: function(content) {
-                            successCallback(JSON.parse(content).events);
-                        }
-                    });
-
-                    return true;
-                }
-            };
-
-            PrimeFaces.ajax.Request.handle(options);
+            // #13346 - schedule events must be called after the viewChange event is fired
+            PrimeFaces.queueTask(() => {
+                var options = {
+                    source: $this.id,
+                    process: $this.id,
+                    update: $this.id,
+                    formId: $this.getParentFormId(),
+                    params: [
+                        {name: $this.id + '_event', value: true},
+                        {name: $this.id + '_start', value: fetchInfo.start.toISOString()},
+                        {name: $this.id + '_end', value:  fetchInfo.end.toISOString()}
+                    ],
+                    onsuccess: function(responseXML, status, xhr) {
+                        PrimeFaces.ajax.Response.handle(responseXML, status, xhr, {
+                            widget: $this,
+                            handle: function(content) {
+                                successCallback(JSON.parse(content).events);
+                            }
+                        });
+    
+                        return true;
+                    }
+                };
+                PrimeFaces.ajax.Request.handle(options)
+            });
         };
     }
 


### PR DESCRIPTION
Fix #13346: Schedule events must be called after the viewChange event is fired