### PR TITLE
Fix #13620: 15.0.3 DataTable: Global select checkbox gets automatically selected when all visible table rows on the current page are selected

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -5145,10 +5145,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             }
 
             var totalEnabled = enabledCheckboxes.length;
-            if(totalEnabled && totalEnabled === selectedCheckboxes.length)
-               this.checkHeaderCheckbox();
-            else
-               this.uncheckHeaderCheckbox();
+            if (this.cfg.selectionPageOnly) {
+                if(totalEnabled && totalEnabled === selectedCheckboxes.length)
+                    this.checkHeaderCheckbox();
+                else
+                    this.uncheckHeaderCheckbox();
+            }
 
             if(checkboxes.length === disabledCheckboxes.length)
                this.disableHeaderCheckbox();


### PR DESCRIPTION
Fix #13620