### PR TITLE
Fix #13715: 15.0.4 IdleMonitor use global storage key

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/idlemonitor/1-idlemonitor.js
@@ -58,7 +58,7 @@ PrimeFaces.widget.IdleMonitor = PrimeFaces.widget.BaseWidget.extend({
 
 
         if (cfg.multiWindowSupport) {
-            var globalLastActiveKey = PrimeFaces.createStorageKey(this.cfg.id, 'IdleMonitor_lastActive');
+            var globalLastActiveKey = PrimeFaces.createStorageKey(this.cfg.id, 'IdleMonitor_lastActive', true);
 
             // always reset with current time on init
             localStorage.setItem(globalLastActiveKey, $(document).data('idleTimerObj' + this.cfg.id).lastActive);


### PR DESCRIPTION
Fix #13715: 15.0.4 IdleMonitor use global storage key