### PR TITLE
Fix #13868: 15.0.5 DataTable render group rows before deferral

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -280,6 +280,10 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
             }
         }
 
+        if(this.cfg.groupColumnIndexes) {
+            this.groupRows();
+        }
+
         this.updateEmptyColspan();
         this.renderDeferred();
     },


### PR DESCRIPTION
Fix #13868: 15.0.5 DataTable render group rows before deferral