### PR TITLE
Fix #13550: 15.0.X support multiple events for ContextMenu attached to DataTable

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -1497,7 +1497,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
         var $this = this;
         var targetSelector = targetId + ' tbody.ui-datatable-data > tr.ui-widget-content';
         var targetEvent = cfg.event + '.row' + this.id;
-        var containerEvent = cfg.event + '.datatable' + this.id;
+        var containerEvent = cfg.event.split(' ').map(e => e + '.datatable' + this.id).join(' ');
         this.contextMenuWidget = menuWidget;
 
         $(document).off(targetEvent, targetSelector).on(targetEvent, targetSelector, null, function(e) {


### PR DESCRIPTION
Fix #13550: 15.0.X support multiple events for ContextMenu attached to DataTable