### PR TITLE
Fix #13792: CSS Transition use UI Delay not MicroTask

### DIFF
--- a/primefaces/src/main/frontend/packages/core/src/core/core.utils.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.utils.ts
@@ -953,7 +953,7 @@ export class Utils {
                             requestAnimationFrame(() => {
                                 core.queueTask(() => {
                                     element.addClass(classNameStates.enterActive);
-                                });
+                                }, 1);
 
                                 element.one('transitionrun.css-transition-show', (event) => {
                                     callTransitionEvent(callbacks, 'onEntering', event);


### PR DESCRIPTION
Fix #13792: CSS Transition use UI Delay not MicroTask