### PR TITLE
Fix #14265: 15.0.9 DatePicker range using date restore from MVS wrong values

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/CalendarUtils.java
@@ -25,6 +25,7 @@ package org.primefaces.util;
 
 import org.primefaces.component.api.UICalendar;
 import org.primefaces.component.datepicker.DatePicker;
+import org.primefaces.convert.DateTimeConverter;
 import org.primefaces.convert.DateTimePatternConverter;
 import org.primefaces.convert.PatternConverter;
 
@@ -312,6 +313,11 @@ public class CalendarUtils {
             Converter converter = calendar.getConverter();
             // always use the user-applied converter first
             if (converter != null) {
+                if (converter instanceof DateTimeConverter) {
+                    ((DateTimeConverter) converter).setPattern(pattern);
+                    ((DateTimeConverter) converter).setLocale(calendar.calculateLocale(context));
+                    ((DateTimeConverter) converter).setTimeZone(calculateTimeZone(calendar.getTimeZone()));
+                }
                 return converter.getAsString(context, calendar, value);
             }
         }


### PR DESCRIPTION
Fix #14265: 15.0.9 DatePicker range using date restore from MVS wrong values