### PR TITLE
Fix #14474: Picklist dragDrop property to disable transfer/reordering

### DIFF
--- a/docs/16_0_0/components/picklist.md
+++ b/docs/16_0_0/components/picklist.md
@@ -58,6 +58,7 @@ orientation | horizontal | String | Defines layout orientation, valid values are
 responsive | false | Boolean | In responsive mode, picklist adjusts itself based on screen width.
 escape | true | Boolean | Defines if labels of the component are escaped or not.
 tabindex | null | String | Position of the element in the tabbing order.
+dragDrop | true | Boolean | Specifies dragdrop based drag and drop transfers and reordering, default is true and works only on supported browsers.
 filterEvent | keyup | String | Client side event to invoke picklist filtering for input fields.
 filterDelay | 300 | Integer  | Delay to wait in milliseconds before sending each filter query.
 escapeValue | true | Boolean | Defines if values of the component are escaped or not.

--- a/docs/16_0_0/gettingstarted/whatsnew.md
+++ b/docs/16_0_0/gettingstarted/whatsnew.md
@@ -20,6 +20,8 @@ Look into [migration guide](https://primefaces.github.io/primefaces/16_0_0/#/../
    * Widget automatically detects if Google Maps is already loaded and supports both static and async loading methods.
 * MenuButton
     * Added new `buttonIcon` attribute to display an icon in place of the button label.
+* PickList
+    * Added new `dragDrop` attribute to be able to disable drag and drop capabilities.
 * SelectOneButton
     * Added new `layout="custom"` to allow complete control over rendering
 * SelectManyButton

--- a/primefaces/src/main/frontend/packages/components/src/picklist/picklist.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/picklist/picklist.widget.js
@@ -157,11 +157,14 @@ PrimeFaces.widget.PickList = class PickList extends PrimeFaces.widget.BaseWidget
         var $this = this,
             reordered = true;
 
+        // #13131 always disable drag and drop on touch devices
+        const dragDropDisabled = ($this.cfg.dragDrop === false) || PrimeFaces.env.isTouchable($this.cfg);
+
         //Sortable lists
         $(this.jqId + ' ul').sortable({
             cancel: '.ui-state-disabled,.ui-chkbox-box',
             connectWith: this.jqId + ' .ui-picklist-list',
-            disabled: PrimeFaces.env.isTouchable($this.cfg), // #13131 disable on touch devices
+            disabled: dragDropDisabled, 
             revert: 1,
             helper: 'clone',
             placeholder: "ui-picklist-item ui-state-highlight",

--- a/primefaces/src/main/java/org/primefaces/component/picklist/PickListBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/picklist/PickListBase.java
@@ -68,7 +68,8 @@ public abstract class PickListBase extends UIInput implements Widget, ClientBeha
         escapeValue,
         transferOnDblclick,
         transferOnCheckboxClick,
-        filterNormalize
+        filterNormalize,
+        dragDrop
     }
 
     public PickListBase() {
@@ -334,5 +335,13 @@ public abstract class PickListBase extends UIInput implements Widget, ClientBeha
 
     public void setFilterNormalize(boolean filterNormalize) {
         getStateHelper().put(PropertyKeys.filterNormalize, filterNormalize);
+    }
+
+    public boolean isDragDrop() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.dragDrop, true);
+    }
+
+    public void setDragDrop(boolean dragDrop) {
+        getStateHelper().put(PropertyKeys.dragDrop, dragDrop);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/picklist/PickListRenderer.java
@@ -145,6 +145,7 @@ public class PickListRenderer extends InputRenderer<PickList> {
                 .attr("effect", component.getEffect())
                 .attr("effectSpeed", component.getEffectSpeed())
                 .attr("escape", component.isEscape())
+                .attr("dragDrop", component.isDragDrop(), true)
                 .attr("showSourceControls", component.isShowSourceControls(), false)
                 .attr("showTargetControls", component.isShowTargetControls(), false)
                 .attr("disabled", component.isDisabled(), false)

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -21241,6 +21241,14 @@
             <required>false</required>
             <type>java.lang.Boolean</type>
         </attribute>
+        <attribute>
+            <description>
+                <![CDATA[Specifies dragdrop based drag and drop transfers and reordering, default is true and works only on supported browsers.]]>
+            </description>
+            <name>dragDrop</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute>
     </tag>
     <tag>
         <description>


### PR DESCRIPTION
Fix #14474: Picklist dragDrop property to disable transfer/reordering
Fix #13131

- [x] New feature for 16.0.0
- [x] called it `dragDrop` which is what FileUpload calls the property
