### PR TITLE
Fix #13945: Firefox hidden input have autocomplete="off"

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -30,6 +30,7 @@ import org.primefaces.component.api.RTLAware;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.convert.ClientConverter;
+import org.primefaces.util.AgentUtils;
 import org.primefaces.util.AjaxRequestBuilder;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
@@ -312,6 +313,10 @@ public abstract class CoreRenderer<T extends UIComponent> extends Renderer<T> {
         }
         if (value != null) {
             writer.writeAttribute("value", value, null);
+        }
+        // autocomplete="off" is invalid HTML but fixes Firefox caching issues
+        if (AgentUtils.isFirefox(context)) {
+            writer.writeAttribute("autocomplete", "off", null);
         }
         writer.endElement("input");
     }


### PR DESCRIPTION
Fix #13945: Hidden input have autocomplete="off"

Since Firefox still has this issue and `autocomplete="off"` is invalid HTML according to W3C: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete

> If including the autocomplete attribute on [hidden](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/hidden) input elements (<input type="hidden">), its value must be an ordered list of space-separated tokens; the on and off keywords are not allowed.

