### PR TITLE
Bump org.apache.felix:maven-bundle-plugin from 5.1.9 to 6.0.0

### DIFF
--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -408,7 +408,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.9</version>
+                <version>6.0.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <supportedProjectTypes>


### PR DESCRIPTION
Bumps org.apache.felix:maven-bundle-plugin from 5.1.9 to 6.0.0.

---
updated-dependencies:
- dependency-name: org.apache.felix:maven-bundle-plugin dependency-type: direct:production update-type: version-update:semver-major ...