### PR TITLE
Fix #14007 Allow disabling autoMonthFormat to prevent the date entered by a user from being set to the min or max date restriction

### DIFF
--- a/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
+++ b/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
@@ -2373,7 +2373,7 @@ $.widget("prime.datePicker", {
     },
 
     onInputChange: function(event) {
-        if ((this.options.autoMonthFormat || !this.inputfield.val() || this.options.showMinMaxRange) && this.options.monthNavigator && this.options.view !== 'month') { 
+        if ((this.options.autoMonthFormat || !this.inputfield.val()) && this.options.monthNavigator && this.options.view !== 'month') { 
             var viewMonth = this.viewDate.getMonth();
             viewMonth = (this.isInMaxYear() && Math.min(this.options.maxDate.getMonth(), viewMonth)) || (this.isInMinYear() && Math.max(this.options.minDate.getMonth(), viewMonth)) || viewMonth;
             this.viewDate.setMonth(viewMonth);
@@ -3564,7 +3564,7 @@ $.widget("prime.datePicker", {
 
         this.viewDate = value;
 
-        if ((this.options.autoMonthFormat || !this.inputfield.val() || this.options.showMinMaxRange) && this.options.monthNavigator && this.options.view !== 'month') {
+        if ((this.options.autoMonthFormat || !this.inputfield.val()) && this.options.monthNavigator && this.options.view !== 'month') {
             var viewMonth = this.viewDate.getMonth();
             viewMonth = (this.isInMaxYear() && Math.min(this.options.maxDate.getMonth(), viewMonth)) || (this.isInMinYear() && Math.max(this.options.minDate.getMonth(), viewMonth)) || viewMonth;
             this.viewDate.setMonth(viewMonth);


### PR DESCRIPTION
Fix #14007 

After investigating showMinMaxRange and autoMonthFormat some more for issue #14007, which seems to be the same as or similar to #10561, it seems like showMinMaxRange doesn't belong within onInputChange or updateViewDate.

In addition, removing this attribute allows the autoMonthFormat to be set to false and disable the automatic update to the date field in the reproducer to the min or max date. Instead, it provides an error.

I could see this being extended to say that if autoMonthFormat, or renamed to something like autoDateFormat, is true and the input is outside of the mindate or maxdate attributes, it should be adjusted regardless of the year. During testing, I noted that setting the time outside of the maxdate also resulted in a validation error. This attribute seems to be very specific in that it only cares about the month within the same year. The attribute was added as part of #9224.