### PR TITLE
Fix #15154 TabView JS error

### DIFF
--- a/primefaces-integration-tests/src/main/webapp/tabview/tabView005.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tabview/tabView005.xhtml
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:tabView id="tabview" scrollable="true">
+                <f:facet name="actions">
+                    <p:commandButton id="actionButton" value="Action" update="@form" process="@this"/>
+                </f:facet>
+                <p:tab title="Tab1">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab title="Tab2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab title="Tab3">
+                    Dummy-Content 3
+                </p:tab>
+                <p:tab title="Tab4">
+                    Dummy-Content 4
+                </p:tab>
+                <p:tab title="Tab5">
+                    Dummy-Content 5
+                </p:tab>
+            </p:tabView>
+
+            <p:commandButton id="button" value="Submit" update="@form"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView005Test.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tabview;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.TabView;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TabView005Test extends AbstractPrimePageTest {
+
+    @Test
+    @DisplayName("TabView: GitHub #15154 scrollable TabView with an actions facet must not throw a JS error on render")
+    void scrollableWithActionsFacet(Page page) {
+        // Assert - page must render without the lastTab selector crashing on init
+        assertNoJavascriptErrors();
+
+        // Act - an unrelated button must remain responsive (regression: an uncaught init
+        // error previously aborted the surrounding widget-init script, leaving other
+        // widgets on the page unresponsive too)
+        page.button.click();
+
+        // Assert
+        assertEquals(5, page.tabView.getTabs().size());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:tabview")
+        TabView tabView;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "tabview/tabView005.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
@@ -85,8 +85,8 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
             this.navcrollerLeft = this.navscroller.children('.ui-tabs-navscroller-btn-left');
             this.navcrollerRight = this.navscroller.children('.ui-tabs-navscroller-btn-right');
             this.navContainer = this.navscroller.children('.ui-tabs-nav');
-            this.firstTab = this.navContainer.children('li.ui-tabs-header:first-child');
-            this.lastTab = this.navContainer.children('li.ui-tabs-header:last-child');
+            this.firstTab = this.navContainer.children('li.ui-tabs-header').first();
+            this.lastTab = this.navContainer.children('li.ui-tabs-header').last();
             this.scrollStateHolder = $(this.jqId + '_scrollState');
         }
         else {


### PR DESCRIPTION
Fix #15154 Fix scrollable TabView throwing an uncaught TypeError when combined with an actions facet. The last tab lookup used
`li.ui-tabs-header:last-child`, which only matches when the header is also the last DOM child - but the actions facet renders its own `<li>` after all headers, so the selector matched nothing and `lastTab.position()` crashed on init. Switched to jQuery's `.first()`/`.last()` instead.