### PR TITLE
Fix #14042: TriStateCheckbox allow string "true","false",""

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/tristatecheckbox/triStateCheckbox002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tristatecheckbox/triStateCheckbox002.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <h3>Constant values</h3>
+            <p:triStateCheckbox id="triStateConstantNull" value="" style="margin-right: 1em;" readonly="true" />
+            <h:outputLabel value="Constant null"/>
+
+            <p:triStateCheckbox id="triStateConstantTrue" value="true" style="margin-right: 1em;" readonly="true"/>
+            <h:outputLabel value="Constant true"/>
+            
+            <p:triStateCheckbox id="triStateConstantFalse" value="false" style="margin-right: 1em;" readonly="true" />
+            <h:outputLabel value="Constant false"/>
+
+            <p:commandButton id="button" update="@form" value="Submit"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tristatecheckbox/TriStateCheckbox002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tristatecheckbox/TriStateCheckbox002Test.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tristatecheckbox;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.TriStateCheckbox;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TriStateCheckbox002Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("TriStateCheckbox: using String constants 'true', 'false' and 'null'")
+    void clickThrough(Page page) {
+        // Arrange
+        TriStateCheckbox triStateConstantNull = page.triStateConstantNull;
+        assertEquals(null, triStateConstantNull.getValue());
+
+        TriStateCheckbox triStateConstantTrue = page.triStateConstantTrue;
+        assertEquals(Boolean.TRUE, triStateConstantTrue.getValue());
+
+        TriStateCheckbox triStateConstantFalse = page.triStateConstantFalse;
+        assertEquals(Boolean.FALSE, triStateConstantFalse.getValue());
+
+        // Act
+        page.button.click();
+
+        // Assert
+        assertEquals(null, triStateConstantNull.getValue());
+        assertEquals(Boolean.TRUE, triStateConstantTrue.getValue());
+        assertEquals(Boolean.FALSE, triStateConstantFalse.getValue());
+        assertConfiguration(triStateConstantNull.getWidgetConfiguration());
+        assertConfiguration(triStateConstantTrue.getWidgetConfiguration());
+        assertConfiguration(triStateConstantFalse.getWidgetConfiguration());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("TriStateCheckbox Config = " + cfg);
+        assertTrue(cfg.has("id"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:triStateConstantNull")
+        TriStateCheckbox triStateConstantNull;
+
+        @FindBy(id = "form:triStateConstantTrue")
+        TriStateCheckbox triStateConstantTrue;
+
+        @FindBy(id = "form:triStateConstantFalse")
+        TriStateCheckbox triStateConstantFalse;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "tristatecheckbox/triStateCheckbox002.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tristatecheckbox/TriStateCheckboxRenderer.java
@@ -67,7 +67,20 @@ public class TriStateCheckboxRenderer extends InputRenderer<TriStateCheckbox> {
     protected void encodeMarkup(FacesContext context, TriStateCheckbox checkbox) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = checkbox.getClientId(context);
-        Boolean value = (Boolean) checkbox.getValue();
+        Object rawValue = checkbox.getValue();
+        Boolean value = null;
+        if (rawValue instanceof String) {
+            String stringValue = (String) rawValue;
+            if (LangUtils.isBlank(stringValue)) {
+                value = null;
+            }
+            else {
+                value = Boolean.valueOf(stringValue);
+            }
+        }
+        else {
+            value = (Boolean) rawValue;
+        }
 
         boolean disabled = checkbox.isDisabled();
         boolean readonly = checkbox.isReadonly();


### PR DESCRIPTION
Fix #14042: TriStateCheckbox allow string "true","false",""

This allows for the string values "true", false", or empty "".