### PR TITLE
Fix #15114: AccordionPanel inactive state support/improve behavior

### DIFF
--- a/docs/16_0_0/components/accordionpanel.md
+++ b/docs/16_0_0/components/accordionpanel.md
@@ -172,3 +172,11 @@ the list of structural style classes;
 | .ui-accordion | Main container |
 | .ui-accordion-header | Tab header |
 | .ui-accordion-content | Tab content |
+
+## Common Mistakes
+
+### Collapsing all tabs
+
+Use `active="none"` or `active="-1"` to render the panel with all tabs collapsed. The legacy
+`activeIndex="-1"` value is also supported. Using this allows the renderer to skip
+evaluating tab keys, avoiding unnecessary evaluation when no tab is active.

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel006.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel006.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Data
+@Named
+@ViewScoped
+public class AccordionPanel006 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> items;
+
+    @PostConstruct
+    public void init() {
+        items = Arrays.asList("Dynamic 1", "Dynamic 2", "Dynamic 3");
+    }
+
+    public List<String> getItems() {
+        return items;
+    }
+
+    public void setItems(List<String> items) {
+        this.items = items;
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel006.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/accordionpanel/accordionPanel006.xhtml
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:accordionPanel id="accordionpanel1" active="-1">
+                <p:tab title="Panel1">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab title="Panel2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab title="Panel3">
+                    Dummy-Content 3
+                </p:tab>
+            </p:accordionPanel>
+
+            <p:accordionPanel id="accordionpanel2" active="none">
+                <p:tab title="Panel1">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab title="Panel2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab title="Panel3">
+                    Dummy-Content 3
+                </p:tab>
+            </p:accordionPanel>
+
+            <p:accordionPanel id="accordionpanel3" activeIndex="-1">
+                <p:tab title="Panel1">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab title="Panel2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab title="Panel3">
+                    Dummy-Content 3
+                </p:tab>
+            </p:accordionPanel>
+
+            <p:accordionPanel id="accordionpanel4" value="#{accordionPanel006.items}" var="item" active="all" multiple="true">
+                <p:tab title="#{item}">
+                    Dummy-Content #{item}
+                </p:tab>
+            </p:accordionPanel>
+
+        </h:form>
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel006Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/accordionpanel/AccordionPanel006Test.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.accordionpanel;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.AccordionPanel;
+import org.primefaces.selenium.component.model.Tab;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AccordionPanel006Test extends AbstractPrimePageTest {
+
+    @Test
+    void test(Page page) {
+        // Assert all inactive accordions have 0 selected tabs
+        assertEquals(0, page.accordionPanel1.getSelectedTabs().size());
+        assertEquals(0, page.accordionPanel2.getSelectedTabs().size());
+        assertEquals(0, page.accordionPanel3.getSelectedTabs().size());
+
+        // Assert dynamic accordion with active="all"
+        List<Tab> selectedTabs = page.accordionPanel4.getSelectedTabs();
+        assertEquals(3, selectedTabs.size());
+
+        assertEquals("Dynamic 1", selectedTabs.get(0).getTitle());
+        assertEquals("Dummy-Content Dynamic 1", selectedTabs.get(0).getContent().getText().trim());
+
+        assertEquals("Dynamic 2", selectedTabs.get(1).getTitle());
+        assertEquals("Dummy-Content Dynamic 2", selectedTabs.get(1).getContent().getText().trim());
+
+        assertEquals("Dynamic 3", selectedTabs.get(2).getTitle());
+        assertEquals("Dummy-Content Dynamic 3", selectedTabs.get(2).getContent().getText().trim());
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:accordionpanel1")
+        AccordionPanel accordionPanel1;
+
+        @FindBy(id = "form:accordionpanel2")
+        AccordionPanel accordionPanel2;
+
+        @FindBy(id = "form:accordionpanel3")
+        AccordionPanel accordionPanel3;
+
+        @FindBy(id = "form:accordionpanel4")
+        AccordionPanel accordionPanel4;
+
+        @Override
+        public String getLocation() {
+            return "accordionpanel/accordionPanel006.xhtml";
+        }
+    }
+
+}

--- a/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/accordion/accordion.widget.js
@@ -70,8 +70,11 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
                 }
             }
         }
