### PR TITLE
Fix #15051: DatePicker mask="true" generates wrong Inputmask format

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker017.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker017.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DatePicker017 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private LocalDateTime localDateTime;
+
+    @PostConstruct
+    public void init() {
+        localDateTime = LocalDateTime.of(2026, 6, 5, 0, 0, 0);
+    }
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker017.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datepicker/DatePicker017.java
@@ -40,6 +40,7 @@ public class DatePicker017 implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private LocalDateTime localDateTime;
+    private LocalDateTime dateTimeEmpty;
 
     @PostConstruct
     public void init() {

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker017.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker017.xhtml
@@ -17,6 +17,10 @@
             <p:datePicker id="datepicker" value="#{datePicker017.localDateTime}"
                           pattern="dd/MM/yyyy HH:mm:ss" showTime="true" mask="true"/>
 
+            <p:datePicker id="datepickerEmpty" value="#{datePicker017.dateTimeEmpty}"
+                          pattern="dd/MM/yyyy HH:mm:ss" mask="true"
+                          showOnFocus="false"/>
+
             <p:commandButton id="button" value="Submit" update="@form"/>
         </h:form>
 

--- a/primefaces-integration-tests/src/main/webapp/datepicker/datePicker017.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datepicker/datePicker017.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages/>
+
+            <p:datePicker id="datepicker" value="#{datePicker017.localDateTime}"
+                          pattern="dd/MM/yyyy HH:mm:ss" showTime="true" mask="true"/>
+
+            <p:commandButton id="button" value="Submit" update="@form"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker017Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker017Test.java
@@ -29,6 +29,7 @@ import org.primefaces.selenium.PrimeExpectedConditions;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.CommandButton;
 import org.primefaces.selenium.component.DatePicker;
+import org.primefaces.selenium.component.base.ComponentUtils;
 
 import java.time.LocalDateTime;
 
@@ -61,12 +62,11 @@ class DatePicker017Test extends AbstractDatePickerTest {
     @DisplayName("DatePicker: mask='true' accepts manual typed input and submits the value")
     void maskManualTyping(Page page) {
         // Arrange
-        DatePicker datePicker = page.datePicker;
+        DatePicker datePicker = page.datePickerEmpty;
 
         // Act
-        datePicker.clear();
-        datePicker.getInput().sendKeys("19021978115519");
-        datePicker.hidePanel();
+        datePicker.getInput().click();
+        ComponentUtils.sendKeys(datePicker.getInput(), "19021978115519");
         page.button.click();
 
         // Assert
@@ -84,7 +84,7 @@ class DatePicker017Test extends AbstractDatePickerTest {
         WebElement panel = datePicker.showPanel();
 
         // Act
-        incrementTimeSegment(panel, "ui-second-picker");
+        incrementTimeSegment(panel);
 
         // Assert
         assertTime(panel, "0", "0", "1");
@@ -104,28 +104,35 @@ class DatePicker017Test extends AbstractDatePickerTest {
     @DisplayName("DatePicker: mask clears incomplete input on blur by default (maskAutoClear)")
     void maskAutoClearIncomplete(Page page) {
         // Arrange
-        DatePicker datePicker = page.datePicker;
+        DatePicker datePicker = page.datePickerEmpty;
 
-        // Act
-        datePicker.clear();
-        datePicker.getInput().sendKeys("1902");
-        datePicker.hidePanel();
+        // Act - type incomplete date
+        datePicker.getInput().click();
+        ComponentUtils.sendKeys(datePicker.getInput(), "1902");
+
+        // Assert - mask partially filled
+        assertEquals("19/02/____ __:__:__", datePicker.getInputValue());
+
+        // Act - blur and submit
         page.button.click();
 
-        // Assert
+        // Assert - incomplete value cleared
         assertNoJavascriptErrors();
         assertEquals("", datePicker.getInputValue());
     }
 
-    protected void incrementTimeSegment(WebElement panel, String pickerClass) {
+    protected void incrementTimeSegment(WebElement panel) {
         PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
-        WebElement picker = panel.findElement(By.className(pickerClass));
+        WebElement picker = panel.findElement(By.className("ui-second-picker"));
         picker.findElement(By.className("ui-picker-up")).click();
     }
 
     public static class Page extends AbstractPrimePage {
         @FindBy(id = "form:datepicker")
         DatePicker datePicker;
+
+        @FindBy(id = "form:datepickerEmpty")
+        DatePicker datePickerEmpty;
 
         @FindBy(id = "form:button")
         CommandButton button;

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker017Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datepicker/DatePicker017Test.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeTek Informatics
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datepicker;
+
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeExpectedConditions;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DatePicker;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatePicker017Test extends AbstractDatePickerTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DatePicker: mask='true' renders the initial value through the mask")
+    void maskInitialValue(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Assert
+        assertNoJavascriptErrors();
+        assertEquals(LocalDateTime.of(2026, 6, 5, 0, 0, 0), datePicker.getValue());
+        assertEquals("05/06/2026 00:00:00", datePicker.getInputValue());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DatePicker: mask='true' accepts manual typed input and submits the value")
+    void maskManualTyping(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Act
+        datePicker.clear();
+        datePicker.getInput().sendKeys("19021978115519");
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        assertEquals("19/02/1978 11:55:19", datePicker.getInputValue());
+        assertEquals(LocalDateTime.of(1978, 2, 19, 11, 55, 19), datePicker.getValue());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("DatePicker: mask='true' keeps input and time picker in sync for every segment")
+    void maskTimePickerSync(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+        WebElement panel = datePicker.showPanel();
+
+        // Act
+        incrementTimeSegment(panel, "ui-second-picker");
+
+        // Assert
+        assertTime(panel, "0", "0", "1");
+        assertEquals("05/06/2026 00:00:01", datePicker.getInputValue());
+
+        // Act
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        assertEquals(LocalDateTime.of(2026, 6, 5, 0, 0, 1), datePicker.getValue());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("DatePicker: mask clears incomplete input on blur by default (maskAutoClear)")
+    void maskAutoClearIncomplete(Page page) {
+        // Arrange
+        DatePicker datePicker = page.datePicker;
+
+        // Act
+        datePicker.clear();
+        datePicker.getInput().sendKeys("1902");
+        datePicker.hidePanel();
+        page.button.click();
+
+        // Assert
+        assertNoJavascriptErrors();
+        assertEquals("", datePicker.getInputValue());
+    }
+
+    protected void incrementTimeSegment(WebElement panel, String pickerClass) {
+        PrimeSelenium.waitGui().until(PrimeExpectedConditions.visibleInViewport(panel));
+        WebElement picker = panel.findElement(By.className(pickerClass));
+        picker.findElement(By.className("ui-picker-up")).click();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datepicker")
+        DatePicker datePicker;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "datepicker/datePicker017.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UICalendar.java
@@ -158,33 +158,22 @@ public abstract class UICalendar extends AbstractPrimeHtmlInputText implements I
     public abstract String calculateWidgetPattern();
 
     /**
-     * @see <a href="https://github.com/RobinHerbots/Inputmask/blob/5.x/README_date.md">Inputmask README_date</a>
+     * Converts a Java date pattern to the format understood by the InputMask plugin.
+     *
+     * @see <a href="https://robinherbots.github.io/Inputmask/#/documentation/datetime">Inputmask datetime documentation</a>
      * @param patternTemplate the date pattern
      * @return the value converted for InputMask plugin
      */
     public String convertPattern(String patternTemplate) {
-        // switch capital and lower M's for InputMask
-        char[] chars = patternTemplate.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            char c = chars[i];
-            if (c == 'm' || c == 'M') {
-                if (Character.isUpperCase(c)) {
-                    chars[i] = Character.toLowerCase(c);
-                }
-                else if (Character.isLowerCase(c)) {
-                    chars[i] = Character.toUpperCase(c);
-                }
-            }
-        }
-        String pattern = new String(chars);
+        String pattern = patternTemplate;
         int countY = LangUtils.countMatches(pattern, 'y');
-        int countM = LangUtils.countMatches(pattern, 'm');
+        int countM = LangUtils.countMatches(pattern, 'M');
         int countD = LangUtils.countMatches(pattern, 'd');
         if (countD == 1) {
             pattern = pattern.replace("d", "dd");
         }
         if (countM == 1) {
-            pattern = pattern.replace("m", "mm");
+            pattern = pattern.replace("M", "MM");
         }
         if (countY == 1) {
             pattern = pattern.replace("y", "yy");


### PR DESCRIPTION
Inputmask 5.0.10-beta.32+ (RobinHerbots/Inputmask#2834) switched to standard Unicode notation (MM=month, mm=minutes), so the M-case swapping in UICalendar#convertPattern() produced an inverted mask.

Fix #15051