### PR TITLE
Fix #15154 15.X TabView JS error

### DIFF
--- a/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
+++ b/primefaces/src/main/resources/META-INF/resources/primefaces/tabview/tabview.js
@@ -85,8 +85,8 @@ PrimeFaces.widget.TabView = PrimeFaces.widget.DeferredWidget.extend({
             this.navcrollerLeft = this.navscroller.children('.ui-tabs-navscroller-btn-left');
             this.navcrollerRight = this.navscroller.children('.ui-tabs-navscroller-btn-right');
             this.navContainer = this.navscroller.children('.ui-tabs-nav');
-            this.firstTab = this.navContainer.children('li.ui-tabs-header:first-child');
-            this.lastTab = this.navContainer.children('li.ui-tabs-header:last-child');
+            this.firstTab = this.navContainer.children('li.ui-tabs-header').first();
+            this.lastTab = this.navContainer.children('li.ui-tabs-header').last();
             this.scrollStateHolder = $(this.jqId + '_scrollState');
         }
         else {


### PR DESCRIPTION
Fix scrollable TabView throwing an uncaught TypeError when combined with an actions facet. The last tab lookup used
`li.ui-tabs-header:last-child`, which only matches when the header is also the last DOM child - but the actions facet renders its own `<li>` after all headers, so the selector matched nothing and `lastTab.position()` crashed on init. Switched to jQuery's `.first()`/`.last()` instead.