### PR TITLE
Fix #14625: SelectOneMenu aria-labelledby fix

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu001.xhtml
@@ -16,7 +16,7 @@
                 <p:autoUpdate/>
             </p:messages>
 
-            <p:outputLabel for="@next" value="SelectOneMenu"/>
+            <p:outputLabel for="@next" value="SelectOneMenu" id="outputlabel" />
             <p:selectOneMenu id="selectonemenu" value="#{selectOneMenu001.value}">
                 <f:selectItem itemLabel="Select a driver" itemValue="" noSelectionOption="true"/>
                 <f:selectItems value="#{selectOneMenu001.drivers}" var="driver" itemLabel="#{driver.name}" itemValue="#{driver.id}"/>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
@@ -27,6 +27,7 @@ import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.OutputLabel;
 import org.primefaces.selenium.component.SelectBooleanCheckbox;
 import org.primefaces.selenium.component.SelectOneMenu;
 
@@ -250,6 +251,21 @@ class SelectOneMenu001Test extends AbstractPrimePageTest {
         assertEquals("SelectOneMenu", selectOneMenu.getAssignedLabelText());
     }
 
+    @Test
+    @Order(12)
+    @DisplayName("SelectOneMenu: ensure aria-labelledby is set from OutputLabel")
+    void ariaLabelledBy(Page page) {
+        // Arrange
+        SelectOneMenu selectOneMenu = page.selectOneMenu;
+        OutputLabel outputLabel = page.outputLabel;
+
+        // Act
+
+        // Assert
+        assertEquals(outputLabel.getId(), selectOneMenu.getLabel().getDomAttribute("aria-labelledby"));
+        assertConfiguration(selectOneMenu.getWidgetConfiguration());
+    }
+
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
         System.out.println("SelectOneMenu Config = " + cfg);
@@ -261,6 +277,10 @@ class SelectOneMenu001Test extends AbstractPrimePageTest {
     }
 
     public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:outputlabel")
+        OutputLabel outputLabel;
+
         @FindBy(id = "form:selectonemenu")
         SelectOneMenu selectOneMenu;
 

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenuRenderer.java
@@ -299,6 +299,11 @@ public class SelectOneMenuRenderer extends SelectOneRenderer<SelectOneMenu> {
             renderPassThruAttributes(context, component, HTML.TAB_INDEX);
             renderDomEvents(context, component, HTML.BLUR_FOCUS_EVENTS);
 
+            String labelledBy = component.getAriaLabelledBy();
+            if (LangUtils.isNotBlank(labelledBy)) {
+                writer.writeAttribute(HTML.ARIA_LABELLEDBY, labelledBy, null);
+            }
+
             String label = component.getLabel();
             if (label != null) {
                 writer.writeText(label, null);


### PR DESCRIPTION
Fix #14625: SelectOneMenu aria-labelledby fix

Removing `renderAccessibilityAttributes` correctly removed readonly and disabled but it missed this part.