### PR TITLE
fix #15078: AutoComplete dynamic+server queryMode can strand an undismissable panel in document.body

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/autocomplete/autocomplete.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/autocomplete/autocomplete.widget.js
@@ -933,6 +933,9 @@ PrimeFaces.widget.AutoComplete = class AutoComplete extends PrimeFaces.widget.Ba
         if (!this.cfg.completeEndpoint) {
             this.requestId = this.requestId + 1 || 1;
             var currentRequestId = this.requestId;
+            // #15078 capture the dynamic-load decision now, since `isDynamicLoaded` is mutable and can
+            // flip (via hide() or another request's oncomplete) before this request's response is handled
+            var wasDynamicLoadRequested = this.cfg.dynamic && !this.isDynamicLoaded;
             options = {
                 source: this.id,
                 process: this.id,
@@ -946,7 +949,7 @@ PrimeFaces.widget.AutoComplete = class AutoComplete extends PrimeFaces.widget.Ba
                             if (this.requestId !== currentRequestId) {
                                 return;
                             }
-                            if (this.cfg.dynamic && !this.isDynamicLoaded) {
+                            if (wasDynamicLoadRequested) {
                                 this.panel = $(content);
                                 this.appendPanel();
                                 this.transition = PrimeFaces.utils.registerCSSTransition(this.panel, 'ui-connected-overlay');
@@ -956,7 +959,7 @@ PrimeFaces.widget.AutoComplete = class AutoComplete extends PrimeFaces.widget.Ba
                             }
 
                             if (this.cfg.cache) {
-                                if (this.cfg.queryMode !== 'server' && !this.isDynamicLoaded && this.cache[query]) {
+                                if (this.cfg.queryMode !== 'server' && !wasDynamicLoadRequested && this.cache[query]) {
                                     this.panel.html(this.cache[query]);
                                 } else {
                                     this.cache[query] = content;
@@ -983,7 +986,7 @@ PrimeFaces.widget.AutoComplete = class AutoComplete extends PrimeFaces.widget.Ba
                 options.params.push({ name: this.id + '_clientCache', value: true });
             }
 
-            if (this.cfg.dynamic && !this.isDynamicLoaded) {
+            if (wasDynamicLoadRequested) {
                 options.params.push({ name: this.id + '_dynamicload', value: true });
             }
         }


### PR DESCRIPTION
fix #15078: AutoComplete dynamic+server queryMode can strand an undismissable panel in document.body

The mutable isDynamicLoaded flag was read once when building the request (to decide whether to send _dynamicload) and again when handling the response (to decide whether the content was a full panel or bare list markup). hide() or a stale request's oncomplete could flip the flag in between, causing the response handler to treat bare markup as a full panel, replacing the real panel with an unstyled, unbound duplicate appended to the body.

Capture the dynamic-load decision once at request-build time and reuse that captured value when processing the response instead of re-reading the flag.