### PR TITLE
#14406: Add TreeTable filterPrune descendants mode with pruning logic / tests

### DIFF
--- a/docs/16_0_0/components/treetable.md
+++ b/docs/16_0_0/components/treetable.md
@@ -39,6 +39,7 @@ filterDelay | 300 | Integer | Delay in milliseconds before sending an ajax filte
 filterEvent | keyup | String | Event triggering filter for input filters. If "enter" it will only filter after ENTER key is pressed.
 filteredValue  | null | TreeNode | TreeNode to keep filtered data.
 filterNormalize | false | Boolean | Defines if filtering would be done using normalized values (accents will be removed from characters). Default is false.
+filterPrune | none | String | Controls pruning during filtering. Use `descendants` to prune non-matching children unless they or their descendants match; `none` keeps children of matching nodes. |
 first | 0 | Integer | Index of the first data to display.
 globalFilter | null | String | Value of the global filter to use when filtering by default.
 globalFilterFunction | null | MethodExpression | Custom implementation to globally filter a value against a constraint.
@@ -151,6 +152,19 @@ Widget: _PrimeFaces.widget.TreeTable_
 | --- | --- | --- | --- |
 | clearFilters() | - | void | Clears all column filters
 
+## Filtering prune mode
+Set `filterPrune="descendants"` to hide non-matching children of a matched node unless they (or their descendants) match the filter. Omit the attribute or use `none` to keep children of matched nodes visible.
+
+```xhtml
+<p:treeTable value="#{bean.root}"
+             var="node"
+             filterPrune="descendants">
+    <p:column headerText="Name" filterBy="#{node.name}" filterMatchMode="contains">
+        #{node.name}
+    </p:column>
+</p:treeTable>
+```
+
 ## ContextMenu
 TreeTable has special integration with context menu, you can even match different context menus
 with different tree nodes using _nodeType_ option of context menu that matches the tree node type.
@@ -211,4 +225,3 @@ Following is the list of structural style classes;
 .ui-treetable-data | Body element of the table containing data
 
 As skinning style classes are global, see the main theming section for more information.
-

