### PR TITLE
Fix #13774 15.0.4 Calendar/DatePicker: does not support timeOnly corectly with SQL time

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -520,9 +520,12 @@ public class CalendarUtils {
         if (date == null) {
             return null;
         }
-        else {
-            return convertDate2ZonedDateTime(date, zoneId).toLocalTime();
+
+        if (date instanceof java.sql.Time) {
+            return ((java.sql.Time) date).toLocalTime();
         }
+
+        return convertDate2ZonedDateTime(date, zoneId).toLocalTime();
     }
 
     public static Date convertLocalDate2Date(LocalDate localDate, ZoneId zoneId) {


### PR DESCRIPTION
Fix #13774 15.0.4 Calendar/DatePicker: does not support timeOnly corectly with SQL time