### PR TITLE
Fix #13532: Captcha respect defaults

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaBase.java
@@ -122,7 +122,17 @@ public abstract class CaptchaBase extends UIInput implements Widget {
     }
 
     public String getExecutor() {
-        return (String) getStateHelper().eval(PropertyKeys.executor, null);
+        return (String) getStateHelper().eval(PropertyKeys.executor, () -> {
+            String type = this.getType();
+            switch (type) {
+                case Captcha.RECAPTCHA:
+                    return "grecaptcha";
+                case Captcha.HCAPTCHA:
+                    return "hcaptcha";
+                default:
+                    return null;
+            }
+        });
     }
 
     public void setExecutor(String executor) {
@@ -130,7 +140,17 @@ public abstract class CaptchaBase extends UIInput implements Widget {
     }
 
     public String getSourceUrl() {
-        return (String) getStateHelper().eval(PropertyKeys.sourceUrl, null);
+        return (String) getStateHelper().eval(PropertyKeys.sourceUrl, () -> {
+            String type = this.getType();
+            switch (type) {
+                case Captcha.RECAPTCHA:
+                    return "https://www.google.com/recaptcha/api.js";
+                case Captcha.HCAPTCHA:
+                    return "https://js.hcaptcha.com/1/api.js";
+                default:
+                    return null;
+            }
+        });
     }
 
     public void setSourceUrl(String sourceUrl) {
@@ -138,7 +158,17 @@ public abstract class CaptchaBase extends UIInput implements Widget {
     }
 
     public String getVerifyUrl() {
-        return (String) getStateHelper().eval(PropertyKeys.verifyUrl, null);
+        return (String) getStateHelper().eval(PropertyKeys.verifyUrl, () -> {
+            String type = this.getType();
+            switch (type) {
+                case Captcha.RECAPTCHA:
+                    return "https://www.google.com/recaptcha/api/siteverify";
+                case Captcha.HCAPTCHA:
+                    return "https://api.hcaptcha.com/siteverify";
+                default:
+                    return null;
+            }
+        });
     }
 
     public void setVerifyUrl(String verifyUrl) {

--- a/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/captcha/CaptchaRenderer.java
@@ -25,11 +25,9 @@ package org.primefaces.component.captcha;
 
 import org.primefaces.renderkit.CoreRenderer;
 import org.primefaces.util.Constants;
-import org.primefaces.util.LangUtils;
 import org.primefaces.util.WidgetBuilder;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -62,33 +60,6 @@ public class CaptchaRenderer extends CoreRenderer<Captcha> {
 
         if (publicKey == null) {
             throw new FacesException("Cannot find public key for catpcha, use " + Captcha.PUBLIC_KEY + " context-param to define one");
-        }
-
-        switch (component.getType()) {
-            case Captcha.RECAPTCHA:
-                if (LangUtils.isBlank(component.getSourceUrl())) {
-                    component.setSourceUrl("https://www.google.com/recaptcha/api.js");
-                }
-                if (LangUtils.isBlank(component.getVerifyUrl())) {
-                    component.setVerifyUrl("https://www.google.com/recaptcha/api/siteverify");
-                }
-                if (LangUtils.isBlank(component.getExecutor())) {
-                    component.setExecutor("grecaptcha");
-                }
-                break;
-            case Captcha.HCAPTCHA:
-                if (LangUtils.isBlank(component.getSourceUrl())) {
-                    component.setSourceUrl("https://js.hcaptcha.com/1/api.js");
-                }
-                if (LangUtils.isBlank(component.getVerifyUrl())) {
-                    component.setVerifyUrl("https://api.hcaptcha.com/siteverify");
-                }
-                if (LangUtils.isBlank(component.getExecutor())) {
-                    component.setExecutor("hcaptcha");
-                }
-                break;
-            default:
-                throw new FacesException(String.format("Captcha type must be one of %s", List.of(Captcha.RECAPTCHA, Captcha.HCAPTCHA)));
         }
 
         encodeMarkup(context, component, publicKey);


### PR DESCRIPTION
Fix #13532: Captcha respect defaults

@tandraschko need some advice here.  I want to set these defaults on the component and typically we do that like this...

```java
 public String getTheme() {
        return (String) getStateHelper().eval(PropertyKeys.theme, "auto");
    }
```

I can't do that here because the defaults are dynamic based on the type either `Google` or `HCaptcha`.

I was setting it on `encodeEnd` but it looks like the form submission then sets them back to NULL because they are not set as true defaults on the statehelper.  

**Is there a single spot where a component can be initialized with defaults?**