### PR TITLE
Fix #14428: FeedReader disable integration tests

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/feedreader/FeedReader001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/feedreader/FeedReader001Test.java
@@ -29,6 +29,7 @@ import org.primefaces.selenium.component.CommandButton;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeedReader001Test extends AbstractPrimePageTest {
 
+    @Disabled("Test relies on a valid RSS feed, which is not always available")
     @Test
     @Order(1)
     @DisplayName("FeedReader: valid RSS just check at least a few articles are returned")
@@ -56,6 +58,7 @@ class FeedReader001Test extends AbstractPrimePageTest {
         assertNoJavascriptErrors();
     }
 
+    @Disabled("Test relies on a valid RSS feed, which is not always available")
     @Test
     @Order(2)
     @DisplayName("FeedReader: invalid RSS URL so ensure error is displayed")


### PR DESCRIPTION
Fix #14428: FeedReader disable integration tests