-        else if (stateHolderVal != null) {
+        else if (stateHolderVal != null && stateHolderVal.length > 0) {
             this.cfg.active = this.stateHolder.val();
+        }
+        else {
+            this.cfg.active = 'none';
         }
 
         this.headers.each(function() {
@@ -197,7 +200,7 @@ PrimeFaces.widget.AccordionPanel = class AccordionPanel extends PrimeFaces.widge
      */
     markLoadedPanels() {
         const markPanelAsLoaded = (index) => {
-            if (index >= 0) {
+            if (index !== null && index !== '' && index >= 0) {
                 this.markAsLoaded(this.panels.eq(index));
             }
         };

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelBase.java
@@ -56,10 +56,10 @@ public abstract class AccordionPanelBase extends UITabPanel implements Widget, R
         return COMPONENT_FAMILY;
     }
 
-    @Property(description = "Id of the active tab.")
+    @Property(description = "Active tab index(es)/key(s). Use 'none'/'-1' to collapse all, or 'all' to expand all.")
     public abstract String getActive();
 
-    @Property(defaultValue = "0", description = "Index of the active tab.")
+    @Property(defaultValue = "0", description = "(Deprecated, use active instead!) Active tab index(es). Supports '-1' or 'all'.")
     public abstract String getActiveIndex();
 
     @Property(description = "Client side callback to execute when a tab is changed.")

--- a/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/accordionpanel/AccordionPanelRenderer.java
@@ -36,8 +36,9 @@ import org.primefaces.util.WidgetBuilder;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
@@ -48,6 +49,10 @@ import jakarta.faces.render.FacesRenderer;
 public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
 
     private static final String SB_RESOLVE_ACTIVE_INDEX = AccordionPanelRenderer.class.getName() + "#resolveActive";
+    private static final String ACTIVE_ALL = "all";
+    private static final String ACTIVE_NONE = "none";
+    private static final String ACTIVE_INDEX_NONE = "-1";
+    private static final String RESOLVED_ACTIVE_NONE = ""; // A value that is compatible with client-side JavaScript
 
     @Override
     public void decode(FacesContext context, AccordionPanel component) {
@@ -185,11 +190,12 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
     protected void encodeTabs(FacesContext context, AccordionPanel component, String active) throws IOException {
         boolean dynamic = component.isDynamic();
         boolean repeating = component.isRepeating();
-        boolean rtl = component.getDir().equalsIgnoreCase("rtl");
+        boolean rtl = "rtl".equalsIgnoreCase(component.getDir());
+        boolean noneActive = RESOLVED_ACTIVE_NONE.equalsIgnoreCase(active) || isNoneActive(active); // Safety net if called directly or overridden
 
-        List<String> activeList = active == null
-                                     ? Collections.emptyList()
-                                     : Arrays.asList(active.split(","));
+        Set<String> activeSet = noneActive
+            ? Collections.emptySet()
+            : new HashSet<>(Arrays.asList(active.split(",")));
 
         if (repeating) {
             int dataCount = component.getRowCount();
@@ -198,7 +204,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
             for (int i = 0; i < dataCount; i++) {
                 component.setIndex(i);
                 if (tab.isRendered()) {
-                    boolean activated = isActive(tab, activeList, i);
+                    boolean activated = isActive(tab, activeSet, i);
                     encodeTab(context, component, tab, i, activated, dynamic, repeating, rtl);
                 }
             }
@@ -212,7 +218,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
                 UIComponent child = component.getChildren().get(i);
                 if (child.isRendered() && child instanceof Tab) {
                     Tab tab = (Tab) child;
-                    boolean activated = isActive(tab, activeList, j);
+                    boolean activated = isActive(tab, activeSet, j);
                     encodeTab(context, component, tab, j, activated, dynamic, repeating, rtl);
                     j++;
                 }
@@ -220,8 +226,11 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         }
     }
 
-    protected boolean isActive(Tab tab, List<String> active, int index) {
-        return (active.contains(tab.getKey()) || active.contains(Integer.toString(index))) && !tab.isDisabled();
+    protected boolean isActive(Tab tab, Set<String> activeSet, int index) {
+        if (activeSet.isEmpty() || tab.isDisabled()) {
+            return false;
+        }
+        return activeSet.contains(tab.getKey()) || activeSet.contains(Integer.toString(index));
     }
 
     protected void encodeTab(FacesContext context, AccordionPanel component, Tab tab, int index, boolean active, boolean dynamic,
@@ -230,6 +239,7 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         ResponseWriter writer = context.getResponseWriter();
         String clientId = tab.getClientId(context);
         Menu optionsMenu = tab.getOptionsMenu();
+        String key = tab.getKey();
 
         String headerStyleClass = getStyleClassBuilder(context)
             .add(active, AccordionPanel.ACTIVE_TAB_HEADER_CLASS, AccordionPanel.TAB_HEADER_CLASS)
@@ -260,8 +270,8 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         writer.writeAttribute(HTML.ARIA_CONTROLS, clientId, null);
         writer.writeAttribute(HTML.ARIA_LABEL, tab.getAriaLabel(), null);
         writer.writeAttribute("tabindex", tabindex, null);
-        if (tab.getKey() != null) {
-            writer.writeAttribute("data-key", tab.getKey(), null);
+        if (key != null) {
+            writer.writeAttribute("data-key", key, null);
         }
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
@@ -374,6 +384,15 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
         writer.endElement("a");
     }
 
+    /**
+     * Checks if a raw attribute input represents an inactive panel state.
+     */
+    protected boolean isNoneActive(String active) {
+        return isValueBlank(active)
+            || ACTIVE_NONE.equalsIgnoreCase(active)
+            || ACTIVE_INDEX_NONE.equals(active);
+    }
+
     protected String resolveActive(FacesContext context, AccordionPanel accordionPanel) {
         String active = accordionPanel.getActive();
 
@@ -382,7 +401,11 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
             active = accordionPanel.getActiveIndex();
         }
 
-        if ("all".equals(active)) {
+        if (isNoneActive(active)) {
+            return RESOLVED_ACTIVE_NONE;
+        }
+
+        if (ACTIVE_ALL.equalsIgnoreCase(active)) {
             StringBuilder sb = SharedStringBuilder.get(context, SB_RESOLVE_ACTIVE_INDEX);
 
             if (accordionPanel.getVar() == null) {
@@ -392,22 +415,25 @@ public class AccordionPanelRenderer extends CoreRenderer<AccordionPanel> {
                         if (childIndex > 0) {
                             sb.append(",");
                         }
-
                         Tab tab = (Tab) child;
                         sb.append(tab.getKey() != null ? tab.getKey() : Integer.toString(childIndex));
-
                         childIndex++;
                     }
                 }
             }
             else {
                 Tab tab = accordionPanel.getDynamicTab();
-                for (int i = 0; i < accordionPanel.getRowCount(); i++) {
-                    accordionPanel.setIndex(i);
-                    if (i > 0) {
-                        sb.append(",");
+                try {
+                    for (int i = 0; i < accordionPanel.getRowCount(); i++) {
+                        accordionPanel.setIndex(i);
+                        if (i > 0) {
+                            sb.append(",");
+                        }
+                        sb.append(tab.getKey() != null ? tab.getKey() : Integer.toString(i));
                     }
-                    sb.append(tab.getKey() != null ? tab.getKey() : Integer.toString(i));
+                }
+                finally {
+                    accordionPanel.setIndex(-1); // Reset index after dynamic loop
                 }
             }
 


### PR DESCRIPTION
- Added server/client support for active="-1" and active="none" (and legacy activeIndex="-1"), skipping tab key evaluations when no tab is active.
- Fixed empty dynamic tab rendering: Prevented JS from falsely marking Tab 0 as cached/loaded after a postback when all tabs are closed.
- Index state cleanup: Ensured setIndex(-1) is called in a finally block to properly reset the index after resolving active keys in dynamic loops.