### PR TITLE
Fix #13593: DataTable clearFilters() fix

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -4418,11 +4418,14 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
         };
 
         var resetWidget = function(widgetElement) {
+            const selector = ':input:not(:disabled):not([readonly]), textarea:not(:disabled):not([readonly])';
             var widget = PrimeFaces.getWidgetById(widgetElement.attr('id'));
             if (widget && typeof widget.resetValue === 'function') {
                 widget.resetValue(true);
+            } else if (widgetElement.is(selector)) {
+                resetInputFields(widgetElement);
             } else {
-                resetInputFields(widgetElement.find(':input:not(:disabled):not([readonly]), textarea:not(:disabled):not([readonly])'));
+                resetInputFields($(this).find(selector));
             }
         };
 


### PR DESCRIPTION
Fix #13593: DataTable clearFilters() fix