### PR TITLE
Fix #14918: DatePicker convert end date properly to 23:59:59 and not the next day

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datepicker/DatePickerRenderer.java
@@ -38,7 +38,6 @@ import java.text.DateFormatSymbols;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -387,7 +386,7 @@ public class DatePickerRenderer extends BaseCalendarRenderer<DatePicker> {
                         LocalDateTime endDate = isDate
                                 ? CalendarUtils.convertDate2LocalDateTime((Date) end)
                                 : (LocalDateTime) end;
-                        endDate = endDate.plusDays(1).minus(1, ChronoUnit.NANOS);
+                        endDate = endDate.toLocalDate().plusDays(1).atStartOfDay().minusNanos(1);
                         range.set(1, isDate ? CalendarUtils.convertLocalDateTime2Date(endDate) : endDate);
                     }
                 }


### PR DESCRIPTION
Fix #14918: DatePicker convert end date properly to 23:59:59 and not the next day

The bug was it was assuming the date was midnight 00:00:00 already.