### PR TITLE
Fix #13671: 15.0.4 SelectCheckboxMenu: Invalid SelectItems' value type not obvious

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/SelectRenderer.java
@@ -142,6 +142,9 @@ public abstract class SelectRenderer extends InputRenderer {
                             addSelectItem(component, selectItems, selectItem, hideNoSelectOption);
                         }
                     }
+                    else {
+                        throw new FacesException("SelectItems' value type is not compatible: " + value.getClass());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #13671: 15.0.4 SelectCheckboxMenu: Invalid SelectItems' value type not obvious