### PR TITLE
Fix #13323: 15.0.1 MenuBar hideDelay=0 only close on document.click

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.menubar.js
@@ -12,8 +12,21 @@
  * @prop {number} [timeoutId] Timeout ID, used for the animation when the menu is shown.
  * 
  * @prop {number} cfg.delay Delay in milliseconds before displaying the sub menu. Default is 0 meaning immediate.
+ * @prop {boolean} cfg.hideOnDocumentClick Whether to hide the menu on document click only if hideDelay is 0. Default is `false`.
  */
 PrimeFaces.widget.Menubar = PrimeFaces.widget.TieredMenu.extend({
+
+    /**
+     * @override
+     * @inheritdoc
+     * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
+     */
+    init: function (cfg) {
+        this._super(cfg);
+
+        // #13323 MenuBar only for hideDelay=0 only closes on document.click
+        this.cfg.hideOnDocumentClick = this.cfg.hideDelay === 0;
+    },
 
     /**
      * @override

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.tieredmenu.js
@@ -26,6 +26,7 @@
  * When set to `false`, click event is required to display this tiered menu.
  * @prop {number} cfg.showDelay Number of milliseconds before displaying menu. Default to 0 immediate.
  * @prop {number} cfg.hideDelay Number of milliseconds before hiding menu, if 0 not hidden until document.click.
+ * @prop {boolean} cfg.hideOnDocumentClick Whether to hide the menu on document click only if hideDelay is 0. Default is `false`.
  * @prop {PrimeFaces.widget.TieredMenu.ToggleEvent} cfg.toggleEvent Event to toggle the submenus.
  */
 PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
@@ -494,7 +495,13 @@ PrimeFaces.widget.TieredMenu = PrimeFaces.widget.Menu.extend({
             }, this.cfg.hideDelay);
         }
         else {
-            this.reset();
+            if (e && this.cfg.hideOnDocumentClick) {
+                // #13323 MenuBar only for hideDelay=0 only closes on document.click
+                e.stopPropagation();
+            }
+            else {
+                this.reset();
+            }
         }
     }
 


### PR DESCRIPTION
Fix #13323: 15.0.1 MenuBar hideDelay=0 only close on document.click