### PR TITLE
Fix #14810: Schedule add escape property to allow HTML tooltips safely

### DIFF
--- a/docs/15_0_0/components/schedule.md
+++ b/docs/15_0_0/components/schedule.md
@@ -30,6 +30,7 @@ columnHeaderFormat | null | String | Format for column headers. (eg `timeGridWee
 dir | ltr | String | Defines direction of schedule. Valid values are "ltr" (default) and "rtl".
 displayEventEnd | null | String | Whether or not to display an event's end time text when it is rendered on the calendar. Value can be a boolean to globally configure for all views or a comma separated list such as "month:false,basicWeek:true" to configure per view.
 draggable | true | Boolean | When true, events are draggable.
+escape | true | Boolean | Defines whether html would be escaped or not for tooltip content and more.
 extender | null | String | Name of JavaScript function to extend the options of the underlying FullCalendar plugin.
 height | null | String | Sets the height of the entire calendar, including header and footer. By default, this option is unset and the calendar’s height is calculated by aspectRatio. If "auto" is specified, the view’s contents will assume a natural height and no scrollbars will be used.
 initialDate | null | java.time.LocalDate | The initial date that is used when schedule loads. If omitted, the schedule starts on the current date

--- a/docs/16_0_0/components/schedule.md
+++ b/docs/16_0_0/components/schedule.md
@@ -30,6 +30,7 @@ columnHeaderFormat | null | String | Format for column headers. (eg `timeGridWee
 dir | ltr | String | Defines direction of schedule. Valid values are "ltr" (default) and "rtl".
 displayEventEnd | null | String | Whether or not to display an event's end time text when it is rendered on the calendar. Value can be a boolean to globally configure for all views or a comma separated list such as "month:false,basicWeek:true" to configure per view.
 draggable | true | Boolean | When true, events are draggable.
+escape | true | Boolean | Defines whether html would be escaped or not for tooltip content and more.
 extender | null | String | Name of JavaScript function to extend the options of the underlying FullCalendar plugin.
 height | null | String | Sets the height of the entire calendar, including header and footer. By default, this option is unset and the calendar’s height is calculated by aspectRatio. If "auto" is specified, the view’s contents will assume a natural height and no scrollbars will be used.
 initialDate | null | java.time.LocalDate | The initial date that is used when schedule loads. If omitted, the schedule starts on the current date

--- a/primefaces/src/main/frontend/packages/schedule/schedule/src/schedule.widget.js
+++ b/primefaces/src/main/frontend/packages/schedule/schedule/src/schedule.widget.js
@@ -272,7 +272,11 @@ PrimeFaces.widget.Schedule = class Schedule extends PrimeFaces.widget.DeferredWi
                             'top': (mouseEnterInfo.jsEvent.pageY + 15) + 'px',
                             'z-index': PrimeFaces.nextZindex()
                         });
-                        $this.tip[0].innerHTML = PrimeFaces.escapeHTML(mouseEnterInfo.event.extendedProps.description);
+                        let description = mouseEnterInfo.event.extendedProps.description;
+                        if($this.cfg.escape !== false) {
+                            description = PrimeFaces.escapeHTML(description);
+                        }
+                        $this.tip[0].innerHTML = description;
                         $this.tip.show();
                     }, 150);
                 }

--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
@@ -199,6 +199,9 @@ public abstract class ScheduleBase extends UIComponentBase implements Widget, RT
             defaultValue = "true")
     public abstract boolean isNoOpener();
 
+    @Property(defaultValue = "true", description = "Defines whether html would be escaped or not for tooltip content and more.")
+    public abstract boolean isEscape();
+
     @Property(description = "Sets the height of the entire calendar, including header and footer."
             + " By default, this option is unset and the calendar's height is calculated by aspectRatio."
             + " If \"auto\" is specified, the view's contents will assume a natural height and no scrollbars will be used.")

--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -179,6 +179,7 @@ public class ScheduleRenderer extends CoreRenderer<Schedule> {
         wb.init("Schedule", component)
                 .attr("urlTarget", component.getUrlTarget(), "_blank")
                 .attr("noOpener", component.isNoOpener(), true)
+                .attr("escape", component.isEscape(), true)
                 .attr("locale", locale.toString())
                 .attr("tooltip", component.isTooltip(), false);
 


### PR DESCRIPTION
Fix #14810: Schedule add escape property to allow HTML tooltips safely
