### PR TITLE
Ci hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,9 @@ jobs:
       matrix:
         java: [11, 25]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -73,9 +73,9 @@ jobs:
           - java: 25
             facesimpl: 'myfaces-4.1'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -85,7 +85,7 @@ jobs:
       - name: Integration Tests
         run: mvn -B -V clean install -fprimefaces-integration-tests/pom.xml -Pintegration-tests,parallel-execution,headless,chrome,theme-aura,csp,${{ matrix.facesimpl }}
       - name: Upload failure-screenshots
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: failed_tests_screenshots_java${{ matrix.java }}_${{ matrix.facesimpl }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - '**/**.md'
 
+permissions:
+  contents: read
+
 env:
     MAVEN_OPTS: >-
         -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/.github/workflows/deploy-showcase.yml
+++ b/.github/workflows/deploy-showcase.yml
@@ -9,6 +9,12 @@ on:
       - 15.X
   workflow_dispatch:
 
+# The docker push to ghcr.io authenticates with GITHUB_TOKEN; the
+# DigitalOcean deploy uses its own token.
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-showcase.yml
+++ b/.github/workflows/deploy-showcase.yml
@@ -15,9 +15,9 @@ jobs:
     if: github.repository == 'primefaces/primefaces'
     name: Build
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: 21
@@ -27,19 +27,19 @@ jobs:
       - name: Build Showcase
         run: mvn clean install -f primefaces-showcase -P tomee -T1C --batch-mode --show-version
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: primefaces-showcase/.
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/primefaces-showcase:${{ github.ref_name }}-latest
       - name: Deploy to DigitalOcean
-        uses: digitalocean/app_action/deploy@v2
+        uses: digitalocean/app_action/deploy@cc55bc9b848d25f9c1c9f831cf843fbab3fbfb15 # v2.0.11
         with:
           project_id: 49e2f18d-d811-49ca-a2a6-b19a29c6b713
           app_name: primefaces-showcase

--- a/.github/workflows/issue-auto-comment.yml
+++ b/.github/workflows/issue-auto-comment.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/issue-inactive-checker.yml
+++ b/.github/workflows/issue-inactive-checker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cannot Replicate
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 20
           days-before-close: 0
@@ -29,7 +29,7 @@ jobs:
           days-before-pr-close: -1
 
       - name: Needs Reproducer
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 20
           days-before-close: 0
@@ -42,7 +42,7 @@ jobs:
           days-before-pr-close: -1
 
       - name: Duplicate
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 20
           days-before-close: 0

--- a/.github/workflows/issue-stale-checker.yml
+++ b/.github/workflows/issue-stale-checker.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is marked as stale because there was no activity on it for the last 2 years. Remove stale label or comment or this will be closed in 30 days'

--- a/.github/workflows/nightly-file.upload.yml
+++ b/.github/workflows/nightly-file.upload.yml
@@ -34,14 +34,14 @@ jobs:
             profile: 'headless,chrome,mojarra-4.1'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/nightly-safari.yml
+++ b/.github/workflows/nightly-safari.yml
@@ -18,14 +18,14 @@ jobs:
         profile: [ 'headless,safari,csp,theme-nova,mojarra-4.0' ]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,11 +48,11 @@ jobs:
             profile: 'chrome,client-state-saving,theme-nova,mojarra-4.1'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Setup firefox
-        uses: browser-actions/setup-firefox@v1
+        uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -64,7 +64,7 @@ jobs:
       - name: Integration Tests
         run: mvn -B -V clean install -fprimefaces-integration-tests/pom.xml -Pintegration-tests,headless,${{ matrix.profile }}
       - name: Upload failure-screenshots
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: failed_tests_screenshots_java${{ matrix.java }}_${{ matrix.profile }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -16,11 +16,11 @@ jobs:
       github.event.workflow_run.head_branch == 'master'
     name: Publish Snapshot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up JDK 11
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-vdldoc.yml
+++ b/.github/workflows/publish-vdldoc.yml
@@ -17,12 +17,12 @@ jobs:
     name: Generate VDL Documentation
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/publish-vdldoc.yml
+++ b/.github/workflows/publish-vdldoc.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ master, main ]
 
+# The last step commits the regenerated docs and pushes them back.
+permissions:
+  contents: write
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRO: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: ${{ env.JAVA_DISTRO }}
           java-version: ${{ env.JAVA_VERSION }}


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v6` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The exposed spots here are `deploy-showcase.yml` (ghcr push and DigitalOcean deploy) and the publish workflows with their registry and signing secrets. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). Dependabot keeps opening its bump PRs exactly as before, it understands sha pins with a version comment.

**Commit 2 adds `permissions:` blocks to the four workflows that had none.** Without one, the GITHUB_TOKEN inherits the repository default scope. Each scope was derived from what the workflow actually does with the token, not guessed:

- `build.yml`: `contents: read` (Sonar only reads PR metadata)
- `publish-snapshot.yml`: `contents: read` (deploys through Sonatype and GPG secrets, the GitHub token is unused)
- `publish-vdldoc.yml`: `contents: write` (the last step commits the regenerated docs back)
- `deploy-showcase.yml`: `contents: read` + `packages: write` (the showcase image push to ghcr.io authenticates with GITHUB_TOKEN)

The issue automation, nightly, stale and release workflows already declare scoped permissions, so they are untouched.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v1`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

All shas were resolved from the upstream repos and cross checked against their release tags. No workflow logic changes.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on master. I will also open a PR which adds it to CI so none of this quietly drifts back, that one is a bonus, this PR stands on its own.