### PR TITLE
DataTable IT: dedupe test helpers and fix naming inconsistencies

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/AbstractDataTableTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/AbstractDataTableTest.java
@@ -29,9 +29,8 @@ import org.primefaces.selenium.component.model.datatable.Row;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
-
-import org.openqa.selenium.HasCapabilities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,32 +78,31 @@ public abstract class AbstractDataTableTest extends AbstractTableTest {
     }
 
     protected void assertRows(DataTable dataTable, List<ProgrammingLanguage> langs) {
-        List<Row> rows = dataTable.getRows();
-        assertRows(rows, langs);
+        assertRows(dataTable, langs, ProgrammingLanguage::getId);
     }
 
     protected void assertRows(List<Row> rows, List<ProgrammingLanguage> langs) {
-        int expectedSize = langs.size();
-        assertNotNull(rows);
-        assertEquals(expectedSize, rows.size());
-
-        int row = 0;
-        for (ProgrammingLanguage programmingLanguage : langs) {
-            String rowText = rows.get(row).getCell(0).getText();
-            assertEquals(programmingLanguage.getId(), Integer.parseInt(rowText.trim()));
-            row++;
-        }
+        assertRows(rows, langs, ProgrammingLanguage::getId);
     }
 
-    protected void logWebDriverCapabilites(DataTable003Test.Page page) {
-        if (page.getWebDriver() instanceof HasCapabilities) {
-            HasCapabilities hasCaps = (HasCapabilities) page.getWebDriver();
-            System.out.println("BrowserName: " + hasCaps.getCapabilities().getBrowserName());
-            System.out.println("Version: " + hasCaps.getCapabilities().getBrowserVersion());
-            System.out.println("Platform: " + hasCaps.getCapabilities().getPlatformName());
-        }
-        else {
-            System.out.println("WebDriver does not implement HasCapabilities --> can´t show version etc");
+    /**
+     * Asserts that the table's rows match the expected items, comparing the first cell of each row
+     * (an id rendered as text) against the id extracted from each item. Model-agnostic so any
+     * backing type (ProgrammingLanguage, Employee, ...) can reuse it.
+     */
+    protected <T> void assertRows(DataTable dataTable, List<T> items, ToIntFunction<T> idExtractor) {
+        assertRows(dataTable.getRows(), items, idExtractor);
+    }
+
+    protected <T> void assertRows(List<Row> rows, List<T> items, ToIntFunction<T> idExtractor) {
+        assertNotNull(rows);
+        assertEquals(items.size(), rows.size());
+
+        int row = 0;
+        for (T item : items) {
+            String rowText = rows.get(row).getCell(0).getText();
+            assertEquals(idExtractor.applyAsInt(item), Integer.parseInt(rowText.trim()));
+            row++;
         }
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable001Test.java
@@ -286,7 +286,6 @@ class DataTable001Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable002Test.java
@@ -335,7 +335,6 @@ class DataTable002Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable003Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable003Test.java
@@ -110,7 +110,6 @@ class DataTable003Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.getBoolean("multiSort"));
         assertFalse(cfg.getBoolean("allowUnsorting"));
     }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable004Test.java
@@ -188,7 +188,6 @@ class DataTable004Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("selectionMode"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005PagingTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005PagingTest.java
@@ -116,7 +116,6 @@ class DataTable005PagingTest extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("selectionMode"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable005Test.java
@@ -155,7 +155,6 @@ class DataTable005Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("selectionMode"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable006Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable006Test.java
@@ -636,7 +636,6 @@ class DataTable006Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg, boolean selectionPageOnly) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertEquals("checkbox", cfg.get("selectionMode"));
         assertEquals(selectionPageOnly, cfg.getBoolean("selectionPageOnly"));
     }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007CellTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007CellTest.java
@@ -151,7 +151,6 @@ class DataTable007CellTest extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("editable"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007LazyTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007LazyTest.java
@@ -128,7 +128,6 @@ class DataTable007LazyTest extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("editable"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable007Test.java
@@ -160,7 +160,6 @@ class DataTable007Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("editable"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable008Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable008Test.java
@@ -102,7 +102,6 @@ class DataTable008Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable009Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable009Test.java
@@ -186,7 +186,6 @@ class DataTable009Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("filter"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable010Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable010Test.java
@@ -148,7 +148,6 @@ class DataTable010Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("selectionMode"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable011Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable011Test.java
@@ -79,7 +79,6 @@ class DataTable011Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable012Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable012Test.java
@@ -96,7 +96,6 @@ class DataTable012Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
     }
 
     public static class Page extends AbstractPrimePage {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable013Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable013Test.java
@@ -57,7 +57,6 @@ class DataTable013Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
     }
 
     public static class Page extends AbstractPrimePage {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable014Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable014Test.java
@@ -84,7 +84,6 @@ class DataTable014Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("stickyHeader"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable015Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable015Test.java
@@ -96,7 +96,6 @@ class DataTable015Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable016Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable016Test.java
@@ -92,7 +92,6 @@ class DataTable016Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("groupColumnIndexes"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable017Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable017Test.java
@@ -72,7 +72,6 @@ class DataTable017Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("groupColumnIndexes"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable018Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable018Test.java
@@ -196,7 +196,6 @@ class DataTable018Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable019Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable019Test.java
@@ -138,7 +138,6 @@ class DataTable019Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable021Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable021Test.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Add and remove rows from filtered DataTable
  * https://github.com/primefaces/primefaces/issues/7336
  */
-public class DataTable021Test extends AbstractDataTableTest {
+class DataTable021Test extends AbstractDataTableTest {
 
     @Test
     @Order(1)

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026DatesTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026DatesTest.java
@@ -30,7 +30,6 @@ import org.primefaces.selenium.component.DataTable;
 import org.primefaces.selenium.component.DatePicker;
 import org.primefaces.selenium.component.SelectManyMenu;
 import org.primefaces.selenium.component.base.ComponentUtils;
-import org.primefaces.selenium.component.model.datatable.Row;
 import org.primefaces.util.CalendarUtils;
 
 import java.time.LocalDate;
@@ -48,7 +47,6 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DataTable026DatesTest extends AbstractDataTableTest {
 
@@ -191,7 +189,6 @@ class DataTable026DatesTest extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));
     }
@@ -232,20 +229,6 @@ class DataTable026DatesTest extends AbstractDataTableTest {
     }
 
     private void assertEmployeeRows(DataTable dataTable, List<Employee> employees) {
-        List<Row> rows = dataTable.getRows();
-        assertEmployeeRows(rows, employees);
-    }
-
-    private void assertEmployeeRows(List<Row> rows, List<Employee> employees) {
-        int expectedSize = employees.size();
-        assertNotNull(rows);
-        assertEquals(expectedSize, rows.size());
-
-        int row = 0;
-        for (Employee employee : employees) {
-            String rowText = rows.get(row).getCell(0).getText();
-            assertEquals(employee.getId(), Integer.parseInt(rowText.trim()));
-            row++;
-        }
+        assertRows(dataTable, employees, Employee::getId);
     }
 }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026NotTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026NotTest.java
@@ -30,7 +30,6 @@ import org.primefaces.selenium.component.DataTable;
 import org.primefaces.selenium.component.DatePicker;
 import org.primefaces.selenium.component.SelectManyMenu;
 import org.primefaces.selenium.component.base.ComponentUtils;
-import org.primefaces.selenium.component.model.datatable.Row;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,7 +43,6 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DataTable026NotTest extends AbstractDataTableTest {
 
@@ -119,7 +117,6 @@ class DataTable026NotTest extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));
     }
@@ -160,20 +157,6 @@ class DataTable026NotTest extends AbstractDataTableTest {
     }
 
     private void assertEmployeeRows(DataTable dataTable, List<Employee> employees) {
-        List<Row> rows = dataTable.getRows();
-        assertEmployeeRows(rows, employees);
-    }
-
-    private void assertEmployeeRows(List<Row> rows, List<Employee> employees) {
-        int expectedSize = employees.size();
-        assertNotNull(rows);
-        assertEquals(expectedSize, rows.size());
-
-        int row = 0;
-        for (Employee employee : employees) {
-            String rowText = rows.get(row).getCell(0).getText();
-            assertEquals(employee.getId(), Integer.parseInt(rowText.trim()));
-            row++;
-        }
+        assertRows(dataTable, employees, Employee::getId);
     }
 }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable026Test.java
@@ -30,7 +30,6 @@ import org.primefaces.selenium.component.DataTable;
 import org.primefaces.selenium.component.DatePicker;
 import org.primefaces.selenium.component.SelectManyMenu;
 import org.primefaces.selenium.component.base.ComponentUtils;
-import org.primefaces.selenium.component.model.datatable.Row;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -45,7 +44,6 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DataTable026Test extends AbstractDataTableTest {
 
@@ -312,7 +310,6 @@ class DataTable026Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));
     }
@@ -353,20 +350,6 @@ class DataTable026Test extends AbstractDataTableTest {
     }
 
     private void assertEmployeeRows(DataTable dataTable, List<Employee> employees) {
-        List<Row> rows = dataTable.getRows();
-        assertEmployeeRows(rows, employees);
-    }
-
-    private void assertEmployeeRows(List<Row> rows, List<Employee> employees) {
-        int expectedSize = employees.size();
-        assertNotNull(rows);
-        assertEquals(expectedSize, rows.size());
-
-        int row = 0;
-        for (Employee employee : employees) {
-            String rowText = rows.get(row).getCell(0).getText();
-            assertEquals(employee.getId(), Integer.parseInt(rowText.trim()));
-            row++;
-        }
+        assertRows(dataTable, employees, Employee::getId);
     }
 }

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable039Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable039Test.java
@@ -94,7 +94,6 @@ class DataTable039Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable041ExpansionTableTest.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable041ExpansionTableTest.java
@@ -35,7 +35,7 @@ import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class Datatable041ExpansionTableTest extends AbstractPrimePageTest {
+class DataTable041ExpansionTableTest extends AbstractPrimePageTest {
 
     @Test
     @Order(1)

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable041Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable041Test.java
@@ -32,7 +32,7 @@ import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class Datatable041Test extends AbstractPrimePageTest {
+class DataTable041Test extends AbstractPrimePageTest {
 
     @Test
     void rowExpansion(Page page) {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable043Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable043Test.java
@@ -151,7 +151,6 @@ class DataTable043Test extends AbstractDataTableTest {
 
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
-        System.out.println("DataTable Config = " + cfg);
         assertTrue(cfg.has("paginator"));
         assertEquals("wgtTable", cfg.getString("widgetVar"));
         assertEquals(0, cfg.getInt("tabindex"));

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable044Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable044Test.java
@@ -33,10 +33,10 @@ import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DataTable044Test extends AbstractDataTableTest {
+class DataTable044Test extends AbstractDataTableTest {
     @Test
     @DisplayName("first index is properly reset when table is filtered externally")
-    public void test(Page page) throws InterruptedException {
+    void test(Page page) throws InterruptedException {
         // Arrange
         page.dataTable.selectPage(2);
 


### PR DESCRIPTION
Tier 1 cleanup of the datatable integration tests:

- AbstractDataTableTest: add a model-agnostic assertRows(DataTable, List<T>, ToIntFunction<T>) and have the ProgrammingLanguage overloads delegate to it. Remove the dead logWebDriverCapabilites method, which was never called and coupled the base class to a concrete subclass Page type.
- Collapse the triplicated assertEmployeeRows loop in DataTable026Test, DataTable026NotTest and DataTable026DatesTest into a one-line delegate to the generic assertRows; drop the now-unused imports.
- Remove leftover System.out.println debug noise from assertConfiguration across the suite (assertNoJavascriptErrors is retained).
- Fix the 041 naming collision/casing: Datatable041Test ->
  DataTable041Test and Datatable041ExpansionTableTest -> DataTable041ExpansionTableTest.
- Make the two outlier public test classes (DataTable021Test, DataTable044Test) package-private to match the rest of the suite.