### PR TITLE
Fix #14479: TabView add new widget selectTabById(id) method

### DIFF
--- a/docs/16_0_0/components/tabview.md
+++ b/docs/16_0_0/components/tabview.md
@@ -173,6 +173,7 @@ Widget: _PrimeFaces.widget.TabView_
 | --- | --- | --- | --- |
 select(index) | index: Index of tab to display | void | Activates tab with given index
 selectTab(index) | index: Index of tab to display | void | (Deprecated, use select instead) Activates tab with given index
+selectTabById(id, silent) | id: The client ID or expression | boolean | Selects the tab with the given client ID or expression. Returns true if the tab was found and selected, false otherwise.
 disable(index) | index: Index of tab to disable | void | Disables tab with given index
 enable(index) | index: Index of tab to enable | void | Enables tab with given index
 remove(index) | index: Index of tab to remove | void | Removes tab with given index

--- a/docs/16_0_0/gettingstarted/whatsnew.md
+++ b/docs/16_0_0/gettingstarted/whatsnew.md
@@ -30,6 +30,9 @@ Look into [migration guide](https://primefaces.github.io/primefaces/16_0_0/#/../
     * Added `dir="rtl"` right to left support.
 * Sticky
     * Added `stickyTopAt` attribute for elements fixed at the top of the page whose height should be considered when positioning the sticky element.
+* TabView
+    * Added new widget method `selectTabById(id, silent)` to select a tab by its client ID or expression at the JavaScript level, matching a tab panel by its DOM id. Returns true if the tab was found and selected, false otherwise.
+
 * TreeTable
     * Added `resizeMode` attribute to support column resizing using the "expand" mode.
     * Added `filterPrune="descendants"` to prune non-matching children unless they or their descendants match a filter.

--- a/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
@@ -856,4 +856,31 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
         PrimeFaces.invokeDeferredRenders(this.id);
     }
 
+    /**
+     * Selects the tab with the given ID. The ID can be a full client ID (e.g., "form:tabView:tabFoo")
+     * or a partial ID relative to this tab view (e.g., "tabFoo" or ":tabFoo").
+     * @param {string | HTMLElement | JQuery | undefined | null} tabId Client ID of the tab to select.
+     * @param {boolean} [silent=false] Controls whether events are triggered. When `true`, the
+     * `onTabChange` callback and AJAX events are not fired.
+     * @return {boolean} `true` if the tab was found and selected, `false` otherwise.
+     */
+    selectTabById(tabId, silent) {
+        if (!tabId) {
+            return false;
+        }
+
+        const tabPanel = PrimeFaces.expressions.SearchExpressionFacade.resolveComponentsAsSelector(this.jq, tabId);
+        if (tabPanel.length === 0) {
+            return false;
+        }
+
+        // Get the index of the panel within the panelContainer
+        const tabIndex = this.panelContainer.children().index(tabPanel);
+        if (tabIndex === -1) {
+            return false;
+        }
+
+        return this.select(tabIndex, silent);
+    }
+
 }

--- a/primefaces/src/main/frontend/packages/core/src/core/core.expressions.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.expressions.ts
@@ -37,7 +37,8 @@ export class SearchExpressionFacade {
 
                 // just a id
                 if (expression.indexOf("@") == -1) {
-                    const element = document.getElementById(expression);
+                    const cleanedExpression = expression.startsWith("#") ? expression.substring(1) : expression;
+                    const element = document.getElementById(cleanedExpression);
                     if (element !== null) {
                         elements = elements.add($(element));
                     }

--- a/primefaces/src/main/frontend/packages/core/src/core/core.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.ts
@@ -597,7 +597,10 @@ export class Core {
      * @return A CSS ID selector for the given ID.
      */
     escapeClientId(id: string): string {
-        return "#" + id.replace(/[:|]/g,"\\$&");
+        // If the id already starts with '#', remove it to avoid double-escaping, but keep escaping all chars.
+        const rawId = id.startsWith("#") ? id.substring(1) : id;
+        // Escape ':' and '|' for jQuery usage.
+        return "#" + rawId.replace(/([:|])/g, "\\$1");
     }
 
     /**


### PR DESCRIPTION
Fix #14479: TabView add new widget selectTabById(id) method

```js
// Get the widget instance
var tabView = PrimeFaces.getWidgetById('myTabView');

// Select by full ID
tabView.selectTabById('#form:myTabView:tab1');
tabView.selectTabById('form:myTabView:tab2');

// Select silently (no events)
tabView.selectTabById(''form:myTabView:tab2', true);
```