### PR TITLE
exclude classes with 3rd party dependencies from beans.xml

### DIFF
--- a/primefaces/src/main/resources/META-INF/beans.xml
+++ b/primefaces/src/main/resources/META-INF/beans.xml
@@ -3,6 +3,26 @@
     xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-    version="4.0" bean-discovery-mode="all"
->
+    version="4.0" bean-discovery-mode="all">
+
+    <scan>
+        <exclude name="org.primefaces.util.ExcelStylesManager"/>
+        <exclude name="org.primefaces.util.ExcelXmlStylesManager"/>
+        <exclude name="org.primefaces.util.ExcelStylesManager$Styles"/>
+        <exclude name="org.primefaces.util.HtmlSanitizer"/>
+
+        <exclude name="org.primefaces.cache.EHCacheProvider"/>
+        <exclude name="org.primefaces.cache.EHCache3Provider"/>
+
+        <exclude name="org.primefaces.component.barcode.BarcodeHandler"/>
+        <exclude name="org.primefaces.component.datatable.export.DataTableExcelExporter"/>
+        <exclude name="org.primefaces.component.datatable.export.DataTableExcelXExporter"/>
+        <exclude name="org.primefaces.component.datatable.export.DataTableExcelXStreamExporter"/>
+        <exclude name="org.primefaces.component.datatable.export.DataTablePDFExporter"/>
+        <exclude name="org.primefaces.component.feedreader.RSSUtils"/>
+        <exclude name="org.primefaces.component.treetable.export.TreeTableExcelExporter"/>
+        <exclude name="org.primefaces.component.treetable.export.TreeTableExcelXExporter"/>
+        <exclude name="org.primefaces.component.treetable.export.TreeTableExcelXStreamExporter"/>
+        <exclude name="org.primefaces.component.treetable.export.TreeTablePDFExporter"/>
+    </scan>
 </beans>


### PR DESCRIPTION
TomEE logs a warning when deploying a bean that requires a class that isn't present on the classpath, thus these beans should probably excluded from scanning to avoid these warnings

Maybe could also be worth it to switch to bean discovery mode annoated and give all JSF classes that are deployed via annotations a scope? As far as I know beans.xml was only added to support org.apache.myfaces.annotation.USE_CDI_FOR_ANNOTATION_SCANNING