### PR TITLE
Fix #13714: MenuButton add new buttonIcon property for icon only display

### DIFF
--- a/docs/16_0_0/components/menubutton.md
+++ b/docs/16_0_0/components/menubutton.md
@@ -19,29 +19,31 @@ MenuButton displays different commands in a popup menu.
 
 | Name | Default | Type | Description |
 | --- | --- | --- | --- |
-| id | null | String | Unique identifier of the component.
-| rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
+| appendTo | null | String | Appends the overlay to the element defined by search expression. Defaults to document body.
+| ariaLabel | null | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
+| autoDisplay | true | Boolean | Defines whether the first level of submenus will be displayed on mouseover or not. When set to false, click event is required to display.
 | binding | null | Object | An el expression that maps to a server side UIComponent instance in a backing bean.
-| value | null | String | Label of the button
-| style | null | String | Style of the main container element
-| styleClass | null | String | Style class of the main container element
-| widgetVar | null | String | Name of the client side widget
-| model | null | MenuModel | MenuModel instance to create menus programmatically
+| buttonIcon | null | String | Icon class to display in place of the button label. If specified, the icon will be shown instead of the value (label) of the button.
+| buttonStyle | null | String | Style of the button
+| buttonStyleClass | null | String | Style class of the button
+| collision | flip | String | For the overlay menu that shows up when the menu button is clicked. When the overlay menu overflows the window in some direction, move it to an alternative position. Supported values are flip, fit, flipfit and none. See https://api.jqueryui.com/position/ for more details. Defaults to flip. When you the body of your layout does not scroll, you may also want to set the option maxHeight.
+| delay | 0 | int | Delay in milliseconds before displaying the submenu. Default is 0 meaning immediate.
 | disabled | false | Boolean | Disables or enables the button.
 | disableOnAjax | true | Boolean | If true, the button will be disabled during Ajax requests triggered by its menu items.
 | icon | null | String | Icon of the menu button.
 | iconPos | left | String | Position of the icon, valid values are left and right.
-| title | null | String | Advisory tooltip information.
-| appendTo | null | String | Appends the overlay to the element defined by search expression. Defaults to document body.
-| menuStyleClass | null | String | Style class of the overlay menu element.
-| ariaLabel | null | String | The aria-label attribute is used to define a string that labels the current element for accessibility.
-| collision | flip | String | For the overlay menu that shows up when the menu button is clicked. When the overlay menu overflows the window in some direction, move it to an alternative position. Supported values are flip, fit, flipfit and none. See https://api.jqueryui.com/position/ for more details. Defaults to flip. When you the body of your layout does not scroll, you may also want to set the option maxHeight.
+| id | null | String | Unique identifier of the component.
 | maxHeight | null | String | The maximum height of the overlay menu that shows up when the menu button is clicked. May be either a number (such as 200), which is interpreted as a height in pixels. Alternatively, may also be a CSS length such as 90vh or 10em. Useful in case the body of your layout does not scroll, especially in combination with the collision property.
-| autoDisplay | true | Boolean | Defines whether the first level of submenus will be displayed on mouseover or not. When set to false, click event is required to display.
-| delay | 0 | int | Delay in milliseconds before displaying the submenu. Default is 0 meaning immediate.
+| menuStyleClass | null | String | Style class of the overlay menu element.
+| model | null | MenuModel | MenuModel instance to create menus programmatically
+| rendered | true | Boolean | Boolean value to specify the rendering of the component, when set to false component will not be rendered.
+| style | null | String | Style of the main container element
+| styleClass | null | String | Style class of the main container element
+| title | null | String | Advisory tooltip information.
 | toggleEvent | hover | String | Event to toggle the submenus, valid values are "hover" and "click".
-| buttonStyle | null | String | Style of the button
-| buttonStyleClass | null | String | Style class of the button
+| value | null | String | Label of the button
+| widgetVar | null | String | Name of the client side widget
+
 
 ## Getting started with the MenuButton
 MenuButton consists of one ore more menuitems. Following menubutton example has three
