### PR TITLE
Fix #14255: 15.0.9 Datatable selection stop propagation on checkbox click

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -1314,6 +1314,9 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                     $this.selectRowWithCheckbox(checkbox, e);
                 else
                     $this.unselectRowWithCheckbox(checkbox, e);
+
+                e.preventDefault();
+                e.stopPropagation();
             });
         }
         else {
@@ -1360,6 +1363,8 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
                     else {
                         $this.selectRowWithCheckbox(checkbox, e);
                     }
+                    e.preventDefault();
+                    e.stopPropagation();
                 },
                 'keydown.dataTable': function(e) {
                     if ($this.cfg.selectionRowMode === 'none' && PrimeFaces.utils.isActionKey(e)) {


### PR DESCRIPTION
Fix #14255: 15.0.9 Datatable selection stop propagation on checkbox click