### PR TITLE
fix #15009: Improved outputLabel for with SelectOneMenu

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu006.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu006.xhtml
@@ -16,7 +16,7 @@
                 <p:autoUpdate/>
             </p:messages>
 
-            <p:outputLabel for="@next" value="SelectOneMenu"/>
+            <p:outputLabel for="@next" value="SelectOneMenu" id="outputlabel"/>
             <p:selectOneMenu id="selectonemenu" value="#{selectOneMenu006.console}" editable="true">
                 <f:selectItem itemLabel="Select One" itemValue="#{null}" noSelectionOption="true"/>
                 <f:selectItems value="#{selectOneMenu006.availableConsoles}"/>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
@@ -266,6 +266,21 @@ class SelectOneMenu001Test extends AbstractPrimePageTest {
         assertConfiguration(selectOneMenu.getWidgetConfiguration());
     }
 
+    @Test
+    @Order(13)
+    @DisplayName("SelectOneMenu: GitHub #15009 non-editable label must omit 'for' (span is not a labelable element)")
+    void labelForOmittedWhenNonEditable(Page page) {
+        // Arrange
+        OutputLabel outputLabel = page.outputLabel;
+
+        // Act
+
+        // Assert - a <label for> may only reference a labelable element; the non-editable menu's focusable
+        // element is a <span>, so 'for' must be omitted and the association handled via aria-labelledby instead.
+        assertNull(outputLabel.getDomAttribute("for"));
+        assertNoJavascriptErrors();
+    }
+
     private void assertConfiguration(JSONObject cfg) {
         assertNoJavascriptErrors();
         System.out.println("SelectOneMenu Config = " + cfg);

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu001Test.java
@@ -268,16 +268,17 @@ class SelectOneMenu001Test extends AbstractPrimePageTest {
 
     @Test
     @Order(13)
-    @DisplayName("SelectOneMenu: GitHub #15009 non-editable label must omit 'for' (span is not a labelable element)")
-    void labelForOmittedWhenNonEditable(Page page) {
+    @DisplayName("SelectOneMenu: GitHub #15009 non-editable label 'for' must reference the hidden native select")
+    void labelForReferencesHiddenSelect(Page page) {
         // Arrange
+        SelectOneMenu selectOneMenu = page.selectOneMenu;
         OutputLabel outputLabel = page.outputLabel;
 
         // Act
 
-        // Assert - a <label for> may only reference a labelable element; the non-editable menu's focusable
-        // element is a <span>, so 'for' must be omitted and the association handled via aria-labelledby instead.
-        assertNull(outputLabel.getDomAttribute("for"));
+        // Assert - the visible focusable element is a non-labelable <span>, so 'for' must reference
+        // the hidden native "_input" <select> instead, which is a real labelable element.
+        assertEquals(selectOneMenu.getId() + "_input", outputLabel.getDomAttribute("for"));
         assertNoJavascriptErrors();
     }
 

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu006Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu006Test.java
@@ -27,6 +27,7 @@ import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.OutputLabel;
 import org.primefaces.selenium.component.SelectOneMenu;
 import org.primefaces.selenium.component.model.Msg;
 
@@ -95,6 +96,21 @@ class SelectOneMenu006Test extends AbstractPrimePageTest {
         assertEquals("SelectOneMenu", selectOneMenu.getAssignedLabelText());
     }
 
+    @Test
+    @Order(4)
+    @DisplayName("SelectOneMenu: GitHub #15009 editable label 'for' must reference the visible editable input")
+    void labelForReferencesEditableInput(Page page) {
+        // Arrange
+        OutputLabel outputLabel = page.outputLabel;
+
+        // Act
+
+        // Assert - editable menu has a real, visible <input> ("_editableInput"); the label's 'for' must point at it
+        // so native click-to-focus works and the target is a labelable element.
+        assertEquals("form:selectonemenu_editableInput", outputLabel.getDomAttribute("for"));
+        assertNoJavascriptErrors();
+    }
+
     private void assertMessage(Page page, int index, String summary, String detail) {
         Msg message = page.messages.getMessage(index);
         assertEquals(summary, message.getSummary());
@@ -108,6 +124,9 @@ class SelectOneMenu006Test extends AbstractPrimePageTest {
     }
 
     public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:outputlabel")
+        OutputLabel outputLabel;
+
         @FindBy(id = "form:selectonemenu")
         SelectOneMenu selectOneMenu;
 

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
@@ -206,14 +206,9 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
 
     @Override
     public WebElement getAssignedLabel() {
-        if (isEditable()) {
-            // editable menus expose a real, labelable <input>, so the label references it via "for"
-            return getWebDriver().findElement(By.cssSelector("label[for='" + getId() + "_editableInput']"));
-        }
-        // non-editable menus have no labelable element (the focusable element is a <span>), so "for" is omitted
-        // and the association is carried by aria-labelledby on that span
-        String labelledBy = getLabel().getDomAttribute("aria-labelledby");
-        return getWebDriver().findElement(By.id(labelledBy));
+        // editable menus expose a real, labelable <input>; non-editable menus have no labelable focusable
+        // element (the visible one is a <span>), so the label references the hidden native "_input" select instead
+        return getWebDriver().findElement(By.cssSelector("label[for='" + getId() + (isEditable() ? "_editableInput" : "_input") + "']"));
     }
 
     @Override

--- a/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
+++ b/primefaces-selenium/primefaces-selenium-components/src/main/java/org/primefaces/selenium/component/SelectOneMenu.java
@@ -206,7 +206,14 @@ public abstract class SelectOneMenu extends AbstractInputComponent {
 
     @Override
     public WebElement getAssignedLabel() {
-        return getWebDriver().findElement(By.cssSelector("label[for='" + getId() + (isEditable() ? "_focus" : "_label") + "']"));
+        if (isEditable()) {
+            // editable menus expose a real, labelable <input>, so the label references it via "for"
+            return getWebDriver().findElement(By.cssSelector("label[for='" + getId() + "_editableInput']"));
+        }
+        // non-editable menus have no labelable element (the focusable element is a <span>), so "for" is omitted
+        // and the association is carried by aria-labelledby on that span
+        String labelledBy = getLabel().getDomAttribute("aria-labelledby");
+        return getWebDriver().findElement(By.id(labelledBy));
     }
 
     @Override

--- a/primefaces/src/main/frontend/packages/components/src/forms/forms.selectonemenu.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/forms/forms.selectonemenu.widget.js
@@ -157,7 +157,8 @@ PrimeFaces.widget.SelectOneMenu = class SelectOneMenu extends PrimeFaces.widget.
         }
 
         if (!this.cfg.editable) {
-            // work-around because clicking a label referring to a div/span (not input) via for-attribute does focus this div/span
+            // non-editable menus omit the label "for" (a <span> is not labelable), so wire click-to-focus
+            // from the aria-labelledby label to the focusable span ourselves
             var labeledBy = this.label.attr('aria-labelledby');
             this.labeledBy = null;
             if (labeledBy) {

--- a/primefaces/src/main/java/org/primefaces/component/api/InputHolder.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/InputHolder.java
@@ -41,6 +41,14 @@ public interface InputHolder {
     String getValidatableInputClientId();
 
     /**
+     * @return the client id the {@code for} attribute of a {@code <label>} should reference, or {@code null} to omit
+     *         {@code for} entirely (e.g. when the component has no labelable element and relies on {@code aria-labelledby}).
+     */
+    default String getLabelClientId() {
+        return getInputClientId();
+    }
+
+    /**
      * @return Client id of the label for aria
      */
     @Property(internal = true)

--- a/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -72,6 +72,7 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
                 .add(component.getStyleClass());
 
         EditableValueHolderState forState = null;
+        String forClientId = null;
 
         final String indicateRequired = component.getIndicateRequired();
         boolean isAuto = "auto".equals(indicateRequired) || "autoSkipDisabled".equals(indicateRequired);
@@ -88,6 +89,8 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
             else {
                 callback.invokeContextCallback(context, forComponent);
             }
+
+            forClientId = callback.getForClientId();
         }
 
         boolean withRequiredIndicator = "true".equals(indicateRequired)
@@ -103,8 +106,8 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
         renderDomEvents(context, component, HTML.LABEL_EVENTS);
         renderRTLDirection(context, component);
 
-        if (!isValueBlank(_for) && forState != null && forState.getClientId() != null) {
-            writer.writeAttribute("for", forState.getClientId(), "for");
+        if (!isValueBlank(_for) && forClientId != null) {
+            writer.writeAttribute("for", forClientId, "for");
         }
 
         if (value != null) {
@@ -196,6 +199,7 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
         private final String value;
         private final StyleClassBuilder styleClassBuilder;
         private final boolean isAuto;
+        private String forClientId;
 
         public ContextCallbackFor(String clientId, String indicateRequired, boolean isAuto, UIComponent label,
                                   StyleClassBuilder styleClassBuilder, String value) {
@@ -210,12 +214,14 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
         @Override
         public void invokeContextCallback(FacesContext context, UIComponent target) {
             if (target instanceof InputHolder) {
+                // a component may expose a dedicated labelable element (or none) for the "for" attribute,
+                // which can differ from its server-side input client id
                 InputHolder inputHolder = ((InputHolder) target);
-                state.setClientId(inputHolder.getLabelClientId());
+                forClientId = inputHolder.getLabelClientId();
                 inputHolder.setAriaLabelledBy(clientId);
             }
             else {
-                state.setClientId(target.getClientId(context));
+                forClientId = target.getClientId(context);
             }
 
             if (target instanceof UIInput) {
@@ -269,6 +275,10 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
 
         public EditableValueHolderState getState() {
             return state;
+        }
+
+        public String getForClientId() {
+            return forClientId;
         }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/outputlabel/OutputLabelRenderer.java
@@ -103,7 +103,7 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
         renderDomEvents(context, component, HTML.LABEL_EVENTS);
         renderRTLDirection(context, component);
 
-        if (!isValueBlank(_for) && forState != null) {
+        if (!isValueBlank(_for) && forState != null && forState.getClientId() != null) {
             writer.writeAttribute("for", forState.getClientId(), "for");
         }
 
@@ -211,7 +211,7 @@ public class OutputLabelRenderer extends CoreRenderer<OutputLabel> {
         public void invokeContextCallback(FacesContext context, UIComponent target) {
             if (target instanceof InputHolder) {
                 InputHolder inputHolder = ((InputHolder) target);
-                state.setClientId(inputHolder.getInputClientId());
+                state.setClientId(inputHolder.getLabelClientId());
                 inputHolder.setAriaLabelledBy(clientId);
             }
             else {

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenu.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenu.java
@@ -193,6 +193,14 @@ public class SelectOneMenu extends SelectOneMenuBaseImpl {
     }
 
     @Override
+    public String getLabelClientId() {
+        // GitHub #15009: a <label for> may only reference a labelable element.
+        // When editable, point at the visible "_editableInput" text field; otherwise the only focusable element
+        // is the non-labelable "_label" span, so omit "for" and rely on aria-labelledby instead.
+        return isEditable() ? getClientId(getFacesContext()) + "_editableInput" : null;
+    }
+
+    @Override
     public String getValidatableInputClientId() {
         return getClientId(getFacesContext()) + "_input";
     }

--- a/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenu.java
+++ b/primefaces/src/main/java/org/primefaces/component/selectonemenu/SelectOneMenu.java
@@ -195,9 +195,9 @@ public class SelectOneMenu extends SelectOneMenuBaseImpl {
     @Override
     public String getLabelClientId() {
         // GitHub #15009: a <label for> may only reference a labelable element.
-        // When editable, point at the visible "_editableInput" text field; otherwise the only focusable element
-        // is the non-labelable "_label" span, so omit "for" and rely on aria-labelledby instead.
-        return isEditable() ? getClientId(getFacesContext()) + "_editableInput" : null;
+        // The visible "_label" span isn't labelable, so point at the hidden native "_input" select instead
+        // (editable mode uses the visible "_editableInput" text field).
+        return getClientId(getFacesContext()) + (isEditable() ? "_editableInput" : "_input");
     }
 
     @Override


### PR DESCRIPTION
fix #15009

`p:outputLabel for="..."` targeting a `p:selectOneMenu` rendered a `for` that pointed at a non-labelable element (`<span>`) or was left orphaned/hidden, failing axe/WAVE/Lighthouse audits.

`for` must always resolve to a real, labelable element:
- Editable menu → `for` references the visible `_editableInput`.
- Non-editable menu → `for` references the hidden native `_input` <select> (labelable, `aria-hidden` + `tabindex="-1"`). The widget already forwards `focus` on that select to the visible interactive span, so native label click-to-focus keeps working. `aria-labelledby` on the span (unchanged) preserves the screen-reader association.

Also added `InputHolder#getLabelClientId()` (defaults to `getInputClientId()`) so components can point `OutputLabel`'s `for` at a different, labelable element than their input client id.
