### PR TITLE
LangUtils: optimizations + minor warnings fix

### DIFF
--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -304,12 +304,6 @@ public class LangUtils {
 
     @SafeVarargs
     public static <E> Set<E> newLinkedHashSet(E... elements) {
-        if (elements.length == 0) {
-            return Collections.emptySet();
-        }
-        else if (elements.length == 1) {
-            return Collections.singleton(elements[0]);
-        }
         Set<E> set = new LinkedHashSet<>(calculateHashMapCapacity(elements.length));
         Collections.addAll(set, elements);
         return set;

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -293,14 +293,10 @@ public class LangUtils {
         return Collections.unmodifiableList(Arrays.asList(args));
     }
 
-    public static int calculateHashMapCapacity(int numMappings) {
-        // same as -> (int) Math.ceil(numMappings / 0.75d) but faster (no floating point ops, no cast)
-        return (numMappings * 4 + 2) / 3;
-    }
-
     @SafeVarargs
     public static <E> Set<E> newLinkedHashSet(E... elements) {
-        Set<E> set = new LinkedHashSet<>(calculateHashMapCapacity(elements.length));
+        int size = (int) Math.ceil(elements.length / 0.75);
+        Set<E> set = new LinkedHashSet<>(size);
         Collections.addAll(set, elements);
         return set;
     }

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -290,10 +290,6 @@ public class LangUtils {
 
     @SafeVarargs
     public static <T> List<T> unmodifiableList(T... args) {
-        // List.of is immutable and for 0, 1 and 2 elements is faster
-        if (args.length < 3) {
-            return List.of(args);
-        }
         return Collections.unmodifiableList(Arrays.asList(args));
     }
 

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -51,7 +51,7 @@ import javax.xml.bind.DatatypeConverter;
 
 public class LangUtils {
 
-    public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+    public static final Object[] EMPTY_OBJECT_ARRAY = {};
     private static final Pattern CAPITAL_CASE = Pattern.compile("(?<=.)(?=\\p{Lu})");
 
     private LangUtils() {
@@ -289,12 +289,28 @@ public class LangUtils {
     }
 
     @SafeVarargs
-    public static final <T> List<T> unmodifiableList(T... args) {
+    public static <T> List<T> unmodifiableList(T... args) {
+        // List.of is immutable and for 0, 1 and 2 elements is faster
+        if (args.length < 3) {
+            return List.of(args);
+        }
         return Collections.unmodifiableList(Arrays.asList(args));
     }
 
+    public static int calculateHashMapCapacity(int numMappings) {
+        // same as -> (int) Math.ceil(numMappings / 0.75d) but faster (no floating point ops, no cast)
+        return (numMappings * 4 + 2) / 3;
+    }
+
+    @SafeVarargs
     public static <E> Set<E> newLinkedHashSet(E... elements) {
-        Set<E> set = new LinkedHashSet<>(elements.length);
+        if (elements.length == 0) {
+            return Collections.emptySet();
+        }
+        else if (elements.length == 1) {
+            return Collections.singleton(elements[0]);
+        }
+        Set<E> set = new LinkedHashSet<>(calculateHashMapCapacity(elements.length));
         Collections.addAll(set, elements);
         return set;
     }


### PR DESCRIPTION
just a couple of optimizations and warning fix:

the `newLinkedHashSet` method now properly 
init the LinkedHashSet to avoid remapping 

the method `calculateHashMapCapacity`
is ported from Java 19 and optimized