--- a/docs/16_0_0/gettingstarted/whatsnew.md
+++ b/docs/16_0_0/gettingstarted/whatsnew.md
@@ -32,3 +32,4 @@ Look into [migration guide](https://primefaces.github.io/primefaces/16_0_0/#/../
     * Added `stickyTopAt` attribute for elements fixed at the top of the page whose height should be considered when positioning the sticky element.
 * TreeTable
     * Added `resizeMode` attribute to support column resizing using the "expand" mode.
+    * Added `filterPrune="descendants"` to prune non-matching children unless they or their descendants match a filter.

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -41,6 +41,8 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
     public static final String DEFAULT_RENDERER = "org.primefaces.component.TreeTableRenderer";
+    public static final String FILTER_PRUNE_NONE = "none";
+    public static final String FILTER_PRUNE_DESCENDANTS = "descendants";
 
     public enum PropertyKeys {
 
@@ -77,6 +79,7 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
         rows,
         first,
         filterBy,
+        filterPrune,
         filterNormalize,
         globalFilter,
         globalFilterFunction,
@@ -411,6 +414,18 @@ public abstract class TreeTableBase extends UITree implements Widget, ClientBeha
 
     public void setFilterDelay(int filterDelay) {
         getStateHelper().put(PropertyKeys.filterDelay, filterDelay);
+    }
+
+    public String getFilterPrune() {
+        return (String) getStateHelper().eval(PropertyKeys.filterPrune, FILTER_PRUNE_NONE);
+    }
+
+    public void setFilterPrune(String filterPrune) {
+        getStateHelper().put(PropertyKeys.filterPrune, filterPrune);
+    }
+
+    public boolean isFilterPruneDescendants() {
+        return FILTER_PRUNE_DESCENDANTS.equals(getFilterPrune());
     }
 
     public String getCellEditMode() {

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -109,7 +109,7 @@ public class FilterFeature implements TreeTableFeature {
 
         // recreate tree node
         TreeNode filteredValue = cloneTreeNode(root, root.getParent());
-        createFilteredValueFromRowKeys(tt, root, filteredValue, filteredRowKeys);
+        createFilteredValueFromRowKeys(tt, root, filteredValue, filteredRowKeys, tt.isFilterPruneDescendants());
 
         tt.updateFilteredValue(context, filteredValue);
         tt.setValue(filteredValue);
@@ -189,20 +189,22 @@ public class FilterFeature implements TreeTableFeature {
         }
     }
 
-    private void createFilteredValueFromRowKeys(TreeTable tt, TreeNode<?> node, TreeNode<?> filteredNode, List<String> filteredRowKeys) {
+    protected void createFilteredValueFromRowKeys(TreeTable tt, TreeNode<?> node, TreeNode<?> filteredNode,
+            List<String> filteredRowKeys, boolean pruneDescendants) {
         int childCount = node.getChildCount();
         for (int i = 0; i < childCount; i++) {
             TreeNode childNode = node.getChildren().get(i);
             String rowKeyOfChildNode = childNode.getRowKey();
 
             for (String rk : filteredRowKeys) {
-                if (rk.equals(rowKeyOfChildNode) || rk.startsWith(rowKeyOfChildNode + "_") || rowKeyOfChildNode.startsWith(rk + "_")) {
+                if (rk.equals(rowKeyOfChildNode) || rk.startsWith(rowKeyOfChildNode + "_")
+                        || (!pruneDescendants && rowKeyOfChildNode.startsWith(rk + "_"))) {
                     TreeNode newNode = cloneTreeNode(childNode, filteredNode);
                     if (rk.startsWith(rowKeyOfChildNode + "_")) {
                         newNode.setExpanded(true);
                     }
 
-                    createFilteredValueFromRowKeys(tt, childNode, newNode, filteredRowKeys);
+                    createFilteredValueFromRowKeys(tt, childNode, newNode, filteredRowKeys, pruneDescendants);
                     break;
                 }
             }

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -30958,6 +30958,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Controls pruning during filtering. "none" keeps children of matching nodes; "descendants" prunes non-matching children unless they or their descendants match. Default is none.]]>
+            </description>
+            <name>filterPrune</name>
+            <required>false</required>
+            <type>java.lang.String</type>
+        </attribute>
+        <attribute>
+            <description>
                 <![CDATA[Defines the cell edit behavior, valid values are "eager" (default) and "lazy".]]>
             </description>
             <name>cellEditMode</name>

--- a/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
@@ -23,13 +23,17 @@
  */
 package org.primefaces.component.treetable.feature;
 
+import org.primefaces.component.api.UITree;
 import org.primefaces.component.treetable.TreeTable;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TreeTableFilterFeatureTest {
 
@@ -61,5 +65,52 @@ class TreeTableFilterFeatureTest {
 
         assertEquals(1, cloneRoot.getChildren().size());
         assertEquals(cloneCustomNode, cloneRoot.getChildren().get(0));
+    }
+
+    @Test
+    void createFilteredValueFromRowKeysKeepsChildrenOnDefaultPrune() {
+        FilterFeature filterFeature = new FilterFeature();
+
+        DefaultTreeNode<String> root = new DefaultTreeNode<>();
+        DefaultTreeNode<String> matchingNode = new DefaultTreeNode<>("Type", "Match", root);
+        DefaultTreeNode<String> childOfMatch = new DefaultTreeNode<>("Type", "Child", matchingNode);
+        new DefaultTreeNode<>("Type", "Other", root);
+        TreeTable treeTable = new TreeTable();
+
+        root.setRowKey(UITree.ROOT_ROW_KEY);
+        treeTable.buildRowKeys(root);
+
+        TreeNode<?> filteredRoot = filterFeature.cloneTreeNode(root, root.getParent());
+        filterFeature.createFilteredValueFromRowKeys(treeTable, root, filteredRoot,
+                List.of(matchingNode.getRowKey()), false);
+
+        assertEquals(1, filteredRoot.getChildCount());
+        TreeNode<?> filteredMatch = filteredRoot.getChildren().get(0);
+        assertEquals(matchingNode.getRowKey(), filteredMatch.getRowKey());
+        assertEquals(1, filteredMatch.getChildCount());
+        assertEquals(childOfMatch.getRowKey(), filteredMatch.getChildren().get(0).getRowKey());
+    }
+
+    @Test
+    void createFilteredValueFromRowKeysPrunesChildrenWhenRequested() {
+        FilterFeature filterFeature = new FilterFeature();
+
+        DefaultTreeNode<String> root = new DefaultTreeNode<>();
+        DefaultTreeNode<String> matchingNode = new DefaultTreeNode<>("Type", "Match", root);
+        new DefaultTreeNode<>("Type", "Child", matchingNode);
+        TreeTable treeTable = new TreeTable();
+
+        root.setRowKey(UITree.ROOT_ROW_KEY);
+        treeTable.buildRowKeys(root);
+
+        TreeNode<?> filteredRoot = filterFeature.cloneTreeNode(root, root.getParent());
+        filterFeature.createFilteredValueFromRowKeys(treeTable, root, filteredRoot,
+                List.of(matchingNode.getRowKey()), true);
+
+        assertEquals(1, filteredRoot.getChildCount());
+        TreeNode<?> filteredMatch = filteredRoot.getChildren().get(0);
+        assertEquals(matchingNode.getRowKey(), filteredMatch.getRowKey());
+        assertEquals(0, filteredMatch.getChildCount());
+        assertTrue(filteredMatch.getChildren().isEmpty());
     }
 }


### PR DESCRIPTION
Fix https://github.com/primefaces/primefaces/issues/14406


Proposal: add an API attribute in treeTable called `filterPrune="descendants"`

Behavior when filterPrune="descendants":

- A node stays if it matches the filter itself OR if any descendant matches.

- A node is pruned only when neither it nor any of its descendants match.

- Defaults to current behavior when the attribute is absent.


---

Proposed API:

* Attribute: filterPrune
* Values: none (default, current behavior: keep all children of a matching node), descendants (prune nonmatching children unless they or their descendants match).
* Usage:


```html
  <p:treeTable value="#{bean.root}"
               var="node"
               filterPrune="descendants">
      <p:column headerText="Name" filterBy="#{node.name}" filterMatchMode="contains">
          #{node.name}
      </p:column>
  </p:treeTable>
```

---

Sample Test project:

http://localhost:8080/

[primefaces-test-14406.zip](https://github.com/user-attachments/files/23755337/primefaces-test-14406.zip)

<img width="708" height="860" alt="image" src="https://github.com/user-attachments/assets/7cea5e33-6290-45b8-98cd-71c50080bfa0" />
