### PR TITLE
Fix #13508: Barcode add quiet zone properties

### DIFF
--- a/docs/15_0_0/components/barcode.md
+++ b/docs/15_0_0/components/barcode.md
@@ -41,6 +41,8 @@ Barcode component is used to display various barcode formats.
 | onmouseup | null | String | onmouseup DOM event handler
 | orientation | 0 | Integer | Orientation in terms of angle. (0, 90, 180, 270)
 | qrErrorConnection | L | String | The QR Code error correction level. L (default) - up to 7% damage. M - up to 15% damage. Q - up to 25% damage. H - up to 30% damage
+| quietZoneHorizontal | 10 | Integer | The horizontal quiet zone of the barcode in pixels.
+| quietZoneVertical | 1 | Integer | The vertical quiet zone of the barcode in pixels.
 | style | null | String | Style of the image
 | styleClass | null | String | Style class of the image
 | title | null | String | Title of the image
@@ -94,6 +96,6 @@ Barcode component uses **Okapi** library underneath to generate barcodes. The fo
 <dependency>
     <groupId>uk.org.okapibarcode</groupId>
     <artifactId>okapibarcode</artifactId>
-    <version>0.4.9</version>
+    <version>0.5.0</version>
 </dependency>
 ```

--- a/docs/16_0_0/components/barcode.md
+++ b/docs/16_0_0/components/barcode.md
@@ -41,6 +41,8 @@ Barcode component is used to display various barcode formats.
 | onmouseup | null | String | onmouseup DOM event handler
 | orientation | 0 | Integer | Orientation in terms of angle. (0, 90, 180, 270)
 | qrErrorConnection | L | String | The QR Code error correction level. L (default) - up to 7% damage. M - up to 15% damage. Q - up to 25% damage. H - up to 30% damage
+| quietZoneHorizontal | 10 | Integer | The horizontal quiet zone of the barcode in pixels.
+| quietZoneVertical | 1 | Integer | The vertical quiet zone of the barcode in pixels.
 | style | null | String | Style of the image
 | styleClass | null | String | Style class of the image
 | title | null | String | Title of the image
@@ -94,6 +96,6 @@ Barcode component uses **Okapi** library underneath to generate barcodes. The fo
 <dependency>
     <groupId>uk.org.okapibarcode</groupId>
     <artifactId>okapibarcode</artifactId>
-    <version>0.4.9</version>
+    <version>0.5.0</version>
 </dependency>
 ```

--- a/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeBase.java
@@ -40,7 +40,9 @@ public abstract class BarcodeBase extends HtmlGraphicImage {
         orientation,
         qrErrorCorrection,
         hrp,
-        magnification
+        magnification,
+        quietZoneHorizontal,
+        quietZoneVertical
     }
 
     public BarcodeBase() {
@@ -106,6 +108,22 @@ public abstract class BarcodeBase extends HtmlGraphicImage {
 
     public void setMagnification(double magnification) {
         getStateHelper().put(PropertyKeys.magnification, magnification);
+    }
+
+    public int getQuietZoneHorizontal() {
+        return (Integer) getStateHelper().eval(PropertyKeys.quietZoneHorizontal, 10);
+    }
+
+    public void setQuietZoneHorizontal(int quietZoneHorizontal) {
+        getStateHelper().put(PropertyKeys.quietZoneHorizontal, quietZoneHorizontal);
+    }
+
+    public int getQuietZoneVertical() {
+        return (Integer) getStateHelper().eval(PropertyKeys.quietZoneVertical, 1);
+    }
+
+    public void setQuietZoneVertical(int quietZoneVertical) {
+        getStateHelper().put(PropertyKeys.quietZoneVertical, quietZoneVertical);
     }
 
 }

--- a/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeHandler.java
@@ -103,9 +103,13 @@ public class BarcodeHandler extends BaseDynamicContentHandler {
             int rotation = Integers.normalizeRotation(Integer.parseInt(params.get("ori")));
             double magnification = Double.parseDouble(params.get("mag"));
             boolean cache = Boolean.parseBoolean(params.get(Constants.DYNAMIC_CONTENT_CACHE_PARAM));
+            int quietZoneHorizontal = Integer.parseInt(params.get("mh"));
+            int quietZoneVertical = Integer.parseInt(params.get("mv"));
 
             generator.setHumanReadableLocation(HumanReadableLocation.valueOf(hrp.toUpperCase(Locale.ROOT)));
             generator.setContent(value);
+            generator.setQuietZoneHorizontal(quietZoneHorizontal);
+            generator.setQuietZoneVertical(quietZoneVertical);
 
             if (generator instanceof QrCode) {
                 ((QrCode) generator).setPreferredEccLevel(EccLevel.valueOf(params.get("qrec")));

--- a/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeRenderer.java
@@ -81,6 +81,8 @@ public class BarcodeRenderer extends CoreRenderer<Barcode> {
                 .append("&").append(Constants.DYNAMIC_CONTENT_CACHE_PARAM).append("=").append(component.isCache())
                 .append("&ori=").append(component.getOrientation())
                 .append("&mag=").append(component.getMagnification())
+                .append("&mh=").append(component.getQuietZoneHorizontal())
+                .append("&mv=").append(component.getQuietZoneVertical())
                 .toString();
 
         writer.startElement("img", component);

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -2104,6 +2104,22 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[The horizontal quiet zone of the barcode in pixels. Default is 10 pixels.]]>
+            </description>
+            <name>quietZoneHorizontal</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
+        </attribute>
+        <attribute>
+            <description>
+                <![CDATA[The vertical quiet zone of the barcode in pixels. Default is 1 pixel.]]>
+            </description>
+            <name>quietZoneVertical</name>
+            <required>false</required>
+            <type>java.lang.Integer</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[The QR Code error correction level. L (default) - up to 7% damage. M - up to 15% damage. Q - up to 25% damage. H - up to 30% damage]]>
             </description>
             <name>qrErrorCorrection</name>


### PR DESCRIPTION
Fix #13508: Barcode add quiet zone properties

EAN and UPC now show their checkdigit.

![image](https://github.com/user-attachments/assets/94b5117a-a68f-4320-8815-d48bcc1c7406)
