### PR TITLE
Fix #15176: Resolve EL expressions for Java keyword properties

### DIFF
--- a/primefaces-cdk/primefaces-cdk-impl/src/main/java/org/primefaces/cdk/impl/subclass/AnnotationProcessor.java
+++ b/primefaces-cdk/primefaces-cdk-impl/src/main/java/org/primefaces/cdk/impl/subclass/AnnotationProcessor.java
@@ -399,6 +399,7 @@ public class AnnotationProcessor extends AbstractProcessor {
         w.println("        }");
         w.println();
         w.println("        @Override public String getName()              { return _name; }");
+        w.println("        @Override public String toString()             { return _name; }");
         w.println("        @Override public Class<?> getType()            { return _type; }");
         w.println("        @Override public String getDescription()       { return _description; }");
         w.println("        @Override public boolean isRequired()          { return _required; }");

--- a/primefaces/src/test/java/org/primefaces/component/message/MessageTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/message/MessageTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.message;
+
+import org.primefaces.mock.FacesContextMock;
+
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MessageTest {
+
+    @Test
+    void forValueExpression() {
+        FacesContext context = new FacesContextMock();
+        ExpressionFactory expressionFactory = context.getApplication().getExpressionFactory();
+        ValueExpression expression = expressionFactory.createValueExpression(context.getELContext(), "#{'input'}", String.class);
+
+        Message message = new Message();
+        message.setValueExpression("for", expression);
+
+        assertEquals("input", message.getFor());
+    }
+}


### PR DESCRIPTION
Generate PropertyKeys.toString() using the original property name so that Faces StateHelper can locate value expressions correctly. This fixes p:message for attributes bound through EL, where "for" was incorrectly resolved as "_for".