### PR TITLE
Fix #13666 - Dialog fit viewport width in addition to height

### DIFF
--- a/docs/16_0_0/components/dialog.md
+++ b/docs/16_0_0/components/dialog.md
@@ -31,7 +31,7 @@ Dialog is a panel component that can overlay other elements on page.
 | dir | ltr | String | Defines text direction, valid values are ltr and rtl.
 | draggable | true | Boolean | Specifies draggability
 | dynamic | false | Boolean | Enables lazy loading of the content with ajax.
-| fitViewport | false | Boolean | Dialog size might exceed viewport if content is bigger than viewport in terms of height. fitViewport option automatically adjusts height to fit dialog within the viewport.
+| fitViewport | false | Boolean | Dialog size might exceed viewport if content is bigger than viewport in terms of height or width. fitViewport option automatically adjusts height and width to fit dialog within the viewport.
 | focus | null | String | Defines which component to apply focus by search expression.
 | footer | null | String | Text of the footer.
 | header | null | String | Text of the header

--- a/docs/16_0_0/core/dialogframework.md
+++ b/docs/16_0_0/core/dialogframework.md
@@ -128,7 +128,7 @@ Here is the full list of configuration options:
 | showEffect | null | String | Effect to use when showing the dialog |
 | hideEffect | null | String | Effect to use when hiding the dialog |
 | position | null | String | Defines where the dialog should be displayed |
-| fitViewport | false | Boolean | Dialog size might exceed viewport if content is bigger than viewport in terms of height. fitViewport option automatically adjusts height to fit dialog within the viewport. |
+| fitViewport | false | Boolean | Dialog size might exceed viewport if content is bigger than viewport in terms of height or width. fitViewport option automatically adjusts height and width to fit dialog within the viewport. |
 | responsive | false | Boolean | In responsive mode, dialog adjusts itself based on screen width. |
 | onShow | null | String | Client side callback to execute when dialog is displayed. |
 | onHide | null | String | Client side callback to execute when dialog is hidden. |

--- a/docs/PrimeFaces.d.ts
+++ b/docs/PrimeFaces.d.ts
@@ -13440,7 +13440,8 @@ declare namespace PrimeFaces.widget {
         dynamic: boolean;
         /**
          * Dialog size might exceed the viewport if the content is taller than viewport in terms
-         * of height. When this is set to `true`, automatically adjust the height to fit the dialog within the viewport.
+         * of height or wider in terms of width. When this is set to `true`, automatically adjust
+         * the height and width to fit the dialog within the viewport.
          */
         fitViewport: boolean;
         /**

--- a/primefaces-showcase/src/main/webapp/ui/overlay/dialog.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/overlay/dialog.xhtml
@@ -29,6 +29,9 @@
 
             <h5>Minimize and Maximize</h5>
             <p:commandButton value="Show" type="button" icon="pi pi-external-link" onclick="PF('dlg4').show()"/>
+
+            <h5>Fit Viewport</h5>
+            <p:commandButton value="Show" type="button" icon="pi pi-external-link" onclick="PF('dlg5').show()"/>
         </div>
 
         <p:dialog header="Header" widgetVar="dlg1" minHeight="40" width="350" showEffect="fade" closeOnEscape="true">
@@ -61,6 +64,23 @@
             Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
             Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
             cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+        </p:dialog>
+
+        <p:dialog header="Header" widgetVar="dlg5" height="1500" width="1500" fitViewport="true">
+            <p class="m-0 mb-2">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+            <p class="m-0 mb-2">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+            <p class="m-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+                cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
         </p:dialog>
 
     </ui:define>

--- a/primefaces/src/main/frontend/packages/components/src/dialog/dialog.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/dialog/dialog.widget.ts
@@ -326,6 +326,11 @@ export class Dialog<Cfg extends DialogCfg = DialogCfg> extends PrimeFaces.widget
      * Makes this dialog fit the current browser window, if the `fitViewport` option is enabled.
      */
     protected fitViewport(): void {
+       this.fitHeight();
+       this.fitWidth();
+    }
+
+    private fitHeight(): void {
         const windowHeight = $(window).height() ?? 0;
 
         const margin = (this.box.outerHeight(true) ?? 0) - (this.box.outerHeight() ?? 0);
@@ -342,6 +347,20 @@ export class Dialog<Cfg extends DialogCfg = DialogCfg> extends PrimeFaces.widget
         }
     }
 
+    private fitWidth(): void {
+        const windowWidth = $(window).width() ?? 0;
+
+        const margin = (this.box.outerWidth(true) ?? 0) - (this.box.outerWidth() ?? 0);
+        const contentPadding = (this.content.innerWidth() ?? 0) - (this.content.width() ?? 0);
+
+        const maxWidth = windowWidth - (margin + contentPadding);
+
+        this.box.css('max-width', maxWidth + 'px');
+
+        if (this.cfg.hasIframe) {
+            this.content.children('iframe').css('max-width', maxWidth + 'px');
+        }
+    }
 
     /**
      * @returns The DOM elements which are allowed to be focused via tabbing.

--- a/primefaces/src/main/frontend/packages/core/index.ts
+++ b/primefaces/src/main/frontend/packages/core/index.ts
@@ -568,7 +568,8 @@ declare global {
 
             /**
              * Dialog size might exceed the viewport if the content is taller than viewport in terms
-             * of height. When this is set to `true`, automatically adjust the height to fit the dialog within the viewport.
+             * of height or wider in terms of width. When this is set to `true`, automatically adjust
+             * the height and width to fit the dialog within the viewport.
              */
             fitViewport: boolean;
 

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -9983,8 +9983,8 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Dialog size might exceed viewport if content is bigger than viewport in terms of height. fitViewport option automatically
-                adjusts height to fit dialog within the viewport.]]>
+                <![CDATA[Dialog size might exceed viewport if content is bigger than viewport in terms of height or width.
+                fitViewport option automatically adjusts height and width to fit dialog within the viewport.]]>
             </description>
             <name>fitViewport</name>
             <required>false</required>


### PR DESCRIPTION
Fixes #13666 by adding a width check to the dialog widget in addition to the height check.

===

This is my first contribution so please let me know if there's anything I'm doing wrong, I added another dialog button to the showcase for testing  / demonstration but I can remove it if it's unnecessary.

I also wasn't sure which docs to modify for this.