### PR TITLE
Fix #13792: 15.0.5 CSS Transition use UI Delay not MicroTask

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -887,7 +887,7 @@ if (!PrimeFaces.utils) {
                                 requestAnimationFrame(function() {
                                     PrimeFaces.queueTask(function() {
                                         element.addClass(classNameStates.enterActive);
-                                    });
+                                    }, 1);
 
                                     element.one('transitionrun.css-transition-show', function(event) {
                                         callTransitionEvent(callbacks, 'onEntering', event);


### PR DESCRIPTION
Fix #13792: 15.0.5 CSS Transition use UI Delay not MicroTask