### PR TITLE
Fix #13546: SelectOneRadio clicking already active label should not trigger change

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/forms/forms.selectoneradio.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/forms/forms.selectoneradio.widget.js
@@ -171,7 +171,10 @@ PrimeFaces.widget.SelectOneRadio = class SelectOneRadio extends PrimeFaces.widge
                 else
                     radio = target.children('.ui-radiobutton-box'); //custom layout
 
-                radio.trigger('click.selectOneRadio');
+                // #13546 only trigger radio if its not already active
+                if (!radio.hasClass('ui-state-active')) {
+                    radio.trigger('click.selectOneRadio');
+                }
 
                 e.preventDefault();
             });


### PR DESCRIPTION
Fix #13546: SelectOneRadio clicking already active label should not trigger change