### PR TITLE
Fix #14970: 15.0.17 Use PrimeFaces.utils.nextStickyZindex in DataTable resize handler

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/datatable/datatable.js
@@ -5391,7 +5391,7 @@ PrimeFaces.widget.DataTable = PrimeFaces.widget.DeferredWidget.extend({
 
                 $this.stickyContainer.hide();
                 $this.resizeTimeout = PrimeFaces.queueTask(function() {
-                    $this.stickyContainer.css({ left: orginTableContent.offset().left + 'px', 'z-index': PrimeFaces.nextZindex() });
+                    $this.stickyContainer.css({ left: orginTableContent.offset().left + 'px', 'z-index': PrimeFaces.utils.nextStickyZindex() });
                     $this.stickyContainer.width(table.outerWidth());
                     // Dispatch the scroll event on the window
                     window.dispatchEvent(new Event('scroll'));


### PR DESCRIPTION
Fix #14970: 15.0.17 Use PrimeFaces.utils.nextStickyZindex in DataTable resize handler