### PR TITLE
Add scroll direction CSS classes `ui-scrollable-x` / `ui-scrollable-y` to scrollBody of Treetable and Datatable

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -1736,6 +1736,16 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
                 $this.adjustScrollWidth();
             }
         });
+
+        // Add or remove CSS classes based on scroll overflow direction
+        const el = this.scrollBody && this.scrollBody[0];
+        if (el) {
+            const hasHorizontalScroll = el.scrollWidth > el.clientWidth;
+            const hasVerticalScroll = el.scrollHeight > el.clientHeight;
+
+            el.classList.toggle('ui-scrollable-x', hasHorizontalScroll);
+            el.classList.toggle('ui-scrollable-y', hasVerticalScroll);
+        }
     }
 
     /**

--- a/primefaces/src/main/frontend/packages/components/src/treetable/treetable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/treetable/treetable.widget.js
@@ -2537,9 +2537,10 @@ PrimeFaces.widget.TreeTable = class TreeTable extends PrimeFaces.widget.Deferred
     }
 
     /**
-     * Updates the vertical scroll position and adjusts the margin.
-     * @private
-     */
+    * Updates the vertical scroll position and adjusts the margin.
+    * Also toggles CSS classes on the scroll body to indicate horizontal/vertical overflow.
+    * @private
+    */
     updateVerticalScroll() {
         if(this.cfg.scrollable && this.cfg.scrollHeight) {
             if(this.bodyTable.outerHeight() < this.scrollBody.outerHeight()) {
@@ -2551,6 +2552,17 @@ PrimeFaces.widget.TreeTable = class TreeTable extends PrimeFaces.widget.Deferred
                 this.scrollFooterBox.css('margin-right', this.marginRight);
             }
         }
+
+        // Add or remove CSS classes based on scroll overflow direction
+        if (!this.scrollBody || !this.scrollBody[0]) {
+            return;
+        }
+        const el = this.scrollBody[0];
+        const hasHorizontalScroll = el.scrollWidth > el.clientWidth;
+        const hasVerticalScroll   = el.scrollHeight > el.clientHeight;
+
+        el.classList.toggle('ui-scrollable-x', hasHorizontalScroll);
+        el.classList.toggle('ui-scrollable-y', hasVerticalScroll);
     }
 
     /**


### PR DESCRIPTION
Fix #14225

Adds CSS classes ui-scrollable-x and ui-scrollable-y to the scrollable body of TreeTable and DataTable to indicate horizontal and vertical scroll overflow.

These classes allow developers to apply conditional styles (e.g. shadows, padding, corner radius) based on the presence of scrollbars.

TreeTable: Added at the end of updateVerticalScroll()
DataTable: Added at the end of setupScrolling()
Classes are updated via:

```js
el.classList.toggle('ui-scrollable-x', el.scrollWidth > el.clientWidth);
el.classList.toggle('ui-scrollable-y', el.scrollHeight > el.clientHeight);
```