### PR TITLE
Fix #13492: Datatable ignore headerRow when updating visibility

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -5728,7 +5728,7 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
 
         // update the visibility of columns but ignore expanded rows and GitHub #7255 grouped headers
         if(this.headers && !this.hasColGroup()) {
-            var rows = this.tbody.find('> tr:not(.ui-expanded-row-content)');
+            var rows = this.tbody.find('> tr:not(.ui-expanded-row-content):not(.ui-datatable-headerrow)');
             for(var i = 0; i < rows.length; i++) {
                 var row = rows.eq(i);
                 var columns = row.find('td');


### PR DESCRIPTION
Fix #13492: Datatable ignore headerRow when updating visibility