### PR TITLE
Fix client side email validator for 15.x

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/view/csv/BeanValidationView.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/view/csv/BeanValidationView.java
@@ -30,6 +30,7 @@ import jakarta.inject.Named;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Max;

--- a/primefaces-showcase/src/main/webapp/ui/csv/bean.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/csv/bean.xhtml
@@ -109,6 +109,11 @@
                     <p:message for="@previous"/>
                     <h:outputText value="#{beanValidationView.positiveOrZero}"/>
 
+                    <p:outputLabel for="@next" value="Email: (@Email)"/>
+                    <p:inputText value="#{beanValidationView.email}" label="Email"/>
+                    <p:message for="@previous"/>
+                    <h:outputText value="#{beanValidationView.email}"/>
+
                     <p:outputLabel for="@next" value="Radio Input"/>
                     <p:selectOneRadio value="#{beanValidationView.bool}">
                         <f:selectItem itemValue="#{true}" itemLabel="True"/>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.bv.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/validation/validation.bv.js
@@ -118,7 +118,7 @@ if (window.PrimeFaces) {
         validate: function(element, value) {
             if(value !== null && !this.EMAIL_ADDRESS_REGEX.test(value)) {
                 var vc = PrimeFaces.validation.ValidationContext;
-                return vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-email-msg'));
+                throw vc.getMessageBV(element, this.MESSAGE_ID, element.data('p-email-msg'));
             }
         }
     };


### PR DESCRIPTION
Noticed this while working on [refactor-part-2-convert-core-to-typescript](https://github.com/blutorange/primefaces/tree/refactor-part-2-convert-core-to-typescript). The client-side Email bean validator does not work. Violations are caught only by the server when the form is submitted.

Can be seen in the showcase when you add input field for emails: Enter an invalid email, then click on `save`. It will show validation errors for other fields that are required and empty, but not for the email input field. 

As per the Validator interface, implementations must not return anything, but throw a validation message when constraint is violated.

Perhaps a candidate for the next 15.0.X release.

```ts
        /**
         * A validator for checking whether the value of an element confirms to certain restrictions.
         */
        export interface Validator {
            /**
             * Validates the given element. If it is not valid, an error message
             * of type {@link BaseFacesMessage} (or an array thereof) should be
             * thrown (via a `throw ...` statement).
             * @param element Element to validate
             * @param value Current value of the element
             * @throws The error message when the element with its current value
             * is not valid. Can be either a {@link BaseFacesMessage} or an
             * array thereof.
             */
            validate(element: JQuery, value?: unknown): void;
        }
```
