### PR TITLE
fix #15080: appendMessage() must only fill its own severity box

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/messages/Messages002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/messages/Messages002Test.java
@@ -27,12 +27,19 @@ import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.model.Msg;
+import org.primefaces.selenium.component.model.Severity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.FindBy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Messages002Test extends AbstractPrimePageTest {
@@ -50,6 +57,25 @@ public class Messages002Test extends AbstractPrimePageTest {
         PrimeSelenium.executeScript("PF('messagesClosable').appendMessage({severity:'info', summary:'Info'});");
 
         assertDisplayed(page.messagesClosable.getCloseButton("info"));
+    }
+
+    @Test
+    @DisplayName("client-side appendMessage: each message only shows in the box of its own severity; GitHub #15080")
+    public void testMultipleSeverities(Page page) {
+        PrimeSelenium.executeScript("PF('messages').appendMessage({severity:'error', summary:'Error'});"
+                    + "PF('messages').appendMessage({severity:'warn', summary:'Warn 1'});"
+                    + "PF('messages').appendMessage({severity:'warn', summary:'Warn 2'});"
+                    + "PF('messages').appendMessage({severity:'info', summary:'Info'});");
+
+        assertEquals(Arrays.asList("Error"), summariesOf(page.messages, Severity.ERROR));
+        assertEquals(Arrays.asList("Warn 1", "Warn 2"), summariesOf(page.messages, Severity.WARN));
+        assertEquals(Arrays.asList("Info"), summariesOf(page.messages, Severity.INFO));
+    }
+
+    private static List<String> summariesOf(Messages messages, Severity severity) {
+        return messages.getMessagesBySeverity(severity).stream()
+                    .map(Msg::getSummary)
+                    .collect(Collectors.toList());
     }
 
     public static class Page extends AbstractPrimePage {

--- a/primefaces/src/main/frontend/packages/components/src/messages/messages.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/messages/messages.widget.ts
@@ -36,7 +36,12 @@ export class Messages<Cfg extends MessagesCfg = MessagesCfg> extends PrimeFaces.
 
         let severityContainer =  this.jq.children('div.ui-messages-' + msg.severity);
         if (severityContainer.length === 0) {
-            severityContainer = this.jq.append(
+            /*
+             * jQuery's append() returns the container it was called on, not the appended element. Create the
+             * severity box separately and use appendTo() so that severityContainer refers to the new box only.
+             * Otherwise the message below would be added to the <ul> of every severity box in this widget.
+             */
+            severityContainer = $(
                  '<div class="ui-messages-' + msg.severity + '">' +
                     (this.cfg.closable ? '<a href="#" class="ui-messages-close" onclick="$(this).parent().slideUp();return false;" role="button" aria-label="' + closeLabel + '">' +
                         '<span class="ui-icon ui-icon-close"></span>' +
@@ -45,7 +50,7 @@ export class Messages<Cfg extends MessagesCfg = MessagesCfg> extends PrimeFaces.
                     '<ul>' +
 
                     '</ul>' +
-                '</div>');
+                '</div>').appendTo(this.jq);
         }
 
         severityContainer.find('ul').append(


### PR DESCRIPTION

fix #15080: appendMessage() must only fill its own severity box

Messages.appendMessage() created a missing severity box with this.jq.append(html). jQuery's append() returns the container it was called on, so the local variable ended up referencing the whole messages container instead of the new box. The following find('ul').append(...) therefore matched the list of every severity box already present and added the message to all of them.

As a result the first client-side message of each new severity also showed up in every previously created severity box, e.g. appending error, warn, warn, info in that order left the error box with an extra copy of the first warn message. Later messages of the same severity were unaffected because the box already existed and the branch was skipped.

Build the box with $(html).appendTo(this.jq) instead, which returns the new element, and add an integration test that appends messages across four severities and asserts each box only contains its own.