### PR TITLE
bugfix: improve ajax error handling with optional chaining for redire…

### DIFF
--- a/primefaces/src/main/frontend/packages/core/src/core/core.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.ts
@@ -1128,7 +1128,7 @@ export class Core {
         }).on('pfAjaxComplete' + namespace, function(e, xhr, settings, args) {
             if (isXhrSource.call(this, widget, settings)) {
                 widget.ajaxCount--;
-                if (widget.ajaxCount > 0 || !args || args.redirect) {
+                if (widget.ajaxCount > 0 || args?.redirect) {
                     return;
                 }
 


### PR DESCRIPTION
…ct check. It was incorrectly returning early when Ajax error happened, preventing re-enabling disabled Ajax button and leaving the UI in an inconsistent state.

fixes #14782