### PR TITLE
Fix #15198 DataTable/TreeTable: keep column filters visible in reflow mode

### DIFF
--- a/primefaces/src/main/frontend/packages/components/src/datatable/datatable.css
+++ b/primefaces/src/main/frontend/packages/components/src/datatable/datatable.css
@@ -355,6 +355,39 @@
         display: none;
     }
 
+    /* Keep column filters usable in reflow mode: stack the filterable header
+       cells instead of hiding the whole thead. */
+    .ui-datatable-reflow thead th.ui-filter-column {
+        box-sizing: border-box;
+        display: block;
+        float: left;
+        clear: left;
+        width: 100% !important;
+        border: 0 none;
+        text-align: left;
+    }
+
+    .ui-datatable-reflow thead th.ui-filter-column .ui-column-title {
+        display: block;
+        font-weight: bold;
+        margin: 0 0 .4em 0;
+        padding: 0;
+    }
+
+    .ui-datatable-reflow thead th.ui-filter-column .ui-sortable-column-icon,
+    .ui-datatable-reflow thead th.ui-filter-column .ui-sortable-column-badge,
+    .ui-datatable-reflow thead th.ui-filter-column .ui-column-resizer {
+        display: none;
+    }
+
+    .ui-datatable-reflow thead th.ui-filter-column .ui-column-filter,
+    .ui-datatable-reflow thead th.ui-filter-column .ui-column-customfilter {
+        display: block;
+        box-sizing: border-box;
+        width: 100% !important;
+        margin: 0;
+    }
+
     .ui-datatable-reflow .ui-datatable-data td[role="gridcell"]:not(.ui-helper-hidden) {
         -moz-box-sizing: border-box;
         -webkit-box-sizing: border-box;

--- a/primefaces/src/main/frontend/packages/components/src/treetable/treetable.css
+++ b/primefaces/src/main/frontend/packages/components/src/treetable/treetable.css
@@ -181,6 +181,39 @@ body .ui-treetable.ui-treetable-scrollable .ui-treetable-scrollable-theadclone t
         display: none;
     }
 
+    /* Keep column filters usable in reflow mode: stack the filterable header
+       cells instead of hiding the whole thead. */
+    .ui-treetable-reflow thead th.ui-filter-column {
+        box-sizing: border-box;
+        display: block;
+        float: left;
+        clear: left;
+        width: 100% !important;
+        border: 0 none;
+        text-align: left;
+    }
+
+    .ui-treetable-reflow thead th.ui-filter-column .ui-column-title {
+        display: block;
+        font-weight: bold;
+        margin: 0 0 .4em 0;
+        padding: 0;
+    }
+
+    .ui-treetable-reflow thead th.ui-filter-column .ui-sortable-column-icon,
+    .ui-treetable-reflow thead th.ui-filter-column .ui-sortable-column-badge,
+    .ui-treetable-reflow thead th.ui-filter-column .ui-column-resizer {
+        display: none;
+    }
+
+    .ui-treetable-reflow thead th.ui-filter-column .ui-column-filter,
+    .ui-treetable-reflow thead th.ui-filter-column .ui-column-customfilter {
+        display: block;
+        box-sizing: border-box;
+        width: 100% !important;
+        margin: 0;
+    }
+
     .ui-treetable-reflow .ui-treetable-data td { 
         text-align: left;
         display: block;


### PR DESCRIPTION
### Problem

`p:dataTable reflow="true"` (and `p:treeTable`) hides every column filter on
viewports `<= 640px`. The reflow media query in `datatable.css` sets
`.ui-datatable-reflow thead th { display: none }`, which removes the whole
header, filter inputs included. Sorting is still possible through the reflow
"Sort By" dropdown; filtering has no fallback, so the table cannot be filtered
on mobile. The filter inputs are still present in the DOM — only hidden by CSS.

### Fix

Within the existing `@media (max-width: 640px)` block, keep the filterable
header cells (`th.ui-filter-column`) visible and stacked (column label +
full-width filter control), and hide the parts that do not apply in reflow
(sort icon / multi-sort badge, column resizer). Columns without a filter keep
their header hidden as before. No Java / JS / API changes. The same change is
mirrored in `treetable.css`.

Fixes #15198 

