### PR TITLE
Fix #14150: Apply default script-src 'self' when CSP_REPORT_ONLY_POLICY is incomplete; update docs

### DIFF
--- a/docs/15_0_0/core/contentsecuritypolicy.md
+++ b/docs/15_0_0/core/contentsecuritypolicy.md
@@ -30,9 +30,17 @@ Browsers will report CSP violations to a user-defined HTTP endpoint using `repor
 </context-param>
 <context-param>
     <param-name>primefaces.CSP_REPORT_ONLY_POLICY</param-name>
-    <param-value>report-uri /my-csp-reports</param-value>
+    <param-value>report-uri /my-csp-reports; script-src 'self'</param-value>
 </context-param>
 ```
+⚠️ Note: primefaces.CSP_REPORT_ONLY_POLICY works the same way as primefaces.CSP_POLICY:
+you can provide a complete CSP policy string containing the directives you need (for example, script-src, default-src, etc.).
+If you do not provide a full policy, PrimeFaces will automatically apply a default policy of:
+
+```
+script-src 'self'
+```
+This ensures the report-only header always contains a valid directive, even if only report-uri is configured.
 
 ## Policy
 There are many ways to configure CSP for different levels of security. Currently, PrimeFaces has chosen to

--- a/docs/16_0_0/core/contentsecuritypolicy.md
+++ b/docs/16_0_0/core/contentsecuritypolicy.md
@@ -30,9 +30,17 @@ Browsers will report CSP violations to a user-defined HTTP endpoint using `repor
 </context-param>
 <context-param>
     <param-name>primefaces.CSP_REPORT_ONLY_POLICY</param-name>
-    <param-value>report-uri /my-csp-reports</param-value>
+    <param-value>report-uri /my-csp-reports; script-src 'self'</param-value>
 </context-param>
 ```
+⚠️ Note: primefaces.CSP_REPORT_ONLY_POLICY works the same way as primefaces.CSP_POLICY:
+you can provide a complete CSP policy string containing the directives you need (for example, script-src, default-src, etc.).
+If you do not provide a full policy, PrimeFaces will automatically apply a default policy of:
+
+```
+script-src 'self'
+```
+This ensures the report-only header always contains a valid directive, even if only report-uri is configured.
 
 ## Policy
 There are many ways to configure CSP for different levels of security. Currently, PrimeFaces has chosen to

--- a/primefaces/src/main/java/org/primefaces/csp/CspPhaseListener.java
+++ b/primefaces/src/main/java/org/primefaces/csp/CspPhaseListener.java
@@ -88,7 +88,14 @@ public class CspPhaseListener implements PhaseListener {
         state.setInitialized(true);
 
         if (LangUtils.isNotBlank(reportOnlyPolicy)) {
-            String policy = reportOnlyPolicy + " 'nonce-" + state.getNonce() + "';";
+            String policy = reportOnlyPolicy.trim();
+            if (!policy.contains("script-src") && !policy.contains("default-src")) {
+                if (!policy.endsWith(";")) {
+                    policy += ";";
+                }
+                policy += " script-src 'self'";
+            }
+            policy += " 'nonce-" + state.getNonce() + "';";
             externalContext.addResponseHeader("Content-Security-Policy-Report-Only", policy);
         }
         else {


### PR DESCRIPTION
Fix #14150 

- Updated contentsecuritypolicy.md to explain that CSP_REPORT_ONLY_POLICY
  must either include a full directive (e.g. script-src, default-src, etc.)
  or will fall back to a default "script-src 'self'".
- Modified CspPhaseListener to append a default directive if missing,
  ensuring valid report-only policies.