### PR TITLE
Fix #15128: CommmandLink renders a default aria-label value even when…

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkBase.java
@@ -74,7 +74,7 @@ public abstract class CommandLinkBase extends HtmlCommandLink implements AjaxSou
     @Property(description = "When set to true client side validation is enabled, global setting is required to be enabled as a prerequisite.")
     public abstract boolean isValidateClient();
 
-    @Property(defaultValue = "The aria-label attribute is used to define a string that labels the current element for accessibility.")
+    @Property(description = "The aria-label attribute is used to define a string that labels the current element for accessibility.")
     public abstract String getAriaLabel();
 
     @Property(defaultValue = "true", description = "If true, the button will be disabled during Ajax requests triggered by the button.")

--- a/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -102,8 +102,9 @@ public class CommandLinkRenderer extends CoreRenderer<CommandLink> {
         writer.writeAttribute("href", "#", null);
         writer.writeAttribute("class", styleClass, null);
 
-        if (!isValueBlank(component.getAriaLabel())) {
-            writer.writeAttribute(HTML.ARIA_LABEL, component.getAriaLabel(), null);
+        String ariaLabel = component.getAriaLabel();
+        if (!isValueBlank(ariaLabel)) {
+            writer.writeAttribute(HTML.ARIA_LABEL, ariaLabel, null);
         }
 
         if (!isValueBlank(form)) {

--- a/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/commandlink/CommandLinkRenderer.java
@@ -101,7 +101,10 @@ public class CommandLinkRenderer extends CoreRenderer<CommandLink> {
         writer.writeAttribute("id", clientId, "id");
         writer.writeAttribute("href", "#", null);
         writer.writeAttribute("class", styleClass, null);
-        writer.writeAttribute(HTML.ARIA_LABEL, component.getAriaLabel(), null);
+
+        if (!isValueBlank(component.getAriaLabel())) {
+            writer.writeAttribute(HTML.ARIA_LABEL, component.getAriaLabel(), null);
+        }
 
         if (!isValueBlank(form)) {
             writer.writeAttribute("data-pf-form", form, null);


### PR DESCRIPTION
… the developer never set one

See #15128 

Changed:
- moved documentation text from defaultValue to description
- only write the aria-label attribute when component.getAriaLabel() is not blank