### PR TITLE
Fix #14810: 15.0.15 Schedule add escape property to restore HTML tooltips

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleBase.java
@@ -76,6 +76,7 @@ public abstract class ScheduleBase extends UIComponentBase implements Widget, RT
         slotEventOverlap,
         urlTarget,
         noOpener,
+        escape,
         dir,
         height
     }
@@ -167,6 +168,14 @@ public abstract class ScheduleBase extends UIComponentBase implements Widget, RT
 
     public void setDraggable(boolean draggable) {
         getStateHelper().put(PropertyKeys.draggable, draggable);
+    }
+
+    public boolean isEscape() {
+        return (Boolean) getStateHelper().eval(PropertyKeys.escape, true);
+    }
+
+    public void setEscape(boolean escape) {
+        getStateHelper().put(PropertyKeys.escape, escape);
     }
 
     public boolean isResizable() {

--- a/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/schedule/ScheduleRenderer.java
@@ -181,6 +181,7 @@ public class ScheduleRenderer extends CoreRenderer {
         wb.init("Schedule", schedule)
                 .attr("urlTarget", schedule.getUrlTarget(), "_blank")
                 .attr("noOpener", schedule.isNoOpener(), true)
+                .attr("escape", schedule.isEscape(), true)
                 .attr("locale", locale.toString())
                 .attr("tooltip", schedule.isTooltip(), false);
 

--- a/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
+++ b/primefaces/src/main/resources/META-INF/primefaces.taglib.xml
@@ -22549,6 +22549,14 @@
         </attribute>
         <attribute>
             <description>
+                <![CDATA[Defines whether html would be escaped or not for tooltip content and more. Default is true.]]>
+            </description>
+            <name>escape</name>
+            <required>false</required>
+            <type>java.lang.Boolean</type>
+        </attribute> 
+        <attribute>
+            <description>
                 <![CDATA[Style of the main container element of schedule.]]>
             </description>
             <name>style</name>

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/schedule/1-schedule.js
@@ -263,7 +263,11 @@ PrimeFaces.widget.Schedule = PrimeFaces.widget.DeferredWidget.extend({
                             'top': (mouseEnterInfo.jsEvent.pageY + 15) + 'px',
                             'z-index': PrimeFaces.nextZindex()
                         });
-                        $this.tip[0].innerHTML = PrimeFaces.escapeHTML(mouseEnterInfo.event.extendedProps.description);
+                        let description = mouseEnterInfo.event.extendedProps.description;
+                        if($this.cfg.escape !== false) {
+                            description = PrimeFaces.escapeHTML(description);
+                        }
+                        $this.tip[0].innerHTML = description;
                         $this.tip.show();
                     }, 150);
                 }


### PR DESCRIPTION
Fix #14810: 15.0.15 Schedule add escape property to restore HTML tooltips