### PR TITLE
Fix #14310: RegisterOverlayHandler should not stop hide() call

### DIFF
--- a/primefaces/src/main/frontend/packages/core/src/core/core.utils.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.utils.ts
@@ -361,9 +361,7 @@ export class Utils {
                 }
             }
 
-            if (core.hideOverlaysOnViewportChange === true) {
-                hideCallback(e, $eventTarget);
-            }
+            hideCallback(e, $eventTarget);
         });
 
         return {


### PR DESCRIPTION
Fix #14310: RegisterOverlayHandler should not stop hide() call

this was introduced in #9488 https://github.com/primefaces/primefaces/commit/5ee445b75e30b6cbf30f40703eb38d567cb4eea7

but i think this one line might have been too aggressive lets see if the integration tests still pass