### PR TITLE
Refactor InFilterConstraint to leverage EqualsFilterConstraint

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable048.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable048.java
@@ -25,32 +25,43 @@ package org.primefaces.integrationtests.datatable;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.model.SelectItem;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
+@Named
+@ViewScoped
 @Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ProgrammingLanguage implements Serializable {
-    private static final long serialVersionUID = 398626647627541586L;
-    private Integer id;
-    private String name;
-    private Integer firstAppeared;
-    private ProgrammingLanguageType type;
-    private boolean selectable;
-    private BigDecimal popularity;
+public class DataTable048 implements Serializable {
 
-    public ProgrammingLanguage(Integer id, String name, Integer firstAppeared, ProgrammingLanguageType type) {
-        this.id = id;
-        this.name = name;
-        this.firstAppeared = firstAppeared;
-        this.type = type;
+    private static final long serialVersionUID = 1L;
+
+    private List<ProgrammingLanguage> progLanguages;
+    private List<SelectItem> popularities;
+
+    @Inject
+    private ProgrammingLanguageService service;
+
+    @PostConstruct
+    public void init() {
+        progLanguages = service.getLangs();
+        popularities = new ArrayList<>(progLanguages.size());
+        popularities.add(new SelectItem(null, "Empty"));
+        progLanguages.forEach(p -> {
+            int id = p.getId();
+            BigDecimal popularity = id % 2 == 0 ? BigDecimal.valueOf(id) : null;
+            if (popularity != null) {
+                popularities.add(new SelectItem(popularity, popularity.toString()));
+                p.setPopularity(popularity);
+            }
+        });
     }
 
-    public enum ProgrammingLanguageType {
-        COMPILED,
-        INTERPRETED
-    }
 }

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable002RowCountOtherImpl.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable002RowCountOtherImpl.xhtml
@@ -27,7 +27,7 @@
 
                 <p:column field="firstAppeared" filterMatchMode="gte"/>
 
-                <p:column field="type" filterMatchMode="exact">
+                <p:column field="type" filterMatchMode="in">
                     <f:facet name="filter">
                         <p:selectCheckboxMenu id="filterType" onchange="PF('datatable').filter()" multiple="true" updateLabel="true">
                             <f:selectItems value="#{dataTable002RowCountOtherImpl.types}"/>

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable048.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable048.xhtml
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:dataTable id="datatable" widgetVar="datatable" value="#{dataTable048.progLanguages}" var="lang">
+                <p:column headerText="ID">
+                    <h:outputText value="#{lang.id}"/>
+                </p:column>
+
+                <p:column headerText="Name">
+                    <h:outputText value="#{lang.name}"/>
+                </p:column>
+
+                <p:column field="popularity" filterMatchMode="in" headerText="Popularity 1">
+                    <f:facet name="filter">
+                        <p:selectCheckboxMenu id="filterPopularity1" onchange="PF('datatable').filter()" multiple="true" updateLabel="true">
+                            <f:converter converterId="jakarta.faces.BigDecimal" />
+                            <f:selectItems value="#{dataTable048.popularities}"/>
+                        </p:selectCheckboxMenu>
+                    </f:facet>
+                </p:column>
+
+                <p:column field="popularity" filterMatchMode="equals" headerText="Popularity 2">
+                    <f:facet name="filter">
+                        <p:selectOneMenu id="filterPopularity2" onchange="PF('datatable').filter()" multiple="true" updateLabel="true">
+                            <f:converter converterId="jakarta.faces.BigDecimal" />
+                            <f:selectItems value="#{dataTable048.popularities}"/>
+                        </p:selectOneMenu>
+                    </f:facet>
+                </p:column>
+            </p:dataTable>
+
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable048Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable048Test.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.DataTable;
+import org.primefaces.selenium.component.SelectCheckboxMenu;
+import org.primefaces.selenium.component.SelectOneMenu;
+import org.primefaces.selenium.component.model.datatable.Row;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DataTable048Test extends AbstractDataTableTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: In filter BigDecimal")
+    public void testInEqualsFilterBigDecimal(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        SelectCheckboxMenu filter1 = getFilter1();
+        SelectOneMenu filter2 = getFilter2();
+        assertNotNull(dataTable);
+        assertNotNull(filter1);
+        assertNotNull(filter2);
+
+        filter1.togglPanel();
+        List<WebElement> filterTypeCheckboxes = filter1.getPanel().findElements(By.cssSelector(".ui-chkbox-box"));
+        // In filter all
+        PrimeSelenium.guardAjax(filterTypeCheckboxes.get(0)).click();
+        filter1.togglPanel();
+
+        // Equals filter 2
+        filter2.toggleDropdown();
+        filter2.select("2");
+
+        // Assert
+        List<Row> rows = dataTable.getRows();
+        assertNotNull(rows);
+        assertEquals(1, rows.size()); //one page
+        assertEquals("2", rows.get(0).getCell(0).getText());
+
+        // Arrange
+        filter2.toggleDropdown();
+        // Equals filter null (all)
+        filter2.select("Empty");
+
+        filter1.togglPanel();
+        filterTypeCheckboxes = filter1.getPanel().findElements(By.cssSelector(".ui-chkbox-box"));
+        PrimeSelenium.guardAjax(filterTypeCheckboxes.get(0)).click();
+        // In filter null
+        PrimeSelenium.guardAjax(filterTypeCheckboxes.get(1)).click();
+        filter1.togglPanel();
+
+        // Assert
+        rows = dataTable.getRows();
+        assertNotNull(rows);
+        assertEquals(3, rows.size()); //one page
+        assertEquals("1", rows.get(0).getCell(0).getText());
+        assertEquals("3", rows.get(1).getCell(0).getText());
+        assertEquals("5", rows.get(2).getCell(0).getText());
+
+        // Assert
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:datatable")
+        DataTable dataTable;
+
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable048.xhtml";
+        }
+
+    }
+
+    private SelectCheckboxMenu getFilter1() {
+        return PrimeSelenium.createFragment(SelectCheckboxMenu.class, By.id("form:datatable:filterPopularity1"));
+    }
+
+    private SelectOneMenu getFilter2() {
+        return PrimeSelenium.createFragment(SelectOneMenu.class, By.id("form:datatable:filterPopularity2"));
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/EqualsFilterConstraint.java
@@ -23,7 +23,10 @@
  */
 package org.primefaces.model.filter;
 
+import org.primefaces.util.LangUtils;
+
 import java.util.Locale;
+import java.util.Objects;
 
 import jakarta.faces.context.FacesContext;
 
@@ -33,16 +36,29 @@ public class EqualsFilterConstraint implements FilterConstraint {
 
     @Override
     public boolean isMatching(FacesContext ctxt, Object value, Object filter, Locale locale) {
-        if (value == filter) {
+        if (Objects.equals(value, filter)) {
             return true;
         }
+        // #8106
+        // Ported from InFilterConstraint: check for "" comparison
+        if (filter instanceof String && LangUtils.isEmpty((String) filter) && value == null) {
+            return true;
+        }
+
+        // If either are null and we get this far, they don't equal
         if (value == null || filter == null) {
             return false;
         }
+
+        // #10730
         // Handle enum values by comparing their string representations
+        // NOTE: This needs to happen _before_ `Comparable` check, even though both Enum and String
+        // are Comparable, because they are different types
         if (value.getClass().isEnum() || filter.getClass().isEnum()) {
             return value.toString().equals(filter.toString());
         }
+
+        // #12666
         // If Comparable, prefer compareTo to handle BigDecimal, etc.
         if (value instanceof Comparable) {
             ComparableFilterConstraint.assertAssignable(filter, value);

--- a/primefaces/src/main/java/org/primefaces/model/filter/InFilterConstraint.java
+++ b/primefaces/src/main/java/org/primefaces/model/filter/InFilterConstraint.java
@@ -23,17 +23,14 @@
  */
 package org.primefaces.model.filter;
 
-import org.primefaces.util.LangUtils;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Objects;
 
 import jakarta.faces.context.FacesContext;
 
-public class InFilterConstraint implements FilterConstraint {
+public class InFilterConstraint extends EqualsFilterConstraint {
 
     private static final long serialVersionUID = 1L;
 
@@ -55,22 +52,9 @@ public class InFilterConstraint implements FilterConstraint {
         }
 
         for (Object filterValue : collection) {
-            if (Objects.equals(value, filterValue)) {
+            // Return true on the first matching value
+            if (super.isMatching(ctxt, value, filterValue, locale)) {
                 return true;
-            }
-
-            // GitHub #8106 check for "" comparison
-            if (filterValue instanceof String && LangUtils.isEmpty((String) filterValue) && value == null) {
-                return true;
-            }
-
-            // #10730
-            // the value might be a enum but the filter is a string
-            if (filterValue instanceof String && LangUtils.isNotEmpty((String) filterValue)
-                    && value != null && value.getClass().isEnum()) {
-                if (Objects.equals(value.toString(), filterValue)) {
-                    return true;
-                }
             }
         }
 


### PR DESCRIPTION
There have been a few issues identified and fixed between InFilterConstraint and EqualsFilterConstraint (e.g., #12666 , #10730, #8106), but they have been fixed separately/inconsistently. Since `in` is effectively `equals` over a collection, I thought it might make sense to leverage one for the other, so any future fixes/enhancements to one always applies to the other. The initial driver for this was to apply the fix for #12666 to `filterMatchMode="in"`.