### PR TITLE
Fix #14403: KeyFilter preventPaste on Safari

### DIFF
--- a/primefaces/src/main/frontend/packages/keyfilter/keyfilter/src/keyfilter.widget.js
+++ b/primefaces/src/main/frontend/packages/keyfilter/keyfilter/src/keyfilter.widget.js
@@ -75,9 +75,18 @@ PrimeFaces.widget.KeyFilter = class KeyFilter extends PrimeFaces.widget.BaseWidg
         });
 
         if (cfg.preventPaste) {
-            //disable paste
+            // Safari requires this to prevent paste from clipboard
+            input.on('beforeinput', function (e) {
+                if (e.originalEvent && e.originalEvent.inputType === 'insertFromPaste') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            });
+
+            // disable paste as a safety measure on all browsers
             input.on('paste', function(e) {
                 e.preventDefault();
+                e.stopPropagation();
             });
         }
     }


### PR DESCRIPTION
Fix #14403: KeyFilter preventPaste on Safari