### PR TITLE
OutputLabel: Add aria-hidden="true" to required indicator for screen reader accessibility (WCAG/BITV)

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/outputlabel/OutputLabel001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/outputlabel/OutputLabel001Test.java
@@ -30,6 +30,8 @@ import org.primefaces.selenium.component.OutputLabel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
@@ -224,25 +226,23 @@ class OutputLabel001Test extends AbstractPrimePageTest {
     @Order(15)
     @DisplayName("OutputLabel: required indicator (*) must have aria-hidden='true' for screen reader accessibility (BITV/WCAG)")
     void requiredIndicator_AriaHidden(Page page) {
-        // required=true
-        assertTrue(page.required.isRequiredIndicatorAriaHidden(),
-                "required label: required indicator span must have aria-hidden='true'");
-        // indicateRequired=true
-        assertTrue(page.indicaterequired.isRequiredIndicatorAriaHidden(),
-                "indicaterequired label: required indicator span must have aria-hidden='true'");
-        // @NotNull bean validation
-        assertTrue(page.notnull.isRequiredIndicatorAriaHidden(),
-                "@NotNull label: required indicator span must have aria-hidden='true'");
-        // @NotBlank bean validation
-        assertTrue(page.notblank.isRequiredIndicatorAriaHidden(),
-                "@NotBlank label: required indicator span must have aria-hidden='true'");
-        // @NotEmpty bean validation
-        assertTrue(page.notempty.isRequiredIndicatorAriaHidden(),
-                "@NotEmpty label: required indicator span must have aria-hidden='true'");
-        // labels WITHOUT required indicator must not falsely claim aria-hidden
-        assertFalse(page.notrequired.isRequiredIndicatorAriaHidden(),
-                "not-required label: must not have a required indicator at all");
+        assertTrue(hasAriaHiddenRequiredIndicator(page.required));
+        assertTrue(hasAriaHiddenRequiredIndicator(page.indicaterequired));
+        assertTrue(hasAriaHiddenRequiredIndicator(page.notnull));
+        assertTrue(hasAriaHiddenRequiredIndicator(page.notblank));
+        assertTrue(hasAriaHiddenRequiredIndicator(page.notempty));
+        assertFalse(hasAriaHiddenRequiredIndicator(page.notrequired));
         assertNoJavascriptErrors();
+    }
+
+    private boolean hasAriaHiddenRequiredIndicator(OutputLabel label) {
+        try {
+            WebElement indicator = label.findElement(By.className("ui-outputlabel-rfi"));
+            return "true".equals(indicator.getDomAttribute("aria-hidden"));
+        }
+        catch (NoSuchElementException e) {
+            return false;
+        }
     }
 
     private void assertLabel(OutputLabel label, String text, boolean required) {

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/outputlabel/OutputLabel001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/outputlabel/OutputLabel001Test.java
@@ -34,7 +34,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class OutputLabel001Test extends AbstractPrimePageTest {
 
@@ -217,6 +219,31 @@ class OutputLabel001Test extends AbstractPrimePageTest {
         assertLabel(label, "Read Only Not Skipped*", true);
     }
 
+
+    @Test
+    @Order(15)
+    @DisplayName("OutputLabel: required indicator (*) must have aria-hidden='true' for screen reader accessibility (BITV/WCAG)")
+    void requiredIndicator_AriaHidden(Page page) {
+        // required=true
+        assertTrue(page.required.isRequiredIndicatorAriaHidden(),
+                "required label: required indicator span must have aria-hidden='true'");
+        // indicateRequired=true
+        assertTrue(page.indicaterequired.isRequiredIndicatorAriaHidden(),
+                "indicaterequired label: required indicator span must have aria-hidden='true'");
+        // @NotNull bean validation
+        assertTrue(page.notnull.isRequiredIndicatorAriaHidden(),
+                "@NotNull label: required indicator span must have aria-hidden='true'");
+        // @NotBlank bean validation
+        assertTrue(page.notblank.isRequiredIndicatorAriaHidden(),
+                "@NotBlank label: required indicator span must have aria-hidden='true'");
+        // @NotEmpty bean validation
+        assertTrue(page.notempty.isRequiredIndicatorAriaHidden(),
+                "@NotEmpty label: required indicator span must have aria-hidden='true'");
+        // labels WITHOUT required indicator must not falsely claim aria-hidden
+        assertFalse(page.notrequired.isRequiredIndicatorAriaHidden(),
+                "not-required label: must not have a required indicator at all");
+        assertNoJavascriptErrors();
+    }
 
     private void assertLabel(OutputLabel label, String text, boolean required) {
         assertEquals(required, label.hasRequiredIndicator());

--- a/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -130,6 +130,7 @@ public class OutputLabelRenderer extends CoreRenderer {
     protected void encodeRequiredIndicator(ResponseWriter writer, OutputLabel label) throws IOException {
         writer.startElement("span", label);
         writer.writeAttribute("class", OutputLabel.REQUIRED_FIELD_INDICATOR_CLASS, null);
+        writer.writeAttribute(HTML.ARIA_HIDDEN, "true", null);
         writer.write("*");
         writer.endElement("span");
     }


### PR DESCRIPTION
**Problem**

The required field indicator (*) rendered by p:outputLabel was read aloud by screen readers as "asterisk"/"star", which is noise for AT users since the aria-required attribute already communicates the required state to assistive technology.

**Solution**

Added aria-hidden="true" to the `<span class="ui-outputlabel-rfi">` element in OutputLabelRenderer.encodeRequiredIndicator(). This hides the visual * from screen readers while keeping it visible for sighted users, satisfying WCAG / BITV.

**Changes**

- OutputLabelRenderer#encodeRequiredIndicator: writes aria-hidden="true" on the required indicator span
- OutputLabel001Test#requiredIndicator_AriaHidden: verifies the attribute is present for all required label variants and absent for non-required ones

fixes #15002 