### PR TITLE
MoveScriptsToBottom optimizations: cpu & memory

### DIFF
--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -25,6 +25,7 @@ package org.primefaces.application.resource;
 
 import org.primefaces.renderkit.RendererUtils;
 import org.primefaces.util.AgentUtils;
+import org.primefaces.util.Constants;
 import org.primefaces.util.LangUtils;
 
 import java.io.IOException;
@@ -34,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
@@ -41,19 +44,33 @@ import javax.faces.context.FacesContext;
 import javax.faces.context.ResponseWriter;
 import javax.faces.context.ResponseWriterWrapper;
 
+
 public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
 
     private static final String SCRIPT_TAG = "script";
     private static final String BODY_TAG = "body";
     private static final String HTML_TAG = "html";
     private static final String TYPE_ATTRIBUTE = "type";
+    private static final Pattern TRACKING_SUFFIX_PATTERN = Pattern.compile("_\\d+$");
+
+    // Map containing all the replacements for the merged script
+    private static final Map<String, String> SCRIPT_REPLACE = Map.of(
+            ";;", ";",
+            "PrimeFaces.settings", "pf.settings",
+            "PrimeFaces.cw", "pf.cw",
+            "PrimeFaces.ab", "pf.ab",
+            "window.PrimeFaces", "pf"
+    );
+
+    // Pattern of all search words in OR
+    private static final Pattern SCRIPT_SEARCH = Pattern.compile(SCRIPT_REPLACE.keySet().stream().map(Pattern::quote).collect(Collectors.joining("|")));
 
     private final MoveScriptsToBottomState state;
+    private final Map<String, String> includeAttributes;
+    private final StringBuilder inline;
 
     private boolean inScript;
     private String scriptType;
-    private Map<String, String> includeAttributes;
-    private StringBuilder inline;
     private boolean scriptsRendered;
 
     private boolean foundHtmlElement;
@@ -72,7 +89,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
         foundBodyElement = false;
 
         includeAttributes = new LinkedHashMap<>(6);
-        inline = new StringBuilder(75);
+        inline = new StringBuilder(256);
     }
 
     @Override
