### PR TITLE
Fix #13978: 15.0.6 OutputPanel missing widgetVar in taglib

### DIFF
--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -19375,6 +19375,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Name of the client side widget.]]>
+            </description>
+            <name>widgetVar</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Style of the html container element.]]>
             </description>
             <name>style</name>


### PR DESCRIPTION
Fix #13978: 15.0.6 OutputPanel missing widgetVar in taglib