### PR TITLE
Warning in documentation regarding p:datatable cell eding mode

### DIFF
--- a/docs/10_0_0/components/datatable.md
+++ b/docs/10_0_0/components/datatable.md
@@ -756,7 +756,7 @@ When it comes to incell editing there are two possible options: _row_ and _cell_
 
 Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
 particular column. By adding a _p:rowEditor_ component you get row controls to 
-start edit columns and commit or cancel changes for one row.
+start editing and commit or cancel changes for one row.
 
 ```xhtml
 <p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
@@ -779,9 +779,10 @@ start edit columns and commit or cancel changes for one row.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
 ### Cell Editing
 

--- a/docs/10_0_0/components/datatable.md
+++ b/docs/10_0_0/components/datatable.md
@@ -749,13 +749,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, _row_ and _cell_. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start edit columns and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -779,8 +783,37 @@ When pencil icon is clicked, row is displayed in editable mode meaning input fac
 and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
 reverts the changes, both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
+
+WARNING: With _cell_ edting mode _required_ attributes and bean validations annotations
+do not apply. Sie this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular ajax based pagination

--- a/docs/10_0_0/components/datatable.md
+++ b/docs/10_0_0/components/datatable.md
@@ -787,7 +787,7 @@ cancel icon reverts the changes. Both options are implemented with ajax interact
 ### Cell Editing
 
 **WARNING**: With _cell_ edting mode _required_ attributes and bean validations annotations
-do not apply. Sie this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
 
 _p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
 to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must

--- a/docs/10_0_0/components/datatable.md
+++ b/docs/10_0_0/components/datatable.md
@@ -785,6 +785,9 @@ reverts the changes, both options are implemented with ajax interaction.
 
 ### Cell Editing
 
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validations annotations
+do not apply. Sie this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
 _p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
 to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
 be set to _cell_.
@@ -809,11 +812,6 @@ be set to _cell_.
 
 </p:dataTable>
 ```
-
-WARNING: With _cell_ edting mode _required_ attributes and bean validations annotations
-do not apply. Sie this [discussion](https://github.com/orgs/primefaces/discussions/1766)
-
-
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular ajax based pagination

--- a/docs/11_0_0/components/datatable.md
+++ b/docs/11_0_0/components/datatable.md
@@ -753,13 +753,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, _row_ and _cell_. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -779,12 +783,40 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validations annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination

--- a/docs/11_0_0/components/datatable.md
+++ b/docs/11_0_0/components/datatable.md
@@ -790,7 +790,7 @@ cancel icon reverts the changes. Both options are implemented with ajax interact
 
 ### Cell Editing
 
-**WARNING**: With _cell_ edting mode _required_ attributes and bean validations annotations
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
 do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
 
 _p:cellEditor_ is again used to define the cell editor of a particular column. In contrast

--- a/docs/12_0_0/components/datatable.md
+++ b/docs/12_0_0/components/datatable.md
@@ -765,13 +765,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, _row_ and _cell_. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -791,12 +795,40 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination

--- a/docs/13_0_0/components/datatable.md
+++ b/docs/13_0_0/components/datatable.md
@@ -784,13 +784,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, `row` and `cell`. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -810,12 +814,40 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination

--- a/docs/14_0_0/components/datatable.md
+++ b/docs/14_0_0/components/datatable.md
@@ -822,13 +822,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, `row` and `cell`. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -848,12 +852,40 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination

--- a/docs/15_0_0/components/datatable.md
+++ b/docs/15_0_0/components/datatable.md
@@ -836,13 +836,17 @@ Additionally, rowExpandMode attribute defines if multiple rows can be expanded a
 or not, valid values are "single" and "multiple" (default).
 
 ## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, `row` and `cell`. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -862,12 +866,40 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination

--- a/docs/16_0_0/components/datatable.md
+++ b/docs/16_0_0/components/datatable.md
@@ -835,14 +835,19 @@ attribute which is evaluated before rendering of each row so value expressions a
 Additionally, rowExpandMode attribute defines if multiple rows can be expanded at the same time
 or not, valid values are "single" and "multiple" (default).
 
-## Editing
-Incell editing provides an easy way to display editable data. _p:cellEditor_ is used to define the cell
-editor of a particular column. There are two types of editing, `row` and `cell`. Row editing is the
-default mode and used by adding a _p:rowEditor_ component as row controls.
 
+## Editing
+
+When it comes to incell editing there are two possible options: _row_ and _cell_
+
+### Row Editing
+
+Row editing is the default mode. p:cellEditor is used to define the cell editor of a 
+particular column. By adding a _p:rowEditor_ component you get row controls to 
+start editing and commit or cancel changes for one row.
 
 ```xhtml
-<p:dataTable var="car" value="#{carBean.cars}" editable="true">
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="row">
     <f:facet name="header">
         In-Cell Editing
     </f:facet>
@@ -862,12 +867,41 @@ default mode and used by adding a _p:rowEditor_ component as row controls.
     </p:column>
 </p:dataTable>
 ```
-When pencil icon is clicked, row is displayed in editable mode meaning input facets are displayed
-and output facets are hidden. Clicking tick icon only saves that particular row and cancel icon
-reverts the changes, both options are implemented with ajax interaction.
+When the pencil icon is clicked, the row is displayed in editable mode, 
+meaning input facets are displayed and output facets are hidden. 
+Clicking the tick icon only saves that particular row and the 
+cancel icon reverts the changes. Both options are implemented with ajax interaction.
 
-Another option for incell editing is cell editing, in this mode a cell switches to edit mode when it is
-clicked, losing focus triggers an ajax event to save the change value.
+### Cell Editing
+
+**WARNING**: With _cell_ edting mode _required_ attributes and bean validation annotations
+do not apply. See this [discussion](https://github.com/orgs/primefaces/discussions/1766)
+
+_p:cellEditor_ is again used to define the cell editor of a particular column. In contrast
+to _row_ editing there is no _p:rowEditor_ component and the _editMode_ attribute must
+be set to _cell_.
+
+```xhtml
+<p:dataTable var="car" value="#{carBean.cars}" editable="true" editMode="cell">
+    <f:facet name="header">
+        In-Cell Editing
+    </f:facet>
+    <p:column headerText="Model">
+        <p:cellEditor>
+            <f:facet name="output">
+                <h:outputText value="#{car.model}" />
+            </f:facet>
+            <f:facet name="input">
+                <h:inputText value="#{car.model}"/>
+            </f:facet>
+        </p:cellEditor>
+    </p:column>
+    //more columns with cell editors
+
+
+</p:dataTable>
+```
+
 
 ## Lazy Loading
 Lazy Loading is an approach to deal with huge datasets efficiently, regular AJAX based pagination


### PR DESCRIPTION
In discussion [1766](https://github.com/orgs/primefaces/discussions/1766) @melloware  asked me to enhance the documentation for primefaces.  I added the enhancement for now only for version 10, but I guess the newer version of primefaces are also concerned.

Changes:

* I split the editing section in row editing and cell editing subsection
* I added a warning concerning cell editing mode and validation