@@ -217,8 +234,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
             for (Entry<String, List<Map<String, String>>> entry : state.getIncludes().entrySet()) {
 
                 List<Map<String, String>> includes = entry.getValue();
-                for (int i = 0; i < includes.size(); i++) {
-                    Map<String, String> attributes = includes.get(i);
+                for (Map<String, String> attributes : includes) {
                     attributes.put(TYPE_ATTRIBUTE, entry.getKey());
                     getWrapped().startElement(SCRIPT_TAG, null);
                     for (Entry<String, String> attribute : attributes.entrySet()) {
@@ -238,7 +254,7 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
             // write inline scripts
             for (Map.Entry<String, List<String>> entry : state.getInlines().entrySet()) {
                 // strip tracking _0, _1, _2 etc off the end of the string
-                String type = entry.getKey().replaceAll("_\\d+$", "");
+                String type = TRACKING_SUFFIX_PATTERN.matcher(entry.getKey()).replaceAll(Constants.EMPTY_STRING);
                 List<String> inlines = entry.getValue();
 
                 String id = UUID.randomUUID().toString();
@@ -273,47 +289,47 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     }
 
     protected String mergeAndMinimizeInlineScripts(String id, String type, List<String> inlines, boolean deferred) {
-        StringBuilder script = new StringBuilder(inlines.size() * 100);
+        final boolean isJavascriptScript = RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type);
+
+        final StringBuilder script = new StringBuilder(inlines.size() * 100);
         for (int i = 0; i < inlines.size(); i++) {
             if (i > 0) {
-                script.append("\n");
+                script.append('\n');
             }
-            script.append(inlines.get(i));
+            // trim the single inline script! (for example <script> console.log('hello'); </script>)
+            // otherwise at the end of the merge you will get "console.log('hello'); ;"
+            script.append( inlines.get(i).trim() );
 
             // append ; only if this is JS code
-            if (RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type)) {
-                script.append(";");
+            if (isJavascriptScript) {
+                script.append(';');
             }
         }
 
-        String minimized = script.toString();
+        if (isJavascriptScript && LangUtils.isNotBlank(script)) {
+            // search and replace PrimeFaces with pf
+            // (single-pass multiple replace with StringBuilder)
+            LangUtils.replace(script, SCRIPT_SEARCH, SCRIPT_REPLACE);
 
-        if (LangUtils.isNotBlank(minimized)) {
-            if (RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type)) {
-                minimized = minimized.replace(";;", ";");
+            // 2. Costruzione finale (Prepending e Appending)
+            script.insert(0, "var pf=window.PrimeFaces;");
 
-                if (minimized.contains("PrimeFaces")) {
-                    minimized = minimized.replace("PrimeFaces.settings", "pf.settings")
-                        .replace("PrimeFaces.cw", "pf.cw")
-                        .replace("PrimeFaces.ab", "pf.ab")
-                        .replace("window.PrimeFaces", "pf");
+            // Check finale per il punto e virgola
+            if ( script.length() > 0 && script.charAt(script.length() - 1) != ';') script.append(';');
 
-                    minimized = "var pf=window.PrimeFaces;" + minimized;
-                }
+            // Aggiunta rimozione elemento
+            script.append("document.getElementById('").append(id).append("').remove();");
 
-                if (!minimized.endsWith(";")) {
-                    minimized += ";";
-                }
-                minimized += "document.getElementById('" + id + "').remove();";
-
-                // deferred scripts have to wait until scripts are loaded before it can execute inline
-                if (deferred) {
-                    minimized = String.format("document.addEventListener(\"DOMContentLoaded\", function() {%s});", minimized);
-                }
+            // deferred scripts have to wait until scripts are loaded before it can execute inline
+            if (deferred) {
+                // Prepend: add the event listener
+                script.insert(0, "document.addEventListener(\"DOMContentLoaded\", function() {");
+                // Append: close the function call
+                script.append("});");
             }
         }
 
-        return minimized;
+        return script.toString();
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -234,7 +234,8 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
             for (Entry<String, List<Map<String, String>>> entry : state.getIncludes().entrySet()) {
 
                 List<Map<String, String>> includes = entry.getValue();
-                for (Map<String, String> attributes : includes) {
+                for (int i = 0; i < includes.size(); i++) {
+                    Map<String, String> attributes = includes.get(i);
                     attributes.put(TYPE_ATTRIBUTE, entry.getKey());
                     getWrapped().startElement(SCRIPT_TAG, null);
                     for (Entry<String, String> attribute : attributes.entrySet()) {

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -311,13 +311,13 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
             // (single-pass multiple replace with StringBuilder)
             LangUtils.replace(script, SCRIPT_SEARCH, SCRIPT_REPLACE);
 
-            // 2. Costruzione finale (Prepending e Appending)
+            // pf declaration
             script.insert(0, "var pf=window.PrimeFaces;");
 
-            // Check finale per il punto e virgola
+            // insert ';' if needed
             if ( script.length() > 0 && script.charAt(script.length() - 1) != ';') script.append(';');
 
-            // Aggiunta rimozione elemento
+            // remove script
             script.append("document.getElementById('").append(id).append("').remove();");
 
             // deferred scripts have to wait until scripts are loaded before it can execute inline

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomResponseWriter.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.faces.FacesException;
 import javax.faces.component.UIComponent;
@@ -52,18 +51,6 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     private static final String HTML_TAG = "html";
     private static final String TYPE_ATTRIBUTE = "type";
     private static final Pattern TRACKING_SUFFIX_PATTERN = Pattern.compile("_\\d+$");
-
-    // Map containing all the replacements for the merged script
-    private static final Map<String, String> SCRIPT_REPLACE = Map.of(
-            ";;", ";",
-            "PrimeFaces.settings", "pf.settings",
-            "PrimeFaces.cw", "pf.cw",
-            "PrimeFaces.ab", "pf.ab",
-            "window.PrimeFaces", "pf"
-    );
-
-    // Pattern of all search words in OR
-    private static final Pattern SCRIPT_SEARCH = Pattern.compile(SCRIPT_REPLACE.keySet().stream().map(Pattern::quote).collect(Collectors.joining("|")));
 
     private final MoveScriptsToBottomState state;
     private final Map<String, String> includeAttributes;
@@ -290,42 +277,63 @@ public class MoveScriptsToBottomResponseWriter extends ResponseWriterWrapper {
     }
 
     protected String mergeAndMinimizeInlineScripts(String id, String type, List<String> inlines, boolean deferred) {
-        final boolean isJavascriptScript = RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type);
+        if (inlines == null || inlines.isEmpty()) {
+            return Constants.EMPTY_STRING;
+        }
 
-        final StringBuilder script = new StringBuilder(inlines.size() * 100);
+        boolean isJavascriptScript = RendererUtils.SCRIPT_TYPE.equalsIgnoreCase(type);
+        boolean hasPrimeFaces = false;
+
+        StringBuilder script = new StringBuilder(inlines.size() * 128 + 128);
         for (int i = 0; i < inlines.size(); i++) {
-            if (i > 0) {
-                script.append('\n');
-            }
             // trim the single inline script! (for example <script> console.log('hello'); </script>)
             // otherwise at the end of the merge you will get "console.log('hello'); ;"
-            script.append( inlines.get(i).trim() );
+            String inline = inlines.get(i).trim();
 
-            // append ; only if this is JS code
-            if (isJavascriptScript) {
-                script.append(';');
+            if (LangUtils.isNotEmpty(inline)) {
+                if (i > 0) {
+                    script.append('\n');
+                }
+
+                if (isJavascriptScript) {
+                    if (inline.contains("PrimeFaces")) {
+                        hasPrimeFaces = true;
+                        inline = inline.replace("PrimeFaces.settings", "pf.settings")
+                                .replace("PrimeFaces.cw", "pf.cw")
+                                .replace("PrimeFaces.ab", "pf.ab")
+                                .replace("window.PrimeFaces", "pf");
+                    }
+
+                    script.append(inline);
+
+                    if (!inline.endsWith(";")) {
+                        script.append(';');
+                    }
+                }
+                else {
+                    script.append(inline);
+                }
             }
         }
 
-        if (isJavascriptScript && LangUtils.isNotBlank(script)) {
-            // search and replace PrimeFaces with pf
-            // (single-pass multiple replace with StringBuilder)
-            LangUtils.replace(script, SCRIPT_SEARCH, SCRIPT_REPLACE);
+        if (LangUtils.isBlank(script)) {
+            return Constants.EMPTY_STRING;
+        }
 
-            // pf declaration
-            script.insert(0, "var pf=window.PrimeFaces;");
+        if (isJavascriptScript) {
+            if (hasPrimeFaces) {
+                script.insert(0, "var pf=window.PrimeFaces;");
+            }
 
-            // insert ';' if needed
-            if ( script.length() > 0 && script.charAt(script.length() - 1) != ';') script.append(';');
+            if (script.charAt(script.length() - 1) != ';') {
+                script.append(';');
+            }
 
-            // remove script
             script.append("document.getElementById('").append(id).append("').remove();");
 
             // deferred scripts have to wait until scripts are loaded before it can execute inline
             if (deferred) {
-                // Prepend: add the event listener
                 script.insert(0, "document.addEventListener(\"DOMContentLoaded\", function() {");
-                // Append: close the function call
                 script.append("});");
             }
         }

--- a/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomState.java
+++ b/primefaces/src/main/java/org/primefaces/application/resource/MoveScriptsToBottomState.java
@@ -34,8 +34,8 @@ public class MoveScriptsToBottomState implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private Map<String, List<Map<String, String>>> includes;
-    private Map<String, List<String>> inlines;
+    private final Map<String, List<Map<String, String>>> includes;
+    private final Map<String, List<String>> inlines;
     private int savedInlineTags;
     private boolean deferred;
 

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -44,6 +44,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.faces.FacesException;
@@ -57,15 +58,15 @@ public class LangUtils {
     private LangUtils() {
     }
 
-    public static boolean isEmpty(String value) {
-        return value == null || value.isEmpty();
+    public static boolean isEmpty(CharSequence value) {
+        return value == null || value.length() == 0; // todo: change to isEmpty() when on Java 15+
     }
 
-    public static boolean isNotEmpty(String value) {
+    public static boolean isNotEmpty(CharSequence value) {
         return !isEmpty(value);
     }
 
-    public static boolean isBlank(String str) {
+    public static boolean isBlank(CharSequence str) {
         if (str == null) {
             return true;
         }
@@ -83,7 +84,7 @@ public class LangUtils {
         return true;
     }
 
-    public static boolean isNotBlank(String value) {
+    public static boolean isNotBlank(CharSequence value) {
         return !isBlank(value);
     }
 
@@ -208,6 +209,48 @@ public class LangUtils {
         }
 
         return str.substring(start, end);
+    }
+
+    /**
+     * Multiple search & replace with single pass on a {@link StringBuilder}.
+     * returns true if something has been replaced.
+     *
+     * @param input the input {@link StringBuilder}
+     * @param search the search {@link Pattern} (ideally with more than one search pattern in OR).
+     * @param replacements the {@link Map} containing multiple replacements.
+     * @return true if at least one replacement occurred.
+     */
+    public static boolean replace(StringBuilder input, Pattern search, Map<String, String> replacements) {
+        if (input == null || LangUtils.isEmpty(input) || search == null || replacements == null || replacements.isEmpty()) {
+            return false;
+        }
+
+        Matcher matcher = search.matcher(input);
+
+        // NO match -> SKIP and return false
+        if (!matcher.find()) return false;
+
+        // temp StringBuilder with 10% more capacity for replacements
+        StringBuilder temp = new StringBuilder(input.length() * 11 / 10);
+
+        // matcher.find() has been called
+        // we need a do {...} while
+        do {
+            String key = matcher.group();
+            String replacement = replacements.get(key);
+            if (replacement != null) {
+                matcher.appendReplacement(temp, Matcher.quoteReplacement(replacement));
+            }
+        }
+        while (matcher.find());
+
+        // append the rest
+        matcher.appendTail(temp);
+
+        // replace the content into the input and return
+        input.setLength(0);
+        input.append(temp);
+        return true;
     }
 
     public static boolean contains(Object[] array, Object object) {

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -44,7 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.faces.FacesException;
@@ -58,11 +57,11 @@ public class LangUtils {
     private LangUtils() {
     }
 
-    public static boolean isEmpty(CharSequence value) {
-        return value == null || value.length() == 0; // todo: change to isEmpty() when on Java 15+
+    public static boolean isEmpty(String value) {
+        return value == null || value.isEmpty();
     }
 
-    public static boolean isNotEmpty(CharSequence value) {
+    public static boolean isNotEmpty(String value) {
         return !isEmpty(value);
     }
 
@@ -209,48 +208,6 @@ public class LangUtils {
         }
 
         return str.substring(start, end);
-    }
-
-    /**
-     * Multiple search & replace with single pass on a {@link StringBuilder}.
-     * returns true if something has been replaced.
-     *
-     * @param input the input {@link StringBuilder}
-     * @param search the search {@link Pattern} (ideally with more than one search pattern in OR).
-     * @param replacements the {@link Map} containing multiple replacements.
-     * @return true if at least one replacement occurred.
-     */
-    public static boolean replace(StringBuilder input, Pattern search, Map<String, String> replacements) {
-        if (input == null || LangUtils.isEmpty(input) || search == null || replacements == null || replacements.isEmpty()) {
-            return false;
-        }
-
-        Matcher matcher = search.matcher(input);
-
-        // NO match -> SKIP and return false
-        if (!matcher.find()) return false;
-
-        // temp StringBuilder with 10% more capacity for replacements
-        StringBuilder temp = new StringBuilder(input.length() * 11 / 10);
-
-        // matcher.find() has been called
-        // we need a do {...} while
-        do {
-            String key = matcher.group();
-            String replacement = replacements.get(key);
-            if (replacement != null) {
-                matcher.appendReplacement(temp, Matcher.quoteReplacement(replacement));
-            }
-        }
-        while (matcher.find());
-
-        // append the rest
-        matcher.appendTail(temp);
-
-        // replace the content into the input and return
-        input.setLength(0);
-        input.append(temp);
-        return true;
     }
 
     public static boolean contains(Object[] array, Object object) {


### PR DESCRIPTION
This version avoid:
-  multiple `String.replace` call on the whole merged skip (memory 6x copy)
-  multiple `String.equals` call
-  mulitple `String` concatenations
- random `';'` at the end of the line due to space inside inline scripts

This version has:
 - final on effective final fields
 - early skip if there are no inline scripts
 - inline trim + check the needs of adding ';'
 - `Constants.EMPTY_STRING` instead of ""

Notes:
A page can contains a lot of inline scripts, that can also be large...
every single call to `String.replace` create a copy of the String,
also the final string prepend + append create a copy of the merged script,
also the final `String.format` internaly use the old StringBuffer plus create a copy of the content...

