### PR TITLE
Fix #13548: Barcode be lenient with EAN/UPC check digits

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/multimedia/barcode.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/barcode.xhtml
@@ -16,7 +16,7 @@
             &lt;dependency&gt;
                &lt;groupId>uk.org.okapibarcode&lt;/groupId&gt;
                &lt;artifactId>okapibarcode&lt;/artifactId&gt;
-               &lt;version>0.4.9&lt;/version&gt;
+               &lt;version>0.5.0&lt;/version&gt;
             &lt;/dependency&gt;
             </code></pre>
     </ui:define>
@@ -39,16 +39,16 @@
                 <p:barcode value="0123456789" type="code128"/>
 
                 <h:outputText value="EAN-8"/>
-                <p:barcode value="1234567" type="ean8"/>
+                <p:barcode value="12345670" type="ean8"/>
 
                 <h:outputText value="EAN-13"/>
-                <p:barcode value="123456789012+12345" type="ean13"/>
+                <p:barcode value="1234567890128" type="ean13"/>
 
                 <h:outputText value="UPC-A (PNG)"/>
-                <p:barcode value="01234567895" type="upca" format="png"/>
+                <p:barcode value="012345678958" type="upca" format="png"/>
 
                 <h:outputText value="UPC-E (Vertical)"/>
-                <p:barcode value="0123457" type="upce" orientation="90"/>
+                <p:barcode value="0123456" type="upce" orientation="90"/>
 
                 <h:outputText value="PDF417"/>
                 <p:barcode value="0123456789" type="pdf417"/>

--- a/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeHandler.java
+++ b/primefaces/src/main/java/org/primefaces/component/barcode/BarcodeHandler.java
@@ -106,6 +106,25 @@ public class BarcodeHandler extends BaseDynamicContentHandler {
             int quietZoneHorizontal = Integer.parseInt(params.get("mh"));
             int quietZoneVertical = Integer.parseInt(params.get("mv"));
 
+            // #13548 be lenient with EAN13 and EAN8 for check digits
+            if (generator instanceof Ean) {
+                Ean ean = (Ean) generator;
+                if (ean.getMode() == Ean.Mode.EAN13 && value.length() == 13) {
+                    value = value.substring(0, 12);
+                }
+                else if (ean.getMode() == Ean.Mode.EAN8 && value.length() == 8) {
+                    value = value.substring(0, 7);
+                }
+            }
+
+            // #13548 be lenient with UPC-A for check digits
+            if (generator instanceof Upc) {
+                Upc upc = (Upc) generator;
+                if (upc.getMode() == Mode.UPCA && value.length() == 12) {
+                    value = value.substring(0, 11);
+                }
+            }
+
             generator.setHumanReadableLocation(HumanReadableLocation.valueOf(hrp.toUpperCase(Locale.ROOT)));
             generator.setContent(value);
             generator.setQuietZoneHorizontal(quietZoneHorizontal);


### PR DESCRIPTION
Fix #13548: Barcode be lenient with EAN/UPC check digits

This recommendation came from the Okapi developers.