### PR TITLE
Fix #13742: 15.0.4 Datatable emptyMessage fill out colspan for rowGroup

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -5606,7 +5606,12 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
     updateEmptyColspan: function() {
         var emptyRow = this.tbody.children('tr:first');
         if(emptyRow && emptyRow.hasClass('ui-datatable-empty-message')) {
-            this.updateColspan(emptyRow);
+            let colspanValue = this.calculateColspan();
+            // #13742 need to re-add the grouped column to fill out the empty row
+            if (this.thead.find('> tr:first th.ui-grouped-column').length > 0) {
+                colspanValue = colspanValue + 1;
+            }
+            this.updateColspan(emptyRow, colspanValue);
         }
     },
 


### PR DESCRIPTION
Fix #13742: 15.0.4 Datatable emptyMessage fill out colspan for rowGroup