### PR TITLE
BlockUI: properly unlock target element during widget cleanup

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/blockui/blockui.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/blockui/blockui.widget.js
@@ -76,10 +76,11 @@ PrimeFaces.widget.BlockUI = class BlockUI extends PrimeFaces.widget.BaseWidget {
      * @private
      */
     _cleanup() {
+        this.deleteTimeout();
         this.content.remove();
         this.blocker.remove();
         this.jq.remove();
-        this.target.attr('aria-busy', false);
+        this.restoreTargetState();
         $(document).off('pfAjaxSend.' + this.id + ' pfAjaxUpdated.' + this.id + ' pfAjaxComplete.' + this.id);
     }
 
@@ -215,6 +216,14 @@ PrimeFaces.widget.BlockUI = class BlockUI extends PrimeFaces.widget.BaseWidget {
                 this.content.hide(duration || 0, resetPositionCallback);
         }
 
+        this.restoreTargetState();
+    }
+
+    /**
+     * Restores mouse events and keyboard focus on the target
+     * @private
+     */
+    restoreTargetState() {
         // restore mouse events on the target
         this.target.attr('aria-busy', false).css({
             'pointer-events': 'auto',
@@ -301,7 +310,7 @@ PrimeFaces.widget.BlockUI = class BlockUI extends PrimeFaces.widget.BaseWidget {
             var height = currentTarget.outerHeight(),
                 width = currentTarget.outerWidth(),
                 offset = currentTarget.offset();
-           
+
             // Only update blocker CSS if dimensions changed
             var currentBlockerHeight = blocker.height();
             var currentBlockerWidth = blocker.width();


### PR DESCRIPTION
Fix #14855