### PR TITLE
Fix #14074: 15.0.7 KeyFilter add inputRegex example

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/input/keyFilter.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/input/keyFilter.xhtml
@@ -24,9 +24,14 @@
                     <p:keyFilter mask="num" />
                 </p:inputText>
 
-                <h5>Regex</h5>
+                <h5>Regex (indivdial key)</h5>
                 <p:inputText>
                     <p:keyFilter regEx="/[ABC]/i"/>
+                </p:inputText>
+
+                <h5>Regex (complete input)</h5>
+                <p:inputText>
+                    <p:keyFilter inputRegEx="/^\d*\.?\d*$/"/>
                 </p:inputText>
 
                 <h5>AutoComplete with TestFunction</h5>


### PR DESCRIPTION
Fix #14074: 15.0.7 KeyFilter add inputRegex example