### PR TITLE
replace deprecated apple-mobile-web-app-capable meta tag

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/core/head/head001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head001.xhtml
@@ -10,7 +10,7 @@
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         </f:facet>
         <f:facet name="last">
-            <meta name="apple-mobile-web-app-capable" content="yes"/>
+            <meta name="mobile-web-app-capable" content="yes"/>
         </f:facet>
         <title>PrimeFaces Selenium</title>
 

--- a/primefaces-integration-tests/src/main/webapp/core/head/head002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head002.xhtml
@@ -10,7 +10,7 @@
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         </f:facet>
         <f:facet name="last">
-            <meta name="apple-mobile-web-app-capable" content="yes"/>
+            <meta name="mobile-web-app-capable" content="yes"/>
         </f:facet>
         <title>PrimeFaces Selenium</title>
     </h:head>

--- a/primefaces-integration-tests/src/main/webapp/core/head/head003.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/core/head/head003.xhtml
@@ -11,7 +11,7 @@
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         </f:facet>
         <f:facet name="last">
-            <meta name="apple-mobile-web-app-capable" content="yes"/>
+            <meta name="mobile-web-app-capable" content="yes"/>
         </f:facet>
         <title>PrimeFaces Selenium</title>
     </h:head>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead001Test.java
@@ -77,7 +77,7 @@ public class CoreHead001Test extends AbstractPrimePageTest {
         // <f:facet name="last">
         WebElement webMeta = headElements.get(5);
         assertEquals(webMeta.getTagName(), "meta");
-        assertEquals(webMeta.getDomAttribute("name"), "apple-mobile-web-app-capable");
+        assertEquals(webMeta.getDomAttribute("name"), "mobile-web-app-capable");
         assertEquals(webMeta.getDomAttribute("content"), "yes");
 
         // Scripts in order

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead002Test.java
@@ -76,7 +76,7 @@ public class CoreHead002Test extends AbstractPrimePageTest {
         // <f:facet name="last">
         WebElement webMeta = headElements.get(4);
         assertEquals("meta", webMeta.getTagName());
-        assertEquals("apple-mobile-web-app-capable", webMeta.getDomAttribute("name"));
+        assertEquals("mobile-web-app-capable", webMeta.getDomAttribute("name"));
         assertEquals("yes", webMeta.getDomAttribute("content"));
 
         // Scripts in order

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/core/head/CoreHead003Test.java
@@ -97,7 +97,7 @@ public class CoreHead003Test extends AbstractPrimePageTest {
          // <f:facet name="last">
         WebElement webMeta = headElements.get(5);
         assertEquals(webMeta.getTagName(), "meta");
-        assertEquals(webMeta.getDomAttribute("name"), "apple-mobile-web-app-capable");
+        assertEquals(webMeta.getDomAttribute("name"), "mobile-web-app-capable");
         assertEquals(webMeta.getDomAttribute("content"), "yes");
 
         WebElement inlineStyle = headElements.get(6);

--- a/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
+++ b/primefaces-showcase/src/main/webapp/WEB-INF/template.xhtml
@@ -19,7 +19,7 @@
                 </script>
             </ui:fragment>
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <meta name="apple-mobile-web-app-capable" content="yes"/>
+            <meta name="mobile-web-app-capable" content="yes"/>
             <link href="#{resource['showcase:images/favicon-32x32.png']}" rel="icon" type="image/png" sizes="32x32"/>
             <link href="#{resource['showcase:images/favicon-16x16.png']}" rel="icon" type="image/png" sizes="16x16"/>
         </f:facet>


### PR DESCRIPTION
For reference: https://web.dev/learn/pwa/enhancements?hl=it#installation_reliability

<img width="978" height="127" alt="image" src="https://github.com/user-attachments/assets/cfab7a0a-94fb-45cb-a0e5-1381f72b41b8" />
