### PR TITLE
Fix #14395: Datatable/TreeTable endsWithLengthUnit handle CSS calc() function

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -566,7 +566,7 @@ public class DataTableRenderer extends DataRenderer<DataTable> {
         writer.writeAttribute("class", DataTable.SCROLLABLE_BODY_CLASS, null);
         writer.writeAttribute("tabindex", "-1", null);
         if (LangUtils.isNotBlank(scrollHeight)) {
-            if (!endsWithLenghtUnit(scrollHeight)) {
+            if (!endsWithLengthUnit(scrollHeight)) {
                 scrollHeight = scrollHeight + "px";
             }
             // % handle specially in the JS code
@@ -728,7 +728,7 @@ public class DataTableRenderer extends DataRenderer<DataTable> {
         }
 
         if (width != null) {
-            String unit = endsWithLenghtUnit(width) ? Constants.EMPTY_STRING : "px";
+            String unit = endsWithLengthUnit(width) ? Constants.EMPTY_STRING : "px";
             if (style != null) {
                 style = style + ";width:" + width + unit;
             }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableRenderer.java
@@ -667,7 +667,7 @@ public class TreeTableRenderer extends DataRenderer<TreeTable> {
         }
 
         if (width != null) {
-            String unit = endsWithLenghtUnit(width) ? Constants.EMPTY_STRING : "px";
+            String unit = endsWithLengthUnit(width) ? Constants.EMPTY_STRING : "px";
             if (style != null) {
                 style = style + ";width:" + width + unit;
             }

--- a/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/CoreRenderer.java
@@ -911,13 +911,37 @@ public abstract class CoreRenderer<T extends UIComponent> extends Renderer<T> {
         ComponentUtils.encodeIndexedId(context, component, index);
     }
 
-    protected boolean endsWithLenghtUnit(String val) {
-        return val.endsWith("px") || val.endsWith("%") // most common first
-                || val.endsWith("cm") || val.endsWith("mm") || val.endsWith("in")
-                || val.endsWith("pt") || val.endsWith("pc")
-                || val.endsWith("em") || val.endsWith("ex") || val.endsWith("ch") || val.endsWith("rem")
-                || val.endsWith("vw") || val.endsWith("vh")
-                || val.endsWith("vmin") || val.endsWith("vmax");
+    /**
+     * Determines if the given CSS value ends with a valid CSS length unit.
+     * Handles the common units and basic "calc()" function (removes a single trailing ')').
+     *
+     * @param val a CSS value string, possibly with a unit, or ending with ')'
+     * @return true if the value ends with a recognized CSS length unit, false otherwise
+     */
+    protected boolean endsWithLengthUnit(String val) {
+        if (LangUtils.isBlank(val)) {
+            return false;
+        }
+        // #14395 support calc() CSS function by stripping a single trailing ')'
+        if (val.endsWith(")")) {
+            val = val.substring(0, val.length() - 1);
+        }
+        // Array of common CSS length units
+        final String[] units = {
+            "px", "%", // most common first
+            "cm", "mm", "in",
+            "pt", "pc",
+            "em", "ex", "ch", "rem",
+            "vw", "vh", "vmin", "vmax"
+        };
+
+        for (int i = 0; i < units.length; i++) {
+            String unit = units[i];
+            if (val.endsWith(unit)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Fix #14395: Datatable/TreeTable endsWithLengthUnit handle CSS calc() function