### PR TITLE
fix: preserve input focus when hovering plain menu items

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/menu/menu001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/menu/menu001.xhtml
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <h:inputText id="input" />
+
+            <p:menu id="menu" widgetVar="menu">
+                <p:menuitem id="first" value="First" url="#first" />
+                <p:menuitem id="second" value="Second" url="#second" />
+                <p:menuitem id="disabled" value="Disabled" url="#disabled" disabled="true" />
+            </p:menu>
+        </h:form>
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menu/Menu001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/menu/Menu001Test.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.menu;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Menu001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Menu: GitHub #15110 hover preserves input focus")
+    void hoverPreservesInputFocus(Page page) {
+        // Arrange
+        WebElement first = page.getMenuLink("form:first");
+        page.input.click();
+
+        // Act
+        new Actions(page.getWebDriver()).moveToElement(first).perform();
+
+        // Assert
+        assertEquals(page.input, page.getWebDriver().switchTo().activeElement());
+        assertTrue(first.getAttribute("class").contains("ui-state-hover"));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Menu: enabled item remains clickable")
+    void clickEnabledItem(Page page) {
+        // Arrange
+        WebElement first = page.getMenuLink("form:first");
+        page.input.click();
+
+        // Act
+        first.click();
+
+        // Assert
+        assertTrue(page.getWebDriver().getCurrentUrl().endsWith("#first"));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Menu: keyboard entry and arrow navigation preserve roving tabindex")
+    void keyboardNavigation(Page page) {
+        // Arrange
+        WebElement first = page.getMenuLink("form:first");
+        WebElement second = page.getMenuLink("form:second");
+        page.input.click();
+
+        // Act
+        page.input.sendKeys(Keys.TAB);
+
+        // Assert
+        assertEquals(first, page.getWebDriver().switchTo().activeElement());
+        assertEquals("0", first.getAttribute("tabindex"));
+        assertEquals("-1", second.getAttribute("tabindex"));
+
+        // Act
+        first.sendKeys(Keys.ARROW_DOWN);
+
+        // Assert
+        assertEquals(second, page.getWebDriver().switchTo().activeElement());
+        assertEquals("-1", first.getAttribute("tabindex"));
+        assertEquals("0", second.getAttribute("tabindex"));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Menu: disabled item hover preserves input focus")
+    void disabledItemHoverPreservesInputFocus(Page page) {
+        // Arrange
+        WebElement disabled = page.getMenuLink("form:disabled");
+        page.input.click();
+
+        // Act
+        new Actions(page.getWebDriver()).moveToElement(disabled).perform();
+
+        // Assert
+        assertEquals(page.input, page.getWebDriver().switchTo().activeElement());
+        assertFalse(disabled.getAttribute("class").contains("ui-state-hover"));
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:input")
+        WebElement input;
+
+        @FindBy(id = "form:menu")
+        WebElement menu;
+
+        WebElement getMenuLink(String menuitemId) {
+            return menu.findElement(By.id(menuitemId));
+        }
+
+        @Override
+        public String getLocation() {
+            return "menu/menu001.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/menu/menu.plainmenu.widget.ts
+++ b/primefaces/src/main/frontend/packages/components/src/menu/menu.plainmenu.widget.ts
@@ -153,11 +153,13 @@ export class PlainMenu<Cfg extends PlainMenuCfg = PlainMenuCfg> extends Menu<Cfg
         // Set the first focusable menu item
         this.resetFocusState();
 
-        // Bind mouse and click events to focus items
-        this.menuitemLinks.on("mouseenter.menu click.menu", function(e) {
+        // Bind mouse events to highlight items without changing browser focus
+        this.menuitemLinks.on("mouseenter.menu", function() {
+            $(this).addClass('ui-state-hover');
+        }).on("mouseleave.menu", function() {
+            $(this).removeClass('ui-state-hover');
+        }).on("click.menu", function(e) {
             $this.focus($(this), e);
-        }).on("mouseleave.menu", function(e) {
-            $this.unfocus($(this), e);
         });
 
         // Bind keyboard navigation events
@@ -206,7 +208,7 @@ export class PlainMenu<Cfg extends PlainMenuCfg = PlainMenuCfg> extends Menu<Cfg
         // Set the first focusable menu item
         this.resetFocus(true);
 
-        // plain menu does not have hover and active states
+        // Clear transient hover and active states for non-overlay menus
         if (!this.cfg.overlay) {
             this.menuitemLinks.removeClass('ui-state-hover ui-state-active');
         }


### PR DESCRIPTION
Separate pointer-hover state handling from focus-driven selection in `menu.plainmenu.widget.ts`, following the existing menu-family convention of applying hover presentation without triggering DOM focus. PrimeFaces 15.0.17 still moves DOM focus away from an input when the pointer enters an item in a plain `p:menu`.

Focus the input, move the pointer over an enabled plain-menu item, and verify the input remains `document.activeElement` while the item receives its normal hover presentation; Focus the input and click an enabled menu item, verifying ordinary click activation remains available and does not introduce a JavaScript error.

Fixes #15110

AI was used for assistance.
