### PR TITLE
Fix #13671: SelectCheckboxMenu: Invalid SelectItems' value type not obvious

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -141,7 +141,8 @@ public abstract class SelectRenderer<T extends UIInput> extends InputRenderer<T>
                             }
                             addSelectItem(component, selectItems, selectItem, hideNoSelectOption);
                         }
-                    } else {
+                    }
+                    else {
                         throw new FacesException("SelectItems' value type is not compatible: " + value.getClass());
                     }
                 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -141,6 +141,8 @@ public abstract class SelectRenderer<T extends UIInput> extends InputRenderer<T>
                             }
                             addSelectItem(component, selectItems, selectItem, hideNoSelectOption);
                         }
+                    } else {
+                        throw new FacesException("SelectItems' value type is not compatible: " + value.getClass());
                     }
                 }
             }


### PR DESCRIPTION
Fix #13671: SelectCheckboxMenu: Invalid SelectItems' value type not obvious

Results in:
```
jakarta.faces.FacesException: SelectItems' value type is not compatible: class java.lang.String
        at org.primefaces.renderkit.SelectRenderer.getSelectItems(SelectRenderer.java:145)
        at org.primefaces.component.selectcheckboxmenu.SelectCheckboxMenuRenderer.encodeMarkup(SelectCheckboxMenuRenderer.java:82)
        at org.primefaces.component.selectcheckboxmenu.SelectCheckboxMenuRenderer.encodeEnd(SelectCheckboxMenuRenderer.java:70)
        at org.primefaces.component.selectcheckboxmenu.SelectCheckboxMenuRenderer.encodeEnd(SelectCheckboxMenuRenderer.java:52)
```