### PR TITLE
Fix #14659: ColorPicker prevent JS recursion in dialog

### DIFF
--- a/primefaces/src/main/frontend/packages/colorpicker/colorpicker/src/colorpicker.widget.js
+++ b/primefaces/src/main/frontend/packages/colorpicker/colorpicker/src/colorpicker.widget.js
@@ -241,7 +241,7 @@ PrimeFaces.widget.ColorPicker = class ColorPicker extends PrimeFaces.widget.Base
         }
         if ($this.hasBehavior('open') || $this.cfg.parent) {
             $this.input.on('open.colorpicker', function(e) {
-                $this.callBehavior('open');
+                $this.callBehavior('open', undefined, false);
                 
                 if ($this.cfg.parent) {
                    // #11076 dialog support of input


### PR DESCRIPTION
Fix #14659: ColorPicker prevent JS recursion in dialog

pass `false` to not have it attempt to fall back to jQuery DOM event "open" which is triggering it on the core ColorPicker again recursively.