### PR TITLE
Fix #13406: 15.0.1 Datatable select checkbox with keyboard

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -1362,7 +1362,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                     }
                 },
                 'keydown.dataTable': function(e) {
-                    if (PrimeFaces.utils.isActionKey(e)) {
+                    if ($this.cfg.selectionRowMode === 'none' && PrimeFaces.utils.isActionKey(e)) {
                         $(this).trigger('click');
                         e.preventDefault();
                     }


### PR DESCRIPTION
Fix #13406: 15.0.1 Datatable select checkbox with keyboard