### PR TITLE
FileUpload: add new "header" facet

### DIFF
--- a/docs/16_0_0/components/fileupload.md
+++ b/docs/16_0_0/components/fileupload.md
@@ -252,6 +252,16 @@ The empty-facet is rendered when no files are added yet. It's rendered in `div` 
 </p:fileUpload>
 ```
 
+### Header Facet
+
+Use the `header` facet to render custom content in the header, next to the buttons.
+
+```xhtml
+<p:fileUpload advanced="true" ...>
+    <f:facet name="header">Only image files are allowed</f:facet>
+</p:fileUpload>
+```
+
 ## Auto Upload
 Default behavior requires a user to trigger the upload process, you can change this way by setting `auto` to `true`.
 Auto uploads are triggered as soon as files are selected from the dialog.

--- a/docs/16_0_0/gettingstarted/whatsnew.md
+++ b/docs/16_0_0/gettingstarted/whatsnew.md
@@ -14,6 +14,8 @@ Look into [migration guide](https://primefaces.github.io/primefaces/16_0_0/#/../
     * Added `showSelectAll` property to show/hide the select all checkbox
 * Dialog/ConfirmDialog
     * Added `dismissableMask` property to allow modal dialog to be closed if you click the background mask
+* FileUpload
+    * Added a `header` facet to render custom content next in the header, to the buttons (in the advanced mode).
 * Input(s)
     * Any component based on these now has an `ariaDescribedBy` property
 * GMap

--- a/primefaces-showcase/src/main/webapp/ui/file/upload/advanced.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/file/upload/advanced.xhtml
@@ -124,7 +124,7 @@
         </div>
 
         <div class="card">
-            <h5>Empty Facet</h5>
+            <h5>Facets</h5>
 
             <p>The empty-facet is rendered when no files are added yet.</p>
 
@@ -134,6 +134,21 @@
                               update="growl">
                     <f:facet name="empty">
                         Drag and drop files to here to upload.
+                    </f:facet>
+                    <p:validateFile sizeLimit="100000" fileLimit="3" allowTypes="/(\.|\/)(gif|jpeg|jpg|png)$/" />
+                </p:fileUpload>
+
+                <p:growl id="growl" showDetail="true" keepAlive="true"/>
+            </h:form>
+
+            <p class="mt-5">Use the header facet to render custom content in the header, next to the buttons.</p>
+
+            <h:form id="buttonFacet" enctype="multipart/form-data">
+                <p:fileUpload id="upload" listener="#{fileUploadView.handleFileUpload}" mode="advanced"
+                              multiple="true"
+                              update="growl">
+                    <f:facet name="header">
+                        Only image files are allowed
                     </f:facet>
                     <p:validateFile sizeLimit="100000" fileLimit="3" allowTypes="/(\.|\/)(gif|jpeg|jpg|png)$/" />
                 </p:fileUpload>

--- a/primefaces/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/fileupload/FileUploadBase.java
@@ -52,6 +52,9 @@ public abstract class FileUploadBase extends PrimeUIInput implements Widget, Sty
     @Facet(description = "Custom content to display when no files are selected.")
     public abstract UIComponent getEmptyFacet();
 
+    @Facet(description = "Custom content to display in the header,  next to the buttons (in advanced mode).")
+    public abstract UIComponent getHeaderFacet();
+
     @Property(description = "Comma separated list of content types to accept.")
     public abstract String getAccept();
 

--- a/primefaces/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/fileupload/FileUploadRenderer.java
@@ -171,6 +171,11 @@ public class FileUploadRenderer extends CoreRenderer<FileUpload> {
             encodeButton(context, component.getCancelLabel(), cancelCssClassBuilder, component.getCancelIcon(), component.getCancelButtonTitle());
         }
 
+        UIComponent headerFacet = component.getHeaderFacet();
+        if (FacetUtils.shouldRenderFacet(headerFacet)) {
+            headerFacet.encodeAll(context);
+        }
+
         writer.endElement("div");
 
         renderChildren(context, component);


### PR DESCRIPTION
I added a new "button" facet which lets the developer render customen content next to the buttons of a p:fileUpload.
Preview:
<img width="1317" height="523" alt="image" src="https://github.com/user-attachments/assets/a2893520-90d6-481d-80cb-5af74032dd05" />
I am not sure about the facet name, open to suggestions...
CC @melloware @tandraschko 

fixes #14909 