### PR TITLE
Fix #14390: BooleanAwareResponswriter for HTML5 boolean attributes

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/multimedia/video.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/multimedia/video.xhtml
@@ -36,7 +36,7 @@
         <div class="card">
             <h5>WEBM</h5>
             <p:video value="/resources/demo/media/sample-webm.webm"
-                     controls="true"
+                     controls="false"
                      width="420"
                      height="250"
                      onplay="console.log('WEBM Started Playing')"

--- a/primefaces/src/main/java/org/primefaces/application/resource/BooleanAwareResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/BooleanAwareResponseWriter.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.application.resource;
+
+import org.primefaces.util.Constants;
+
+import java.io.IOException;
+import java.util.Set;
+
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.context.ResponseWriterWrapper;
+
+/**
+ * A ResponseWriter decorator that automatically handles HTML5 boolean attributes.
+ * Boolean attributes are written in naked form (e.g., "disabled") when their value
+ * is "true" or Boolean.TRUE. If the value is "false", they are omitted entirely.
+ */
+public class BooleanAwareResponseWriter extends ResponseWriterWrapper {
+
+    // -------------------------------------------------------------------------
+    //  HTML5 Boolean Attributes (complete, spec-correct)
+    // -------------------------------------------------------------------------
+    private static final Set<String> BOOLEAN_ATTRS = Set.of(
+            "allowfullscreen",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "controls",
+            "default",
+            "defer",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "selected"
+    );
+
+    public BooleanAwareResponseWriter(ResponseWriter wrapped) {
+        super(wrapped);
+    }
+
+    // -------------------------------------------------------------------------
+    //  Automatic boolean-attribute handling
+    // -------------------------------------------------------------------------
+    @Override
+    public void writeAttribute(String name, Object value, String property) throws IOException {
+
+        if (name != null && BOOLEAN_ATTRS.contains(name.toLowerCase())) {
+            // Omit attribute if value is explicitly false (Boolean.FALSE, string "false", or null)
+            boolean shouldOmit = false;
+
+            if (value == null) {
+                shouldOmit = true;
+            }
+            else if (value instanceof Boolean) {
+                shouldOmit = !((Boolean) value);
+            }
+            else {
+                String s = value.toString().trim().toLowerCase();
+                shouldOmit = "false".equals(s);
+            }
+
+            if (shouldOmit) {
+                // If false or null → output nothing
+                return;
+            }
+
+            // Otherwise, output the attribute (including empty string, "true", etc.)
+            // Use writeAttribute with empty string to ensure JSF buffers it correctly
+            // This will output name="" which is valid HTML5 for boolean attributes
+            getWrapped().writeAttribute(name, Constants.EMPTY_STRING, property);
+            return;
+        }
+
+        // Non-boolean attributes → normal delegation
+        getWrapped().writeAttribute(name, value, property);
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
+++ b/primefaces/src/main/java/org/primefaces/context/PrimeFacesContext.java
@@ -23,6 +23,7 @@
  */
 package org.primefaces.context;
 
+import org.primefaces.application.resource.BooleanAwareResponseWriter;
 import org.primefaces.application.resource.MoveScriptsToBottomResponseWriter;
 import org.primefaces.application.resource.MoveScriptsToBottomState;
 import org.primefaces.config.PrimeConfiguration;
@@ -89,7 +90,8 @@ public class PrimeFacesContext extends FacesContextWrapper {
         ResponseWriter wrappedWriter = writer;
         while (wrappedWriter != null) {
             if (wrappedWriter instanceof ResponseWriterWrapper) {
-                if (wrappedWriter instanceof MoveScriptsToBottomResponseWriter
+                if (wrappedWriter instanceof BooleanAwareResponseWriter
+                        || wrappedWriter instanceof MoveScriptsToBottomResponseWriter
                         || wrappedWriter instanceof CspResponseWriter) {
                     alreadyWrapped = true;
                     break;
@@ -101,12 +103,14 @@ public class PrimeFacesContext extends FacesContextWrapper {
             }
         }
 
-        if (!alreadyWrapped) {
-            if (csp && !getPartialViewContext().isAjaxRequest()) {
+        if (!alreadyWrapped && !getPartialViewContext().isAjaxRequest()) {
+            writer = new BooleanAwareResponseWriter(writer);
+
+            if (csp) {
                 writer = new CspResponseWriter(writer, cspState);
             }
 
-            if (moveScriptsToBottom && !getPartialViewContext().isAjaxRequest()) {
+            if (moveScriptsToBottom) {
                 writer = new MoveScriptsToBottomResponseWriter(writer, moveScriptsToBottomState);
             }
         }

--- a/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -121,14 +121,10 @@ public abstract class CoreRenderer<T extends UIComponent> extends Renderer<T> {
     protected void renderPassThruAttributes(FacesContext context, UIComponent component, List<String> attrs) throws IOException {
         //pre-defined attributes
         if (attrs != null && !attrs.isEmpty()) {
-            ResponseWriter writer = context.getResponseWriter();
-
             for (int i = 0; i < attrs.size(); i++) {
                 String attribute = attrs.get(i);
                 Object value = component.getAttributes().get(attribute);
-                if (shouldRenderAttribute(value)) {
-                    writer.writeAttribute(attribute, value.toString(), attribute);
-                }
+                renderAttribute(context, component, attribute, value);
             }
         }
 

--- a/primefaces/src/test/java/org/primefaces/application/resource/BooleanAwareResponseWriterTest.java
+++ b/primefaces/src/test/java/org/primefaces/application/resource/BooleanAwareResponseWriterTest.java
@@ -1,0 +1,248 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2025 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.application.resource;
+
+import java.io.IOException;
+
+import jakarta.faces.context.ResponseWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class BooleanAwareResponseWriterTest {
+
+    private BooleanAwareResponseWriter writer;
+    private ResponseWriter wrappedWriter;
+
+    @BeforeEach
+    void setup() {
+        wrappedWriter = mock(ResponseWriter.class);
+        writer = new BooleanAwareResponseWriter(wrappedWriter);
+    }
+
+    @Test
+    void booleanAttributeWithBooleanTrue() throws IOException {
+        writer.writeAttribute("disabled", Boolean.TRUE, null);
+
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithBooleanFalse() throws IOException {
+        writer.writeAttribute("disabled", Boolean.FALSE, null);
+
+        verify(wrappedWriter, never()).writeAttribute(anyString(), any(), anyString());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithStringTrue() throws IOException {
+        writer.writeAttribute("checked", "true", null);
+
+        verify(wrappedWriter).writeAttribute("checked", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithStringFalse() throws IOException {
+        writer.writeAttribute("checked", "false", null);
+
+        verify(wrappedWriter, never()).writeAttribute(anyString(), any(), anyString());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithNull() throws IOException {
+        writer.writeAttribute("required", null, null);
+
+        // null is treated as false, so attribute should be omitted
+        verify(wrappedWriter, never()).writeAttribute(anyString(), any(), anyString());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithEmptyString() throws IOException {
+        writer.writeAttribute("disabled", "", null);
+
+        // empty string is treated as true (not "false"), so attribute should be written
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithWhitespaceString() throws IOException {
+        writer.writeAttribute("disabled", "   ", null);
+
+        // whitespace string is treated as true (not "false"), so attribute should be written
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeCaseInsensitive() throws IOException {
+        writer.writeAttribute("DISABLED", Boolean.TRUE, null);
+        writer.writeAttribute("Disabled", Boolean.TRUE, null);
+        writer.writeAttribute("DiSaBlEd", Boolean.TRUE, null);
+        writer.writeAttribute("disabled", "disabled", null);
+
+        verify(wrappedWriter).writeAttribute("DISABLED", "", null);
+        verify(wrappedWriter).writeAttribute("Disabled", "", null);
+        verify(wrappedWriter).writeAttribute("DiSaBlEd", "", null);
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void nonBooleanAttributeDelegates() throws IOException {
+        writer.writeAttribute("id", "myId", "id");
+        writer.writeAttribute("class", "myClass", null);
+        writer.writeAttribute("href", "http://example.com", null);
+
+        verify(wrappedWriter).writeAttribute("id", "myId", "id");
+        verify(wrappedWriter).writeAttribute("class", "myClass", null);
+        verify(wrappedWriter).writeAttribute("href", "http://example.com", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void nullAttributeNameDelegates() throws IOException {
+        writer.writeAttribute(null, "value", null);
+
+        verify(wrappedWriter).writeAttribute(null, "value", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void allBooleanAttributes() throws IOException {
+        // Test a sample of boolean attributes
+        String[] booleanAttrs = {
+            "allowfullscreen", "async", "autofocus", "autoplay",
+            "checked", "controls", "default", "defer",
+            "disabled", "formnovalidate", "hidden", "ismap",
+            "itemscope", "loop", "multiple", "muted",
+            "nomodule", "novalidate", "open", "playsinline",
+            "readonly", "required", "reversed", "selected"
+        };
+
+        for (String attr : booleanAttrs) {
+            reset(wrappedWriter);
+            writer.writeAttribute(attr, Boolean.TRUE, null);
+            verify(wrappedWriter).writeAttribute(attr, "", null);
+            verify(wrappedWriter, never()).write(anyString());
+        }
+    }
+
+    @Test
+    void booleanAttributeWithStringTrueCaseInsensitive() throws IOException {
+        writer.writeAttribute("disabled", "True", null);
+        writer.writeAttribute("disabled", "TRUE", null);
+        writer.writeAttribute("disabled", "TrUe", null);
+
+        verify(wrappedWriter, times(3)).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithStringFalseCaseInsensitive() throws IOException {
+        writer.writeAttribute("disabled", "False", null);
+        writer.writeAttribute("disabled", "FALSE", null);
+        writer.writeAttribute("disabled", "FaLsE", null);
+
+        // string "false" (case-insensitive) should omit the attribute
+        verify(wrappedWriter, never()).writeAttribute(anyString(), any(), anyString());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithNumericZero() throws IOException {
+        writer.writeAttribute("disabled", 0, null);
+
+        // numeric 0 is treated as true (not "false"), so attribute should be written
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void booleanAttributeWithNumericOne() throws IOException {
+        writer.writeAttribute("disabled", 1, null);
+
+        // numeric 1 is treated as true (not "false"), so attribute should be written
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void mixedBooleanAndNonBooleanAttributes() throws IOException {
+        writer.writeAttribute("id", "myId", "id");
+        writer.writeAttribute("disabled", Boolean.TRUE, null);
+        writer.writeAttribute("class", "myClass", null);
+        writer.writeAttribute("checked", Boolean.FALSE, null);
+        writer.writeAttribute("required", Boolean.TRUE, null);
+
+        verify(wrappedWriter).writeAttribute("id", "myId", "id");
+        verify(wrappedWriter).writeAttribute("disabled", "", null);
+        verify(wrappedWriter).writeAttribute("class", "myClass", null);
+        verify(wrappedWriter).writeAttribute("required", "", null);
+        verify(wrappedWriter, never()).writeAttribute(eq("checked"), any(), any());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void propertyParameterPreservedForNonBoolean() throws IOException {
+        writer.writeAttribute("id", "myId", "id");
+        writer.writeAttribute("class", "myClass", "styleClass");
+
+        verify(wrappedWriter).writeAttribute("id", "myId", "id");
+        verify(wrappedWriter).writeAttribute("class", "myClass", "styleClass");
+    }
+
+    @Test
+    void videoControlsAttribute() throws IOException {
+        // Test the video controls example - controls should be written as controls=""
+        writer.writeAttribute("controls", Boolean.TRUE, null);
+
+        verify(wrappedWriter).writeAttribute("controls", "", null);
+        verify(wrappedWriter, never()).write(anyString());
+    }
+
+    @Test
+    void videoElementWithMultipleAttributes() throws IOException {
+        // Simulate a video element with id, controls, and other attributes
+        writer.writeAttribute("id", "j_idt149_video", "id");
+        writer.writeAttribute("controls", Boolean.TRUE, null);
+        writer.writeAttribute("autoplay", Boolean.FALSE, null);
+        writer.writeAttribute("muted", Boolean.TRUE, null);
+
+        verify(wrappedWriter).writeAttribute("id", "j_idt149_video", "id");
+        verify(wrappedWriter).writeAttribute("controls", "", null);
+        verify(wrappedWriter).writeAttribute("muted", "", null);
+        verify(wrappedWriter, never()).writeAttribute(eq("autoplay"), any(), any());
+        verify(wrappedWriter, never()).write(anyString());
+    }
+}
+


### PR DESCRIPTION
Fix #14390: BooleanAwareResponswriter for HTML5 boolean attributes

## Overview

`BooleanAwareResponseWriter` is a decorator class that extends `ResponseWriterWrapper` to automatically handle HTML5 boolean attributes according to the HTML5 specification. It ensures that boolean attributes are written in the correct format without requiring manual handling in individual renderers.

## What It Does

The class intercepts calls to `writeAttribute()` and applies special handling for HTML5 boolean attributes:

- **When value is `true`**: Writes the attribute in "naked" form (e.g., `<input disabled>`)
- **When value is `false`**: Omits the attribute entirely (e.g., `<input>` instead of `<input disabled="false">`)
- **When value is `null` or empty**: Treats as `false` and omits the attribute entirely

### Supported Boolean Attributes

The class recognizes 24 HTML5 boolean attributes:
- `allowfullscreen`, `async`, `autofocus`, `autoplay`
- `checked`, `controls`, `default`, `defer`
- `disabled`, `formnovalidate`, `hidden`, `ismap`
- `itemscope`, `loop`, `multiple`, `muted`
- `nomodule`, `novalidate`, `open`, `playsinline`
- `readonly`, `required`, `reversed`, `selected`

## How It Works

1. **Interception**: Overrides `writeAttribute(String name, Object value, String property)` to intercept all attribute writes
2. **Detection**: Checks if the attribute name (case-insensitive) is in the set of known boolean attributes
3. **Value Processing**:
   - If `Boolean.FALSE` → omits the attribute
   - If string `"false"` (case-insensitive) → omits the attribute
   - Otherwise (including `Boolean.TRUE`, `"true"`, `disabled`,`empty string) → writes as `name=""` (valid HTML5 format)
4. **Delegation**: Non-boolean attributes are passed through unchanged to the wrapped `ResponseWriter`

## Integration

The class is automatically applied in `PrimeFacesContext.setResponseWriter()`:
- It wraps the `ResponseWriter` **first**, before other decorators (CSP, MoveScriptsToBottom)
- It checks for existing wrappers to avoid double-wrapping
- It's applied globally to all PrimeFaces rendering operations

## Improvements Over Previous State

### Before BooleanAwareResponseWriter

**Problems:**
1. **Inconsistent Output**: Different renderers handled boolean attributes differently
   - Some wrote `disabled="true"` (invalid HTML5)
   - Some wrote `disabled="disabled"` (XHTML style)
   - Some wrote `disabled=""` (correct but inconsistent)
   - Some forgot to omit attributes when `false`

2. **Code Duplication**: Each renderer had to manually check and format boolean attributes:
   ```java
   // Example of manual handling (repeated in many renderers)
   if (component.isDisabled()) {
       writer.writeAttribute("disabled", "", null);
   }
   // Or worse:
   writer.writeAttribute("disabled", component.isDisabled() ? "disabled" : null, null);
   ```

3. **Maintenance Burden**: Adding new boolean attributes or fixing formatting required changes across multiple renderer classes

4. **HTML5 Compliance**: Output didn't always conform to HTML5 specification, which could cause:
   - Validation errors
   - Unexpected browser behavior
   - Accessibility issues

### After BooleanAwareResponseWriter

**Benefits:**
1. **Centralized Logic**: Single point of control for all boolean attribute handling
2. **Automatic Compliance**: All renderers automatically produce HTML5-compliant output
3. **Simplified Renderers**: Renderers can simply call `writeAttribute()` with boolean values without special handling:
   ```java
   // Now renderers can simply write:
   writer.writeAttribute("disabled", component.isDisabled(), null);
   // The decorator handles the formatting automatically
   ```

4. **Consistency**: All components produce consistent HTML output across the entire framework
5. **Future-Proof**: New boolean attributes can be added to the set without touching individual renderers
6. **Correct Behavior**: 
   - `false` values are properly omitted (not written as `disabled="false"`)
   - `true` values are written in the correct HTML5 format
   - Case-insensitive string handling for flexibility

## Technical Details

- **Implementation Pattern**: Decorator pattern using `ResponseWriterWrapper`
- **Performance**: Uses a `Set<String>` for O(1) lookup of boolean attributes
- **Case Handling**: Case-insensitive attribute name matching
- **Value Handling**: Supports both `Boolean` objects and string representations
- **JSF Integration**: Uses `writeAttribute()` with empty string to ensure proper JSF buffering and avoid timing issues

## Example Output

**Before:**
```html
<input disabled="true" />
<input disabled="false" />
<input disabled="disabled" />
```

**After:**
```html
<input disabled />
<input />
<input disabled />
```

This ensures all boolean attributes follow the HTML5 specification where the presence of the attribute indicates `true` and its absence indicates `false`.

Here is video with `controls="true"` and `controls="false"` now

<img width="716" height="1021" alt="image" src="https://github.com/user-attachments/assets/5c0b1af4-f6d6-4cb0-b60b-7fb54c432036" />
