### PR TITLE
bugfix: ajax error event is handled instead of being ignored

### DIFF
--- a/primefaces/src/main/frontend/packages/core/src/core/core.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.ts
@@ -1125,7 +1125,7 @@ export class Core {
                 }
                 button.prepend(loadIcon);
             }
-        }).on('pfAjaxComplete' + namespace, function(e, xhr, settings, args) {
+        }).on('pfAjaxComplete pfAjaxError' + namespace, function(e, xhr, settings, args) {
             if (isXhrSource.call(this, widget, settings)) {
                 widget.ajaxCount--;
                 if (widget.ajaxCount > 0 || !args || args.redirect) {

--- a/primefaces/src/main/frontend/packages/core/src/core/core.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.ts
@@ -1125,7 +1125,7 @@ export class Core {
                 }
                 button.prepend(loadIcon);
             }
-        }).on('pfAjaxComplete pfAjaxError' + namespace, function(e, xhr, settings, args) {
+        }).on('pfAjaxComplete' + namespace + ' pfAjaxError' + namespace, function(e, xhr, settings, args) {
             if (isXhrSource.call(this, widget, settings)) {
                 widget.ajaxCount--;
                 if (widget.ajaxCount > 0 || !args || args.redirect) {


### PR DESCRIPTION
Respond properly to `pfAjaxError`
fixes #14782 