### PR TITLE
Two fixes for minimized dialogs

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/dialog/dialog.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/dialog/dialog.widget.ts
@@ -382,6 +382,9 @@ export class Dialog<Cfg extends DialogCfg = DialogCfg> extends PrimeFaces.widget
      */
     show(duration?: number | string): void {
         if(this.isVisible()) {
+			if(this.minimized) {
+				this.toggleMinimize();
+			}
             return;
         }
 
@@ -480,6 +483,10 @@ export class Dialog<Cfg extends DialogCfg = DialogCfg> extends PrimeFaces.widget
         if (!this.isVisible()) {
             return;
         }
+
+		if(this.minimized) {
+			this.toggleMinimize();
+		}
 
         this.lastOffset = [ this.box.css('top'), this.box.css('left') ];
 


### PR DESCRIPTION
1. The close button currently does nothing to minimized dialogs. Un-minimize it before closing it in the `hide` function.
2. Calling `show` on a minimized dialog does nothing. This change un-minimizes the dialog when `show` is called.
Fix #14324
