### PR TITLE
#9254: Fix TreeTable rendering issue after clearFilters()

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable009.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable009.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.model.TreeNode;
+
+import java.io.Serializable;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class TreeTable009 implements Serializable {
+
+    private static final long serialVersionUID = -3049074201208091930L;
+
+    private TreeNode<Document> root;
+    private boolean otherRoot;
+
+    @Inject
+    private DocumentService service;
+
+    @PostConstruct
+    public void init() {
+        root = service.createDocuments();
+    }
+
+    public void switchRoot() {
+        root = otherRoot ? service.createDocuments() : service.createOtherDocuments();
+        otherRoot = !otherRoot;
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/treetable/treeTable009.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/treetable/treeTable009.xhtml
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <p:treeTable value="#{treeTable009.root}" var="document" id="treeTable" widgetVar="treeTable" filterEvent="enter">
+                <p:column headerText="Name" filterBy="#{document.name}" filterMatchMode="contains">
+                    <h:outputText value="#{document.name}"/>
+                </p:column>
+                <p:column headerText="Size" sortBy="#{document.size}">
+                    <h:outputText value="#{document.size}"/>
+                </p:column>
+                <p:column headerText="Type" filterBy="#{document.type}" filterMatchMode="exact">
+                    <f:facet name="filter">
+                        <p:selectOneMenu onchange="PF('treeTable').filter()" styleClass="custom-filter">
+                            <f:selectItem itemLabel="Select One" itemValue="#{null}" noSelectionOption="true"/>
+                            <f:selectItem itemLabel="Folder" itemValue="Folder"/>
+                            <f:selectItem itemLabel="Application" itemValue="Application"/>
+                            <f:selectItem itemLabel="Zip" itemValue="Zip"/>
+                            <f:selectItem itemLabel="Text" itemValue="Text"/>
+                            <f:selectItem itemLabel="Document" itemValue="Document"/>
+                            <f:selectItem itemLabel="Resume" itemValue="Resume"/>
+                            <f:selectItem itemLabel="Excel" itemValue="Excel"/>
+                            <f:selectItem itemLabel="PDF" itemValue="PDF"/>
+                            <f:selectItem itemLabel="Link" itemValue="Link"/>
+                            <f:selectItem itemLabel="Picture" itemValue="Picture"/>
+                            <f:selectItem itemLabel="Video" itemValue="Video"/>
+                        </p:selectOneMenu>
+                    </f:facet>
+
+                    <h:outputText value="#{document.type}"/>
+                </p:column>
+            </p:treeTable>
+
+            <p:commandButton id="buttonClearFilters" type="button" value="Clear Filters" onclick="PF('treeTable').clearFilters()"/>
+            <p:commandButton id="buttonSwitchRoot" value="Switch Root" update="@form" action="#{treeTable009.switchRoot}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable009Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable009Test.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.TreeTable;
+import org.primefaces.selenium.component.model.treetable.Row;
+
+import java.util.List;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for #9254 - TreeTable: clearFilters() breaks the table when filtering
+ * is enabled. The client-side clearFilters() API resets the filter inputs and triggers a
+ * filter request; the stale filterBy entries then keep null values, so filtering ran
+ * against a null root and shadowed the (new) model on the next render, freezing the table.
+ */
+class TreeTable009Test extends AbstractTreeTableTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("TreeTable: clearFilters() then switch data - https://github.com/primefaces/primefaces/issues/9254")
+    void clearFiltersThenSwitchData(Page page) {
+        // Arrange
+        TreeTable treeTable = page.treeTable;
+        assertRows(treeTable, root);
+
+        // Act - apply a column filter so the filterBy map gets populated
+        treeTable.filter("Name", "down");
+
+        // Assert - only the matching node is shown
+        List<Row> rows = treeTable.getRows();
+        assertEquals(1, rows.size());
+        assertEquals("Downloads", rows.get(0).getCell(0).getText());
+
+        // Act - clear all filters via the client-side API (sends a filter AJAX request)
+        PrimeSelenium.executeScript(true, "PF('treeTable').clearFilters()");
+
+        // Assert - all rows are shown again and the model is restored
+        assertRows(treeTable, root);
+
+        // Act - switch to the other root while the stale filterBy entries remain
+        page.buttonSwitchRoot.click();
+
+        // Assert - the table must reflect the new model instead of staying frozen
+        assertRows(treeTable, rootOtherDocument);
+
+        assertConfiguration(treeTable.getWidgetConfiguration());
+    }
+
+    private void assertConfiguration(JSONObject cfg) {
+        assertNoJavascriptErrors();
+        System.out.println("TreeTable Config = " + cfg);
+        assertEquals("treeTable", cfg.getString("widgetVar"));
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:treeTable")
+        TreeTable treeTable;
+
+        @FindBy(id = "form:buttonSwitchRoot")
+        CommandButton buttonSwitchRoot;
+
+        @Override
+        public String getLocation() {
+            return "treetable/treeTable009.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -97,9 +97,16 @@ public class FilterFeature implements TreeTableFeature {
 
     public void filter(FacesContext context, TreeTable tt, TreeNode root) {
         Map<String, FilterMeta> filterBy = tt.getFilterByAsMap();
-        // After clearFilters(), stale filterBy entries remain with null values.
-        // isEmpty() alone can't detect this, so we also check for active filters;
-        // without this, we'd filter against a null root and shadow the model value.
+        // After clearFilters(), stale filterBy entries remain with null values,
+        // so isEmpty() alone can't detect this case. Without the check below,
+        // filter() would run against the null root set by decode() and leave
+        // the table empty. Also restore the model value via the value expression
+        // so subsequent renders don't see the nulled local value.
+        //
+        // decode() calls setValue(null) to reset filter state before re-applying
+        // any filter values from the request. When there are no active filters,
+        // the original early return never restored the value, leaving that null
+        // in place to shadow the value expression on the next render.
         boolean noActiveFilters = filterBy.isEmpty() || filterBy.values().stream().noneMatch(FilterMeta::isActive);
         if (noActiveFilters) {
             tt.updateFilteredValue(context, null);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -110,7 +110,7 @@ public class FilterFeature implements TreeTableFeature {
         boolean noActiveFilters = filterBy.isEmpty() || filterBy.values().stream().noneMatch(FilterMeta::isActive);
         if (noActiveFilters) {
             tt.updateFilteredValue(context, null);
-            ValueExpression ve = tt.getValueExpression("value");
+            ValueExpression ve = tt.getValueExpression(TreeTable.PropertyKeys.value.name());
             if (ve != null) {
                 TreeNode<?> originalValue = (TreeNode<?>) ve.getValue(context.getELContext());
                 tt.setValue(originalValue);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
 import jakarta.faces.FacesException;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.PhaseId;
@@ -96,7 +97,17 @@ public class FilterFeature implements TreeTableFeature {
 
     public void filter(FacesContext context, TreeTable tt, TreeNode root) {
         Map<String, FilterMeta> filterBy = tt.getFilterByAsMap();
-        if (filterBy.isEmpty()) {
+        boolean noActiveFilters = filterBy.isEmpty() || filterBy.values().stream().noneMatch(FilterMeta::isActive);
+        if (noActiveFilters) {
+            tt.updateFilteredValue(context, null);
+            ValueExpression ve = tt.getValueExpression("value");
+            if (ve != null) {
+                TreeNode<?> originalValue = (TreeNode<?>) ve.getValue(context.getELContext());
+                tt.setValue(originalValue);
+                if (originalValue != null) {
+                    tt.setRowKey(originalValue, null);
+                }
+            }
             return;
         }
 

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -110,7 +110,7 @@ public class FilterFeature implements TreeTableFeature {
         boolean noActiveFilters = filterBy.isEmpty() || filterBy.values().stream().noneMatch(FilterMeta::isActive);
         if (noActiveFilters) {
             tt.updateFilteredValue(context, null);
-            ValueExpression ve = tt.getValueExpression(TreeTable.PropertyKeys.value.name());
+            ValueExpression ve = tt.getValueExpression(TreeTable.PropertyKeys.value);
             if (ve != null) {
                 TreeNode<?> originalValue = (TreeNode<?>) ve.getValue(context.getELContext());
                 tt.setValue(originalValue);

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/FilterFeature.java
@@ -97,6 +97,9 @@ public class FilterFeature implements TreeTableFeature {
 
     public void filter(FacesContext context, TreeTable tt, TreeNode root) {
         Map<String, FilterMeta> filterBy = tt.getFilterByAsMap();
+        // After clearFilters(), stale filterBy entries remain with null values.
+        // isEmpty() alone can't detect this, so we also check for active filters;
+        // without this, we'd filter against a null root and shadow the model value.
         boolean noActiveFilters = filterBy.isEmpty() || filterBy.values().stream().noneMatch(FilterMeta::isActive);
         if (noActiveFilters) {
             tt.updateFilteredValue(context, null);

--- a/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
@@ -26,14 +26,29 @@ package org.primefaces.component.treetable.feature;
 import org.primefaces.component.api.UITree;
 import org.primefaces.component.treetable.TreeTable;
 import org.primefaces.model.DefaultTreeNode;
+import org.primefaces.model.FilterMeta;
 import org.primefaces.model.TreeNode;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import jakarta.el.ELContext;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TreeTableFilterFeatureTest {
 
@@ -112,5 +127,58 @@ class TreeTableFilterFeatureTest {
         assertEquals(matchingNode.getRowKey(), filteredMatch.getRowKey());
         assertEquals(0, filteredMatch.getChildCount());
         assertTrue(filteredMatch.getChildren().isEmpty());
+    }
+
+    @Test
+    void filterWithEmptyFilterByRestoresModelValue() {
+        FacesContext context = mock(FacesContext.class);
+        ELContext elContext = mock(ELContext.class);
+        when(context.getELContext()).thenReturn(elContext);
+
+        FilterFeature filterFeature = new FilterFeature();
+
+        TreeTable treeTable = mock(TreeTable.class);
+        when(treeTable.getFilterByAsMap()).thenReturn(Collections.emptyMap());
+
+        TreeNode<?> modelValue = new DefaultTreeNode();
+        ValueExpression valueExpression = mock(ValueExpression.class);
+        when(treeTable.getValueExpression("value")).thenReturn(valueExpression);
+        when(valueExpression.getValue(elContext)).thenReturn(modelValue);
+
+        DefaultTreeNode root = new DefaultTreeNode();
+        filterFeature.filter(context, treeTable, root);
+
+        verify(treeTable).updateFilteredValue(context, null);
+        verify(treeTable).setValue(modelValue);
+        verify(treeTable).setRowKey(modelValue, null);
+    }
+
+    @Test
+    void filterWithInactiveFilterEntriesRestoresModelValue() {
+        FacesContext context = mock(FacesContext.class);
+        ELContext elContext = mock(ELContext.class);
+        when(context.getELContext()).thenReturn(elContext);
+
+        FilterFeature filterFeature = new FilterFeature();
+
+        FilterMeta inactiveFilter = mock(FilterMeta.class);
+        when(inactiveFilter.isActive()).thenReturn(false);
+        Map<String, FilterMeta> filterBy = new HashMap<>();
+        filterBy.put("type", inactiveFilter);
+
+        TreeTable treeTable = mock(TreeTable.class);
+        when(treeTable.getFilterByAsMap()).thenReturn(filterBy);
+
+        TreeNode<?> modelValue = new DefaultTreeNode();
+        ValueExpression valueExpression = mock(ValueExpression.class);
+        when(treeTable.getValueExpression("value")).thenReturn(valueExpression);
+        when(valueExpression.getValue(elContext)).thenReturn(modelValue);
+
+        DefaultTreeNode root = new DefaultTreeNode();
+        filterFeature.filter(context, treeTable, root);
+
+        verify(treeTable).updateFilteredValue(context, null);
+        verify(treeTable).setValue(modelValue);
+        verify(treeTable).setRowKey(modelValue, null);
     }
 }

--- a/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
@@ -41,11 +41,7 @@ import jakarta.faces.context.FacesContext;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/feature/TreeTableFilterFeatureTest.java
@@ -138,7 +138,7 @@ class TreeTableFilterFeatureTest {
 
         TreeNode<?> modelValue = new DefaultTreeNode();
         ValueExpression valueExpression = mock(ValueExpression.class);
-        when(treeTable.getValueExpression("value")).thenReturn(valueExpression);
+        when(treeTable.getValueExpression(TreeTable.PropertyKeys.value)).thenReturn(valueExpression);
         when(valueExpression.getValue(elContext)).thenReturn(modelValue);
 
         DefaultTreeNode root = new DefaultTreeNode();
@@ -167,7 +167,7 @@ class TreeTableFilterFeatureTest {
 
         TreeNode<?> modelValue = new DefaultTreeNode();
         ValueExpression valueExpression = mock(ValueExpression.class);
-        when(treeTable.getValueExpression("value")).thenReturn(valueExpression);
+        when(treeTable.getValueExpression(TreeTable.PropertyKeys.value)).thenReturn(valueExpression);
         when(valueExpression.getValue(elContext)).thenReturn(modelValue);
 
         DefaultTreeNode root = new DefaultTreeNode();


### PR DESCRIPTION
Resolve: #9254 instead of workaround

clearFilters() leaves stale filterBy entries with null values, so the `isEmpty()` check was skipped and filtering ran against a null root. The empty filtered value then shadowed the model on the next render.

After the resolution:

Filter:

<img width="608" height="259" alt="image" src="https://github.com/user-attachments/assets/b0cdca29-00a2-4df4-a4d1-974e47891415" />

Clear Filter:

<img width="616" height="323" alt="image" src="https://github.com/user-attachments/assets/0e92e3e1-b2f3-4276-b810-5f3cc1efc522" />

Switch Node:

<img width="616" height="323" alt="image" src="https://github.com/user-attachments/assets/163c0e18-4af8-4f7a-a119-cf2c117d2e02" />

