### PR TITLE
Fix #13620: DataTable: Global select checkbox gets automatically selected when all visible table rows on the current page are selected

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -5146,10 +5146,12 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
             }
 
             var totalEnabled = enabledCheckboxes.length;
-            if(totalEnabled && totalEnabled === selectedCheckboxes.length)
-               this.checkHeaderCheckbox();
-            else
-               this.uncheckHeaderCheckbox();
+            if (this.cfg.selectionPageOnly) {
+                if(totalEnabled && totalEnabled === selectedCheckboxes.length)
+                    this.checkHeaderCheckbox();
+                else
+                    this.uncheckHeaderCheckbox();
+            }
 
             if(checkboxes.length === disabledCheckboxes.length)
                this.disableHeaderCheckbox();


### PR DESCRIPTION
@melloware Quick option: just disallow it for `selectionPageOnly="false"`. This works and the other issue referenced is still resolved. But I think the more comprehensive solution would be to refactor selection to pass the selectable row keys back and forth, along with the selection itself, so the JS can better check/do things in the non-page only cases...

Fix #13620