### PR TITLE
Fix #14837: 15.0.15 Panel fix statefulness for items that are not top level submenus

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.panelmenu.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/menu/menu.panelmenu.js
@@ -388,10 +388,9 @@ PrimeFaces.widget.PanelMenu = PrimeFaces.widget.BaseWidget.extend({
      */
     expandTreeItem: function(submenu, restoring) {
         var submenuLink = submenu.find('> .ui-menuitem-link');
-
-        submenuLink.find('> .ui-menuitem-text').attr('aria-expanded', true);
+        submenuLink.find('> .ui-menuitem-text').attr('aria-expanded', "true");
         submenuLink.find('> .ui-panelmenu-icon').addClass('ui-icon-triangle-1-s');
-        submenu.children('.ui-menu-list').show();
+        submenu.children('.ui-menu-list').removeClass('ui-helper-hidden').show();
 
         if(!restoring) {
             this.updateExpandedNodes();
@@ -404,10 +403,9 @@ PrimeFaces.widget.PanelMenu = PrimeFaces.widget.BaseWidget.extend({
      */
     collapseTreeItem: function(submenu) {
         var submenuLink = submenu.find('> .ui-menuitem-link');
-
         submenuLink.find('> .ui-menuitem-text').attr('aria-expanded', "false");
         submenuLink.find('> .ui-panelmenu-icon').removeClass('ui-icon-triangle-1-s').addClass('ui-icon-triangle-1-e');
-        submenu.children('.ui-menu-list').hide();
+        submenu.children('.ui-menu-list').addClass('ui-helper-hidden').hide();
 
         this.updateExpandedNodes();
     },
@@ -525,7 +523,7 @@ PrimeFaces.widget.PanelMenu = PrimeFaces.widget.BaseWidget.extend({
         });
 
         $this.jq.find('.ui-menu-parent > .ui-menu-list:not(.ui-helper-hidden)').each(function() {
-            $this.collapseTreeItem($(this));
+            $this.collapseTreeItem($(this).parent());
         });
     },
 


### PR DESCRIPTION
Fix #14837: 15.0.15 Panel fix statefulness for items that are not top level submenus

This was my misunderstanding i thought only top level Submenu's were persistent but it can be ANY submenu. The code now works exactly as it did in 15.0.10.