@@ -70,6 +72,21 @@ If the body of your web page is scrollable, this is not an issue, users can scro
     <!-- many menuitems -->
 </p:menuButton>
 ```
+
+### Button Icon Example
+
+You can use the `buttonIcon` attribute to display an icon in place of the button label. When this attribute is set, the icon class you provide will be shown instead of the value (label) of the button.
+
+```xhtml
+<p:menuButton buttonIcon="pi pi-save" title="Options">
+    <p:menuitem value="Save" action="#{bean.save}" />
+    <p:menuitem value="Update" action="#{bean.update}" />
+    <p:menuitem value="Delete" action="#{bean.delete}" />
+</p:menuButton>
+```
+
+In the above example, the menu button will display the "save" icon (`pi pi-save`) instead of a text label.
+
 
 ## Client Side API
 Widget: `PrimeFaces.widget.MenuButton`

--- a/docs/16_0_0/gettingstarted/whatsnew.md
+++ b/docs/16_0_0/gettingstarted/whatsnew.md
@@ -18,6 +18,8 @@ Look into [migration guide](https://primefaces.github.io/primefaces/16_0_0/#/../
    * Added `apiVersion` attribute to specify API version (weekly, beta, alpha, or specific version).
    * Added `libraries` attribute to load additional Google Maps libraries (e.g., places, geometry).
    * Widget automatically detects if Google Maps is already loaded and supports both static and async loading methods.
+* MenuButton
+    * Added new `buttonIcon` attribute to display an icon in place of the button label.
 * SelectOneButton
     * Added new `layout="custom"` to allow complete control over rendering
 * SelectManyButton

--- a/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/menu/menuButton.xhtml
@@ -45,6 +45,15 @@
                     <p:menuitem value="Update" action="#{menuView.sleepAndUpdate}" update="messages" icon="pi pi-refresh"/>
                     <p:menuitem value="Delete" action="#{menuView.sleepAndDelete}" update="messages" icon="pi pi-times"/>
                 </p:menuButton>
+
+                <h5>Button Icon</h5>
+                <p:menuButton buttonIcon="pi pi-save" title="Options">
+                    <p:menuitem value="Save (Non-Ajax)" action="#{menuView.save}" ajax="false" update="messages" icon="pi pi-save"/>
+                    <p:menuitem value="Update" action="#{menuView.update}" update="messages" icon="pi pi-refresh"/>
+                    <p:menuitem value="Delete" action="#{menuView.delete}" update="messages" icon="pi pi-times"/>
+                    <p:divider/>
+                    <p:menuitem value="Website" url="http://www.primefaces.org" icon="pi pi-external-link"/>
+                </p:menuButton>
             </h:form>
         </div>
     </ui:define>

--- a/primefaces/src/main/java/org/primefaces/component/menubutton/MenuButtonBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/menubutton/MenuButtonBase.java
@@ -51,7 +51,8 @@ public abstract class MenuButtonBase extends AbstractMenu implements Widget {
         delay,
         buttonStyle,
         buttonStyleClass,
-        disableOnAjax
+        disableOnAjax,
+        buttonIcon
     }
 
     public MenuButtonBase() {
@@ -206,5 +207,13 @@ public abstract class MenuButtonBase extends AbstractMenu implements Widget {
 
     public void setDisableOnAjax(boolean disableOnAjax) {
         getStateHelper().put(PropertyKeys.disableOnAjax, disableOnAjax);
+    }
+
+    public String getButtonIcon() {
+        return (String) getStateHelper().eval(PropertyKeys.buttonIcon, null);
+    }
+
+    public void setButtonIcon(String buttonIcon) {
+        getStateHelper().put(PropertyKeys.buttonIcon, buttonIcon);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/menubutton/MenuButtonRenderer.java
@@ -74,10 +74,11 @@ public class MenuButtonRenderer extends TieredMenuRenderer {
         ResponseWriter writer = context.getResponseWriter();
         boolean isIconLeft = button.getIconPos().equals("left");
         String value = button.getValue();
+        String buttonIcon = button.getButtonIcon();
         String buttonClass = getStyleClassBuilder(context)
                 .add(button.getButtonStyleClass())
                 .add(isIconLeft, HTML.BUTTON_TEXT_ICON_LEFT_BUTTON_CLASS, HTML.BUTTON_TEXT_ICON_RIGHT_BUTTON_CLASS)
-                .add(isValueBlank(value), HTML.BUTTON_ICON_ONLY_BUTTON_CLASS)
+                .add(isValueBlank(value) && isValueBlank(buttonIcon), HTML.BUTTON_ICON_ONLY_BUTTON_CLASS)
                 .add(disabled, "ui-state-disabled")
                 .build();
 
@@ -113,7 +114,15 @@ public class MenuButtonRenderer extends TieredMenuRenderer {
         writer.startElement("span", null);
         writer.writeAttribute("class", HTML.BUTTON_TEXT_CLASS, null);
 
-        renderButtonValue(writer, true, button.getValue(), button.getTitle(), button.getAriaLabel());
+        if (!isValueBlank(buttonIcon)) {
+            // Render buttonIcon instead of label
+            writer.startElement("span", null);
+            writer.writeAttribute("class", buttonIcon, null);
+            writer.endElement("span");
+        }
+        else {
+            renderButtonValue(writer, true, button.getValue(), button.getTitle(), button.getAriaLabel());
+        }
 
         writer.endElement("span");
 

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -17694,6 +17694,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Icon to display on the button instead of the label.]]>
+            </description>
+            <name>buttonIcon</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Icon of the menu button.]]>
             </description>
             <name>icon</name>


### PR DESCRIPTION
Fix #13714: MenuButton add new buttonIcon property for icon only display

Added new buttonIcon for icon Only display

<img width="176" height="131" alt="image" src="https://github.com/user-attachments/assets/34b08d05-128d-4e6b-8e17-33c37645e9bc" />


```xml
<p:menuButton buttonIcon="pi pi-save" title="Options">

</p:menuButton>
```