### PR TITLE
fix #15057: colspan is counted only from active checkboxex ignoring static columns

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
@@ -681,7 +681,15 @@ PrimeFaces.widget.ColumnToggler = class ColumnToggler extends PrimeFaces.widget.
      * @return {number} The calculated `colspan` for the rows.
      */
     calculateColspan() {
-        return this.itemContainer.find('> .ui-columntoggler-item > .ui-chkbox > .ui-chkbox-box.ui-state-active').length;
+	const visibleColumns = this.itemContainer
+            .find('> .ui-columntoggler-item > .ui-chkbox > .ui-chkbox-box.ui-state-active')
+            .length;
+
+        const visibleStaticColumns = this.thead
+            .find('> tr > th.ui-static-column:not(.ui-helper-hidden)')
+            .length;
+
+        return visibleColumns + visibleStaticColumns;
     }
 
     /**

--- a/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/columntoggler/columntoggler.widget.js
@@ -681,7 +681,7 @@ PrimeFaces.widget.ColumnToggler = class ColumnToggler extends PrimeFaces.widget.
      * @return {number} The calculated `colspan` for the rows.
      */
     calculateColspan() {
-	const visibleColumns = this.itemContainer
+	    const visibleColumns = this.itemContainer
             .find('> .ui-columntoggler-item > .ui-chkbox > .ui-chkbox-box.ui-state-active')
             .length;
 


### PR DESCRIPTION
calculateColspan() should include both:

- visible toggleable columns, and
- static columns (.ui-static-column).

In other words, the calculated colspan should account for all visible columns in the table, including those that cannot be toggled.