### PR TITLE
Fix "undefined TypeError" triggered for some error handler cases

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/core/core.ajax.js
@@ -380,9 +380,10 @@ if (!PrimeFaces.ajax) {
              * @param {string} errorMessage The error message.
              */
             handleError: function(errorName, errorMessage) {
+                var exceptionHandlers = [];
                 if (errorName) {
                     // try to invoke specific AjaxExceptionHandler
-                    var exceptionHandlers = PrimeFaces.getWidgetsByType(PrimeFaces.widget.AjaxExceptionHandler);
+                    exceptionHandlers = PrimeFaces.getWidgetsByType(PrimeFaces.widget.AjaxExceptionHandler);
                     for (var exceptionHandler of exceptionHandlers) {
                         if (exceptionHandler.handles(errorName)) {
                             exceptionHandler.handle(errorName, errorMessage);


### PR DESCRIPTION
If `errorName` is falsy, `exceptionHandlers` is never initialized and causes a failure later.

This is fixed in the master branch, during the Typescript migration, this error was found and fixed, but it is still present in the pure JS version (and therefore also present on the latest 15.x release).

Fix #14670 

### Testing
I build a local PrimeFaces JAR and integrated it into my project and the error was gone.