### PR TITLE
Fix #13465: ContextMenu must always be rendered

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/contextmenu/ContextMenuRenderer.java
@@ -75,4 +75,8 @@ public class ContextMenuRenderer extends TieredMenuRenderer {
         encodeMenu(context, menu, style, styleClass, HTML.ARIA_ORIENTATION_VERTICAL);
     }
 
+    @Override
+    protected boolean shouldBeRendered(FacesContext context, AbstractMenu abstractMenu) {
+        return true; // GitHub #13465 we should always render the context menu
+    }
 }


### PR DESCRIPTION
Fix #13465: ContextMenu must always be rendered