### PR TITLE
Fix #15161 Tree: reset rowKey after render

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree008.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tree/Tree008.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tree;
+
+import org.primefaces.model.TreeNode;
+
+import java.io.Serializable;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class Tree008 implements Serializable {
+
+    @Inject
+    private TreeNodeService treeNodeService;
+
+    private TreeNode<String> root;
+
+    @PostConstruct
+    public void init() {
+        root = treeNodeService.createNodes();
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/tree/tree008.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tree/tree008.xhtml
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html"
+    xmlns:f="jakarta.faces.core" xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+        <h:form id="form">
+            <p:tree id="tree" value="#{tree008.root}" var="document" widgetVar="tree">
+                <p:treeNode>
+                    <h:outputText value="#{document}" />
+                </p:treeNode>
+            </p:tree>
+
+            <!-- the tree must not leak its var, so this renders empty and not the data of the last node -->
+            <h:outputText id="after" value="after=[#{document}]" />
+
+            <p:commandButton id="buttonUpdate" value="Update" update="@form" />
+
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree008Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tree/Tree008Test.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tree;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Tree;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class Tree008Test extends AbstractTreeTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Tree: GitHub #15161 the iteration variable does not leak into what renders after the tree")
+    void varDoesNotLeakAfterRender(Page page) {
+        // Arrange
+        Tree tree = page.tree;
+        assertNotNull(tree);
+
+        // Assert
+        assertEquals("after=[]", page.after.getText());
+
+        // Act
+        PrimeSelenium.guardAjax(page.buttonUpdate).click();
+
+        // Assert
+        assertEquals("after=[]", page.after.getText());
+
+        assertConfiguration(tree.getWidgetConfiguration());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:tree")
+        Tree tree;
+
+        @FindBy(id = "form:after")
+        WebElement after;
+
+        @FindBy(id = "form:buttonUpdate")
+        CommandButton buttonUpdate;
+
+        @Override
+        public String getLocation() {
+            return "tree/tree008.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -285,6 +285,10 @@ public class TreeRenderer extends CoreRenderer<Tree> {
             encodeMarkup(context, component);
             encodeScript(context, component);
         }
+
+        // the row key ends up in the client id of every descendant and puts the node in the request map under var,
+        // so the tree must not be left standing on a node once it has been encoded
+        component.setRowKey(root, null);
     }
 
     protected void encodeFilteredNodes(FacesContext context, Tree component, TreeNode<?> node, String filteredValue, Locale filterLocale)

--- a/primefaces/src/test/java/org/primefaces/component/tree/TreeRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/tree/TreeRendererTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.tree;
+
+import org.primefaces.mock.CollectingResponseWriter;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.model.DefaultTreeNode;
+import org.primefaces.model.TreeNode;
+
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TreeRendererTest {
+
+    /**
+     * The row the tree stands on ends up in the client id of everything below it, and it puts the node it holds in
+     * the request map under the tree's var. So a render which iterated the tree leaves it standing on no row. The
+     * state of a child is saved under the client id it reports at the end of the render, and whatever renders after
+     * the tree resolves the var of its own scope.
+     */
+    @Test
+    void encodeEndLeavesTheTreeStandingOnNoRow() throws Exception {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        TreeNode<String> root = new DefaultTreeNode<>();
+        new DefaultTreeNode<>("one", root);
+        new DefaultTreeNode<>("two", root);
+
+        UITreeNode treeNode = new UITreeNode();
+        treeNode.setType("default");
+
+        Tree tree = new Tree();
+        tree.setId("tree");
+        tree.setVar("node");
+        tree.setValue(root);
+        tree.getChildren().add(treeNode);
+
+        new TreeRenderer().encodeEnd(context, tree);
+
+        assertNull(tree.getRowKey());
+        assertEquals(tree.getClientId(context), tree.getContainerClientId(context));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("node"));
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/mock/ExternalContextMock.java
+++ b/primefaces/src/test/java/org/primefaces/mock/ExternalContextMock.java
@@ -39,6 +39,9 @@ import jakarta.faces.context.ExternalContext;
 public class ExternalContextMock extends ExternalContext {
 
     private Map<String, Object> applicationMap = new HashMap<String, Object>();
+    private Map<String, Object> requestMap = new HashMap<String, Object>();
+    private Map<String, String> requestParameterMap = new HashMap<String, String>();
+    private Map<String, String> requestHeaderMap = new HashMap<String, String>();
 
     @Override
     public void dispatch(String path) throws IOException {
@@ -107,7 +110,7 @@ public class ExternalContextMock extends ExternalContext {
 
     @Override
     public Map<String, String> getRequestHeaderMap() {
-        return null;
+        return requestHeaderMap;
     }
 
     @Override
@@ -127,12 +130,12 @@ public class ExternalContextMock extends ExternalContext {
 
     @Override
     public Map<String, Object> getRequestMap() {
-        return null;
+        return requestMap;
     }
 
     @Override
     public Map<String, String> getRequestParameterMap() {
-        return null;
+        return requestParameterMap;
     }
 
     @Override


### PR DESCRIPTION

Fix #15161 Tree: reset rowKey after render- #15162

TreeRenderer left the tree standing on the last rendered node. That leaked the iteration variable into whatever renders after the tree, and gave every descendant a row prefixed client id at the end of RENDER_RESPONSE, so their partial state was saved under an id the postback never rebuilds.

Reset the row key at the end of encodeEnd, like TreeTableRenderer and UIData.encodeEnd already do.