### PR TITLE
Add 'Unsupported features' to JPALazyDataModel docs

### DIFF
--- a/docs/15_0_0/components/datatable.md
+++ b/docs/15_0_0/components/datatable.md
@@ -1083,6 +1083,10 @@ Map<String, FilterMeta> filterMeta = Collections.emptyMap();
 List<MyEntity> result = lazyDataModel.load(0, lazyDataModel.count(filterMeta), sortMeta, filterMeta);
 ```
 
+#### Unsupported features
+
+Due to its implementation based on Criteria API, certain features of `DataTable` simply cannot work with `JPALazyDataModel` but may "fail silently". To aid implementors in avoiding running into issues, we've compiled (and will continue to add to) a list of features in this category:
+* `filterFunction` - `p:column`'s `filterFunction` attribute will have no effect if `JPALazyDataModel` is used; alternative filter customizations listed above should be used instead
 
 ### FlowLogix JPALazyDataModel (PrimeFaces Community)
 `JPALazyDataModel` implementation that's fully integrated with Jakarta EE and `@Inject`able.

--- a/docs/16_0_0/components/datatable.md
+++ b/docs/16_0_0/components/datatable.md
@@ -1096,6 +1096,11 @@ public class MyJPALazyDataModel<T> extends JPALazyDataModel<T> {
 }
 ```
 
+#### Unsupported features
+
+Due to its implementation based on Criteria API, certain features of `DataTable` simply cannot work with `JPALazyDataModel` but may "fail silently". To aid implementors in avoiding running into issues, we've compiled (and will continue to add to) a list of features in this category:
+* `filterFunction` - `p:column`'s `filterFunction` attribute will have no effect if `JPALazyDataModel` is used; alternative filter customizations listed above should be used instead
+
 ### FlowLogix JPALazyDataModel (PrimeFaces Community)
 `JPALazyDataModel` implementation that's fully integrated with Jakarta EE and `@Inject`able.
 


### PR DESCRIPTION
A coworker got spun around the axel trying to implement `filterFunction` for our `JPALazyDataModel` impl. On the surface (not understanding the details of how `JPALazyDataModel` is implemented) it was a valid assumption that the feature should work and how it acts when it does not is very hard to trace. Given that, and I think it's something that actually can't be implemented, I opted to add a new section to the docs to begin listing features that are not implemented so future devs don't run into the same situation.

Ex. how `filterFunction` "fails silently"
[jpalazydatamodel-filterfunction.zip](https://github.com/user-attachments/files/20302274/jpalazydatamodel-filterfunction.zip)

cc @melloware @tandraschko 
