### PR TITLE
Fix #13427: 15.0.1 DataView missing rowIndexVar in taglib

### DIFF
--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -9278,6 +9278,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Name of iterator to refer each row index.]]>
+            </description>
+            <name>rowIndexVar</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Number of rows to display per page. Default value is 0 meaning to display all data available.]]>
             </description>
             <name>rows</name>


### PR DESCRIPTION
Fix #13427: 15.0.1 DataView missing rowIndexVar in taglib