### PR TITLE
Fix #15161 15.X Tree: reset rowKey after render (#15162)

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -286,7 +286,7 @@ public class TreeRenderer extends CoreRenderer {
 
         // the row key ends up in the client id of every descendant and puts the node in the request map under var,
         // so the tree must not be left standing on a node once it has been encoded
-        component.setRowKey(root, null);
+        tree.setRowKey(root, null);
     }
 
     protected void encodeFilteredNodes(FacesContext context, Tree tree, TreeNode<?> node, String filteredValue, Locale filterLocale)

--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -283,6 +283,10 @@ public class TreeRenderer extends CoreRenderer {
             encodeMarkup(context, tree);
             encodeScript(context, tree);
         }
+
+        // the row key ends up in the client id of every descendant and puts the node in the request map under var,
+        // so the tree must not be left standing on a node once it has been encoded
+        component.setRowKey(root, null);
     }
 
     protected void encodeFilteredNodes(FacesContext context, Tree tree, TreeNode<?> node, String filteredValue, Locale filterLocale)


### PR DESCRIPTION
TreeRenderer left the tree standing on the last rendered node. That leaked the iteration variable into whatever renders after the tree, and gave every descendant a row prefixed client id at the end of RENDER_RESPONSE, so their partial state was saved under an id the postback never rebuilds.

Reset the row key at the end of encodeEnd, like TreeTableRenderer and UIData.encodeEnd already do.