### PR TITLE
Dialog: remove incorrect implicitDefaultValue on appendTo

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/dialog/DialogBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/dialog/DialogBase.java
@@ -127,7 +127,7 @@ public abstract class DialogBase extends UIPanel implements Widget, RTLAware, St
     @Property(description = "Client-side callback to execute when dialog is shown.")
     public abstract String getOnShow();
 
-    @Property(implicitDefaultValue = "@(body)", description = "Append dialog to the element with the given identifier.")
+    @Property(description = "Append dialog to the element with the given identifier.")
     public abstract String getAppendTo();
 
     @Property(defaultValue = "true", description = "Renders dialog header.")


### PR DESCRIPTION
Dialog does not default to '@(body)' in runtime (DynamicOverlayWidget explicitly excludes Dialog and leaves the element in-place in the DOM). Remove implicitDefaultValue to prevent generating incorrect VDL documentation.