### PR TITLE
Fix #13911: 15.0.6 AutoComplete clear event is fired when item via dropdown is selected with forceSelection

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/autocomplete/autocomplete.js
@@ -594,7 +594,7 @@ PrimeFaces.widget.AutoComplete = PrimeFaces.widget.BaseWidget.extend({
             $this.checkMatchedItem = true;
         }).on('change.autoComplete', function(e) {
             var value = e.currentTarget.value,
-                valid = $this.isValid(value, true);
+                valid = $this.isValid(value, false);
 
             if ($this.cfg.forceSelection && $this.currentInputValue === '' && !valid) {
                 $this.preventInputChangeEvent = true;


### PR DESCRIPTION
Fix #13911: 15.0.6 AutoComplete clear event is fired when item via dropdown is selected with forceSelection