### PR TITLE
Fix #13945: 15.0.6 Firefox hidden input have autocomplete="off"

### DIFF
--- a/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -30,6 +30,7 @@ import org.primefaces.component.api.RTLAware;
 import org.primefaces.context.PrimeApplicationContext;
 import org.primefaces.context.PrimeRequestContext;
 import org.primefaces.convert.ClientConverter;
+import org.primefaces.util.AgentUtils;
 import org.primefaces.util.AjaxRequestBuilder;
 import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.Constants;
@@ -312,6 +313,10 @@ public abstract class CoreRenderer extends Renderer {
         }
         if (value != null) {
             writer.writeAttribute("value", value, null);
+        }
+        // autocomplete="off" is invalid HTML but fixes Firefox caching issues
+        if (AgentUtils.isFirefox(context)) {
+            writer.writeAttribute("autocomplete", "off", null);
         }
         writer.endElement("input");
     }


### PR DESCRIPTION
Fix #13945: 15.0.6 Hidden input have autocomplete="one-time-code"