### PR TITLE
ITs: stabilize CommandLink001Test.nonAjaxSubmit:95

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/commandlink/CommandLink001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/commandlink/CommandLink001Test.java
@@ -25,6 +25,7 @@ package org.primefaces.integrationtests.commandlink;
 
 import org.primefaces.selenium.AbstractPrimePage;
 import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeExpectedConditions;
 import org.primefaces.selenium.PrimeSelenium;
 import org.primefaces.selenium.component.CommandLink;
 import org.primefaces.selenium.component.Messages;
@@ -92,6 +93,8 @@ class CommandLink001Test extends AbstractPrimePageTest {
         PrimeSelenium.guardHttp(page.linkNonAjax).click();
 
         // Assert - full submit re-renders the page; counter reflects the single submit
+        PrimeSelenium.waitGui().until(ExpectedConditions.and(PrimeExpectedConditions.documentLoaded(),
+                PrimeExpectedConditions.visibleAndAnimationComplete(page.messages)));
         assertEquals("Submit", page.messages.getMessage(0).getSummary());
         assertEquals("Counter: 1", page.messages.getMessage(0).getDetail());
         assertEquals("1", page.counter.getText());


### PR DESCRIPTION
 » NoSuchElement no such element: Unable to locate element: {"method":"css selector","selector":"#form\:messages"}