### PR TITLE
Fix #13858: Extending validateFile with allowMediaTypes

### DIFF
--- a/docs/16_0_0/validators/validateFile.md
+++ b/docs/16_0_0/validators/validateFile.md
@@ -13,13 +13,15 @@ By default it will validate on the server side but you can enable [client side v
 
 ## Attributes
 
-| Name           | Default | Type    | Description     |
-|----------------| ------- |---------| ----------------- |
-| allowTypes     | null    | String  | Javascript regular expression for accepted file types, e.g., /(\.|\/)(gif|jpeg|jpg|png)$/
-| fileLimit      | null    | Integer | Maximum number of files to be uploaded.
-| sizeLimit      | null    | Long    | Individual file size limit in bytes. Default is unlimited.
-| contentType    | null    | Boolean | Whether the contentType should be validated based on the accept attribute of the attached component. Default is false.
-| virusScan      | null    | Boolean | Whether virus scan should be performed. Default is false.
+| Name            | Default | Type    | Description                                                                                                            |
+|-----------------|---------|---------|------------------------------------------------------------------------------------------------------------------------|
+| allowTypes      | null    | String  | Javascript regular expression for accepted file types, e.g., /(\.|\/)(gif|jpeg|jpg|png)$/                              |
+| fileLimit       | null    | Integer | Maximum number of files to be uploaded.                                                                                |
+| sizeLimit       | null    | Long    | Individual file size limit in bytes. Default is unlimited.                                                             |
+| contentType     | null    | Boolean | Whether the contentType should be validated based on the accept attribute of the attached component. Default is false. |
+| virusScan       | null    | Boolean | Whether virus scan should be performed. Default is false.                                                              |
+| allowMediaTypes | null    | String  | Comma-separated list of allowed media types for content type validation (takes precedence over the accept attribute),  |
+|                 |         |         | e.g. application/pdf,image/jpeg,image/png                                                                              |
 
 ## Getting Started
 Either attach it to `p:fileUpload` or `h:inputFile`. Even [client side validation (CSV)](/core/csv.md) is supported:

--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -43,6 +43,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -470,4 +471,27 @@ public class FileUploadUtils {
             return decimalFormat.format((bytes / Math.pow(1024, i))) + " " + sizes[i];
         }
     }
+
+    /**
+     * Extracts file extensions from an HTML accept attribute and converts them to a JavaScript-compatible
+     * regular expression pattern. Only processes dot-prefixed extensions (e.g., ".pdf", ".doc") and
+     * ignores MIME types (e.g., "image/*", "text/plain").
+     * @param componentAccept Raw accept attribute from the component (e.g., ".pdf,.doc,image/*")
+     * @return a regex pattern matching the file extensions (e.g., "/.*\.(pdf|doc)/"), or null if no valid extensions found
+     */
+    public static String extractAllowTypes(String componentAccept) {
+        if (LangUtils.isBlank(componentAccept)) return null;
+        return Arrays.stream(componentAccept.split(","))
+                .map(String::trim)
+                .filter(part -> part.startsWith("."))
+                .map(part -> part.substring(1).trim())
+                .filter(ext -> !ext.isEmpty())
+                .filter(ext -> ext.matches("[a-zA-Z0-9]{1,10}"))
+                .distinct()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        list -> list.isEmpty() ? null : "/.*\\.(" + String.join("|", list) + ")/"
+                ));
+    }
+
 }

