### PR TITLE
Fix #14310: 15.0.10 RegisterOverlayHandler should not stop hide() call

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.utils.js
@@ -329,9 +329,7 @@ if (!PrimeFaces.utils) {
                     }
                 }
 
-                if (PrimeFaces.hideOverlaysOnViewportChange === true) {
-                    hideCallback(e, $eventTarget);
-                }
+                hideCallback(e, $eventTarget);
             });
 
             return {


### PR DESCRIPTION
Fix #14310: 15.0.10 RegisterOverlayHandler should not stop hide() call