### PR TITLE
Fix #13406: Datatable select checkbox with keyboard

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -1363,7 +1363,7 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
                     }
                 },
                 'keydown.dataTable': function(e) {
-                    if (PrimeFaces.utils.isActionKey(e)) {
+                    if ($this.cfg.selectionRowMode === 'none' && PrimeFaces.utils.isActionKey(e)) {
                         $(this).trigger('click');
                         e.preventDefault();
                     }


### PR DESCRIPTION
Fix #13406: Datatable select checkbox with keyboard