### PR TITLE
Refactor: precompile frequently used regex patterns for better performance

### DIFF
--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContentMarkerUtil.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContentMarkerUtil.java
@@ -62,12 +62,6 @@ public class FileContentMarkerUtil {
 
     private static final Pattern SC_BEAN_PATTERN = Pattern.compile("#\\{([^.]*)\\.?.*?}");
 
-    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
-
-    private static final Pattern EIGHT_SPACES_PATTERN = Pattern.compile("\\s{8}");
-
-    private static final Pattern LINE_SPLIT_PATTERN = Pattern.compile("(?<=\\n)");
-
     private static final String SC_PREFIX = "org.primefaces.showcase";
 
     private FileContentMarkerUtil() {
@@ -234,12 +228,12 @@ public class FileContentMarkerUtil {
     }
 
     private static String prettyFormat(String value) {
-        String[] chunks = LINE_SPLIT_PATTERN.split(value, 0);
-        StringBuilder pretty = new StringBuilder();
+        String[] chunks = value.split("(?<=\\n)");
+        String pretty = "";
         for (String chunk : chunks) {
-            pretty.append(EIGHT_SPACES_PATTERN.matcher(chunk).replaceFirst(""));
+            pretty += chunk.replaceFirst("\\s{8}", "");
         }
-        return pretty.toString();
+        return pretty;
     }
 
     /**
@@ -262,6 +256,6 @@ public class FileContentMarkerUtil {
     }
 
     private static String createFullPath(String filename) {
-        return "/" + DOT_PATTERN.matcher(filename).replaceAll("/") + ".java";
+        return "/" + filename.replaceAll("\\.", "/") + ".java";
     }
 }

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContentMarkerUtil.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/util/FileContentMarkerUtil.java
@@ -62,6 +62,12 @@ public class FileContentMarkerUtil {
 
     private static final Pattern SC_BEAN_PATTERN = Pattern.compile("#\\{([^.]*)\\.?.*?}");
 
+    private static final Pattern DOT_PATTERN = Pattern.compile("\\.");
+
+    private static final Pattern EIGHT_SPACES_PATTERN = Pattern.compile("\\s{8}");
+
+    private static final Pattern LINE_SPLIT_PATTERN = Pattern.compile("(?<=\\n)");
+
     private static final String SC_PREFIX = "org.primefaces.showcase";
 
     private FileContentMarkerUtil() {
@@ -228,12 +234,12 @@ public class FileContentMarkerUtil {
     }
 
     private static String prettyFormat(String value) {
-        String[] chunks = value.split("(?<=\\n)");
-        String pretty = "";
+        String[] chunks = LINE_SPLIT_PATTERN.split(value, 0);
+        StringBuilder pretty = new StringBuilder();
         for (String chunk : chunks) {
-            pretty += chunk.replaceFirst("\\s{8}", "");
+            pretty.append(EIGHT_SPACES_PATTERN.matcher(chunk).replaceFirst(""));
         }
-        return pretty;
+        return pretty.toString();
     }
 
     /**
@@ -256,6 +262,6 @@ public class FileContentMarkerUtil {
     }
 
     private static String createFullPath(String filename) {
-        return "/" + filename.replaceAll("\\.", "/") + ".java";
+        return "/" + DOT_PATTERN.matcher(filename).replaceAll("/") + ".java";
     }
 }

--- a/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
+++ b/primefaces/src/main/java/org/primefaces/application/exceptionhandler/PrimeExceptionHandler.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 import jakarta.el.ELException;
 import jakarta.faces.FacesException;
@@ -69,6 +70,7 @@ public class PrimeExceptionHandler extends ExceptionHandlerWrapper {
 
     private static final Logger LOGGER = Logger.getLogger(PrimeExceptionHandler.class.getName());
     private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd HH:mm:ss";
+    private static final Pattern NEWLINE_PATTERN = Pattern.compile("(\r\n|\n)");
 
     private final Lazy<PrimeConfiguration> config;
 
@@ -270,7 +272,7 @@ public class PrimeExceptionHandler extends ExceptionHandlerWrapper {
 
         try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
             rootCause.printStackTrace(pw);
-            info.setFormattedStackTrace(EscapeUtils.forXml(sw.toString()).replaceAll("(\r\n|\n)", "<br/>"));
+            info.setFormattedStackTrace(NEWLINE_PATTERN.matcher(EscapeUtils.forXml(sw.toString())).replaceAll("<br/>"));
         }
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN);

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
@@ -47,6 +48,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     private static final String BODY_TAG = "body";
     private static final String HTML_TAG = "html";
     private static final String TYPE_ATTRIBUTE = "type";
+    private static final Pattern TRACKING_SUFFIX_PATTERN = Pattern.compile("_\\d+$");
 
     private final MoveScriptsToBottomState state;
 
@@ -238,7 +240,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
             // write inline scripts
             for (Map.Entry<String, List<String>> entry : state.getInlines().entrySet()) {
                 // strip tracking _0, _1, _2 etc off the end of the string
-                String type = entry.getKey().replaceAll("_\\d+$", "");
+                String type = TRACKING_SUFFIX_PATTERN.matcher(entry.getKey()).replaceAll("");
                 List<String> inlines = entry.getValue();
 
                 String id = UUID.randomUUID().toString();

--- a/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/imagecropper/ImageCropperRenderer.java
@@ -46,6 +46,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.imageio.ImageIO;
 
@@ -62,6 +63,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 
 public class ImageCropperRenderer extends CoreRenderer<ImageCropper> {
+
+    private static final Pattern IMAGE_TYPE_PATTERN = Pattern.compile("^image/([^;]+);?.*$");
 
     @Override
     public void decode(FacesContext context, ImageCropper component) {
@@ -235,7 +238,7 @@ public class ImageCropperRenderer extends CoreRenderer<ImageCropper> {
         }
 
         if (contentType != null) {
-            format = contentType.replaceFirst("^image/([^;]+);?.*$", "$1");
+            format = IMAGE_TYPE_PATTERN.matcher(contentType).replaceFirst("$1");
         }
         else {
             int queryStringIndex = imagePath.indexOf('?');

--- a/primefaces/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputtextarea/InputTextareaRenderer.java
@@ -35,6 +35,7 @@ import org.primefaces.util.WidgetBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -42,6 +43,8 @@ import jakarta.faces.context.ResponseWriter;
 import jakarta.faces.event.PhaseId;
 
 public class InputTextareaRenderer extends InputRenderer<InputTextarea> {
+
+    private static final Pattern NEWLINE_NORMALIZE_PATTERN = Pattern.compile("\\r\\n?");
 
     @Override
     public void decode(FacesContext context, InputTextarea component) {
@@ -57,7 +60,7 @@ public class InputTextareaRenderer extends InputRenderer<InputTextarea> {
 
         if (submittedValue != null) {
             // #5381: normalize new lines to match JavaScript
-            submittedValue = submittedValue.replaceAll("\\r\\n?", "\n");
+            submittedValue = NEWLINE_NORMALIZE_PATTERN.matcher(submittedValue).replaceAll("\n");
             int maxlength = component.getMaxlength();
             if (submittedValue.length() > maxlength) {
                 submittedValue = LangUtils.substring(submittedValue, 0, maxlength);

--- a/primefaces/src/main/java/org/primefaces/renderkit/DataRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/DataRenderer.java
@@ -46,6 +46,7 @@ import org.primefaces.util.WidgetBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -64,6 +65,8 @@ public class DataRenderer<T extends UIComponent & Pageable> extends CoreRenderer
             .put("{JumpToPageDropdown}", new JumpToPageDropdownRenderer())
             .put("{JumpToPageInput}", new JumpToPageInputRenderer())
             .build();
+
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("\\<.*?\\>");
 
     public static void addPaginatorElement(String element, PaginatorElementRenderer renderer) {
         PAGINATOR_ELEMENTS.put(element, renderer);
@@ -221,7 +224,7 @@ public class DataRenderer<T extends UIComponent & Pageable> extends CoreRenderer
                 UIComponent headerFacet = column.getFacet("header");
                 if (FacetUtils.shouldRenderFacet(headerFacet)) {
                     // encode and strip all HTML tags
-                    ariaHeaderText = ComponentUtils.encodeComponent(headerFacet, context).replaceAll("\\<.*?\\>", Constants.EMPTY_STRING);
+                    ariaHeaderText = HTML_TAG_PATTERN.matcher(ComponentUtils.encodeComponent(headerFacet, context)).replaceAll(Constants.EMPTY_STRING);
                 }
             }
 

--- a/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/ComponentUtils.java
@@ -93,6 +93,9 @@ public class ComponentUtils {
     // regex for finding ID's
     private static final Pattern ID_PATTERN = Pattern.compile("\\sid=\"(.*?)\"");
 
+    // regex for finding Sources
+    private static final Pattern SOURCE_PATTERN = Pattern.compile("source:&quot;(.*?)&quot;");
+
 
     private ComponentUtils() {
     }
@@ -605,8 +608,8 @@ public class ComponentUtils {
         }
 
         // replace 'id=' and 'source:' values
-        encodedComponent = encodedComponent.replaceAll("\\sid=\"(.*?)\"", " id=\"$1" + separator + index + "\"");
-        encodedComponent = encodedComponent.replaceAll("source:&quot;(.*?)&quot;", " source:&quot;$1" + separator + index + "&quot;");
+        encodedComponent = ID_PATTERN.matcher(encodedComponent).replaceAll(" id=\"$1" + separator + index + "\"");
+        encodedComponent = SOURCE_PATTERN.matcher(encodedComponent).replaceAll(" source:&quot;$1" + separator + index + "&quot;");
 
         originalWriter.write(encodedComponent);
     }

--- a/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
+++ b/primefaces/src/main/java/org/primefaces/util/CurrencyValidator.java
@@ -26,6 +26,7 @@ package org.primefaces.util;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * <p>
@@ -45,6 +46,7 @@ public class CurrencyValidator extends BigDecimalValidator {
     /** DecimalFormat's currency symbol */
     public static final char CURRENCY_SYMBOL = '\u00A4';
     public static final String CURRENCY_SYMBOL_STR = Character.toString(CURRENCY_SYMBOL);
+    private static final Pattern SPACE_PATTERN = Pattern.compile(Constants.SPACE);
 
     private static final long serialVersionUID = -4201640771171486514L;
 
@@ -141,7 +143,7 @@ public class CurrencyValidator extends BigDecimalValidator {
 
         // between JDK8 and 11 some space characters became non breaking space '\u00A0'
         if (formatter.getPositivePrefix().indexOf(Constants.NON_BREAKING_SPACE) >= 0) {
-            value = value.replaceAll(Constants.SPACE, Constants.NON_BREAKING_SPACE_STR);
+            value = SPACE_PATTERN.matcher(value).replaceAll(Constants.NON_BREAKING_SPACE_STR);
         }
 
         // Initial parse of the value

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -53,6 +53,7 @@ public class LangUtils {
 
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
     private static final Pattern CAPITAL_CASE = Pattern.compile("(?<=.)(?=\\p{Lu})");
+    private static final Pattern DIACRITICS_PATTERN = Pattern.compile("\\p{M}");
 
     private LangUtils() {
     }
@@ -555,7 +556,7 @@ public class LangUtils {
             return Constants.EMPTY_STRING;
         }
 
-        return java.text.Normalizer.normalize(strValue, java.text.Normalizer.Form.NFD).replaceAll("\\p{M}", Constants.EMPTY_STRING);
+        return DIACRITICS_PATTERN.matcher(java.text.Normalizer.normalize(strValue, java.text.Normalizer.Form.NFD)).replaceAll(Constants.EMPTY_STRING);
     }
 
     private static boolean withDecimalsParsing(final String str, final int beginIdx) {


### PR DESCRIPTION
While working on the codebase, I noticed several regex patterns being compiled repeatedly at runtime. I identified most of these occurrences and refactored the code to use precompiled Pattern instances as static final fields.