### PR TITLE
Fix #14487: DatePicker widget setDate(null) should trigger AJAX

### DIFF
--- a/primefaces/src/main/frontend/packages/datepicker/datepicker/src/datepicker.widget.js
+++ b/primefaces/src/main/frontend/packages/datepicker/datepicker/src/datepicker.widget.js
@@ -489,6 +489,11 @@ PrimeFaces.widget.DatePicker = class DatePicker extends PrimeFaces.widget.BaseWi
      */
     setDate(date) {
         this.jq.datePicker('setDate', date);
+
+        // #14487 AJAX is not triggered on setDate(null). Specifically not done in the Prime Datepicker widget.
+        if (!date) {
+            this.fireDateSelectEvent();
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #14487: DatePicker widget setDate(null) should trigger AJAX