### PR TITLE
Fix #14727: 15.0.14 ColumnToggler: ColumnToggleEvent contains incorrect UIColumn if previous column(s) are not rendered

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
+++ b/primefaces/src/main/java/org/primefaces/component/columntoggler/ColumnToggler.java
@@ -36,6 +36,7 @@ import org.primefaces.util.MapBuilder;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.faces.application.ResourceDependency;
 import javax.faces.component.UIComponent;
@@ -90,7 +91,8 @@ public class ColumnToggler extends ColumnTogglerBase {
             Visibility visibility = Visibility.valueOf(params.get(clientId + "_visibility"));
             int index = Integer.parseInt(params.get(clientId + "_index"));
 
-            UIColumn column = ((UITable) getDataSourceComponent()).getColumns().get(index);
+            UIColumn column = ((UITable) getDataSourceComponent()).getColumns().stream().filter(UIColumn::isRendered)
+                .collect(Collectors.toList()).get(index);
             super.queueEvent(new ColumnToggleEvent(this, ((AjaxBehaviorEvent) event).getBehavior(), column, visibility, index));
         }
         else if (event instanceof AjaxBehaviorEvent && "close".equals(eventName)) {


### PR DESCRIPTION
Fix #14727: 15.0.14 ColumnToggler: ColumnToggleEvent contains incorrect UIColumn if previous column(s) are not rendered

With fix applied:
<img width="3840" height="737" alt="image" src="https://github.com/user-attachments/assets/a82f093e-5099-4450-a6c2-fdb2d0897111" />
