### PR TITLE
Fix #14204: 15.0.9 Spinner evaluate paste event

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/spinner/spinner.js
@@ -197,6 +197,18 @@ PrimeFaces.widget.Spinner = PrimeFaces.widget.BaseWidget.extend({
                 $this.format();
             }
         })
+        .on('paste.spinner', function(e) {
+            PrimeFaces.queueTask(function() {
+                $this.updateValue();
+                if ($this.value) {
+                    $this.input.trigger('change');
+                    $this.format();
+                }
+                else {
+                    $this.input.val('');
+                }
+            });
+        })
         .on('blur.spinner', function(e) {
             $this.format();
         })


### PR DESCRIPTION
Fix #14204: 15.0.9 Spinner evaluate paste event