### PR TITLE
DualListModel: do not create empty arrays if not needed

### DIFF
--- a/primefaces/src/main/java/org/primefaces/model/DualListModel.java
+++ b/primefaces/src/main/java/org/primefaces/model/DualListModel.java
@@ -32,10 +32,12 @@ public class DualListModel<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private List<T> source = new ArrayList<>();
-    private List<T> target = new ArrayList<>();
+    private List<T> source;
+    private List<T> target;
 
     public DualListModel() {
+        this.source = new ArrayList<>();
+        this.target = new ArrayList<>();
     }
 
     public DualListModel(List<T> source, List<T> target) {


### PR DESCRIPTION
Super minor thing. If the second constructor of DualListModel is used, two empty arrays are created (field initialization). Both of them are dead on arrival.