### PR TITLE
Message: set the default value of the showSummary attribute to false

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/message/MessageBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/message/MessageBase.java
@@ -59,7 +59,7 @@ public abstract class MessageBase extends UIMessage implements UINotification, W
     @Property(description = "Defines a list of keys and clientIds, which should NOT be rendered by this component. Separated by space or comma.")
     public abstract String getForIgnores();
 
-    @Property(defaultValue = "true", description = "Specifies if the summary of the FacesMessage should be displayed.")
+    @Property(defaultValue = "false", description = "Specifies if the summary of the FacesMessage should be displayed.")
     @Override
     public abstract boolean isShowSummary();
 


### PR DESCRIPTION
As it was in PF 15 -> https://primefaces.github.io/primefaces/15_0_0/#/components/messages?id=attributes
https://github.com/primefaces/primefaces/blob/eb0f453dac5f0d35e7d452f0e277668647b4a6c0/primefaces/src/main/resources/META-INF/primefaces.taglib.xml#L18107-L18114