### PR TITLE
Fix #14705: 15.0.14 Sidebar top/bottom CSS height should be auto

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/sidebar/sidebar.css
@@ -30,7 +30,7 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: 10em;
+    height: auto;
     -webkit-transform: translateY(-100%);
     transform: translateY(-100%);
 }
@@ -39,7 +39,7 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 10em;
+    height: auto;
     -webkit-transform: translateY(100%);
     transform: translateY(100%);
 }


### PR DESCRIPTION
Fix #14705: 15.0.14 Sidebar top/bottom CSS height should be auto