### PR TITLE
Fix #15184: FileUpload add Tomcat docs to all versions

### DIFF
--- a/docs/11_0_0/components/fileupload.md
+++ b/docs/11_0_0/components/fileupload.md
@@ -353,6 +353,12 @@ For legacy browsers, that do not support HMTL5 features like canvas or file api,
 (iframe is used for transport, detailed file informations are not shown,  GIF animation instead of progress bar).
 It is suggested to offer simple uploader as a fallback.
 
+## Configuration for Tomcat since June 2025 (>= 9.0.106, >= 10.1.42, >= 11.0.8)
+> maxPartCount limits the total number of parts in a multi-part request and maxPartHeaderSize limits the size of the headers provided with each part.
+
+See https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Common_Attributes for additional information.
+
+
 ## Filter Configuration
 
 Filter configuration is required if you are using commons uploader only. Two configuration options

--- a/docs/12_0_0/components/fileupload.md
+++ b/docs/12_0_0/components/fileupload.md
@@ -352,6 +352,12 @@ For legacy browsers, that do not support HMTL5 features like canvas or file api,
 (iframe is used for transport, detailed file informations are not shown,  GIF animation instead of progress bar).
 It is suggested to offer simple uploader as a fallback.
 
+## Configuration for Tomcat since June 2025 (>= 9.0.106, >= 10.1.42, >= 11.0.8)
+> maxPartCount limits the total number of parts in a multi-part request and maxPartHeaderSize limits the size of the headers provided with each part.
+
+See https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Common_Attributes for additional information.
+
+
 ## Filter Configuration
 
 Filter configuration is required if you are using commons uploader only. Two configuration options

--- a/docs/13_0_0/components/fileupload.md
+++ b/docs/13_0_0/components/fileupload.md
@@ -352,6 +352,12 @@ For legacy browsers, that do not support HMTL5 features like canvas or file api,
 (iframe is used for transport, detailed file informations are not shown,  GIF animation instead of progress bar).
 It is suggested to offer simple uploader as a fallback.
 
+## Configuration for Tomcat since June 2025 (>= 9.0.106, >= 10.1.42, >= 11.0.8)
+> maxPartCount limits the total number of parts in a multi-part request and maxPartHeaderSize limits the size of the headers provided with each part.
+
+See https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Common_Attributes for additional information.
+
+
 ## Filter Configuration
 
 Filter configuration is required if you are using commons uploader only. Two configuration options

--- a/docs/14_0_0/components/fileupload.md
+++ b/docs/14_0_0/components/fileupload.md
@@ -361,6 +361,12 @@ For legacy browsers, that do not support HMTL5 features like canvas or file api,
 (iframe is used for transport, detailed file informations are not shown,  GIF animation instead of progress bar).
 It is suggested to offer simple uploader as a fallback.
 
+## Configuration for Tomcat since June 2025 (>= 9.0.106, >= 10.1.42, >= 11.0.8)
+> maxPartCount limits the total number of parts in a multi-part request and maxPartHeaderSize limits the size of the headers provided with each part.
+
+See https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Common_Attributes for additional information.
+
+
 ## Filter Configuration
 
 Filter configuration is required if you are using commons uploader only. Two configuration options

--- a/docs/8_0/components/fileupload.md
+++ b/docs/8_0/components/fileupload.md
@@ -253,6 +253,12 @@ uses graceful degradation so that iframe is used for transport, detailed file in
 and a gif animation is displayed instead of progress bar. It is suggested to offer simple uploader as a
 fallback.
 
+## Configuration for Tomcat since June 2025 (>= 9.0.106, >= 10.1.42, >= 11.0.8)
+> maxPartCount limits the total number of parts in a multi-part request and maxPartHeaderSize limits the size of the headers provided with each part.
+
+See https://tomcat.apache.org/tomcat-11.0-doc/config/http.html#Common_Attributes for additional information.
+
+
 ## Filter Configuration
 
 Filter configuration is required if you are using commons uploader only. Two configuration options


### PR DESCRIPTION
Fix #15184: FileUpload add Tomcat docs to all versions