### PR TITLE
Fix #13323: MenuBar hideDelay=0 only close on document.click

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/menu/menu.menubar.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/menu/menu.menubar.widget.ts
@@ -22,6 +22,13 @@ export interface MenubarCfg extends TieredMenuCfg {
  */
 export class Menubar<Cfg extends MenubarCfg = MenubarCfg> extends TieredMenu<Cfg> {
 
+    override init(cfg: PrimeType.widget.PartialWidgetCfg<Cfg>): void {
+        super.init(cfg);
+
+        // #13323 MenuBar only for hideDelay=0 only closes on document.click
+        this.cfg.hideOnDocumentClick = this.cfg.hideDelay === 0;
+    }
+
     override showSubmenu(menuitem: JQuery, submenu: JQuery, focus?: boolean): void {
         let pos: JQueryUI.JQueryPositionOptions | null = null;
 

--- a/primefaces/src/main/frontend/packages/components/src/menu/menu.tieredmenu.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/menu/menu.tieredmenu.widget.ts
@@ -17,6 +17,10 @@ export interface TieredMenuCfg extends MenuCfg {
      */
     hideDelay: number;
     /**
+     * Whether to hide the menu on document click only if hideDelay is 0. Default is `false`.
+     */
+    hideOnDocumentClick: boolean;
+    /**
      * Number of milliseconds before displaying menu. Default to 0 immediate.
      */
     showDelay: number;
@@ -25,7 +29,7 @@ export interface TieredMenuCfg extends MenuCfg {
      */
     toggleEvent: PrimeType.widget.TieredMenu.ToggleEvent;
 }
-    
+
 /**
  * __PrimeFaces TieredMenu Widget__
  * 
@@ -136,7 +140,7 @@ export class TieredMenu<Cfg extends TieredMenuCfg = TieredMenuCfg> extends Menu<
         // Build event string based on toggle mode
         var focusOnClick = this.cfg.toggleEvent === 'click';
         var linkEvents = "mouseenter.tieredFocus" + (focusOnClick ? " click.tieredFocus" : "");
-        
+
         // Bind mouse/click events to manage focus
         this.links.on(linkEvents, function(e) {
             var $link = $(this),
@@ -265,7 +269,7 @@ export class TieredMenu<Cfg extends TieredMenuCfg = TieredMenuCfg> extends Menu<
                 if (submenu.length === 1) {
                     $this.deactivate(menuitem);
                     $this.deactivate(submenu);
-                    $this.activate(submenu, true,false);
+                    $this.activate(submenu, true, false);
                 }
             }
 
@@ -534,7 +538,13 @@ export class TieredMenu<Cfg extends TieredMenuCfg = TieredMenuCfg> extends Menu<
             }, this.cfg.hideDelay);
         }
         else {
-            this.reset();
+            if (this.cfg.hideOnDocumentClick) {
+                // #13323 MenuBar only for hideDelay=0 only closes on document.click
+                e?.stopPropagation();
+            }
+            else {
+                this.reset();
+            }
         }
     }
 


### PR DESCRIPTION
Fix #13323: MenuBar hideDelay=0 only close on document.click