--- a/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/FileUploadUtils.java
@@ -476,12 +476,12 @@ public class FileUploadUtils {
      * Extracts file extensions from an HTML accept attribute and converts them to a JavaScript-compatible
      * regular expression pattern. Only processes dot-prefixed extensions (e.g., ".pdf", ".doc") and
      * ignores MIME types (e.g., "image/*", "text/plain").
-     * @param componentAccept Raw accept attribute from the component (e.g., ".pdf,.doc,image/*")
+     * @param accept Raw accept attribute from the component (e.g., ".pdf,.doc,image/*")
      * @return a regex pattern matching the file extensions (e.g., "/.*\.(pdf|doc)/"), or null if no valid extensions found
      */
-    public static String extractAllowTypes(String componentAccept) {
-        if (LangUtils.isBlank(componentAccept)) return null;
-        return Arrays.stream(componentAccept.split(","))
+    public static String extractAllowTypes(String accept) {
+        if (LangUtils.isBlank(accept)) return null;
+        return Arrays.stream(accept.split(","))
                 .map(String::trim)
                 .filter(part -> part.startsWith("."))
                 .map(part -> part.substring(1).trim())

--- a/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
+++ b/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
@@ -35,7 +35,6 @@ import org.primefaces.util.MessageFactory;
 import org.primefaces.validate.base.AbstractPrimeValidator;
 import org.primefaces.virusscan.VirusException;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,37 +141,17 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
     private String resolveAllowTypes(String componentAccept, UIComponent component) {
         String allowTypes = getAllowTypes();
         if (LangUtils.isBlank(allowTypes) && Boolean.TRUE.equals(getContentType())) {
-            String extractedAllowTypes = extractAllowTypes(componentAccept);
+            String extractedAllowTypes = FileUploadUtils.extractAllowTypes(componentAccept);
             if (LangUtils.isNotBlank(extractedAllowTypes)) {
                 allowTypes = extractedAllowTypes;
             }
             else {
-                LOGGER.log(Level.WARNING, "Attribute allowTypes is missing in p:validateFile. ClientId: " + component.getClientId());
+                LOGGER.log(Level.WARNING,
+                    "Either allowTypes attribute in p:validateFile or accept attribute with filename extension(s) in p:fileUpload is required. ClientId: "
+                    + component.getClientId());
             }
         }
         return allowTypes;
-    }
-
-    /**
-     * Extracts file extensions from an HTML accept attribute and converts them to a JavaScript-compatible
-     * regular expression pattern. Only processes dot-prefixed extensions (e.g., ".pdf", ".doc") and
-     * ignores MIME types (e.g., "image/*", "text/plain").
-     * @param componentAccept Raw accept attribute from the component (e.g., ".pdf,.doc,image/*")
-     * @return a regex pattern matching the file extensions (e.g., "/.*\.(pdf|doc)/"), or null if no valid extensions found
-     */
-    private static String extractAllowTypes(String componentAccept) {
-        if (LangUtils.isBlank(componentAccept)) return null;
-        return Arrays.stream(componentAccept.split(","))
-                .map(String::trim)
-                .filter(part -> part.startsWith("."))
-                .map(part -> part.substring(1).trim())
-                .filter(ext -> !ext.isEmpty())
-                .filter(ext -> ext.matches("[a-zA-Z0-9]{1,10}"))
-                .distinct()
-                .collect(Collectors.collectingAndThen(
-                        Collectors.toList(),
-                        list -> list.isEmpty() ? null : "/.*\\.(" + String.join("|", list) + ")/"
-                ));
     }
 
     protected void validateUploadedFiles(FacesContext context, UploadedFiles uploadedFiles, String accept, String allowTypes) {

--- a/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
+++ b/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
@@ -35,10 +35,13 @@ import org.primefaces.util.MessageFactory;
 import org.primefaces.validate.base.AbstractPrimeValidator;
 import org.primefaces.virusscan.VirusException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import jakarta.faces.application.FacesMessage;
@@ -60,51 +63,119 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
         fileLimit,
         sizeLimit,
         contentType,
-        virusScan;
+        virusScan,
+        allowMediaTypes
     }
+
+    private static final Logger LOGGER = Logger.getLogger(FileValidator.class.getName());
 
     @Override
     public void validate(FacesContext context, UIComponent component, Object value) throws ValidatorException {
-
+        String componentAccept;
+        UploadedFile singleFile = null;
+        UploadedFiles multipleFiles = null;
         if (component instanceof FileUpload) {
-            String accept = Boolean.TRUE.equals(getContentType()) ? ((FileUpload) component).getAccept() : null;
+            FileUpload fileUpload = (FileUpload) component;
+            componentAccept = fileUpload.getAccept();
             if (value instanceof UploadedFile) {
-                UploadedFile uploadedFile = (UploadedFile) value;
-
-                validateUploadedFile(context, uploadedFile, accept);
+                singleFile = (UploadedFile) value;
             }
             else if (value instanceof UploadedFiles) {
-                UploadedFiles uploadedFiles = (UploadedFiles) value;
-
-                validateUploadedFiles(context, uploadedFiles, accept);
-            }
-            else if (value != null) {
-                throw new IllegalArgumentException("Argument of type '" + value.getClass().getName() + "' not supported");
+                multipleFiles = (UploadedFiles) value;
             }
         }
         else if (component instanceof HtmlInputFile) {
-            String accept = Boolean.TRUE.equals(getContentType()) ? (String) component.getAttributes().get("accept") : null;
-
+            HtmlInputFile inputFile = (HtmlInputFile) component;
+            componentAccept = (String) inputFile.getAttributes().get("accept");
             if (value instanceof Part) {
-                UploadedFile uploadedFile = new NativeUploadedFile((Part) value, getSizeLimit(), null);
-                validateUploadedFile(context, uploadedFile, accept);
+                singleFile = new NativeUploadedFile((Part) value, getSizeLimit(), null);
             }
             else if (value instanceof List) {
-                List<UploadedFile> uploadedFiles = (List<UploadedFile>) ((List) value).stream()
+                List<UploadedFile> files = (List<UploadedFile>) ((List) value).stream()
                         .map(part -> new NativeUploadedFile((Part) part, getSizeLimit(), null))
                         .collect(Collectors.toList());
-                validateUploadedFiles(context, new UploadedFiles(uploadedFiles), accept);
-            }
-            else if (value != null) {
-                throw new IllegalArgumentException("Argument of type '" + value.getClass().getName() + "' not supported");
+                multipleFiles = new UploadedFiles(files);
             }
         }
         else {
-            throw new IllegalArgumentException("Component of type '" + component.getClass() + "' not supported");
+            throw new IllegalArgumentException("Component of type '" + component.getClass().getName() + "' not supported");
+        }
+        if (value != null && singleFile == null && multipleFiles == null) {
+            throw new IllegalArgumentException("Argument of type '" + value.getClass().getName() + "' not supported");
+        }
+        String accept = resolveAccept(componentAccept);
+        String allowTypes = resolveAllowTypes(componentAccept, component);
+        if (singleFile != null) {
+            validateUploadedFile(context, singleFile, accept, allowTypes);
+        }
+        else if (multipleFiles != null) {
+            validateUploadedFiles(context, multipleFiles, accept, allowTypes);
         }
     }
 
-    protected void validateUploadedFiles(FacesContext context, UploadedFiles uploadedFiles, String accept) {
+    /**
+     * Resolves the accept value for validation.
+     * If content-type validation is enabled, returns either the validator's allowMediaTypes
+     * or the component's accept attribute.
+     * @param componentAccept Raw accept attribute from the component
+     * @return the accept value to use for validation, or null if content type validation is disabled
+     */
+    private String resolveAccept(String componentAccept) {
+        if (Boolean.TRUE.equals(getContentType())) {
+            if (LangUtils.isNotBlank(getAllowMediaTypes())) {
+                return getAllowMediaTypes();
+            }
+            return componentAccept;
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the allowed file types pattern for validation.
+     * Returns the validator's allowTypes if configured. If allowTypes is not configured
+     * and content-type validation is enabled, extracts file extensions from the component's
+     * accept attribute and converts them to a regex pattern.
+     * @param componentAccept Raw accept attribute from the component
+     * @param component The UI component being validated
+     * @return the file types pattern to use for validation, or null if none found
+     */
+    private String resolveAllowTypes(String componentAccept, UIComponent component) {
+        String allowTypes = getAllowTypes();
+        if (LangUtils.isBlank(allowTypes) && Boolean.TRUE.equals(getContentType())) {
+            String extractedAllowTypes = extractAllowTypes(componentAccept);
+            if (LangUtils.isNotBlank(extractedAllowTypes)) {
+                allowTypes = extractedAllowTypes;
+            }
+            else {
+                LOGGER.log(Level.WARNING, "Attribute allowTypes is missing in p:validateFile. ClientId: " + component.getClientId());
+            }
+        }
+        return allowTypes;
+    }
+
+    /**
+     * Extracts file extensions from an HTML accept attribute and converts them to a JavaScript-compatible
+     * regular expression pattern. Only processes dot-prefixed extensions (e.g., ".pdf", ".doc") and
+     * ignores MIME types (e.g., "image/*", "text/plain").
+     * @param componentAccept Raw accept attribute from the component (e.g., ".pdf,.doc,image/*")
+     * @return a regex pattern matching the file extensions (e.g., "/.*\.(pdf|doc)/"), or null if no valid extensions found
+     */
+    private static String extractAllowTypes(String componentAccept) {
+        if (LangUtils.isBlank(componentAccept)) return null;
+        return Arrays.stream(componentAccept.split(","))
+                .map(String::trim)
+                .filter(part -> part.startsWith("."))
+                .map(part -> part.substring(1).trim())
+                .filter(ext -> !ext.isEmpty())
+                .filter(ext -> ext.matches("[a-zA-Z0-9]{1,10}"))
+                .distinct()
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        list -> list.isEmpty() ? null : "/.*\\.(" + String.join("|", list) + ")/"
+                ));
+    }
+
+    protected void validateUploadedFiles(FacesContext context, UploadedFiles uploadedFiles, String accept, String allowTypes) {
         Integer fileLimit = getFileLimit();
         if (fileLimit != null && uploadedFiles.getFiles().size() > fileLimit) {
             throw new ValidatorException(
@@ -114,7 +185,7 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
         long totalSize = 0;
         for (UploadedFile file : uploadedFiles.getFiles()) {
             totalSize += file.getSize();
-            validateUploadedFile(context, file, accept);
+            validateUploadedFile(context, file, accept, allowTypes);
         }
 
         Long sizeLimit = getSizeLimit();
@@ -125,7 +196,7 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
         }
     }
 
-    protected void validateUploadedFile(FacesContext context, UploadedFile uploadedFile, String accept) {
+    protected void validateUploadedFile(FacesContext context, UploadedFile uploadedFile, String accept, String allowTypes) {
         PrimeApplicationContext applicationContext = PrimeApplicationContext.getCurrentInstance(context);
 
         Long sizeLimit = getSizeLimit();
@@ -135,7 +206,6 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
                             uploadedFile.getFileName(), FileUploadUtils.formatBytes(sizeLimit, LocaleUtils.getCurrentLocale(context))));
         }
 
-        String allowTypes = getAllowTypes();
         if (!FileUploadUtils.isValidType(applicationContext, uploadedFile, allowTypes, accept)) {
             throw new ValidatorException(
                     MessageFactory.getFacesMessage(context, ALLOW_TYPES_MESSAGE_ID, FacesMessage.SEVERITY_ERROR, uploadedFile.getFileName(),
@@ -180,7 +250,6 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
         return VALIDATOR_ID;
     }
 
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -198,8 +267,6 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
     public int hashCode() {
         return Objects.hash(getStateHelper());
     }
-
-
 
     public Integer getFileLimit() {
         return (Integer) getStateHelper().eval(PropertyKeys.fileLimit, null);
@@ -239,5 +306,13 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
 
     public void setVirusScan(Boolean virusScan) {
         getStateHelper().put(PropertyKeys.virusScan, virusScan);
+    }
+
+    public String getAllowMediaTypes() {
+        return (String) getStateHelper().eval(PropertyKeys.allowMediaTypes, null);
+    }
+
+    public void setAllowMediaTypes(String allowMediaTypes) {
+        getStateHelper().put(PropertyKeys.allowMediaTypes, allowMediaTypes);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
+++ b/primefaces/src/main/java/org/primefaces/validate/FileValidator.java
@@ -116,15 +116,15 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
      * Resolves the accept value for validation.
      * If content-type validation is enabled, returns either the validator's allowMediaTypes
      * or the component's accept attribute.
-     * @param componentAccept Raw accept attribute from the component
+     * @param accept Raw accept attribute from the component
      * @return the accept value to use for validation, or null if content type validation is disabled
      */
-    private String resolveAccept(String componentAccept) {
+    private String resolveAccept(String accept) {
         if (Boolean.TRUE.equals(getContentType())) {
             if (LangUtils.isNotBlank(getAllowMediaTypes())) {
                 return getAllowMediaTypes();
             }
-            return componentAccept;
+            return accept;
         }
         return null;
     }
@@ -134,14 +134,14 @@ public class FileValidator extends AbstractPrimeValidator implements ClientValid
      * Returns the validator's allowTypes if configured. If allowTypes is not configured
      * and content-type validation is enabled, extracts file extensions from the component's
      * accept attribute and converts them to a regex pattern.
-     * @param componentAccept Raw accept attribute from the component
+     * @param accept Raw accept attribute from the component
      * @param component The UI component being validated
      * @return the file types pattern to use for validation, or null if none found
      */
-    private String resolveAllowTypes(String componentAccept, UIComponent component) {
+    private String resolveAllowTypes(String accept, UIComponent component) {
         String allowTypes = getAllowTypes();
         if (LangUtils.isBlank(allowTypes) && Boolean.TRUE.equals(getContentType())) {
-            String extractedAllowTypes = FileUploadUtils.extractAllowTypes(componentAccept);
+            String extractedAllowTypes = FileUploadUtils.extractAllowTypes(accept);
             if (LangUtils.isNotBlank(extractedAllowTypes)) {
                 allowTypes = extractedAllowTypes;
             }

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -158,6 +158,16 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Comma-separated list of allowed media types for content type validation.
+                When specified, this takes precedence over the accept attribute for content type validation.
+                Example: "application/pdf,image/jpeg,image/png,text/plain"]]>
+            </description>
+            <name>allowMediaTypes</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
     </tag>
 
     <tag>

--- a/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
+++ b/primefaces/src/test/java/org/primefaces/util/FileUploadUtilsTest.java
@@ -46,13 +46,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -473,6 +476,73 @@ class FileUploadUtilsTest {
         assertEquals(expected, FileUploadUtils.formatAllowTypes(input));
     }
 
+    @Test
+    void extractAllowTypes_Null() {
+        String result = FileUploadUtils.extractAllowTypes(null);
+        assertNull(result);
+    }
 
+    @Test
+    void extractAllowTypes_Whitespace() {
+        String result = FileUploadUtils.extractAllowTypes("   ");
+        assertNull(result);
+    }
+
+    @Test
+    void extractAllowTypes_Single() {
+        String result = FileUploadUtils.extractAllowTypes(".pdf");
+        assertEquals("/.*\\.(pdf)/", result);
+    }
+
+    @Test
+    void extractAllowTypes_Multiple() {
+        String result = FileUploadUtils.extractAllowTypes(".pdf,.doc,.txt");
+        assertEquals("/.*\\.(pdf|doc|txt)/", result);
+    }
+
+    @Test
+    void extractAllowTypes_Mixed() {
+        String result = FileUploadUtils.extractAllowTypes("image/*,.jpg,.png,text/plain,.doc");
+        assertEquals("/.*\\.(jpg|png|doc)/", result);
+    }
+
+    @Test
+    void extractAllowTypes_OnlyMimeTypes() {
+        String result = FileUploadUtils.extractAllowTypes("image/*,text/plain,application/json");
+        assertNull(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        ".pdf-backup",
+        ".doc@old",
+        ".txt#new",
+        ".file.ext",
+        ".doc with spaces",
+        ".verylongextensionname",
+        ".123456789012345",
+        ".",
+        ".  ",
+        ".doc-",
+        ".pdf+",
+        ".txt*"
+    })
+    void extractAllowTypes_Invalid(String extension) {
+        String result = FileUploadUtils.extractAllowTypes(extension);
+        assertNull(result);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "'.pdf,.doc', '/.*\\.(pdf|doc)/'",
+        "'.jpg,.png,.gif', '/.*\\.(jpg|png|gif)/'",
+        "'.txt,.pdf,.doc,.xlsx', '/.*\\.(txt|pdf|doc|xlsx)/'",
+        "'.a,.b,.c', '/.*\\.(a|b|c)/'",
+        "'.mp3,.mp4,.avi', '/.*\\.(mp3|mp4|avi)/'"
+    })
+    void extractAllowTypes_Regex(String input, String expectedOutput) {
+        String result = FileUploadUtils.extractAllowTypes(input);
+        assertEquals(expectedOutput, result);
+    }
 
 }


### PR DESCRIPTION
This PR introduces enhanced file validation capabilities with the following changes:

- New allowMediaTypes property: Allows specifying MIME types directly on the validator (e.g., image/*, application/pdf) as an alternative to the component's accept attribute
- resolveAccept() method: Determines the appropriate accept value for validation, prioritizing validator's allowMediaTypes over component's accept attribute when content-type validation is enabled
- resolveAllowTypes() method: Intelligently resolves file extension patterns, either from the validator's allowTypes property or by extracting extensions from the component's accept attribute
- extractAllowTypes() method: Converts HTML accept attributes containing file extensions (e.g., .pdf,.doc) into JavaScript-compatible regex patterns, filtering out MIME types and invalid extensions

These changes provide more flexibility in file validation configuration while maintaining backward compatibility. 

Fix #13858 
Fix #14932
