### PR TITLE
Fix #14673: Datatable legacy field resolve for array style EL

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UIColumn.java
@@ -57,7 +57,7 @@ public interface UIColumn {
     /**
      * Used to extract bean's property from a value expression in static columns (e.g. "#{car.year}" = year)
      */
-    Pattern STATIC_FIELD_VE_LEGACY_PATTERN = Pattern.compile("^#\\{\\w+\\.([\\w.]+)}$");
+    Pattern STATIC_FIELD_VE_LEGACY_PATTERN = Pattern.compile("^#\\{\\w+(?:\\.|\\[')([\\w.]+)(?:'\\])?}$");
 
     /**
      * Used to extract UIColumn#field if not defined. Supports strictly two kind of expressions:

--- a/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
@@ -61,6 +61,9 @@ class DataTableTest {
         when(exprVE.getExpressionString()).thenReturn("#{car.wrapper.year}");
         assertEquals("wrapper.year", column.resolveField(context, exprVE));
 
+        when(exprVE.getExpressionString()).thenReturn("#{car['year']}");
+        assertEquals("year", column.resolveField(context, exprVE));
+
         when(exprVE.getExpressionString()).thenReturn("#{car}");
         assertNull(column.resolveField(context, exprVE));
 


### PR DESCRIPTION
Fix #14673: Datatable legacy field resolve for array style EL

@tandraschko Confirmed this fixed our production issue and added unit test

<img width="2102" height="817" alt="image" src="https://github.com/user-attachments/assets/494915d3-67b5-4366-8136-6158a07aefc8" />