### PR TITLE
optimize memory consumption for dataExporter[type=PDF]

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTableExporter.java
@@ -34,10 +34,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import jakarta.faces.context.FacesContext;
 
 public abstract class DataTableExporter<P, O extends ExporterOptions> extends TableExporter<DataTable, P, O> {
+
+    private static final Logger LOGGER = Logger.getLogger(DataTableExporter.class.getName());
 
     private static final int NO_ROW_INDEX_REQUIRED = Integer.MIN_VALUE;
 
@@ -114,11 +118,13 @@ public abstract class DataTableExporter<P, O extends ExporterOptions> extends Ta
                 do {
                     items = lazyDataModel.load(offset, batchSize, table.getActiveSortMeta(), table.getActiveFilterMeta());
                     lazyDataModel.setWrappedData(items);
-                    for (int rowIndex = 0; rowIndex < items.size(); rowIndex++) {
-                        exportRow(context, table, rowIndex);
-                    }
+                    exportRowsPortion(context, table, items);
                     offset += items.size();
-                } while ((bufferized && !items.isEmpty()) || (!bufferized && offset < batchSize));
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        float procent = lazyDataModel.getRowCount() != 0 ? 100F * offset / lazyDataModel.getRowCount() : Float.NaN;
+                        LOGGER.fine(String.format("Exported %1$d of %2$d (%3$.0f%%) items", offset, lazyDataModel.getRowCount(), procent));
+                    }
+                } while (!Thread.currentThread().isInterrupted() && ((bufferized && !items.isEmpty()) || (!bufferized && offset < batchSize)));
 
                 //restore
                 table.setRowIndex(-1);
@@ -137,6 +143,12 @@ public abstract class DataTableExporter<P, O extends ExporterOptions> extends Ta
 
             //restore
             table.setFirst(first);
+        }
+    }
+
+    protected void exportRowsPortion(FacesContext context, DataTable table, List<Object> rowsPortion) {
+        for (int rowIndex = 0; rowIndex < rowsPortion.size(); rowIndex++) {
+            exportRow(context, table, rowIndex);
         }
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/export/DataTablePDFExporter.java
@@ -35,6 +35,7 @@ import org.primefaces.util.LangUtils;
 
 import java.awt.Color;
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
@@ -113,11 +114,14 @@ public class DataTablePDFExporter extends DataTableExporter<Document, PDFOptions
 
             int columnsCount = getExportableColumns(table).size();
             pdfTable = new PdfPTable(columnsCount);
+            pdfTable.setComplete(false);
+            document.add(pdfTable);
             super.exportTable(context, table, index);
+            pdfTable.setComplete(true);
             document.add(pdfTable);
         }
         catch (DocumentException e) {
-            throw new IOException(e.getMessage());
+            throw new IOException(e.getMessage(), e);
         }
     }
 
@@ -268,5 +272,11 @@ public class DataTablePDFExporter extends DataTableExporter<Document, PDFOptions
         }
 
         addCell(pdfTable, cell);
+    }
+
+    @Override
+    protected void exportRowsPortion(FacesContext context, DataTable table, List<Object> rowsPortion) {
+        super.exportRowsPortion(context, table, rowsPortion);
+        document.add(pdfTable);
     }
 }


### PR DESCRIPTION
In current implementation component dataExporter with type=PDF and batchSize=<any number> stores data from lazyDataMode in memory (structure PdfPTable). After all data is read this PdfPTable is used for creating table in PDF. This is big (and unnecessary) memory overhead. Current memory consumption could be visualized with diagram:

<img width="525" height="383" alt="dataexporter-pdf" src="https://github.com/user-attachments/assets/b9cc4453-3020-416d-946a-534f0139411a" />

Red line -- memory consumption in current implementation
Blue line -- memory consumption with adjustments of this PR. 

As a key to optimization is a feature [LargeElement#setComplete(boolean)](https://github.com/LibrePDF/OpenPDF/blob/e5e0de83ef4369d4bfd2ecdf1b01aed639a0d574/openpdf-core/src/main/java/org/openpdf/text/pdf/PdfPTable.java#L1691) of OpenPDF used, demonstrated in details with [this unit-test](https://github.com/LibrePDF/OpenPDF/blob/e5e0de83ef4369d4bfd2ecdf1b01aed639a0d574/openpdf-core/src/test/java/org/openpdf/text/pdf/TablePdfTest.java#L31).

Adjustments of PR:
1) solve the problem OOM, described by issue #10656, for exporting to PDF 
2) make possible export process interruption from other threads