### PR TITLE
CDK plugin: add taglib description

### DIFF
--- a/primefaces-cdk/primefaces-cdk-impl/src/main/java/org/primefaces/cdk/impl/taglib/TaglibMojo.java
+++ b/primefaces-cdk/primefaces-cdk-impl/src/main/java/org/primefaces/cdk/impl/taglib/TaglibMojo.java
@@ -107,6 +107,12 @@ public class TaglibMojo extends AbstractMojo {
     private String displayName;
 
     /**
+     * Taglib description
+     */
+    @Parameter
+    private String description;
+
+    /**
      * Perform taglib XML generation
      */
     @Override
@@ -349,6 +355,9 @@ public class TaglibMojo extends AbstractMojo {
         faceletTaglib.addElement("namespace").addText(uri);
         faceletTaglib.addElement("short-name").addText(shortName);
         faceletTaglib.addElement("display-name").addText(displayName);
+        if (description != null && !description.isEmpty()) {
+            faceletTaglib.addElement("description").addText(description);
+        }
 
         for (FunctionInfo functionInfo : functionInfos) {
             Element function = faceletTaglib.addElement("function");

--- a/primefaces/pom.xml
+++ b/primefaces/pom.xml
@@ -329,6 +329,7 @@
                             <uri>http://primefaces.org/ui</uri>
                             <shortName>primefaces</shortName>
                             <displayName>PrimeFaces</displayName>
+                            <description>PrimeFaces UI components.</description>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This brings back the description in the generated taglib file:
<img width="490" height="123" alt="image" src="https://github.com/user-attachments/assets/da08604f-5c69-413c-a522-600bce07f5f0" />
