### PR TITLE
NativeFileUploadDecoder.getUploadDirectory optimization

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
+++ b/primefaces/src/main/java/org/primefaces/component/fileupload/NativeFileUploadDecoder.java
@@ -29,7 +29,6 @@ import org.primefaces.util.FileUploadUtils;
 import org.primefaces.util.LangUtils;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -77,7 +76,7 @@ public class NativeFileUploadDecoder extends AbstractFileUploadDecoder<HttpServl
 
     @Override
     public String getUploadDirectory(HttpServletRequest request) {
-        return Collections.list(request.getAttributeNames()).stream()
+        return LangUtils.stream(request.getAttributeNames())
                 .map(request::getAttribute)
                 .filter(MultipartConfigElement.class::isInstance)
                 .map(MultipartConfigElement.class::cast)

--- a/primefaces/src/main/java/org/primefaces/util/LangUtils.java
+++ b/primefaces/src/main/java/org/primefaces/util/LangUtils.java
@@ -36,6 +36,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -44,7 +45,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import javax.faces.FacesException;
 import javax.xml.bind.DatatypeConverter;
@@ -297,6 +302,14 @@ public class LangUtils {
         Set<E> set = new LinkedHashSet<>(elements.length);
         Collections.addAll(set, elements);
         return set;
+    }
+
+    public static <T> Stream<T> stream(Enumeration<T> enumeration) {
+        if (enumeration == null) {
+            return Stream.empty();
+        }
+
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(enumeration.asIterator(), Spliterator.ORDERED), false);
     }
 
     public static boolean isClassAvailable(String name) {


### PR DESCRIPTION

This version avoid the usage of Collections.list(...) 
which internally iterate over the passed Enumeration 
and create a copy returning an ArrayList.

