### PR TITLE
AccordionPanel: key-based active state (#13890)

### DIFF
--- a/docs/16_0_0/components/accordionpanel.md
+++ b/docs/16_0_0/components/accordionpanel.md
@@ -17,31 +17,31 @@ AccordionPanel is a container component that displays content in stacked format.
 
 ## Attributes
 
-| Name          | Default | Type       | Description     |
-| ------------- | ------- | ---------- | ----------------- |
-| id            | null    | String     | Unique identifier of the component
-| binding       | null    | Object     | An EL expression that maps to a server side UIComponent instance in a backing bean.
-| value         | null    | List       | List to iterate to display dynamic number of tabs.
-| var           | null    | String     | Name of iterator to use in a dynamic number of tabs.
-| varStatus     | null    | String     | Name of the exported request scoped variable to represent state of the iteration same as in ui:repeat varStatus.
-| activeIndex   | 0       | String     | Index of the active tab or a comma separated string of indexes when multiple mode is on. Alternative: all.
-| cache         | true    | Boolean    | Defines if activating a dynamic tab should load the contents from server again.
-| dir           | ltr     | String     | Defines text direction, valid values are ltr and rtl.
-| dynamic       | false   | Boolean    | Defines the toggle mode.
-| multiple      | false   | Boolean    | Controls multiple selection.
-| onTabChange   | null    | String     | Client side callback to invoke when an inactive tab is clicked.
-| onTabClose    | null    | String     | Client side callback to invoke when a tab is closed.
-| onTabShow     | null    | String     | Client side callback to invoke when a tab gets activated.
-| prependId     | true    | Boolean    | AccordionPanel is a naming container thus prepends its id to its children by default a false value turns this behavior off except for dynamic tabs.
-| rendered      | true    | Boolean    | Boolean value to specify the rendering of the component.
-| style         | null    | String     | Inline style of the container element.
-| styleClass    | null    | String     | Style class of the container element.
-| tabController | null    | MethodExpr | Server side listener to decide whether a tab change or tab close should be allowed.
-| tabindex      | 0       | String     | Position of the headers in the tabbing order.
-| toggleSpeed   | 500     | Integer    | Speed of toggling in milliseconds
+| Name           | Default | Type       | Description     |
+|----------------| ------- | ---------- | ----------------- |
+| id             | null    | String     | Unique identifier of the component
+| binding        | null    | Object     | An EL expression that maps to a server side UIComponent instance in a backing bean.
+| value          | null    | List       | List to iterate to display dynamic number of tabs.
+| var            | null    | String     | Name of iterator to use in a dynamic number of tabs.
+| varStatus      | null    | String     | Name of the exported request scoped variable to represent state of the iteration same as in ui:repeat varStatus.
+| active         | 0       | String     | Index or key of the active tab or a comma separated string of indexes/keys when multiple mode is on. Alternative: all.
+| cache          | true    | Boolean    | Defines if activating a dynamic tab should load the contents from server again.
+| dir            | ltr     | String     | Defines text direction, valid values are ltr and rtl.
+| dynamic        | false   | Boolean    | Defines the toggle mode.
+| multiple       | false   | Boolean    | Controls multiple selection.
+| onTabChange    | null    | String     | Client side callback to invoke when an inactive tab is clicked.
+| onTabClose     | null    | String     | Client side callback to invoke when a tab is closed.
+| onTabShow      | null    | String     | Client side callback to invoke when a tab gets activated.
+| prependId      | true    | Boolean    | AccordionPanel is a naming container thus prepends its id to its children by default a false value turns this behavior off except for dynamic tabs.
+| rendered       | true    | Boolean    | Boolean value to specify the rendering of the component.
+| style          | null    | String     | Inline style of the container element.
+| styleClass     | null    | String     | Style class of the container element.
+| tabController  | null    | MethodExpr | Server side listener to decide whether a tab change or tab close should be allowed.
+| tabindex       | 0       | String     | Position of the headers in the tabbing order.
+| toggleSpeed    | 500     | Integer    | Speed of toggling in milliseconds
 | scrollIntoView |null    | String     | Should the tab scroll into view. One of start, center, end, nearest, or null if disabled. Default is null
-| widgetVar     | null    | String     | Name of the client side widget.
-| multiViewState| false   | Boolean    | Whether to keep Panel state across views, defaults to false.
+| widgetVar      | null    | String     | Name of the client side widget.
+| multiViewState | false   | Boolean    | Whether to keep Panel state across views, defaults to false.
 
 ## Getting Started with Accordion Panel
 Accordion panel consists of one or more tabs and each tab can group any content. Titles can also be

--- a/docs/16_0_0/components/accordionpanel.md
+++ b/docs/16_0_0/components/accordionpanel.md
@@ -24,6 +24,7 @@ AccordionPanel is a container component that displays content in stacked format.
 | value          | null    | List       | List to iterate to display dynamic number of tabs.
 | var            | null    | String     | Name of iterator to use in a dynamic number of tabs.
 | varStatus      | null    | String     | Name of the exported request scoped variable to represent state of the iteration same as in ui:repeat varStatus.
+| activeIndex    | 0       | String     | (DEPRECATED, use active instead!) Index of the active tab or a comma separated string of indexes when multiple mode is on. Alternative: all.
 | active         | 0       | String     | Index or key of the active tab or a comma separated string of indexes/keys when multiple mode is on. Alternative: all.
 | cache          | true    | Boolean    | Defines if activating a dynamic tab should load the contents from server again.
 | dir            | ltr     | String     | Defines text direction, valid values are ltr and rtl.

--- a/docs/migrationguide/16_0_0.md
+++ b/docs/migrationguide/16_0_0.md
@@ -167,3 +167,5 @@ To the following, so that any long dialog content is now scrollable by default:
 * Positioning/dragging/resizing/reopening of `<p:dialog positionType="absolute">` has been improved; previously this was off relative to the window scroll position.
 * The window scroll event will not anymore reset the position of any dragged dialog.
 
+### AccordionPanel
+* The attribute `activeIndex` has been renamed to `active`, it now supports keys defined with they `key` attribute in `p:tab` alongside indices to smoother handle dynamically rendered tabs,

--- a/docs/migrationguide/16_0_0.md
+++ b/docs/migrationguide/16_0_0.md
@@ -156,7 +156,7 @@ To the following, so that any long dialog content is now scrollable by default:
     </div>
 </div>
 ```
-
+ 
 * The `ui-dialog` now represents the scrollable layer and the `ui-dialog-box` now represents the actual dialog box.
 * The prime use case is that `modal="true" blockScroll="true"` will now finally present a scrollable modal when content is longer than viewport.
 * It is recommended to set either `modal="true" blockScroll="true"` *or* `positionType="absolute"` on any `<p:dialog>` with possibly long content, so that no duplicate scrollbars appear, else just use `fitViewport="true"` instead.
@@ -168,4 +168,4 @@ To the following, so that any long dialog content is now scrollable by default:
 * The window scroll event will not anymore reset the position of any dragged dialog.
 
 ### AccordionPanel
-* The attribute `activeIndex` has been renamed to `active`, it now supports keys defined with they `key` attribute in `p:tab` alongside indices to smoother handle dynamically rendered tabs,
+* The attribute `activeIndex` has been renamed to `active`, it now supports keys defined with they `key` attribute in `p:tab` alongside indices to smoother handle dynamically rendered tabs. `activeIndex` is now deprecated and wil be removed in a future version.

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel003.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel003.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Data
+@Named
+@ViewScoped
+public class AccordionPanel003 implements Serializable {
+    private boolean isFirstTabRendered;
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel004.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Data
+@Named
+@ViewScoped
+public class AccordionPanel004 implements Serializable {
+    private boolean isFirstTabRendered;
+
+    public List<String> getTabs() {
+        List<String> tabs = new ArrayList<>(3);
+
+        if (isFirstTabRendered) {
+            tabs.add("tab1");
+        }
+
+        tabs.add("tab2");
+        tabs.add("tab3");
+
+        return tabs;
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel003.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:selectBooleanCheckbox id="toggle" value="#{accordionPanel003.firstTabRendered}">
+                <p:ajax process="@this" update="accordionpanel"/>
+            </p:selectBooleanCheckbox>
+
+            <p:accordionPanel id="accordionpanel" multiViewState="true" active="tab2,tab3">
+                <p:tab key="tab1" title="Tab 1" rendered="#{accordionPanel003.firstTabRendered}">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab key="tab2" title="Tab 2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab key="tab3" title="Tab 3">
+                    Dummy-Content 3
+                </p:tab>
+            </p:accordionPanel>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel004.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:selectBooleanCheckbox id="toggle" value="#{accordionPanel004.firstTabRendered}">
+                <p:ajax process="@this" update="accordionpanel"/>
+            </p:selectBooleanCheckbox>
+
+            <p:accordionPanel id="accordionpanel" multiViewState="true" active="tab2,tab3"
+                              value="#{accordionPanel004.tabs}" var="tab">
+                <p:tab key="#{tab}" title="#{tab}">
+                    Dummy-Content #{tab}
+                </p:tab>
+            </p:accordionPanel>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel003Test.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.AccordionPanel;
+import org.primefaces.selenium.component.SelectBooleanCheckbox;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AccordionPanel003Test extends AbstractPrimePageTest {
+    @Test
+    public void test(Page page) {
+        // Arrange
+        AccordionPanel accordionPanel = page.accordionPanel;
+        SelectBooleanCheckbox toggle = page.toggle;
+
+        // Act
+        toggle.click();
+
+        // Assert
+        assertEquals(2, accordionPanel.getSelectedTabs().size());
+        assertEquals("Tab 2", accordionPanel.getSelectedTabs().get(0).getTitle());
+        assertEquals("Tab 3", accordionPanel.getSelectedTabs().get(1).getTitle());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:toggle")
+        SelectBooleanCheckbox toggle;
+
+        @FindBy(id = "form:accordionpanel")
+        AccordionPanel accordionPanel;
+
+        @Override
+        public String getLocation() {
+            return "accordionpanel/accordionPanel003.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel004Test.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.AccordionPanel;
+import org.primefaces.selenium.component.SelectBooleanCheckbox;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AccordionPanel004Test extends AbstractPrimePageTest {
+    @Test
+    public void test(Page page) {
+        // Arrange
+        AccordionPanel accordionPanel = page.accordionPanel;
+        SelectBooleanCheckbox toggle = page.toggle;
+
+        // Act
+        toggle.click();
+
+        // Assert
+        assertEquals(2, accordionPanel.getSelectedTabs().size());
+        assertEquals("tab2", accordionPanel.getSelectedTabs().get(0).getTitle());
+        assertEquals("tab3", accordionPanel.getSelectedTabs().get(1).getTitle());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:toggle")
+        SelectBooleanCheckbox toggle;
+
+        @FindBy(id = "form:accordionpanel")
+        AccordionPanel accordionPanel;
+
+        @Override
+        public String getLocation() {
+            return "accordionpanel/accordionPanel004.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
@@ -13,7 +13,7 @@
  * read-only and should not be modified.
  * @extends {PrimeFaces.widget.BaseWidgetCfg} cfg
  *
- * @prop {number[]} cfg.active List of tabs that are currently active (open). Each item is a 0-based index of a tab.
+ * @prop {number[]} cfg.active List of tabs that are currently active (open). Each item is either a key or a 0-based index of a tab.
  * @prop {boolean} cfg.cache `true` if activating a dynamic tab should not load the contents from server again and use
  * the cached contents; or `false` if the caching is disabled.
  * @prop {string} cfg.collapsedIcon The icon class name for the collapsed icon.
@@ -64,9 +64,9 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
             this.cfg.active = [];
 
             if (stateHolderVal != null && stateHolderVal.length > 0) {
-                var indexes = this.stateHolder.val().split(',');
-                for (const index of indexes) {
-                    this.cfg.active.push(index);
+                var activated = this.stateHolder.val().split(',');
+                for (const active of activated) {
+                    this.cfg.active.push(active);
                 }
             }
         }

--- a/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
@@ -233,7 +233,7 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
 
         var shouldLoad = this.cfg.dynamic && !this.isLoaded(panel);
 
-        let key = header.attr('tabKey') ?? index;
+        let key = header.attr('data-key') ?? index;
 
         //update state
         if (this.cfg.multiple)
@@ -347,7 +347,7 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
                 $this.cfg.onTabClose.call($this, panel);
         });
 
-        let key = header.attr('tabKey') ?? index;
+        let key = header.attr('data-key') ?? index;
 
         this.removeFromSelection(key);
         this.saveState();

--- a/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
@@ -66,12 +66,12 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
             if (stateHolderVal != null && stateHolderVal.length > 0) {
                 var indexes = this.stateHolder.val().split(',');
                 for (const index of indexes) {
-                    this.cfg.active.push(parseInt(index));
+                    this.cfg.active.push(index);
                 }
             }
         }
         else if (stateHolderVal != null) {
-            this.cfg.active = parseInt(this.stateHolder.val());
+            this.cfg.active = this.stateHolder.val();
         }
 
         this.headers.each(function() {
@@ -233,11 +233,13 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
 
         var shouldLoad = this.cfg.dynamic && !this.isLoaded(panel);
 
+        let key = header.attr('tabKey') ?? index;
+
         //update state
         if (this.cfg.multiple)
-            this.addToSelection(index);
+            this.addToSelection(key);
         else
-            this.cfg.active = index;
+            this.cfg.active = key;
 
         this.saveState();
 
@@ -260,8 +262,12 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
      */
     selectAll() {
         var $this = this;
-        this.panels.each(function(index) {
-            $this.select(index);
+        this.panels.each(function(index, element) {
+            let header = element.prev();
+            let key = header.attr('tabKey') ?? index;
+
+            $this.select(key);
+
             if (!$this.cfg.multiple) {
                 return false; // breaks
             }
@@ -281,14 +287,11 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
             return;
         }
 
-        if (this.cfg.controlled) {
-            this.fireTabCloseEvent(index);
-        }
-        else {
+        if (!this.cfg.controlled) {
             this.hide(index);
-
-            this.fireTabCloseEvent(index);
         }
+
+        this.fireTabCloseEvent(index);
     }
 
     /**
@@ -296,8 +299,11 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
      */
     unselectAll() {
         var $this = this;
-        this.panels.each(function(index) {
-            $this.unselect(index);
+        this.panels.each(function(index, element) {
+            let header = element.prev();
+            let key = header.attr('tabKey') ?? index;
+
+            $this.unselect(key);
         });
     }
 
@@ -347,7 +353,9 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
                 $this.cfg.onTabClose.call($this, panel);
         });
 
-        this.removeFromSelection(index);
+        let key = header.attr('tabKey') ?? index;
+
+        this.removeFromSelection(key);
         this.saveState();
     }
 

--- a/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
@@ -262,11 +262,8 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
      */
     selectAll() {
         var $this = this;
-        this.panels.each(function(index, element) {
-            let header = element.prev();
-            let key = header.attr('tabKey') ?? index;
-
-            $this.select(key);
+        this.panels.each(function(index) {
+            $this.select(index);
 
             if (!$this.cfg.multiple) {
                 return false; // breaks
@@ -299,11 +296,8 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
      */
     unselectAll() {
         var $this = this;
-        this.panels.each(function(index, element) {
-            let header = element.prev();
-            let key = header.attr('tabKey') ?? index;
-
-            $this.unselect(key);
+        this.panels.each(function(index) {
+            $this.unselect(index);
         });
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
@@ -159,10 +159,18 @@ public class AccordionPanel extends AccordionPanelBase {
         super.processUpdates(context);
 
         ELContext elContext = getFacesContext().getELContext();
-        ValueExpression expr = ValueExpressionAnalyzer.getExpression(elContext,
+        ValueExpression activeExpr = ValueExpressionAnalyzer.getExpression(elContext,
                 getValueExpression(PropertyKeys.active.toString()), true);
-        if (expr != null && !expr.isReadOnly(elContext)) {
-            expr.setValue(elContext, getActive());
+        if (activeExpr != null && !activeExpr.isReadOnly(elContext)) {
+            activeExpr.setValue(elContext, getActive());
+            resetActive();
+        }
+
+        // Deprecated
+        ValueExpression activeIndexExpr = ValueExpressionAnalyzer.getExpression(elContext,
+                getValueExpression(PropertyKeys.activeIndex.toString()), true);
+        if (activeIndexExpr != null && !activeIndexExpr.isReadOnly(elContext)) {
+            activeIndexExpr.setValue(elContext, getActive());
             resetActive();
         }
     }

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
@@ -161,22 +161,22 @@ public class AccordionPanel extends AccordionPanelBase {
         ELContext elContext = getFacesContext().getELContext();
         ValueExpression activeExpr = ValueExpressionAnalyzer.getExpression(elContext,
                 getValueExpression(PropertyKeys.active.toString()), true);
-        if (activeExpr != null && !activeExpr.isReadOnly(elContext)) {
-            activeExpr.setValue(elContext, getActive());
-            resetActive();
+
+        // Fallback to deprecated activeIndex
+        if (activeExpr == null) {
+            activeExpr = ValueExpressionAnalyzer.getExpression(elContext,
+                    getValueExpression(PropertyKeys.activeIndex.toString()), true);
         }
 
-        // Deprecated
-        ValueExpression activeIndexExpr = ValueExpressionAnalyzer.getExpression(elContext,
-                getValueExpression(PropertyKeys.activeIndex.toString()), true);
-        if (activeIndexExpr != null && !activeIndexExpr.isReadOnly(elContext)) {
-            activeIndexExpr.setValue(elContext, getActive());
+        if (activeExpr != null && !activeExpr.isReadOnly(elContext)) {
+            activeExpr.setValue(elContext, getActive());
             resetActive();
         }
     }
 
     protected void resetActive() {
         getStateHelper().remove(PropertyKeys.active);
+        getStateHelper().remove(PropertyKeys.activeIndex);
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanel.java
@@ -160,15 +160,15 @@ public class AccordionPanel extends AccordionPanelBase {
 
         ELContext elContext = getFacesContext().getELContext();
         ValueExpression expr = ValueExpressionAnalyzer.getExpression(elContext,
-                getValueExpression(PropertyKeys.activeIndex.toString()), true);
+                getValueExpression(PropertyKeys.active.toString()), true);
         if (expr != null && !expr.isReadOnly(elContext)) {
-            expr.setValue(elContext, getActiveIndex());
-            resetActiveIndex();
+            expr.setValue(elContext, getActive());
+            resetActive();
         }
     }
 
-    protected void resetActiveIndex() {
-        getStateHelper().remove(PropertyKeys.activeIndex);
+    protected void resetActive() {
+        getStateHelper().remove(PropertyKeys.active);
     }
 
     @Override
@@ -188,7 +188,7 @@ public class AccordionPanel extends AccordionPanelBase {
     public void restoreMultiViewState() {
         AccordionState as = getMultiViewState(false);
         if (as != null) {
-            setActiveIndex(as.getActiveIndex());
+            setActive(as.getActive());
         }
     }
 
@@ -203,6 +203,6 @@ public class AccordionPanel extends AccordionPanelBase {
 
     @Override
     public void resetMultiViewState() {
-        setActiveIndex(null);
+        setActive(null);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
@@ -42,6 +42,7 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
 
         widgetVar,
         active,
+        activeIndex,
         style,
         styleClass,
         onTabChange,
@@ -75,11 +76,19 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
     }
 
     public String getActive() {
-        return (String) getStateHelper().eval(PropertyKeys.active, "0");
+        return (String) getStateHelper().eval(PropertyKeys.active, "first");
     }
 
     public void setActive(String active) {
         getStateHelper().put(PropertyKeys.active, active);
+    }
+
+    public String getActiveIndex() {
+        return (String) getStateHelper().eval(PropertyKeys.activeIndex, "0");
+    }
+
+    public void setActiveIndex(String activeIndex) {
+        getStateHelper().put(PropertyKeys.active, activeIndex);
     }
 
     public String getStyle() {

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
@@ -41,7 +41,7 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
     public enum PropertyKeys {
 
         widgetVar,
-        activeIndex,
+        active,
         style,
         styleClass,
         onTabChange,
@@ -74,12 +74,12 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
         getStateHelper().put(PropertyKeys.widgetVar, widgetVar);
     }
 
-    public String getActiveIndex() {
-        return (String) getStateHelper().eval(PropertyKeys.activeIndex, "0");
+    public String getActive() {
+        return (String) getStateHelper().eval(PropertyKeys.active, "0");
     }
 
-    public void setActiveIndex(String activeIndex) {
-        getStateHelper().put(PropertyKeys.activeIndex, activeIndex);
+    public void setActive(String active) {
+        getStateHelper().put(PropertyKeys.active, active);
     }
 
     public String getStyle() {

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
@@ -76,7 +76,7 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
     }
 
     public String getActive() {
-        return (String) getStateHelper().eval(PropertyKeys.active, "first");
+        return (String) getStateHelper().eval(PropertyKeys.active, null);
     }
 
     public void setActive(String active) {

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
@@ -88,7 +88,7 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
     }
 
     public void setActiveIndex(String activeIndex) {
-        getStateHelper().put(PropertyKeys.active, activeIndex);
+        getStateHelper().put(PropertyKeys.activeIndex, activeIndex);
     }
 
     public String getStyle() {

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -377,29 +377,32 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
         String active = accordionPanel.getActive();
         if ("all".equals(active)) {
-            int childCount = 0;
+            StringBuilder sb = SharedStringBuilder.get(context, SB_RESOLVE_ACTIVE_INDEX);
 
-            String var = accordionPanel.getVar();
-            if (var == null) {
+            if (accordionPanel.getVar() == null) {
+                int childIndex = 0;
                 for (UIComponent child : accordionPanel.getChildren()) {
                     if (child.isRendered() && child instanceof Tab) {
-                        childCount++;
+                        if (childIndex > 0) {
+                            sb.append(",");
+                        }
+
+                        Tab tab = (Tab) child;
+                        sb.append(tab.getKey() != null ? tab.getKey() : Integer.toString(childIndex));
+
+                        childIndex++;
                     }
                 }
             }
             else {
-                childCount = accordionPanel.getRowCount();
-
-                // add some puffer for dynamic added tabs
-                childCount += childCount * 2;
-            }
-
-            StringBuilder sb = SharedStringBuilder.get(context, SB_RESOLVE_ACTIVE_INDEX);
-            for (int i = 0; i < childCount; i++) {
-                if (i > 0) {
-                    sb.append(",");
+                Tab tab = accordionPanel.getDynamicTab();
+                for (int i = 0; i < accordionPanel.getRowCount(); i++) {
+                    accordionPanel.setIndex(i);
+                    if (i > 0) {
+                        sb.append(",");
+                    }
+                    sb.append(tab.getKey() != null ? tab.getKey() : Integer.toString(i));
                 }
-                sb.append(i);
             }
 
             active = sb.toString();

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -212,7 +212,14 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
     }
 
     protected boolean isActive(Tab tab, List<String> activeIndexes, int index) {
-        boolean active = activeIndexes.indexOf(Integer.toString(index)) != -1;
+        String key = tab.getKey();
+
+        // fallback to index-based approach
+        if (key == null) {
+            key = Integer.toString(index);
+        }
+
+        boolean active = activeIndexes.indexOf(key) != -1;
         return active && !tab.isDisabled();
     }
 
@@ -252,6 +259,9 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         writer.writeAttribute(HTML.ARIA_CONTROLS, clientId, null);
         writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("tabindex", tabindex, null);
+        if (tab.getKey() != null) {
+            writer.writeAttribute("tabKey", tab.getKey(), null);
+        }
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
         }

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -64,7 +64,12 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
             if (component.isMultiViewState()) {
                 AccordionState as = component.getMultiViewState(true);
-                as.setActive(component.getActive());
+                String activeState = component.getActive();
+                if (activeState == null) {
+                    activeState = component.getActiveIndex();
+                }
+
+                as.setActive(activeState);
             }
         }
 
@@ -252,7 +257,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("tabindex", tabindex, null);
         if (tab.getKey() != null) {
-            writer.writeAttribute("tabKey", tab.getKey(), null);
+            writer.writeAttribute("data-key", tab.getKey(), null);
         }
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -370,7 +370,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
         // Deprecated
         if (active == null) {
-            accordionPanel.getActiveIndex();
+            active = accordionPanel.getActiveIndex();
         }
 
         if ("all".equals(active)) {

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -45,7 +45,7 @@ import jakarta.faces.context.ResponseWriter;
 
 public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
-    private static final String SB_RESOLVE_ACTIVE_INDEX = AccordionPanelRenderer.class.getName() + "#resolveActiveIndex";
+    private static final String SB_RESOLVE_ACTIVE_INDEX = AccordionPanelRenderer.class.getName() + "#resolveActive";
 
     @Override
     public void decode(FacesContext context, AccordionPanel component) {
@@ -56,15 +56,15 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
             if (isValueBlank(active)) {
                 // set an empty string instead of null - otherwise the stateHelper will re-evaluate to the default value
                 // see GitHub #3140
-                component.setActiveIndex("");
+                component.setActive("");
             }
             else {
-                component.setActiveIndex(active);
+                component.setActive(active);
             }
 
             if (component.isMultiViewState()) {
                 AccordionState as = component.getMultiViewState(true);
-                as.setActiveIndex(component.getActiveIndex());
+                as.setActive(component.getActive());
             }
         }
 
@@ -117,7 +117,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         String styleClass = component.getStyleClass();
         styleClass = styleClass == null ? AccordionPanel.CONTAINER_CLASS : AccordionPanel.CONTAINER_CLASS + " " + styleClass;
 
-        String activeIndex = resolveActiveIndex(context, component);
+        String active = resolveActive(context, component);
 
         if (ComponentUtils.isRTL(context, component)) {
             styleClass = styleClass + " ui-accordion-rtl";
@@ -134,9 +134,9 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
         renderDynamicPassThruAttributes(context, component);
 
-        encodeTabs(context, component, activeIndex);
+        encodeTabs(context, component, active);
 
-        encodeStateHolder(context, component, activeIndex);
+        encodeStateHolder(context, component, active);
 
         writer.endElement("div");
     }
@@ -168,21 +168,21 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         wb.finish();
     }
 
-    protected void encodeStateHolder(FacesContext context, AccordionPanel component, String activeIndex) throws IOException {
+    protected void encodeStateHolder(FacesContext context, AccordionPanel component, String active) throws IOException {
         String clientId = component.getClientId(context);
         String stateHolderId = clientId + "_active";
 
-        renderHiddenInput(context, stateHolderId, activeIndex, false);
+        renderHiddenInput(context, stateHolderId, active, false);
     }
 
-    protected void encodeTabs(FacesContext context, AccordionPanel component, String activeIndex) throws IOException {
+    protected void encodeTabs(FacesContext context, AccordionPanel component, String active) throws IOException {
         boolean dynamic = component.isDynamic();
         boolean repeating = component.isRepeating();
         boolean rtl = component.getDir().equalsIgnoreCase("rtl");
 
-        List<String> activeIndexes = activeIndex == null
+        List<String> activeList = active == null
                                      ? Collections.emptyList()
-                                     : Arrays.asList(activeIndex.split(","));
+                                     : Arrays.asList(active.split(","));
 
         if (repeating) {
             int dataCount = component.getRowCount();
@@ -190,8 +190,8 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
             for (int i = 0; i < dataCount; i++) {
                 component.setIndex(i);
-                boolean active = isActive(tab, activeIndexes, i);
-                encodeTab(context, component, tab, i, active, dynamic, repeating, rtl);
+                boolean activated = isActive(tab, activeList, i);
+                encodeTab(context, component, tab, i, activated, dynamic, repeating, rtl);
             }
 
             component.setIndex(-1);
@@ -203,15 +203,15 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
                 UIComponent child = component.getChildren().get(i);
                 if (child.isRendered() && child instanceof Tab) {
                     Tab tab = (Tab) child;
-                    boolean active = isActive(tab, activeIndexes, j);
-                    encodeTab(context, component, tab, j, active, dynamic, repeating, rtl);
+                    boolean activated = isActive(tab, activeList, j);
+                    encodeTab(context, component, tab, j, activated, dynamic, repeating, rtl);
                     j++;
                 }
             }
         }
     }
 
-    protected boolean isActive(Tab tab, List<String> activeIndexes, int index) {
+    protected boolean isActive(Tab tab, List<String> active, int index) {
         String key = tab.getKey();
 
         // fallback to index-based approach
@@ -219,8 +219,8 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
             key = Integer.toString(index);
         }
 
-        boolean active = activeIndexes.indexOf(key) != -1;
-        return active && !tab.isDisabled();
+        boolean activated = active.indexOf(key) != -1;
+        return activated && !tab.isDisabled();
     }
 
     protected void encodeTab(FacesContext context, AccordionPanel component, Tab tab, int index, boolean active, boolean dynamic,
@@ -373,10 +373,10 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         writer.endElement("a");
     }
 
-    protected String resolveActiveIndex(FacesContext context, AccordionPanel accordionPanel) {
+    protected String resolveActive(FacesContext context, AccordionPanel accordionPanel) {
 
-        String activeIndex = accordionPanel.getActiveIndex();
-        if ("all".equals(activeIndex)) {
+        String active = accordionPanel.getActive();
+        if ("all".equals(active)) {
             int childCount = 0;
 
             String var = accordionPanel.getVar();
@@ -402,9 +402,9 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
                 sb.append(i);
             }
 
-            activeIndex = sb.toString();
+            active = sb.toString();
         }
 
-        return activeIndex;
+        return active;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -374,8 +374,13 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
     }
 
     protected String resolveActive(FacesContext context, AccordionPanel accordionPanel) {
-
         String active = accordionPanel.getActive();
+
+        // Deprecated
+        if (active == null) {
+            accordionPanel.getActiveIndex();
+        }
+
         if ("all".equals(active)) {
             StringBuilder sb = SharedStringBuilder.get(context, SB_RESOLVE_ACTIVE_INDEX);
 

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -212,15 +212,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
     }
 
     protected boolean isActive(Tab tab, List<String> active, int index) {
-        String key = tab.getKey();
-
-        // fallback to index-based approach
-        if (key == null) {
-            key = Integer.toString(index);
-        }
-
-        boolean activated = active.indexOf(key) != -1;
-        return activated && !tab.isDisabled();
+        return (active.contains(tab.getKey()) || active.contains(Integer.toString(index))) && !tab.isDisabled();
     }
 
     protected void encodeTab(FacesContext context, AccordionPanel component, Tab tab, int index, boolean active, boolean dynamic,

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionState.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionState.java
@@ -29,13 +29,13 @@ public class AccordionState implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private String activeIndex;
+    private String active;
 
-    public String getActiveIndex() {
-        return activeIndex;
+    public String getActive() {
+        return active;
     }
 
-    public void setActiveIndex(String activeIndex) {
-        this.activeIndex = activeIndex;
+    public void setActive(String active) {
+        this.active = active;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabBase.java
@@ -39,7 +39,8 @@ public abstract class TabBase extends UIPanel {
         closable,
         titletip,
         ariaLabel,
-        menuTitle
+        menuTitle,
+        key
     }
 
     public TabBase() {
@@ -113,6 +114,14 @@ public abstract class TabBase extends UIPanel {
 
     public void setMenuTitle(String menuTitle) {
         getStateHelper().put(PropertyKeys.menuTitle, menuTitle);
+    }
+
+    public String getKey() {
+        return (String) getStateHelper().eval(PropertyKeys.key, null);
+    }
+
+    public void setKey(String key) {
+        getStateHelper().put(PropertyKeys.key, key);
     }
 
 }

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -725,9 +725,9 @@
         </attribute>
         <attribute>
             <description>
-                <![CDATA[Index of the active tab or a comma separated string of indexes when multiple mode is on. Alternative: all. Default: 0.]]>
+                <![CDATA[Index or key of the active tab or a comma separated string of indexes/keys when multiple mode is on. Alternative: all. Default: 0.]]>
             </description>
-            <name>activeIndex</name>
+            <name>active</name>
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -27916,6 +27916,14 @@
             <required>false</required>
             <type>java.lang.String</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Unique key to identify this tab]]>
+            </description>
+            <name>key</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
     <tag>
         <description>

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -725,6 +725,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[(DEPRECATED, use active instead!) Index of the active tab or a comma separated string of indexes when multiple mode is on. Alternative: all. Default: 0.]]>
+            </description>
+            <name>activeIndex</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Index or key of the active tab or a comma separated string of indexes/keys when multiple mode is on. Alternative: all. Default: 0.]]>
             </description>
             <name>active</name>


### PR DESCRIPTION
Fix #13890, `p:tab` now has a key attribute, which can be used to reference it in the `active` attribute (renamed from activeIndex) in `p:accordionPanel`.

Referencing tabs by index is still fully supported