### PR TITLE
fix #15087: DataTable rowReorder must ignore the dragged row's own expansion row

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable050.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable050.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.event.ReorderEvent;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DataTable050 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<ProgrammingLanguage> progLanguages;
+
+    private Integer fromIndex;
+
+    private Integer toIndex;
+
+    @Inject
+    private ProgrammingLanguageService service;
+
+    @PostConstruct
+    public void init() {
+        progLanguages = service.getLangs();
+    }
+
+    /**
+     * @return the current order of the model, which the DataTable reorders itself because the model is list backed
+     */
+    public String getOrder() {
+        return progLanguages.stream().map(ProgrammingLanguage::getName).collect(Collectors.joining(","));
+    }
+
+    public void onRowReorder(ReorderEvent event) {
+        fromIndex = event.getFromIndex();
+        toIndex = event.getToIndex();
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable050.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable050.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces"
+      xmlns:h="jakarta.faces.html">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:dataTable id="datatable" value="#{dataTable050.progLanguages}" var="lang" rowKey="#{lang.id}" draggableRows="true">
+                <p:ajax event="rowReorder" listener="#{dataTable050.onRowReorder}" update="@form"/>
+
+                <p:column style="width:2rem">
+                    <p:rowToggler/>
+                </p:column>
+
+                <p:column headerText="Name">
+                    <h:outputText value="#{lang.name}"/>
+                </p:column>
+
+                <p:rowExpansion>
+                    <h:outputText value="Expansion of #{lang.name}"/>
+                </p:rowExpansion>
+            </p:dataTable>
+
+            <h:outputText id="order" value="#{dataTable050.order}"/>
+            <h:outputText id="fromIndex" value="#{dataTable050.fromIndex}"/>
+            <h:outputText id="toIndex" value="#{dataTable050.toIndex}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable050Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable050Test.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.DataTable;
+import org.primefaces.selenium.component.model.datatable.Row;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("DataTable-rowreorder")
+@Tag("DataTable-rowexpansion")
+class DataTable050Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: rowReorder of a collapsed row reports the dropped position")
+    void reorderCollapsedRow(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+
+        // Act - drag "TypeScript" (index 3) one position up
+        dragRowOnto(page, 3, 2);
+
+        // Assert
+        assertEquals("3", page.fromIndex.getText());
+        assertEquals("2", page.toIndex.getText());
+        assertEquals("Java,C#,TypeScript,JavaScript,Python", page.order.getText());
+        assertEquals("TypeScript", dataTable.getRow(2).getCell(1).getText());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: rowReorder of an expanded row reports the dropped position, not one row too far")
+    void reorderExpandedRow(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        dataTable.getRow(3).expand();
+
+        // Act - drag the expanded "TypeScript" (index 3) one position up
+        dragRowOnto(page, 3, 2);
+
+        // Assert - the expansion row of the dragged row must not shift the reported index
+        assertEquals("3", page.fromIndex.getText());
+        assertEquals("2", page.toIndex.getText());
+        assertEquals("Java,C#,TypeScript,JavaScript,Python", page.order.getText());
+        assertEquals("TypeScript", dataTable.getRow(2).getCell(1).getText());
+        assertNoJavascriptErrors();
+    }
+
+    /**
+     * Drags the row at {@code fromIndex} onto the row at {@code toIndex}. jQuery UI sortable is driven by mouse events, so the drag has to be performed
+     * step by step: press, exceed the drag threshold, move over the target row and release there.
+     *
+     * @param page the page under test
+     * @param fromIndex index of the row to drag
+     * @param toIndex index of the row to drop it on
+     */
+    private void dragRowOnto(Page page, int fromIndex, int toIndex) {
+        Row source = page.dataTable.getRow(fromIndex);
+        Row target = page.dataTable.getRow(toIndex);
+        WebElement sourceHandle = source.getCell(1).getWebElement();
+        WebElement targetElement = target.getWebElement();
+
+        Actions actions = new Actions(page.getWebDriver());
+        actions.moveToElement(sourceHandle)
+                .clickAndHold()
+                .moveByOffset(0, -10)
+                .moveToElement(targetElement)
+                .moveByOffset(0, -(targetElement.getSize().getHeight() / 2) + 1)
+                .release();
+
+        PrimeSelenium.guardAjax(actions.build()).perform();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datatable")
+        DataTable dataTable;
+
+        @FindBy(id = "form:order")
+        WebElement order;
+
+        @FindBy(id = "form:fromIndex")
+        WebElement fromIndex;
+
+        @FindBy(id = "form:toIndex")
+        WebElement toIndex;
+
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable050.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.widget.js
@@ -5120,29 +5120,11 @@ PrimeFaces.widget.DataTable = class DataTable extends PrimeFaces.widget.Deferred
             },
             update: function(event, ui) {
                 var fromIndex = ui.item.data('ri');
-                var fromNode = ui.item;
-                var itemIndex = ui.item.index();
-                var toIndex = $this.paginator ? $this.paginator.getFirst() + itemIndex : itemIndex;
-                var isDirectionUp = fromIndex >= toIndex;
 
                 // #5296 must not count header group rows
                 // #6557 must not count expanded rows
-                if (isDirectionUp) {
-                    for (let i = 0; i <= toIndex; i++) {
-                        fromNode = fromNode.next('tr');
-                        if (fromNode.hasClass('ui-rowgroup-header') || fromNode.hasClass('ui-expanded-row-content')){
-                            toIndex--;
-                        }
-                    }
-                } else {
-                    fromNode.prevAll('tr').each(function() {
-                        var node = $(this);
-                        if (node.hasClass('ui-rowgroup-header') || node.hasClass('ui-expanded-row-content')){
-                            toIndex--;
-                        }
-                    });
-                }
-                toIndex = Math.max(toIndex, 0);
+                var itemIndex = ui.item.prevAll('tr').not('.ui-rowgroup-header').not('.ui-expanded-row-content').length;
+                var toIndex = $this.paginator ? $this.paginator.getFirst() + itemIndex : itemIndex;
 
                 $this.syncRowParity();
 


### PR DESCRIPTION
Fixes #15087

### Problem

`DataTable.makeRowsDraggable()` derives the drop index from the DOM index of the dragged row and then decrements it for every `ui-rowgroup-header` / `ui-expanded-row-content` row it walks over (added in #6589 for #5296 / #6557). Walking forward from the dragged row also hits the dragged row's **own** expansion row, so dropping an expanded row reports a `toIndex` one position too far up and the row is moved one slot beyond the drop target. Collapsed rows are unaffected.

### Fix

Count the data rows that precede the dragged row instead:

```js
var itemIndex = ui.item.prevAll('tr').not('.ui-rowgroup-header').not('.ui-expanded-row-content').length;
```
Direction independent, never sees the dragged row's own expansion row, and keeps the #5296 / #6557 behavior. The Math.max(toIndex, 0) clamp is dropped because a .length cannot be negative. Rows of other kinds (e.g. ui-datatable-summaryrow) are still counted as data rows — unchanged behavior, not addressed here.

Test

Second commit adds the DataTable050 triad: the same drag is performed once with the row collapsed (control) and once expanded, asserting the reported fromIndex/toIndex and the resulting model order.

Verified both ways with mvn verify -f primefaces-integration-tests/pom.xml -Pintegration-tests,headless,chrome,mojarra-4.0 -Dit.test=DataTable050Test:

- with the fix: Tests run: 2, Failures: 0
- with the fix reverted: reorderExpandedRow fails with expected: <2> but was: <1>, reorderCollapsedRow still passes

mvn clean install (unit tests included) is green. The test commit is separate so it can be dropped if the manual jQuery UI drag stepping is not wanted — the suite has no drag helper and the DataTable selenium wrapper exposes no reorder API.

Not run: the full IT suite, MyFaces, CSP and non-Chrome browsers.