### PR TITLE
Fix #14649: FloatLabel CSS fix cutting off p's and g's

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/forms/forms.css
+++ b/primefaces/src/main/frontend/packages/components/src/forms/forms.css
@@ -1182,6 +1182,7 @@ body .ui-cascadeselect-item-content .ui-cascadeselect-group-icon {
 
 .ui-float-label .ui-outputlabel {
     display: block;
+    min-height: 100%;
     max-width: 95%;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Fix #14649: FloatLabel CSS fix cutting off p's and g's