### PR TITLE
Enable TypeScript flag "erasableSyntaxOnly"

### DIFF
--- a/primefaces/src/main/frontend/.yarn/sdks/typescript/package.json
+++ b/primefaces/src/main/frontend/.yarn/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript",
-  "version": "5.7.3-sdk",
+  "version": "5.8.2-sdk",
   "main": "./lib/typescript.js",
   "type": "commonjs",
   "bin": {

--- a/primefaces/src/main/frontend/packages/chart/chart/index.ts
+++ b/primefaces/src/main/frontend/packages/chart/chart/index.ts
@@ -1,7 +1,7 @@
 import * as ChartJs from "chart.js";
 import "chartjs-adapter-moment";
 import zoomPlugin from "chartjs-plugin-zoom";
-import Hammer = require("hammerjs");
+import Hammer from "hammerjs";
 
 import "./src/chart.widget.js";
 import { createChartJsGlobal, type ChartJsGlobal } from "./src/chart.global.js";

--- a/primefaces/src/main/frontend/packages/chart/chart/tsconfig.json
+++ b/primefaces/src/main/frontend/packages/chart/chart/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../../../tsconfig-base.json",
 	"compilerOptions": {
 		"composite": true,
+		"allowSyntheticDefaultImports": true,
 		"rootDir": ".",
 		"outDir": "dist",
 		"types": [

--- a/primefaces/src/main/frontend/packages/filedownload/filedownload/index.ts
+++ b/primefaces/src/main/frontend/packages/filedownload/filedownload/index.ts
@@ -1,4 +1,4 @@
-import downloadJs = require("downloadjs");
+import downloadJs from "downloadjs";
 
 import { download as pfDownload } from "./src/pf.filedownload.js";
 

--- a/primefaces/src/main/frontend/packages/filedownload/filedownload/src/pf.filedownload.ts
+++ b/primefaces/src/main/frontend/packages/filedownload/filedownload/src/pf.filedownload.ts
@@ -1,4 +1,4 @@
-import downloadJs = require("downloadjs");
+import downloadJs from "downloadjs";
 
 /**
  * Fetches the resource at the given URL and prompts the user to download that file, without leaving the current

--- a/primefaces/src/main/frontend/tsconfig-base.json
+++ b/primefaces/src/main/frontend/tsconfig-base.json
@@ -16,6 +16,7 @@
 		"allowUmdGlobalAccess": true,
 		"resolvePackageJsonExports": true,
 		"noResolve": false,
+		"erasableSyntaxOnly": true,
 		"esModuleInterop": false,
 		"isolatedDeclarations": true,
 		"isolatedModules": true,


### PR DESCRIPTION
Enable [erasableSyntaxOnly](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly), available since TypeScript 5.8

This prevents us from accidentally using features such as [enums](https://www.typescriptlang.org/docs/handbook/enums.html) or [parameter properties](https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties) that are legacy features not aligned with TypeScript's design goals anymore. I.e. ensures it's just plain JavaScript with type annotation, nothing more.

> Nowadays there is a pretty strict design goal that TS will not add features that emit JS from non-JS syntax.

(Also mentioned in their [feature request issue template](https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/.github/ISSUE_TEMPLATE/feature_request.yml)