### PR TITLE
Fix #14043: 15.0.7 TriStateCheckbox do not fire valueChange if readonly/disabled

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckbox.java
+++ b/primefaces/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckbox.java
@@ -44,6 +44,10 @@ public class TriStateCheckbox extends TriStateCheckboxBase {
 
     @Override
     public void validate(FacesContext context) {
+        if (isDisabled() || isReadonly()) {
+            return;
+        }
+
         Object submittedValue = getSubmittedValue();
         if (submittedValue != null) {
             super.validate(context);


### PR DESCRIPTION
Fix #14043: 15.0.7 TriStateCheckbox do not fire valueChange if readonly/disabled