### PR TITLE
Use single Tomcat version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <junit.version>5.12.0</junit.version>
         <poi.version>5.4.0</poi.version>
         <jacoco.version>0.8.12</jacoco.version>
+        <tomcat.version>10.1.34</tomcat.version>
 
         <sonar.skip>true</sonar.skip>
         <sonar.coverage.jacoco.xmlReportPaths>../primefaces-coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/primefaces-integration-tests/pom.xml
+++ b/primefaces-integration-tests/pom.xml
@@ -33,7 +33,6 @@
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <lombok.version>1.18.36</lombok.version>
         <myfaces.version>4.0.2</myfaces.version>
-        <tomcat.version>10.1.34</tomcat.version>
         <resteasy.version>6.2.11.Final</resteasy.version>
         <jetty.version>12.0.16</jetty.version>
     </properties>

--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>10.1.30</version>
+            <version>${tomcat.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Content type validation in FileUploadUtilsTest -->


### PR DESCRIPTION
This lets us declare just one Tomcat version for both Unit tests and Integration tests now that we only have 1 set of integration Tests