### PR TITLE
ITs: stabilize ConfirmDialog001Test

### DIFF
--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/confirmdialog/ConfirmDialog001Test.java
@@ -39,6 +39,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -214,6 +215,8 @@ class ConfirmDialog001Test extends AbstractPrimePageTest {
         PrimeSelenium.guardHttp(dialog.getYesButton()).click();
 
         // Assert
+        PrimeSelenium.waitGui().until(ExpectedConditions.and(PrimeExpectedConditions.documentLoaded(),
+                PrimeExpectedConditions.visibleAndAnimationComplete(page.message)));
         assertEquals("Full page submitted", page.message.getMessage(0).getDetail());
         assertDialog(page, false);
     }


### PR DESCRIPTION
 ConfirmDialog001Test.nonAjaxYes:217 » NoSuchElement no such element: Unable to locate element: {"method":"css selector","selector":"#form\:message"}