### PR TITLE
Fix #14970: Use nextStickyZIndex in DataTable resize handler

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -5392,7 +5392,7 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
 
                 $this.stickyContainer.hide();
                 $this.resizeTimeout = PrimeFaces.queueTask(function() {
-                    $this.stickyContainer.css({ left: orginTableContent.offset().left + 'px', 'z-index': PrimeFaces.nextZindex() });
+                    $this.stickyContainer.css({ left: orginTableContent.offset().left + 'px', 'z-index': PrimeFaces.utils.nextStickyZindex() });
                     $this.stickyContainer.width(table.outerWidth());
                     // Dispatch the scroll event on the window
                     window.dispatchEvent(new Event('scroll'));


### PR DESCRIPTION
Use the function for the next sticky z-index in DataTable's resize handler.

Potentially fixes #14970, though I'm still unsure why the z-index has to be set at all.