### PR TITLE
fix #15058: paginator jump-to-page gets a stable id and bounded numeric input

### DIFF
--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/paginator.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/paginator.xhtml
@@ -10,16 +10,19 @@
     </ui:define>
 
     <ui:define name="description">
-        DataTable provides a highly customizable ajax paginator.
+        DataTable provides a highly customizable ajax paginator. The paginatorTemplate selects which elements are
+        rendered, e.g. page links, a jump-to-page input or a jump-to-page dropdown.
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
     <ui:param name="widgetLink" value="DataTable-1"/>
 
     <ui:define name="implementation">
-        <div class="card">
-            <h:form>
-                <p:dataTable var="customer" value="#{dtPaginatorView.customers}" rows="10"
+
+        <h:form id="form">
+            <div class="card">
+                <h5 style="margin-top:0">Basic</h5>
+                <p:dataTable id="basic" var="customer" value="#{dtPaginatorView.customers}" rows="10"
                              paginator="true" paginatorPosition="both"
                              paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                              currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
@@ -50,8 +53,84 @@
                     </f:facet>
 
                 </p:dataTable>
-            </h:form>
-        </div>
+            </div>
+
+            <div class="card">
+                <h5>Page Links</h5>
+                <p:dataTable id="pageLinks" var="customer" value="#{dtPaginatorView.customers}" rows="10"
+                             paginator="true" pageLinks="5"
+                             paginatorTemplate="{FirstPageLink} {PageLinks} {LastPageLink}">
+
+                    <p:column headerText="Name">
+                        <h:outputText value="#{customer.name}" />
+                    </p:column>
+
+                    <p:column headerText="Country">
+                        <h:outputText value="#{customer.country.name}" />
+                    </p:column>
+
+                    <p:column headerText="Company">
+                        <h:outputText value="#{customer.company}" />
+                    </p:column>
+
+                    <p:column headerText="Representative">
+                        <h:outputText value="#{customer.representative.name}" />
+                    </p:column>
+
+                </p:dataTable>
+            </div>
+
+            <div class="card">
+                <h5>Jump to page by numbered input</h5>
+                <p:dataTable id="jumpInput" var="customer" value="#{dtPaginatorView.customers}" rows="10"
+                             paginator="true" paginatorPosition="both"
+                             paginatorTemplate="{FirstPageLink} {PreviousPageLink} {JumpToPageInput} {NextPageLink} {LastPageLink}">
+
+                    <p:column headerText="Name">
+                        <h:outputText value="#{customer.name}" />
+                    </p:column>
+
+                    <p:column headerText="Country">
+                        <h:outputText value="#{customer.country.name}" />
+                    </p:column>
+
+                    <p:column headerText="Company">
+                        <h:outputText value="#{customer.company}" />
+                    </p:column>
+
+                    <p:column headerText="Representative">
+                        <h:outputText value="#{customer.representative.name}" />
+                    </p:column>
+
+                </p:dataTable>
+            </div>
+
+            <div class="card">
+                <h5>Jump to page by dropdown</h5>
+                <p:dataTable id="jumpDropdown" var="customer" value="#{dtPaginatorView.customers}" rows="10"
+                             paginator="true"
+                             paginatorTemplate="{FirstPageLink} {PreviousPageLink} {JumpToPageDropdown} {NextPageLink} {LastPageLink}">
+
+                    <p:column headerText="Name">
+                        <h:outputText value="#{customer.name}" />
+                    </p:column>
+
+                    <p:column headerText="Country">
+                        <h:outputText value="#{customer.country.name}" />
+                    </p:column>
+
+                    <p:column headerText="Company">
+                        <h:outputText value="#{customer.company}" />
+                    </p:column>
+
+                    <p:column headerText="Representative">
+                        <h:outputText value="#{customer.representative.name}" />
+                    </p:column>
+
+                </p:dataTable>
+            </div>
+        </h:form>
+
     </ui:define>
 
 </ui:composition>

