### PR TITLE
Fix #14390: 15.0.11 Passthrough attribute String "false" should be treated like boolean false

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/video/Video.java
+++ b/primefaces/src/main/java/org/primefaces/component/video/Video.java
@@ -50,14 +50,6 @@ public class Video extends UIMedia {
         return COMPONENT_FAMILY;
     }
 
-    public boolean isControls() {
-        return (boolean) getStateHelper().eval(PropertyKeys.controls, true);
-    }
-
-    public void setControls(boolean controls) {
-        getStateHelper().put(PropertyKeys.controls, controls);
-    }
-
     public String getWidth() {
         return (String) getStateHelper().eval(PropertyKeys.width, null);
     }


### PR DESCRIPTION
Fix #14390: 15.0.11 Passthrough attribute String "false" should be treated like boolean false

@tandraschko got to teh bottom of this.  The magic is in `shouldRenderAttribute` if a passthrough attribute is a `String` its not respecting "true" and "false".  If it was a `Boolean` it was.

so I added a check to treat `false` like boolean false to not render the attribute instead of rendering `controls="false"`.

```java
protected boolean shouldRenderAttribute(Object value) {
        if (value == null) {
            return false;
        }

        if (value instanceof Boolean) {
            return (Boolean) value;
        }
        else if (value instanceof Number) {
            Number number = (Number) value;

            if (value instanceof Integer) {
                return number.intValue() != Integer.MIN_VALUE;
            }
            else if (value instanceof Double) {
                return number.doubleValue() != Double.MIN_VALUE;
            }
            else if (value instanceof Long) {
                return number.longValue() != Long.MIN_VALUE;
            }
            else if (value instanceof Byte) {
                return number.byteValue() != Byte.MIN_VALUE;
            }
            else if (value instanceof Float) {
                return number.floatValue() != Float.MIN_VALUE;
            }
            else if (value instanceof Short) {
                return number.shortValue() != Short.MIN_VALUE;
            }
        }
        else if (value instanceof String) {
            // #14390: passthrough attribute with "false" should be treated like boolean false
            return !"false".equalsIgnoreCase((String) value);
        }

        return true;
    }
```