### PR TITLE
Fix #14321: Datatable pre-encode to ensure selectAll is correct

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTable.java
@@ -293,6 +293,15 @@ public class DataTable extends DataTableBase {
     }
 
     @Override
+    protected void preEncode(FacesContext context) {
+        super.preEncode(context);
+
+        if (isSelectAll() && ((List<?>) getSelection()).isEmpty()) {
+            setSelectAll(false);
+        }
+    }
+
+    @Override
     public void processEvent(ComponentSystemEvent event) throws AbortProcessingException {
         super.processEvent(event);
 


### PR DESCRIPTION
Fix #14321: Datatable pre-encode to ensure selectAll is correct