### PR TITLE
Switching to a central definition of dart-sass version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <tomcat.version>10.1.48</tomcat.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <dart-sass.version>1.79.6</dart-sass.version>
+        <dart-sass.version>1.97.3</dart-sass.version>
 
         <sonar.skip>true</sonar.skip>
         <sonar.coverage.jacoco.xmlReportPaths>../primefaces-coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <tomcat.version>10.1.48</tomcat.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <dart-sass.version>1.97.3</dart-sass.version>
+        <dart-sass.version>1.79.6</dart-sass.version>
 
         <sonar.skip>true</sonar.skip>
         <sonar.coverage.jacoco.xmlReportPaths>../primefaces-coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <jacoco.version>0.8.14</jacoco.version>
         <tomcat.version>10.1.48</tomcat.version>
         <slf4j.version>2.0.17</slf4j.version>
+        <dart-sass.version>1.79.6</dart-sass.version>
 
         <sonar.skip>true</sonar.skip>
         <sonar.coverage.jacoco.xmlReportPaths>../primefaces-coverage/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>

--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -266,6 +266,7 @@
                     <noSourceMap>true</noSourceMap>
                     <style>COMPRESSED</style>
                     <quiet>false</quiet>
+                    <version>${dart-sass.version}</version>
                 </configuration>
             </plugin>
             <plugin>

--- a/primefaces-themes/pom.xml
+++ b/primefaces-themes/pom.xml
@@ -29,7 +29,7 @@
                         <noSourceMap>true</noSourceMap>
                         <style>COMPRESSED</style>
                         <quiet>false</quiet>
-                        <version>1.79.6</version>
+                        <version>${dart-sass.version}</version>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Currently, the version of dart‑sass is defined only in the primefaces-themes module, while primefaces-showcase uses no explicit version. This makes builds not necessarily reproducible across environments. In addition, some environments require offline availability, which is only possible when the dart‑sass version is pinned consistently.

This pull request introduces a centralized definition of the dart‑sass version and ensures that both primefaces-themes and primefaces-showcase use the same version. As part of this improvement, the dependency is set to the correct dart‑sass version (1.79.6, https://github.com/sass/dart-sass/releases) according to #13833.

I hope this change helps make the build process more stable, predictable, and contributor‑friendly. Looking forward to your feedback!