### PR TITLE
Fix #15035: clean up dynamic AutoComplete panels on refresh

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,5 +1,0 @@
-{
-  "fork_synced_at": "2026-07-26T10:22:54.686307+00:00",
-  "commits_behind_before_sync": 0,
-  "action_taken": "noop"
-}

--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-26T10:22:54.686307+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/autocomplete/AutoComplete007.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/autocomplete/AutoComplete007.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.autocomplete;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class AutoComplete007 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String value;
+
+    public List<String> completeText(String query) {
+        List<String> results = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            results.add(query + i);
+        }
+
+        return results;
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/autocomplete/autoComplete007.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/autocomplete/autoComplete007.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:autoComplete id="autocomplete"
+                            widgetVar="autocomplete"
+                            value="#{autoComplete007.value}"
+                            completeMethod="#{autoComplete007.completeText}"
+                            dynamic="true"
+                            queryDelay="10" />
+
+            <p:remoteCommand name="refreshAutocomplete" update="autocomplete" />
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/autocomplete/AutoComplete007Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/autocomplete/AutoComplete007Test.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.autocomplete;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.AutoComplete;
+
+import java.util.List;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutoComplete007Test extends AbstractPrimePageTest {
+
+    private static final By PANEL = By.id("form:autocomplete_panel");
+
+    @Test
+    @Order(1)
+    @DisplayName("AutoComplete: GitHub #15035 removes a loaded dynamic panel when refreshed")
+    void refreshLoadedDynamicPanel(Page page) {
+        // Arrange
+        AutoComplete autoComplete = page.autoComplete;
+        autoComplete.search("test");
+        WebElement oldPanel = autoComplete.getPanel();
+        assertDisplayed(oldPanel);
+        assertEquals(1, getPanels().size());
+
+        // Act
+        PrimeSelenium.executeScript(true, "refreshAutocomplete()");
+
+        // Assert
+        assertEquals(0, getPanels().size());
+        assertEquals(0L, getWidgetPanelLength());
+        assertNoJavascriptErrors();
+
+        // Act - query the refreshed widget
+        autoComplete.search("new");
+
+        // Assert - the new panel works and can be hidden
+        assertEquals(1, getPanels().size());
+        assertDisplayed(autoComplete.getPanel());
+        assertEquals(List.of("new0", "new1", "new2", "new3", "new4", "new5", "new6", "new7", "new8", "new9"),
+                autoComplete.getItemValues());
+        autoComplete.hide();
+        assertNotDisplayed(PANEL);
+        assertConfiguration(autoComplete.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("AutoComplete: refreshes before the dynamic panel is loaded")
+    void refreshBeforeDynamicPanelLoaded(Page page) {
+        // Arrange
+        AutoComplete autoComplete = page.autoComplete;
+        assertEquals(0, getPanels().size());
+        assertEquals(0L, getWidgetPanelLength());
+
+        // Act
+        PrimeSelenium.executeScript(true, "refreshAutocomplete()");
+
+        // Assert
+        assertEquals(0, getPanels().size());
+        assertEquals(0L, getWidgetPanelLength());
+
+        // Act - load the panel after refresh
+        autoComplete.search("test");
+
+        // Assert
+        assertEquals(1, getPanels().size());
+        assertDisplayed(autoComplete.getPanel());
+        assertEquals(10, autoComplete.getItemValues().size());
+        assertConfiguration(autoComplete.getWidgetConfiguration());
+    }
+
+    private List<WebElement> getPanels() {
+        return getWebDriver().findElements(PANEL);
+    }
+
+    private Long getWidgetPanelLength() {
+        return PrimeSelenium.executeScript("return PF('autocomplete').panel.length");
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("AutoComplete Config = " + cfg);
+        assertTrue(cfg.getBoolean("dynamic"));
+        assertFalse(cfg.getBoolean("cache"));
+        assertEquals("server", cfg.getString("queryMode"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:autocomplete")
+        AutoComplete autoComplete;
+
+        @Override
+        public String getLocation() {
+            return "autocomplete/autoComplete007.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/autocomplete/autocomplete.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/autocomplete/autocomplete.widget.js
@@ -212,6 +212,11 @@ PrimeFaces.widget.AutoComplete = class AutoComplete extends PrimeFaces.widget.Ba
      * @param {PrimeFaces.PartialWidgetCfg<TCfg>} cfg
      */
     refresh(cfg) {
+        if (this.cfg.dynamic && this.isDynamicLoaded && this.panel.length) {
+            this.unbindPanelEvents();
+            this.panel.remove();
+        }
+
         super.refresh(cfg);
     }
 


### PR DESCRIPTION
Keep the correction in the AutoComplete lifecycle so other consumers of the shared dynamic-overlay utility retain their existing duplicate-overlay semantics. With `dynamic="true"`, AutoComplete renders its suggestion panel only during the first dynamic query and moves that panel to the configured `appendTo` container, normally `body`.

Happy path: load and display the dynamic suggestion panel, invoke the AJAX self-update while it remains open, and verify the old panel ID is absent from the DOM, the refreshed widget owns no panel until queried again, and no JavaScript errors occur; Edge cases: refresh the dynamic AutoComplete before its panel has ever loaded, then query it; also query again after an open-panel refresh and verify exactly one newly loaded panel appears with working suggestions and hide behavior.

Fixes #15035

AI was used for assistance.
