### PR TITLE
Fix #14487: 150.11 DatePicker widget setDate(null) should trigger AJAX

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datepicker/1-datepicker.js
@@ -478,6 +478,11 @@ PrimeFaces.widget.DatePicker = PrimeFaces.widget.BaseWidget.extend({
      */
     setDate: function(date) {
         this.jq.datePicker('setDate', date);
+
+        // #14487 AJAX is not triggered on setDate(null). Specifically not done in the Prime Datepicker widget.
+        if (!date) {
+            this.fireDateSelectEvent();
+        }
     },
 
     /**


### PR DESCRIPTION
Fix #14487: 150.11 DatePicker widget setDate(null) should trigger AJAX