### PR TITLE
Fix #14055: headers update after column dropping, duplicate columntoggler state

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
@@ -98,7 +98,7 @@ PrimeFaces.widget.ColumnToggler = class ColumnToggler extends PrimeFaces.widget.
         this.itemContainer = this.panel.children('ul');
 
         var stateHolderId = this.tableId + "_columnTogglerState";
-        this.togglerStateHolder = $(stateHolderId);
+        this.togglerStateHolder = $(PrimeFaces.escapeClientId(stateHolderId));
         if (this.togglerStateHolder.length === 0) {
             this.togglerStateHolder = $('<input type="hidden" id="' + stateHolderId + '" name="' + stateHolderId + '" autocomplete="off"></input>');
             this.table.append(this.togglerStateHolder);

--- a/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
@@ -98,8 +98,11 @@ PrimeFaces.widget.ColumnToggler = class ColumnToggler extends PrimeFaces.widget.
         this.itemContainer = this.panel.children('ul');
 
         var stateHolderId = this.tableId + "_columnTogglerState";
-        this.togglerStateHolder = $('<input type="hidden" id="' + stateHolderId + '" name="' + stateHolderId + '" autocomplete="off"></input>');
-        this.table.append(this.togglerStateHolder);
+        this.togglerStateHolder = $(stateHolderId);
+        if (this.togglerStateHolder.length === 0) {
+            this.togglerStateHolder = $('<input type="hidden" id="' + stateHolderId + '" name="' + stateHolderId + '" autocomplete="off"></input>');
+            this.table.append(this.togglerStateHolder);
+        }
         this.togglerState = [];
 
         // select all checkbox

--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -5043,6 +5043,9 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
                 //save order
                 $this.saveColumnOrder();
 
+                // update headers
+                $this.headers = $this.thead.find('> tr > th');
+
                 //fire colReorder event
                 if($this.hasBehavior('colReorder')) {
                     var ext = null;


### PR DESCRIPTION
1. headers should be updated after column order is changed, otherwise sorting does not work well
2. columntoggler state should not be duplicated with the same ID. There must be the one.
Fix #14055 