### PR TITLE
Fix #14331: 15.0.10 TextEditor allow H1-H6 through sanitizer

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/HtmlSanitizer.java
+++ b/primefaces/src/main/java/org/primefaces/util/HtmlSanitizer.java
@@ -56,9 +56,9 @@ public class HtmlSanitizer {
 
     private static final PolicyFactory HTML_STYLES_SANITIZER = Sanitizers.STYLES
             .and(new HtmlPolicyBuilder()
-            .allowElements("span", "li", "p", "u", "strong", "em", "s")
+            .allowElements("span", "li", "p", "u", "strong", "em", "s", "h1", "h1", "h2", "h3", "h4", "h5", "h6")
             .allowAttributes("class")
-            .onElements("span", "li", "p", "u", "strong", "em", "s")
+            .onElements("span", "li", "p", "u", "strong", "em", "s", "h1", "h1", "h2", "h3", "h4", "h5", "h6")
             .toFactory());
 
     private static final PolicyFactory HTML_DENY_ALL_SANITIZER = new HtmlPolicyBuilder().toFactory();


### PR DESCRIPTION
Fix #14331: 15.0.10 TextEditor allow H1-H6 through sanitizer