--- a/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageDropdownRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageDropdownRenderer.java
@@ -38,8 +38,12 @@ public class JumpToPageDropdownRenderer implements PaginatorElementRenderer {
         ResponseWriter writer = context.getResponseWriter();
         int currentPage = pageable.getPage();
         int pageCount = pageable.getPageCount();
+        String id = buildId(context, pageable, "jumpToPage");
 
         writer.startElement("select", null);
+        writer.writeAttribute("id", id, null);
+        writer.writeAttribute("name", id, null);
+        writer.writeAttribute("autocomplete", "off", null);
         writer.writeAttribute("class", UIPageableData.PAGINATOR_JTP_SELECT_CLASS, null);
         writer.writeAttribute("value", pageable.getPage(), null);
 

--- a/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageInputRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageInputRenderer.java
@@ -36,8 +36,15 @@ public class JumpToPageInputRenderer implements PaginatorElementRenderer {
     @Override
     public void render(FacesContext context, Pageable pageable) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
+        String id = buildId(context, pageable, "jumpToPage");
 
         writer.startElement("input", null);
+        writer.writeAttribute("id", id, null);
+        writer.writeAttribute("name", id, null);
+        writer.writeAttribute("type", "number", null);
+        writer.writeAttribute("min", 1, null);
+        writer.writeAttribute("max", pageable.getPageCount(), null);
+        writer.writeAttribute("autocomplete", "off", null);
         writer.writeAttribute("class", UIPageableData.PAGINATOR_JTP_INPUT_CLASS, null);
         writer.writeAttribute("value", pageable.getPage() + 1, null);
         writer.endElement("input");

--- a/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageInputRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/paginator/JumpToPageInputRenderer.java
@@ -37,15 +37,19 @@ public class JumpToPageInputRenderer implements PaginatorElementRenderer {
     public void render(FacesContext context, Pageable pageable) throws IOException {
         ResponseWriter writer = context.getResponseWriter();
         String id = buildId(context, pageable, "jumpToPage");
+        int pageCount = pageable.getPageCount();
+        // expose the number of digits so the stylesheet can size the input to the live page count
+        int digits = Integer.toString(Math.max(pageCount, 1)).length();
 
         writer.startElement("input", null);
         writer.writeAttribute("id", id, null);
         writer.writeAttribute("name", id, null);
         writer.writeAttribute("type", "number", null);
         writer.writeAttribute("min", 1, null);
-        writer.writeAttribute("max", pageable.getPageCount(), null);
+        writer.writeAttribute("max", pageCount, null);
         writer.writeAttribute("autocomplete", "off", null);
         writer.writeAttribute("class", UIPageableData.PAGINATOR_JTP_INPUT_CLASS, null);
+        writer.writeAttribute("style", "--p-jtp-digits:" + digits, null);
         writer.writeAttribute("value", pageable.getPage() + 1, null);
         writer.endElement("input");
     }

--- a/primefaces/src/main/java/org/primefaces/component/paginator/PaginatorElementRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/paginator/PaginatorElementRenderer.java
@@ -26,10 +26,42 @@ package org.primefaces.component.paginator;
 import org.primefaces.component.api.Pageable;
 
 import java.io.IOException;
+import java.util.Objects;
 
+import javax.faces.component.UINamingContainer;
 import javax.faces.context.FacesContext;
 
 public interface PaginatorElementRenderer {
 
+    /**
+     * Key under which the currently rendered paginator position ({@code "top"} or {@code "bottom"}) is stored in the
+     * {@link FacesContext} attributes while a paginator is being encoded, so element renderers can build unique ids.
+     */
+    String PAGINATOR_POSITION_KEY = "primefaces.paginator.Position";
+
     void render(FacesContext context, Pageable pageable) throws IOException;
+
+    /**
+     * Builds a stable id for an interactive paginator element so AJAX focus restoration can re-focus it. The plain
+     * {@code clientId + suffix} is used by default; only when the paginator is rendered at both positions is the
+     * {@code top}/{@code bottom} position appended to keep the id unique within the document.
+     *
+     * @param context the current {@link FacesContext}
+     * @param pageable the paginator being rendered
+     * @param suffix the element-specific suffix (e.g. {@code "jumpToPage"})
+     * @return the id to render on the element
+     */
+    default String buildId(FacesContext context, Pageable pageable, String suffix) {
+        char separator = UINamingContainer.getSeparatorChar(context);
+        String id = pageable.getClientId(context) + separator + suffix;
+
+        if ("both".equalsIgnoreCase(pageable.getPaginatorPosition())) {
+            String position = Objects.toString(context.getAttributes().get(PAGINATOR_POSITION_KEY), null);
+            if (position != null) {
+                id += "_" + position;
+            }
+        }
+
+        return id;
+    }
 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/DataRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/DataRenderer.java
@@ -109,22 +109,29 @@ public class DataRenderer extends CoreRenderer {
         writer.startElement("div", null);
         writer.writeAttribute("class", UIPageableData.PAGINATOR_CENTER_CONTENT_CLASS, null);
         String[] elements = pageable.getPaginatorTemplate().split(" ");
-        for (String element : elements) {
-            PaginatorElementRenderer renderer = PAGINATOR_ELEMENTS.get(element);
-            if (renderer != null) {
-                renderer.render(context, pageable);
-            }
-            else {
-                if (element.startsWith("{") && element.endsWith("}")) {
-                    UIComponent elementFacet = pageable.getFacet(element);
-                    if (elementFacet != null) {
-                        elementFacet.encodeAll(context);
-                    }
+        // expose the currently rendered position so element renderers can build unique ids (e.g. jump-to-page input)
+        context.getAttributes().put(PaginatorElementRenderer.PAGINATOR_POSITION_KEY, position);
+        try {
+            for (String element : elements) {
+                PaginatorElementRenderer renderer = PAGINATOR_ELEMENTS.get(element);
+                if (renderer != null) {
+                    renderer.render(context, pageable);
                 }
                 else {
-                    writer.write(element + " ");
+                    if (element.startsWith("{") && element.endsWith("}")) {
+                        UIComponent elementFacet = pageable.getFacet(element);
+                        if (elementFacet != null) {
+                            elementFacet.encodeAll(context);
+                        }
+                    }
+                    else {
+                        writer.write(element + " ");
+                    }
                 }
             }
+        }
+        finally {
+            context.getAttributes().remove(PaginatorElementRenderer.PAGINATOR_POSITION_KEY);
         }
         // end center facet
         writer.endElement("div");

--- a/primefaces/src/main/resources/META-INF/resources/primefaces/paginator/paginator.css
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/paginator/paginator.css
@@ -76,6 +76,12 @@
     -webkit-box-shadow: none;
 }
 
+.ui-paginator .ui-paginator-jtp-input {
+    /* fit the live page count: one ch per digit plus room for padding and the number spinner */
+    width: calc(var(--p-jtp-digits, 3) * 1ch + 2.5rem);
+    text-align: center;
+}
+
 /* Responsive */
 @media (max-width: 640px) {
     .ui-paginator .ui-paginator-pages {


### PR DESCRIPTION
 ## Fixes
  Closes #15058, and implements the numeric-input request from #14944.

  ## Problem
  The paginator's jump-to-page controls (`{JumpToPageInput}` / `{JumpToPageDropdown}`) had two defects:

  1. **Focus lost after AJAX.** The elements were rendered without an `id`.
     PrimeFaces' AJAX focus restoration (`PrimeFaces.ajax.Response.handleReFocus`)
     re-focuses the previously active element **by id**, so after every page jump
     focus was lost — a real problem for keyboard and screen-reader users on long tables.

  2. **No numeric validation.** The input was a plain text field with no `type="number"`,
     `min`, or `max`, so the browser could not validate the entered page against the
     valid `1..pageCount` range, and mobile devices did not show a numeric keypad.

  ## Changes
  - **Stable ids** on both the jump-to-page `<input>` and `<select>` (`id` + `name`),
    so focus survives AJAX updates.
  - The input now renders as `type="number"` with `min="1"` and `max="{pageCount}"`
    for browser-level range validation and a numeric mobile keyboard.
  - Ids stay **unique** when `paginatorPosition="both"`: the `top`/`bottom` position is
    appended only in that case (`…:jumpToPage_top` / `…:jumpToPage_bottom`), mirroring the
    existing `…_paginator_top/bottom` container ids. The rendered position is forwarded to the
    element renderers via a `FacesContext` attribute (no change to the public
    `PaginatorElementRenderer` interface); the id-building logic is shared as a
    `default` method on that interface.
  - **Input width now fits the live page count** (relates to the width discussion in #14944):
    the renderer emits the page-count digit count as a `--p-jtp-digits` custom property and
    `paginator.css` derives the width from it (`calc(var(--p-jtp-digits, 3) * 1ch + 2.5rem)`).
    The `width` is declared in the class rule, so themes/apps can still override it with plain CSS.
  - **Showcase:** split the DataTable paginator demo into dedicated `paginatorTemplate`
    examples — page links, jump-to-page by input, and jump-to-page by dropdown — alongside
    the existing basic example.

  ## Notes
  - `size` was intentionally **not** used to constrain width: it is ignored on `type="number"`
    inputs, so the width is controlled via CSS instead.

  ## Testing
  - `mvn -pl primefaces install` builds cleanly.
  - Verified via the updated showcase paginator page: with `paginatorPosition="both"`, two
    jump-to-page inputs render with distinct ids (`…jumpToPage_top` / `…jumpToPage_bottom`),
    both `type="number"` with correct `min`/`max`, and focus is retained in the same input
    after an AJAX page jump.