### PR TITLE
Fix #14917: Datepicker - respect defaultTime when navigating months

### DIFF
--- a/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
+++ b/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
@@ -2500,12 +2500,10 @@ $.widget("prime.datePicker", {
                 newViewDate.setMonth(newViewDate.getMonth() - 1, 1);
             }
 
-            // previous (check first day of month at 00:00:00)
-            newViewDate = this.truncateDate(newViewDate);
-
             // #5967 check if month can be navigated to by checking last day in month
             var testDate = new Date(newViewDate.getTime()),
                 minDate = this.options.minDate;
+            testDate = this.truncateDate(testDate);
             testDate.setMonth(testDate.getMonth() + 1);
             testDate.setHours(-1);
             if (this.options.showMinMaxRange && minDate && minDate > testDate) {
@@ -2563,12 +2561,11 @@ $.widget("prime.datePicker", {
                 newViewDate.setMonth(newViewDate.getMonth() + 1, 1);
             }
 
-            // next (check last day of month)
-            newViewDate = this.truncateDate(newViewDate);
-
             // #5967 check if month can be navigated to by checking first day next month
-            var maxDate = this.options.maxDate;
-            if (this.options.showMinMaxRange && maxDate && maxDate < newViewDate) {
+            var testDate = new Date(newViewDate.getTime()),
+                maxDate = this.options.maxDate;
+            testDate = this.truncateDate(testDate);
+            if (this.options.showMinMaxRange && maxDate && maxDate < testDate) {
                 this.setNavigationState(newViewDate);
                 event.preventDefault();
                 event.stopPropagation();

--- a/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
+++ b/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
@@ -2565,6 +2565,7 @@ $.widget("prime.datePicker", {
             // #5967 check if month can be navigated to by checking first day next month
             var testDate = new Date(newViewDate.getTime()),
                 maxDate = this.options.maxDate;
+            // next (check last day of month)
             testDate = this.truncateDate(testDate);
             if (this.options.showMinMaxRange && maxDate && maxDate < testDate) {
                 this.setNavigationState(newViewDate);

--- a/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
+++ b/primefaces/src/main/frontend/packages/datepicker/datepicker/src/jquery.ui.prime.datepicker.cjs
@@ -2503,6 +2503,7 @@ $.widget("prime.datePicker", {
             // #5967 check if month can be navigated to by checking last day in month
             var testDate = new Date(newViewDate.getTime()),
                 minDate = this.options.minDate;
+             // previous (check first day of month at 00:00:00)
             testDate = this.truncateDate(testDate);
             testDate.setMonth(testDate.getMonth() + 1);
             testDate.setHours(-1);


### PR DESCRIPTION
Fixes #14917. When navigating between months, the time was reset because the viewDate was truncated. The truncation was used to check whether the new date was still within the defined bounds (minDate, maxDate).

My proposal is to avoid truncating viewDate and instead introduce an extra variable, testDate, which is used for the bounds check.