### PR TITLE
Fix #15163 #15164 #15165 #15166 #15167 reset iteration state after render

### DIFF
--- a/docs/migrationguide/17_0_0.md
+++ b/docs/migrationguide/17_0_0.md
@@ -1,0 +1,28 @@
+# Migration guide 16.0.0 -> 17.0.0
+
+## Renderers are wrapped
+
+PrimeFaces now installs a `RenderKitFactory` (`org.primefaces.renderkit.PrimeRenderKitFactory`). Its render kit hands
+out every PrimeFaces renderer, meaning every `org.primefaces.renderkit.CoreRenderer`, inside a
+`org.primefaces.renderkit.PrimeRendererWrapper`. The wrapper resets the iteration state of components which implement
+`org.primefaces.component.api.IterationCleanupAware` after `decode` and after `encodeEnd`, so that a row index, a row
+key or an iteration variable never outlives the phase which set it.
+
+Renderers of the Faces implementation and of other component libraries are handed out untouched.
+
+This only matters if you cast the result of `RenderKit#getRenderer` to a PrimeFaces renderer type:
+
+```java
+// throws ClassCastException as of 17.0.0
+DataTableRenderer renderer = (DataTableRenderer) context.getRenderKit()
+        .getRenderer(DataTable.COMPONENT_FAMILY, DataTable.DEFAULT_RENDERER);
+```
+
+`PrimeRendererWrapper` implements `jakarta.faces.FacesWrapper`, so unwrap it:
+
+```java
+DataTableRenderer renderer = ComponentUtils.getUnwrappedRenderer(context,
+        DataTable.COMPONENT_FAMILY, DataTable.DEFAULT_RENDERER);
+```
+
+`ComponentUtils#getUnwrappedRenderer` already existed and works on both versions.

--- a/docs/migrationguide/migrationguide.md
+++ b/docs/migrationguide/migrationguide.md
@@ -1,5 +1,6 @@
 # Migration Guide
 
+* [16.0.0 -> 17.0.0](../migrationguide/17_0_0.md)
 * [15.0.0 -> 16.0.0](../migrationguide/16_0_0.md)
 * [14.0.0 -> 15.0.0](../migrationguide/15_0_0.md)
 * [13.0.0 -> 14.0.0](../migrationguide/14_0_0.md)

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DataTable052 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private List<ProgrammingLanguage> progLanguages;
+    private List<Team> teams;
+
+    @Inject
+    private ProgrammingLanguageService service;
+
+    @PostConstruct
+    public void init() {
+        progLanguages = service.getLangs();
+        teams = Arrays.asList(
+                new Team("alpha", Arrays.asList("alpha-1", "alpha-2")),
+                new Team("beta", Arrays.asList("beta-1", "beta-2")));
+    }
+
+    public List<String> getColumns() {
+        return Arrays.asList("id", "name");
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Team implements Serializable {
+
+        @Serial private static final long serialVersionUID = 1L;
+
+        private String name;
+        private List<String> stats;
+    }
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/timeline/Timeline004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/timeline/Timeline004.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.timeline;
+
+import org.primefaces.model.timeline.TimelineEvent;
+import org.primefaces.model.timeline.TimelineGroup;
+import org.primefaces.model.timeline.TimelineModel;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDate;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class Timeline004 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private TimelineModel<String, String> model;
+
+    @PostConstruct
+    public void init() {
+        model = new TimelineModel<>();
+
+        model.addGroup(new TimelineGroup<>("releases", "Releases"));
+        model.add(TimelineEvent.<String>builder().data("PrimeFaces 14").group("releases").startDate(LocalDate.of(2024, 4, 1)).build());
+        model.add(TimelineEvent.<String>builder().data("PrimeFaces 15").group("releases").startDate(LocalDate.of(2025, 4, 1)).build());
+        model.add(TimelineEvent.<String>builder().data("PrimeFaces 16").group("releases").startDate(LocalDate.of(2026, 4, 1)).build());
+    }
+}

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+
+            <p:dataTable id="dynamic" var="lang" value="#{dataTable052.progLanguages}">
+                <p:columns id="cols" var="col" value="#{dataTable052.columns}" headerText="#{col}">
+                    <h:outputText value="#{lang[col]}"/>
+                </p:columns>
+            </p:dataTable>
+
+            <!-- p:columns must not leak its var, so this renders empty and not the last column -->
+            <h:outputText id="afterCols" value="afterCols=[#{col}]"/>
+
+            <p:dataTable id="grouped" var="team" value="#{dataTable052.teams}">
+                <p:columnGroup type="header">
+                    <p:row>
+                        <p:column headerText="Stats"/>
+                    </p:row>
+                </p:columnGroup>
+
+                <p:subTable id="stats" var="stat" value="#{team.stats}">
+                    <f:facet name="header">
+                        <h:outputText value="#{team.name}"/>
+                    </f:facet>
+                    <p:column>
+                        <h:outputText value="#{stat}"/>
+                    </p:column>
+                </p:subTable>
+            </p:dataTable>
+
+            <!-- p:subTable must not leak its var, so this renders empty and not the last row -->
+            <h:outputText id="afterSub" value="afterSub=[#{stat}]"/>
+
+            <p:commandButton id="buttonUpdate" value="Update" update="@form"/>
+
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/timeline/timeline004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/timeline/timeline004.xhtml
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+
+            <p:timeline id="timeline" value="#{timeline004.model}" height="250px" var="event" varGroup="group">
+                <f:facet name="group">
+                    <h:outputText value="#{group}"/>
+                </f:facet>
+                <h:outputText value="#{event}"/>
+            </p:timeline>
+
+            <!-- the timeline must not leak its vars, so these render empty and not the last event and group -->
+            <h:outputText id="afterEvent" value="afterEvent=[#{event}]"/>
+            <h:outputText id="afterGroup" value="afterGroup=[#{group}]"/>
+
+            <p:commandButton id="buttonUpdate" value="Update" update="@form"/>
+
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DataTable;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * GitHub #15165 and #15166: a component which iterates must not leave its iteration variable in the request map, so
+ * that whatever renders after it resolves the variable of its own scope instead of the last row it rendered.
+ */
+class DataTable052Test extends AbstractDataTableTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: GitHub #15166 p:columns does not leak its var into what renders after the table")
+    void dynamicColumnsVarDoesNotLeakAfterRender(Page page) {
+        // Arrange
+        assertTrue(page.dynamic.isDisplayed());
+
+        // Assert
+        assertEquals("afterCols=[]", page.afterCols.getText());
+
+        // Act
+        PrimeSelenium.guardAjax(page.buttonUpdate).click();
+
+        // Assert
+        assertEquals("afterCols=[]", page.afterCols.getText());
+
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: GitHub #15165 p:subTable does not leak its var into what renders after the table")
+    void subTableVarDoesNotLeakAfterRender(Page page) {
+        // Arrange
+        assertTrue(page.grouped.isDisplayed());
+
+        // Assert
+        assertEquals("afterSub=[]", page.afterSub.getText());
+
+        // Act
+        PrimeSelenium.guardAjax(page.buttonUpdate).click();
+
+        // Assert
+        assertEquals("afterSub=[]", page.afterSub.getText());
+
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:dynamic")
+        DataTable dynamic;
+
+        @FindBy(id = "form:afterCols")
+        WebElement afterCols;
+
+        @FindBy(id = "form:grouped")
+        DataTable grouped;
+
+        @FindBy(id = "form:afterSub")
+        WebElement afterSub;
+
+        @FindBy(id = "form:buttonUpdate")
+        CommandButton buttonUpdate;
+
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable052.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/timeline/Timeline004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/timeline/Timeline004Test.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.timeline;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Timeline;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * GitHub #15167: the timeline puts the event it renders in the request map under its var and the group under its
+ * varGroup, so neither may outlive the render.
+ */
+class Timeline004Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Timeline: GitHub #15167 var and varGroup do not leak into what renders after the timeline")
+    void varsDoNotLeakAfterRender(Page page) {
+        // Arrange
+        assertTrue(page.timeline.isDisplayed());
+
+        // Assert
+        assertEquals("afterEvent=[]", page.afterEvent.getText());
+        assertEquals("afterGroup=[]", page.afterGroup.getText());
+
+        // Act
+        PrimeSelenium.guardAjax(page.buttonUpdate).click();
+
+        // Assert
+        assertEquals("afterEvent=[]", page.afterEvent.getText());
+        assertEquals("afterGroup=[]", page.afterGroup.getText());
+
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:timeline")
+        Timeline timeline;
+
+        @FindBy(id = "form:afterEvent")
+        WebElement afterEvent;
+
+        @FindBy(id = "form:afterGroup")
+        WebElement afterGroup;
+
+        @FindBy(id = "form:buttonUpdate")
+        CommandButton buttonUpdate;
+
+        @Override
+        public String getLocation() {
+            return "timeline/timeline004.xhtml";
+        }
+    }
+}

--- a/primefaces-showcase/src/main/java/org/primefaces/showcase/util/taglib/TagInfo.java
+++ b/primefaces-showcase/src/main/java/org/primefaces/showcase/util/taglib/TagInfo.java
@@ -35,6 +35,7 @@ import org.primefaces.cdk.api.utils.ReflectionUtils;
 import org.primefaces.cdk.api.validator.PrimeValidator;
 import org.primefaces.cdk.spi.taglib.Tag;
 import org.primefaces.cdk.spi.taglib.TagType;
+import org.primefaces.util.ComponentUtils;
 import org.primefaces.util.LangUtils;
 
 import java.util.Arrays;
@@ -43,7 +44,6 @@ import java.util.stream.Collectors;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.context.FacesContext;
-import jakarta.faces.render.RenderKit;
 import jakarta.faces.render.Renderer;
 
 import lombok.Getter;
@@ -82,8 +82,8 @@ public class TagInfo {
                 componentFamily = ((UIComponent) instance).getFamily();
 
                 if (LangUtils.isNotBlank(tag.getRendererType())) {
-                    RenderKit renderKit = context.getRenderKit();
-                    Renderer<?> renderer = renderKit.getRenderer(componentFamily, tag.getRendererType());
+                    // the render kit hands out PrimeFaces renderers wrapped, and we want to report the real class
+                    Renderer<?> renderer = ComponentUtils.getUnwrappedRenderer(context, componentFamily, tag.getRendererType());
                     rendererClass = renderer.getClass().getName();
                 }
 

--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -47,6 +47,22 @@ import jakarta.faces.context.FacesContext;
 
 public interface ColumnAware {
 
+    /**
+     * Resets every {@link Columns} below this component, so that it no longer stands on the column which was rendered
+     * last. {@link DynamicColumn#applyModel()} is called from a lot of places while a table renders and
+     * {@link DynamicColumn#cleanModel()} matches none of them, so the reset happens once, when the table is done.
+     *
+     * @param context the {@link FacesContext}.
+     */
+    default void resetDynamicColumns(FacesContext context) {
+        forEachColumn(context, (UIComponent) this, false, false, false, column -> {
+            if (column instanceof Columns columns && columns.getRowIndex() != -1) {
+                columns.setRowIndex(-1);
+            }
+            return true;
+        });
+    }
+
     default void forEachColumn(Predicate<UIColumn> callback) {
         forEachColumn(true, true, false, callback);
     }

--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -51,16 +51,32 @@ public interface ColumnAware {
      * Resets every {@link Columns} below this component, so that it no longer stands on the column which was rendered
      * last. {@link DynamicColumn#applyModel()} is called from a lot of places while a table renders and
      * {@link DynamicColumn#cleanModel()} matches none of them, so the reset happens once, when the table is done.
-     *
-     * @param context the {@link FacesContext}.
+     * <p>
+     * This walks the children itself instead of going through
+     * {@link #forEachColumn(FacesContext, UIComponent, boolean, boolean, boolean, Predicate)}, on purpose. That one
+     * evaluates EL: it visits a {@code ui:repeat} to look for a {@link Column} inside it, which can never hold a
+     * {@link Columns} anyway, and it applies the stateless model of each dynamic column. A cleanup runs after a phase
+     * which may have thrown, so it must not evaluate anything which could throw a second time and bury the original
+     * exception.
      */
-    default void resetDynamicColumns(FacesContext context) {
-        forEachColumn(context, (UIComponent) this, false, false, false, column -> {
-            if (column instanceof Columns columns && columns.getRowIndex() != -1) {
-                columns.setRowIndex(-1);
+    default void resetDynamicColumns() {
+        resetDynamicColumns((UIComponent) this);
+    }
+
+    private static void resetDynamicColumns(UIComponent parent) {
+        for (int i = 0; i < parent.getChildCount(); i++) {
+            UIComponent child = parent.getChildren().get(i);
+
+            if (child instanceof Columns columns) {
+                if (columns.getRowIndex() != -1) {
+                    columns.setRowIndex(-1);
+                }
             }
-            return true;
-        });
+            else if (child instanceof ColumnGroup || child instanceof Row || child instanceof ColumnAware) {
+                // a p:columns can also sit in a column group, below its rows, or in a nested column aware component
+                resetDynamicColumns(child);
+            }
+        }
     }
 
     default void forEachColumn(Predicate<UIColumn> callback) {

--- a/primefaces/src/main/java/org/primefaces/component/api/IterationCleanupAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/IterationCleanupAware.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.api;
+
+import jakarta.faces.context.FacesContext;
+
+/**
+ * Implemented by components whose renderer leaves iteration state behind: a row index, a row key, or an iteration
+ * variable in the request map. {@code org.primefaces.renderkit.PrimeRendererWrapper} calls
+ * {@link #cleanupIterationState(FacesContext)} right after the renderer's {@code decode} and {@code encodeEnd}, also
+ * when either threw, so that the state never outlives the phase of the component which set it.
+ * <p>
+ * State left behind has two effects for the rest of the request. The iteration variable resolves to the last row for
+ * everything which renders after the component. And where the component folds the row into the client id it hands its
+ * children, their state is saved under a client id which the next request does not rebuild.
+ */
+public interface IterationCleanupAware {
+
+    /**
+     * Resets whatever iteration state this component has set. Called after {@code decode} and after {@code encodeEnd},
+     * so it must be safe to call when nothing was set, when it was already reset, and when the phase threw halfway.
+     *
+     * @param context the {@link FacesContext}.
+     */
+    void cleanupIterationState(FacesContext context);
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/PrimeUIData.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/PrimeUIData.java
@@ -52,13 +52,22 @@ import jakarta.faces.event.PhaseId;
 /**
  * Enhanced version of the Faces UIData.
  */
-public abstract class PrimeUIData extends UIDataPatch {
+public abstract class PrimeUIData extends UIDataPatch implements IterationCleanupAware {
 
     private static final Logger LOGGER = Logger.getLogger(PrimeUIData.class.getName());
 
     public enum PropertyKeys {
         rowIndexVar,
         lazy,
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        // the row index ends up in the client id of every descendant and puts the row in the request map under var,
+        // so we must not be left standing on a row once the phase which put us there is done
+        if (getRowIndex() != -1) {
+            setRowIndex(-1);
+        }
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/api/UITree.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITree.java
@@ -66,7 +66,7 @@ import jakarta.faces.event.PhaseId;
 import jakarta.faces.event.PostValidateEvent;
 import jakarta.faces.event.PreValidateEvent;
 
-public abstract class UITree extends UIComponentBase implements NamingContainer {
+public abstract class UITree extends UIComponentBase implements NamingContainer, IterationCleanupAware {
 
     public static final String SEPARATOR = "_";
     public static final String REQUIRED_MESSAGE_ID = "primefaces.tree.REQUIRED";
@@ -148,6 +148,15 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
         }
 
         restoreDescendantState();
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        // the row key ends up in the client id of every descendant and puts the node in the request map under var,
+        // so we must not be left standing on a node once the phase which put us there is done
+        if (rowKey != null) {
+            setRowKey(null, null, null);
+        }
     }
 
     private void addToPreselection(TreeNode<?> node) {

--- a/primefaces/src/main/java/org/primefaces/component/badge/Badge.java
+++ b/primefaces/src/main/java/org/primefaces/component/badge/Badge.java
@@ -26,6 +26,7 @@ package org.primefaces.component.badge;
 import org.primefaces.cdk.api.FacesComponentInfo;
 import org.primefaces.model.badge.BadgeModel;
 import org.primefaces.model.badge.DefaultBadgeModel;
+import org.primefaces.util.ComponentUtils;
 
 import jakarta.faces.application.ResourceDependency;
 import jakarta.faces.component.FacesComponent;
@@ -54,7 +55,7 @@ public class Badge extends BadgeBaseImpl {
     public static final String ICON_CLASS = "ui-badge-icon";
 
     public BadgeRenderer getRenderer() {
-        return (BadgeRenderer) getFacesContext().getRenderKit().getRenderer(getFamily(), getRendererType());
+        return ComponentUtils.getUnwrappedRenderer(getFacesContext(), getFamily(), getRendererType());
     }
 
     public static Badge create(FacesContext context) {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -47,6 +47,7 @@ import org.primefaces.event.data.PageEvent;
 import org.primefaces.event.data.SortEvent;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AjaxBehaviorEvent;
 
 @FacesComponentBase
@@ -90,6 +91,13 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
     @Override
     public String getFamily() {
         return COMPONENT_FAMILY;
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        super.cleanupIterationState(context);
+
+        resetDynamicColumns(context);
     }
 
     @Facet(description = "Empty message content of the datatable.")

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableBase.java
@@ -97,7 +97,7 @@ public abstract class DataTableBase extends UIPageableData implements Widget, RT
     public void cleanupIterationState(FacesContext context) {
         super.cleanupIterationState(context);
 
-        resetDynamicColumns(context);
+        resetDynamicColumns();
     }
 
     @Facet(description = "Empty message content of the datatable.")

--- a/primefaces/src/main/java/org/primefaces/component/overlaypanel/OverlayPanel.java
+++ b/primefaces/src/main/java/org/primefaces/component/overlaypanel/OverlayPanel.java
@@ -45,7 +45,7 @@ public class OverlayPanel extends OverlayPanelBaseImpl {
     public static final String CONTENT_CLASS = "ui-overlaypanel-content";
 
     public OverlayPanelRenderer getRenderer() {
-        return (OverlayPanelRenderer) getFacesContext().getRenderKit().getRenderer(getFamily(), getRendererType());
+        return ComponentUtils.getUnwrappedRenderer(getFacesContext(), getFamily(), getRendererType());
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/subtable/SubTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/subtable/SubTableBase.java
@@ -26,12 +26,14 @@ package org.primefaces.component.subtable;
 import org.primefaces.cdk.api.FacesComponentBase;
 import org.primefaces.cdk.api.Facet;
 import org.primefaces.cdk.api.Property;
+import org.primefaces.component.api.IterationCleanupAware;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIData;
+import jakarta.faces.context.FacesContext;
 
 @FacesComponentBase
-public abstract class SubTableBase extends UIData {
+public abstract class SubTableBase extends UIData implements IterationCleanupAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -48,6 +50,15 @@ public abstract class SubTableBase extends UIData {
     @Override
     public String getFamily() {
         return COMPONENT_FAMILY;
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        // UIData folds the row index into our own client id and into the client id of every descendant, and it puts
+        // the row in the request map under var, so we must not be left standing on a row once we are done
+        if (getRowIndex() != -1) {
+            setRowIndex(-1);
+        }
     }
 
     @Override

--- a/primefaces/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/DefaultTimelineUpdater.java
@@ -264,6 +264,11 @@ public class DefaultTimelineUpdater extends TimelineUpdater implements PhaseList
             catch (IOException e) {
                 LOGGER.log(Level.WARNING, e, () -> "Timeline with id " + clientId + " could not be updated, at least one CRUD operation failed");
             }
+            finally {
+                // encodeGroup and encodeEvent put the group and the event in the request map, and this path patches
+                // the widget over JS without re-rendering the timeline, so no encodeEnd follows to clean up after them
+                timeline.cleanupIterationState(context);
+            }
         });
     }
 

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
@@ -42,6 +42,7 @@ import org.primefaces.model.timeline.TimelineModel;
 import org.primefaces.util.LangUtils;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.faces.component.UIComponent;
@@ -68,6 +69,12 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, RT
 
     public static final String DEFAULT_RENDERER = "org.primefaces.component.TimelineRenderer";
 
+    /**
+     * What the request map held under var and varGroup before the encoding replaced it, so that the encoding can put
+     * it back. Null while nothing was replaced.
+     */
+    private Map<String, Object> replacedVars;
+
     public TimelineBase() {
         setRendererType(DEFAULT_RENDERER);
     }
@@ -77,19 +84,53 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, RT
         return COMPONENT_FAMILY;
     }
 
-    @Override
-    public void cleanupIterationState(FacesContext context) {
-        // the renderer puts the event it encodes in the request map under var, and the group under varGroup,
-        // so neither may outlive the encoding
+    /**
+     * Puts the event or the group which is being encoded in the request map, remembering what was there before, so
+     * that {@link #cleanupIterationState(FacesContext)} can put it back. Restoring rather than removing matters
+     * because a timeline nested in an outer iteration may share the name with it, and removing would destroy the
+     * outer value.
+     *
+     * @param context the {@link FacesContext}.
+     * @param name the name of the variable, {@code var} or {@code varGroup}. Ignored when blank.
+     * @param value the value to expose under it.
+     */
+    public void setIterationVar(FacesContext context, String name, Object value) {
+        if (LangUtils.isBlank(name)) {
+            return;
+        }
+
         Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
 
-        if (LangUtils.isNotBlank(getVar())) {
-            requestMap.remove(getVar());
+        if (replacedVars == null) {
+            replacedVars = new HashMap<>(2);
+        }
+        if (!replacedVars.containsKey(name)) {
+            replacedVars.put(name, requestMap.get(name));
         }
 
-        if (LangUtils.isNotBlank(getVarGroup())) {
-            requestMap.remove(getVarGroup());
+        requestMap.put(name, value);
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        // only what the encoding actually replaced is put back, so a decode, or a render which never reached an
+        // event, leaves the request map alone
+        if (replacedVars == null) {
+            return;
         }
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+
+        for (Map.Entry<String, Object> replacedVar : replacedVars.entrySet()) {
+            if (replacedVar.getValue() != null) {
+                requestMap.put(replacedVar.getKey(), replacedVar.getValue());
+            }
+            else {
+                requestMap.remove(replacedVar.getKey());
+            }
+        }
+
+        replacedVars = null;
     }
 
     @Facet(description = "Group content of the timeline.")

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
@@ -28,6 +28,7 @@ import org.primefaces.cdk.api.FacesBehaviorEvents;
 import org.primefaces.cdk.api.FacesComponentBase;
 import org.primefaces.cdk.api.Facet;
 import org.primefaces.cdk.api.Property;
+import org.primefaces.component.api.IterationCleanupAware;
 import org.primefaces.component.api.RTLAware;
 import org.primefaces.component.api.StyleAware;
 import org.primefaces.component.api.Widget;
@@ -38,11 +39,14 @@ import org.primefaces.event.timeline.TimelineModificationEvent;
 import org.primefaces.event.timeline.TimelineRangeEvent;
 import org.primefaces.event.timeline.TimelineSelectEvent;
 import org.primefaces.model.timeline.TimelineModel;
+import org.primefaces.util.LangUtils;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 import jakarta.faces.component.UIComponent;
 import jakarta.faces.component.UIComponentBase;
+import jakarta.faces.context.FacesContext;
 
 @FacesComponentBase
 @FacesBehaviorEvents({
@@ -58,7 +62,7 @@ import jakarta.faces.component.UIComponentBase;
     @FacesBehaviorEvent(name = "lazyload", event = TimelineLazyLoadEvent.class, description = "Fired when lazy loading is triggered to fetch events."),
     @FacesBehaviorEvent(name = "drop", event = TimelineDragDropEvent.class, description = "Fired when a draggable item is dropped onto the timeline.")
 })
-public abstract class TimelineBase extends UIComponentBase implements Widget, RTLAware, StyleAware {
+public abstract class TimelineBase extends UIComponentBase implements Widget, RTLAware, StyleAware, IterationCleanupAware {
 
     public static final String COMPONENT_FAMILY = "org.primefaces.component";
 
@@ -71,6 +75,21 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, RT
     @Override
     public String getFamily() {
         return COMPONENT_FAMILY;
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        // the renderer puts the event it encodes in the request map under var, and the group under varGroup,
+        // so neither may outlive the encoding
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+
+        if (LangUtils.isNotBlank(getVar())) {
+            requestMap.remove(getVar());
+        }
+
+        if (LangUtils.isNotBlank(getVarGroup())) {
+            requestMap.remove(getVarGroup());
+        }
     }
 
     @Facet(description = "Group content of the timeline.")

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineBase.java
@@ -89,6 +89,8 @@ public abstract class TimelineBase extends UIComponentBase implements Widget, RT
      * that {@link #cleanupIterationState(FacesContext)} can put it back. Restoring rather than removing matters
      * because a timeline nested in an outer iteration may share the name with it, and removing would destroy the
      * outer value.
+     * <p>
+     * NOTE: this is for internal usage only!
      *
      * @param context the {@link FacesContext}.
      * @param name the name of the variable, {@code var} or {@code varGroup}. Ignored when blank.

--- a/primefaces/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/timeline/TimelineRenderer.java
@@ -324,8 +324,8 @@ public class TimelineRenderer extends CoreRenderer<Timeline> {
         fsw.write("{id: \"" + EscapeUtils.forJavaScriptBlock(group.getId()) + "\"");
 
         Object data = group.getData();
-        if (LangUtils.isNotBlank(component.getVarGroup()) && data != null) {
-            context.getExternalContext().getRequestMap().put(component.getVarGroup(), data);
+        if (data != null) {
+            component.setIterationVar(context, component.getVarGroup(), data);
         }
         if (FacetUtils.shouldRenderFacet(groupFacet)) {
             String groupRender = encodeAllToString(context, writer, fswHtml, groupFacet);
@@ -481,8 +481,8 @@ public class TimelineRenderer extends CoreRenderer<Timeline> {
         }
 
         Object data = event.getData();
-        if (LangUtils.isNotBlank(component.getVar()) && data != null) {
-            context.getExternalContext().getRequestMap().put(component.getVar(), data);
+        if (data != null) {
+            component.setIterationVar(context, component.getVar(), data);
         }
 
         if (event.getTitle() != null) {

--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -285,8 +285,6 @@ public class TreeRenderer extends CoreRenderer<Tree> {
             encodeMarkup(context, component);
             encodeScript(context, component);
         }
-
-        // the tree is left standing on the node which was encoded last, UITree#cleanupIterationState resets it
     }
 
     protected void encodeFilteredNodes(FacesContext context, Tree component, TreeNode<?> node, String filteredValue, Locale filterLocale)

--- a/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tree/TreeRenderer.java
@@ -286,9 +286,7 @@ public class TreeRenderer extends CoreRenderer<Tree> {
             encodeScript(context, component);
         }
 
-        // the row key ends up in the client id of every descendant and puts the node in the request map under var,
-        // so the tree must not be left standing on a node once it has been encoded
-        component.setRowKey(root, null);
+        // the tree is left standing on the node which was encoded last, UITree#cleanupIterationState resets it
     }
 
     protected void encodeFilteredNodes(FacesContext context, Tree component, TreeNode<?> node, String filteredValue, Locale filterLocale)

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -94,7 +94,7 @@ public abstract class TreeTableBase extends UITree implements Widget, Pageable, 
     public void cleanupIterationState(FacesContext context) {
         super.cleanupIterationState(context);
 
-        resetDynamicColumns(context);
+        resetDynamicColumns();
     }
 
     @Facet(description = "Header content of the treetable.")

--- a/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/TreeTableBase.java
@@ -46,6 +46,7 @@ import org.primefaces.event.data.SortEvent;
 import org.primefaces.model.TreeNode;
 
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
 
 @FacesComponentBase
 @FacesBehaviorEvents({
@@ -87,6 +88,13 @@ public abstract class TreeTableBase extends UITree implements Widget, Pageable, 
     @Override
     public String getFamily() {
         return COMPONENT_FAMILY;
+    }
+
+    @Override
+    public void cleanupIterationState(FacesContext context) {
+        super.cleanupIterationState(context);
+
+        resetDynamicColumns(context);
     }
 
     @Facet(description = "Header content of the treetable.")

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
@@ -42,7 +42,12 @@ import jakarta.faces.render.Renderer;
 @SuppressWarnings("rawtypes")
 public class PrimeRenderKit extends RenderKitWrapper {
 
-    private final Map<String, Map<String, Renderer>> wrappers = new ConcurrentHashMap<>();
+    /**
+     * Keyed by the renderer itself, which is an application scoped singleton without an equals of its own. That is one
+     * lookup and no key to build, on a path which {@code UIComponentBase} walks several times per component per
+     * request, and a renderer which is replaced simply becomes a different key.
+     */
+    private final Map<Renderer, Renderer> wrappers = new ConcurrentHashMap<>();
 
     public PrimeRenderKit(RenderKit wrapped) {
         super(wrapped);
@@ -56,25 +61,7 @@ public class PrimeRenderKit extends RenderKitWrapper {
             return renderer;
         }
 
-        // the wrapper is stateless, but a stable instance per family and type keeps renderers comparable by identity
-        Map<String, Renderer> wrappersByType = wrappers.computeIfAbsent(family, k -> new ConcurrentHashMap<>());
-        Renderer wrapper = wrappersByType.get(rendererType);
-
-        if (!(wrapper instanceof PrimeRendererWrapper primeRendererWrapper) || primeRendererWrapper.getWrapped() != renderer) {
-            wrapper = new PrimeRendererWrapper(renderer);
-            wrappersByType.put(rendererType, wrapper);
-        }
-
-        return wrapper;
-    }
-
-    @Override
-    public void addRenderer(String family, String rendererType, Renderer renderer) {
-        Map<String, Renderer> wrappersByType = wrappers.get(family);
-        if (wrappersByType != null) {
-            wrappersByType.remove(rendererType);
-        }
-
-        super.addRenderer(family, rendererType, renderer);
+        // the wrapper is stateless, but a stable instance per renderer keeps renderers comparable by identity
+        return wrappers.computeIfAbsent(renderer, PrimeRendererWrapper::new);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.renderkit;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.faces.render.RenderKit;
+import jakarta.faces.render.RenderKitWrapper;
+import jakarta.faces.render.Renderer;
+
+/**
+ * {@link RenderKit} which hands out every PrimeFaces {@link CoreRenderer} inside a {@link PrimeRendererWrapper}, so
+ * that a component can clean up its iteration state in one place instead of every renderer having to remember it.
+ * <p>
+ * Only {@link CoreRenderer} instances are wrapped. Renderers of the Faces implementation and of other component
+ * libraries are handed out untouched, so that code which casts them to their own type keeps working.
+ *
+ * @see org.primefaces.component.api.IterationCleanupAware
+ */
+@SuppressWarnings("rawtypes")
+public class PrimeRenderKit extends RenderKitWrapper {
+
+    private final Map<String, Map<String, Renderer>> wrappers = new ConcurrentHashMap<>();
+
+    public PrimeRenderKit(RenderKit wrapped) {
+        super(wrapped);
+    }
+
+    @Override
+    public Renderer getRenderer(String family, String rendererType) {
+        Renderer renderer = super.getRenderer(family, rendererType);
+
+        if (!(renderer instanceof CoreRenderer)) {
+            return renderer;
+        }
+
+        // the wrapper is stateless, but a stable instance per family and type keeps renderers comparable by identity
+        Map<String, Renderer> wrappersByType = wrappers.computeIfAbsent(family, k -> new ConcurrentHashMap<>());
+        Renderer wrapper = wrappersByType.get(rendererType);
+
+        if (!(wrapper instanceof PrimeRendererWrapper primeRendererWrapper) || primeRendererWrapper.getWrapped() != renderer) {
+            wrapper = new PrimeRendererWrapper(renderer);
+            wrappersByType.put(rendererType, wrapper);
+        }
+
+        return wrapper;
+    }
+
+    @Override
+    public void addRenderer(String family, String rendererType, Renderer renderer) {
+        Map<String, Renderer> wrappersByType = wrappers.get(family);
+        if (wrappersByType != null) {
+            wrappersByType.remove(rendererType);
+        }
+
+        super.addRenderer(family, rendererType, renderer);
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKit.java
@@ -42,12 +42,17 @@ import jakarta.faces.render.Renderer;
 @SuppressWarnings("rawtypes")
 public class PrimeRenderKit extends RenderKitWrapper {
 
+    private static final char KEY_SEPARATOR = '\0';
+
     /**
-     * Keyed by the renderer itself, which is an application scoped singleton without an equals of its own. That is one
-     * lookup and no key to build, on a path which {@code UIComponentBase} walks several times per component per
-     * request, and a renderer which is replaced simply becomes a different key.
+     * Keyed by family and renderer type, so that the key space stays bounded by the number of registered renderer
+     * types. Keying by the renderer itself would be one lookup less, but a {@link RenderKitWrapper} further down the
+     * chain is free to build a new renderer per lookup, the way this class does itself, and the map would then grow
+     * by about the component count on every request, forever. The cached wrapper is handed out only while it still
+     * wraps what the delegate returns, which also covers a renderer replaced through
+     * {@link #addRenderer(String, String, Renderer)}.
      */
-    private final Map<Renderer, Renderer> wrappers = new ConcurrentHashMap<>();
+    private final Map<String, PrimeRendererWrapper> wrappers = new ConcurrentHashMap<>();
 
     public PrimeRenderKit(RenderKit wrapped) {
         super(wrapped);
@@ -62,6 +67,14 @@ public class PrimeRenderKit extends RenderKitWrapper {
         }
 
         // the wrapper is stateless, but a stable instance per renderer keeps renderers comparable by identity
-        return wrappers.computeIfAbsent(renderer, PrimeRendererWrapper::new);
+        String key = family + KEY_SEPARATOR + rendererType;
+        PrimeRendererWrapper wrapper = wrappers.get(key);
+
+        if (wrapper == null || wrapper.getWrapped() != renderer) {
+            wrapper = new PrimeRendererWrapper(renderer);
+            wrappers.put(key, wrapper);
+        }
+
+        return wrapper;
     }
 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKitFactory.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRenderKitFactory.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.renderkit;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.RenderKit;
+import jakarta.faces.render.RenderKitFactory;
+
+/**
+ * {@link RenderKitFactory} to wrap the {@link RenderKit} with our {@link PrimeRenderKit}.
+ */
+public class PrimeRenderKitFactory extends RenderKitFactory {
+
+    private final Map<String, PrimeRenderKit> renderKits = new ConcurrentHashMap<>();
+
+    public PrimeRenderKitFactory(RenderKitFactory wrapped) {
+        super(wrapped);
+    }
+
+    @Override
+    public void addRenderKit(String renderKitId, RenderKit renderKit) {
+        renderKits.remove(renderKitId);
+
+        getWrapped().addRenderKit(renderKitId, renderKit);
+    }
+
+    @Override
+    public RenderKit getRenderKit(FacesContext context, String renderKitId) {
+        RenderKit renderKit = getWrapped().getRenderKit(context, renderKitId);
+
+        if (renderKit == null || renderKit instanceof PrimeRenderKit) {
+            return renderKit;
+        }
+
+        // a RenderKit is application scoped, so the wrapper is cached to keep its renderer wrappers alive
+        PrimeRenderKit wrapper = renderKits.get(renderKitId);
+
+        if (wrapper == null || wrapper.getWrapped() != renderKit) {
+            wrapper = new PrimeRenderKit(renderKit);
+            renderKits.put(renderKitId, wrapper);
+        }
+
+        return wrapper;
+    }
+
+    @Override
+    public Iterator<String> getRenderKitIds() {
+        return getWrapped().getRenderKitIds();
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.renderkit;
+
+import org.primefaces.component.api.IterationCleanupAware;
+
+import java.io.IOException;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.Renderer;
+import jakarta.faces.render.RendererWrapper;
+
+/**
+ * Wraps a {@link CoreRenderer} to give every PrimeFaces component a single place to clean up after itself.
+ * <p>
+ * A renderer which iterates sets a row index, a row key or an iteration variable, and historically each one had to
+ * remember to reset it before it returned. The ones which forgot leaked the iteration variable into the rest of the
+ * request and gave their children a row prefixed client id which the next request does not rebuild. Components which
+ * implement {@link IterationCleanupAware} are reset here instead, also when the phase threw.
+ * <p>
+ * Both {@code decode} and {@code encodeEnd} are covered. They are the last thing which
+ * {@code UIComponentBase#processDecodes} and {@code UIComponentBase#encodeEnd} do, so nothing which still needs the
+ * row runs after them.
+ *
+ * @see PrimeRenderKit
+ */
+@SuppressWarnings("rawtypes")
+public class PrimeRendererWrapper extends RendererWrapper {
+
+    public PrimeRendererWrapper(Renderer wrapped) {
+        super(wrapped);
+    }
+
+    @Override
+    public void decode(FacesContext context, UIComponent component) {
+        try {
+            super.decode(context, component);
+        }
+        finally {
+            cleanupIterationState(context, component);
+        }
+    }
+
+    @Override
+    public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+        try {
+            super.encodeEnd(context, component);
+        }
+        finally {
+            cleanupIterationState(context, component);
+        }
+    }
+
+    private static void cleanupIterationState(FacesContext context, UIComponent component) {
+        if (component instanceof IterationCleanupAware iterationCleanupAware) {
+            iterationCleanupAware.cleanupIterationState(context);
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
@@ -55,27 +55,67 @@ public class PrimeRendererWrapper extends RendererWrapper {
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
+        RuntimeException thrown = null;
+
         try {
             super.decode(context, component);
         }
-        finally {
-            cleanupIterationState(context, component);
+        catch (RuntimeException e) {
+            thrown = e;
+        }
+
+        cleanupIterationState(context, component, thrown);
+
+        if (thrown != null) {
+            throw thrown;
         }
     }
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+        Exception thrown = null;
+
         try {
             super.encodeEnd(context, component);
         }
-        finally {
-            cleanupIterationState(context, component);
+        catch (IOException | RuntimeException e) {
+            thrown = e;
+        }
+
+        cleanupIterationState(context, component, thrown);
+
+        if (thrown instanceof IOException ioException) {
+            throw ioException;
+        }
+        if (thrown instanceof RuntimeException runtimeException) {
+            throw runtimeException;
         }
     }
 
-    private static void cleanupIterationState(FacesContext context, UIComponent component) {
-        if (component instanceof IterationCleanupAware iterationCleanupAware) {
+    /**
+     * Cleans up after the component, without ever hiding the exception which the phase itself threw. A cleanup can
+     * throw in its own right: a table whose value expression blew up halfway through the render throws the same way
+     * again while the cleanup walks its children. The caller needs to see the original, so a cleanup failure is
+     * attached to it as a suppressed exception and only rethrown when the phase itself completed.
+     *
+     * @param context the {@link FacesContext}.
+     * @param component the component which was decoded or encoded.
+     * @param thrown what the phase threw, or {@code null} when it completed.
+     */
+    private static void cleanupIterationState(FacesContext context, UIComponent component, Exception thrown) {
+        if (!(component instanceof IterationCleanupAware iterationCleanupAware)) {
+            return;
+        }
+
+        try {
             iterationCleanupAware.cleanupIterationState(context);
+        }
+        catch (RuntimeException e) {
+            if (thrown == null) {
+                throw e;
+            }
+
+            thrown.addSuppressed(e);
         }
     }
 }

--- a/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
+++ b/primefaces/src/main/java/org/primefaces/renderkit/PrimeRendererWrapper.java
@@ -55,41 +55,28 @@ public class PrimeRendererWrapper extends RendererWrapper {
 
     @Override
     public void decode(FacesContext context, UIComponent component) {
-        RuntimeException thrown = null;
-
         try {
             super.decode(context, component);
         }
-        catch (RuntimeException e) {
-            thrown = e;
-        }
-
-        cleanupIterationState(context, component, thrown);
-
-        if (thrown != null) {
+        catch (Throwable thrown) {
+            cleanupIterationState(context, component, thrown);
             throw thrown;
         }
+
+        cleanupIterationState(context, component, null);
     }
 
     @Override
     public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
-        Exception thrown = null;
-
         try {
             super.encodeEnd(context, component);
         }
-        catch (IOException | RuntimeException e) {
-            thrown = e;
+        catch (Throwable thrown) {
+            cleanupIterationState(context, component, thrown);
+            throw thrown;
         }
 
-        cleanupIterationState(context, component, thrown);
-
-        if (thrown instanceof IOException ioException) {
-            throw ioException;
-        }
-        if (thrown instanceof RuntimeException runtimeException) {
-            throw runtimeException;
-        }
+        cleanupIterationState(context, component, null);
     }
 
     /**
@@ -97,12 +84,15 @@ public class PrimeRendererWrapper extends RendererWrapper {
      * throw in its own right: a table whose value expression blew up halfway through the render throws the same way
      * again while the cleanup walks its children. The caller needs to see the original, so a cleanup failure is
      * attached to it as a suppressed exception and only rethrown when the phase itself completed.
+     * <p>
+     * An {@link Error} out of the cleanup is not caught. It is not a lesser failure than what the phase threw, so it
+     * wins rather than being filed away as suppressed.
      *
      * @param context the {@link FacesContext}.
      * @param component the component which was decoded or encoded.
      * @param thrown what the phase threw, or {@code null} when it completed.
      */
-    private static void cleanupIterationState(FacesContext context, UIComponent component, Exception thrown) {
+    private static void cleanupIterationState(FacesContext context, UIComponent component, Throwable thrown) {
         if (!(component instanceof IterationCleanupAware iterationCleanupAware)) {
             return;
         }

--- a/primefaces/src/main/resources/META-INF/faces-config.xml
+++ b/primefaces/src/main/resources/META-INF/faces-config.xml
@@ -8,6 +8,7 @@
     <factory>
         <partial-view-context-factory>org.primefaces.context.PrimePartialViewContextFactory</partial-view-context-factory>
         <faces-context-factory>org.primefaces.context.PrimeFacesContextFactory</faces-context-factory>
+        <render-kit-factory>org.primefaces.renderkit.PrimeRenderKitFactory</render-kit-factory>
     </factory>
 
     <lifecycle>

--- a/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
@@ -30,6 +30,8 @@ import org.primefaces.el.MyBean;
 import org.primefaces.el.MyContainer;
 import org.primefaces.mock.FacesContextMock;
 
+import java.util.Arrays;
+
 import jakarta.el.ExpressionFactory;
 import jakarta.el.ValueExpression;
 import jakarta.faces.context.FacesContext;
@@ -46,6 +48,38 @@ class DataTableTest {
     void allowUnsorting() {
         DataTable table = new DataTable();
         assertFalse(table.isAllowUnsorting());
+    }
+
+    /**
+     * The row the table stands on ends up in the client id of every descendant and puts the row in the request map
+     * under the table's var, and the same holds for the column a p:columns stands on. The scroll, cell edit, row edit
+     * and add row ajax requests never reach encodeTbody, which is the only place which used to reset the row index,
+     * so the reset has to happen after encodeEnd, for every request which encoded the table.
+     */
+    @Test
+    void cleanupIterationStateLeavesTheTableStandingOnNoRowAndNoColumn() {
+        FacesContext context = new FacesContextMock();
+
+        Columns columns = new Columns();
+        columns.setId("cols");
+        columns.setVar("col");
+        columns.setValue(Arrays.asList("id", "name"));
+
+        DataTable table = new DataTable();
+        table.setId("table");
+        table.setVar("row");
+        table.setValue(Arrays.asList("one", "two"));
+        table.getChildren().add(columns);
+
+        table.setRowIndex(1);
+        columns.setRowIndex(1);
+
+        table.cleanupIterationState(context);
+
+        assertEquals(-1, table.getRowIndex());
+        assertEquals(-1, columns.getRowIndex());
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("row"));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("col"));
     }
 
     @Test

--- a/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datatable/DataTableTest.java
@@ -29,8 +29,11 @@ import org.primefaces.component.columns.Columns;
 import org.primefaces.el.MyBean;
 import org.primefaces.el.MyContainer;
 import org.primefaces.mock.FacesContextMock;
+import org.primefaces.renderkit.PrimeRendererWrapper;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
 
 import jakarta.el.ExpressionFactory;
 import jakarta.el.ValueExpression;
@@ -80,6 +83,32 @@ class DataTableTest {
         assertEquals(-1, columns.getRowIndex());
         assertFalse(context.getExternalContext().getRequestMap().containsKey("row"));
         assertFalse(context.getExternalContext().getRequestMap().containsKey("col"));
+    }
+
+    /**
+     * DraggableRowsFeature#decode stands the table on the row which was dragged and returns without resetting it, so
+     * the decode has to leave the table standing on no row too. There is no page level reproducer for this: the row
+     * reorder request renders one fragment and nothing renders after it.
+     */
+    @Test
+    void decodeLeavesTheTableStandingOnNoRow() {
+        FacesContext context = new FacesContextMock();
+
+        DataTable table = new DataTable();
+        table.setId("table");
+        table.setVar("row");
+        table.setValue(new ArrayList<>(Arrays.asList("one", "two", "three")));
+
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        params.put(table.getClientId(context) + "_rowreorder", "true");
+        params.put(table.getClientId(context) + "_fromIndex", "0");
+        params.put(table.getClientId(context) + "_toIndex", "2");
+
+        new PrimeRendererWrapper(new DataTableRenderer()).decode(context, table);
+
+        assertEquals(-1, table.getRowIndex());
+        assertEquals(table.getClientId(context), table.getContainerClientId(context));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("row"));
     }
 
     @Test

--- a/primefaces/src/test/java/org/primefaces/component/subtable/SubTableRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/subtable/SubTableRendererTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.subtable;
+
+import org.primefaces.component.column.Column;
+import org.primefaces.mock.CollectingResponseWriter;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.renderkit.PrimeRendererWrapper;
+
+import java.util.Arrays;
+
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SubTableRendererTest {
+
+    /**
+     * The row the sub table stands on ends up in its own client id and in the client id of everything below it, and it
+     * puts the row it holds in the request map under the sub table's var. So a render which iterated the sub table
+     * leaves it standing on no row.
+     */
+    @Test
+    void encodeEndLeavesTheSubTableStandingOnNoRow() throws Exception {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        Column column = new Column();
+        column.getChildren().add(new UIOutput());
+
+        SubTable subTable = new SubTable();
+        subTable.setId("subTable");
+        subTable.setVar("stat");
+        subTable.setValue(Arrays.asList("one", "two"));
+        subTable.getChildren().add(column);
+
+        new PrimeRendererWrapper(new SubTableRenderer()).encodeEnd(context, subTable);
+
+        assertEquals(-1, subTable.getRowIndex());
+        assertEquals(subTable.getId(), subTable.getClientId(context));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("stat"));
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/component/timeline/DefaultTimelineUpdaterTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/timeline/DefaultTimelineUpdaterTest.java
@@ -1,0 +1,111 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.timeline;
+
+import org.primefaces.mock.CollectingResponseWriter;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.model.timeline.TimelineEvent;
+import org.primefaces.model.timeline.TimelineGroup;
+import org.primefaces.model.timeline.TimelineModel;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.event.PhaseEvent;
+import jakarta.faces.event.PhaseId;
+import jakarta.faces.lifecycle.Lifecycle;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+
+class DefaultTimelineUpdaterTest {
+
+    /**
+     * The updater patches the widget over JS without re-rendering the timeline, so no encodeEnd follows to clean up
+     * after it. It calls encodeGroup and encodeEvent all the same, which put the group and the event in the request
+     * map, so it has to clean up after itself.
+     */
+    @Test
+    void processCrudOperationsLeavesNoVarBehind() {
+        FacesContext context = newContext();
+        Timeline timeline = newTimeline(context);
+
+        DefaultTimelineUpdater updater = new DefaultTimelineUpdater(timeline.getClientId(context), "widget");
+        updater.add(TimelineEvent.builder().data("added").group("group").startDate(LocalDateTime.now()).build());
+        updater.beforePhase(new PhaseEvent(context, PhaseId.RENDER_RESPONSE, mock(Lifecycle.class)));
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        assertFalse(requestMap.containsKey("event"));
+        assertFalse(requestMap.containsKey("group"));
+    }
+
+    @Test
+    void processCrudOperationsRestoresTheVarOfAnOuterIteration() {
+        FacesContext context = newContext();
+        Timeline timeline = newTimeline(context);
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        requestMap.put("event", "the row of the outer table");
+        requestMap.put("group", "the group of the outer table");
+
+        DefaultTimelineUpdater updater = new DefaultTimelineUpdater(timeline.getClientId(context), "widget");
+        updater.add(TimelineEvent.builder().data("added").group("group").startDate(LocalDateTime.now()).build());
+        updater.beforePhase(new PhaseEvent(context, PhaseId.RENDER_RESPONSE, mock(Lifecycle.class)));
+
+        assertEquals("the row of the outer table", requestMap.get("event"));
+        assertEquals("the group of the outer table", requestMap.get("group"));
+    }
+
+    private static FacesContext newContext() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setLocale(Locale.ENGLISH);
+        context.setViewRoot(viewRoot);
+        return context;
+    }
+
+    private static Timeline newTimeline(FacesContext context) {
+        TimelineModel<Object, Object> model = new TimelineModel<>();
+        model.addGroup(new TimelineGroup<>("group", "the group"));
+        model.add(TimelineEvent.builder().data("one").group("group").startDate(LocalDateTime.now()).build());
+
+        Timeline timeline = new Timeline();
+        timeline.setId("timeline");
+        timeline.setVar("event");
+        timeline.setVarGroup("group");
+        timeline.setValue(model);
+
+        context.getViewRoot().getChildren().add(timeline);
+        // the updater looks the real renderer up, so the mock render kit has to hand it out
+        context.getRenderKit().addRenderer(Timeline.COMPONENT_FAMILY, Timeline.DEFAULT_RENDERER, new TimelineRenderer());
+
+        return timeline;
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/component/timeline/TimelineRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/timeline/TimelineRendererTest.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.timeline;
+
+import org.primefaces.mock.CollectingResponseWriter;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.model.timeline.TimelineEvent;
+import org.primefaces.model.timeline.TimelineGroup;
+import org.primefaces.model.timeline.TimelineModel;
+import org.primefaces.renderkit.PrimeRendererWrapper;
+
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class TimelineRendererTest {
+
+    /**
+     * The timeline puts the event it renders in the request map under its var, and the group under its varGroup. So a
+     * render which iterated the events leaves neither behind, and whatever renders after the timeline resolves the var
+     * of its own scope.
+     */
+    @Test
+    void encodeEndLeavesNoVarBehind() throws Exception {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setLocale(Locale.ENGLISH);
+        context.setViewRoot(viewRoot);
+
+        TimelineModel<Object, Object> model = new TimelineModel<>();
+        model.addGroup(new TimelineGroup<>("group", "the group"));
+        model.add(TimelineEvent.builder().data("one").group("group").startDate(LocalDateTime.now()).build());
+        model.add(TimelineEvent.builder().data("two").group("group").startDate(LocalDateTime.now()).build());
+
+        Timeline timeline = new Timeline();
+        timeline.setId("timeline");
+        timeline.setVar("event");
+        timeline.setVarGroup("group");
+        timeline.setValue(model);
+
+        new PrimeRendererWrapper(new TimelineRenderer()).encodeEnd(context, timeline);
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        assertFalse(requestMap.containsKey("event"));
+        assertFalse(requestMap.containsKey("group"));
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/component/timeline/TimelineRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/timeline/TimelineRendererTest.java
@@ -39,6 +39,7 @@ import jakarta.faces.context.FacesContext;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class TimelineRendererTest {
@@ -71,5 +72,59 @@ class TimelineRendererTest {
         Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
         assertFalse(requestMap.containsKey("event"));
         assertFalse(requestMap.containsKey("group"));
+    }
+
+    /**
+     * A timeline nested in an outer iteration may share the variable name with it. Removing the name would destroy the
+     * outer value, so what was there before the timeline encoded is put back.
+     */
+    @Test
+    void encodeEndRestoresTheVarOfAnOuterIteration() throws Exception {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+        UIViewRoot viewRoot = new UIViewRoot();
+        viewRoot.setLocale(Locale.ENGLISH);
+        context.setViewRoot(viewRoot);
+
+        TimelineModel<Object, Object> model = new TimelineModel<>();
+        model.addGroup(new TimelineGroup<>("group", "the group"));
+        model.add(TimelineEvent.builder().data("one").group("group").startDate(LocalDateTime.now()).build());
+
+        Timeline timeline = new Timeline();
+        timeline.setId("timeline");
+        timeline.setVar("event");
+        timeline.setVarGroup("group");
+        timeline.setValue(model);
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        requestMap.put("event", "the row of the outer table");
+        requestMap.put("group", "the group of the outer table");
+
+        new PrimeRendererWrapper(new TimelineRenderer()).encodeEnd(context, timeline);
+
+        assertEquals("the row of the outer table", requestMap.get("event"));
+        assertEquals("the group of the outer table", requestMap.get("group"));
+    }
+
+    /**
+     * The cleanup runs after decode as well, where the renderer never touched the request map, so it must leave a
+     * same named variable of an outer iteration alone.
+     */
+    @Test
+    void decodeLeavesTheVarOfAnOuterIterationAlone() {
+        FacesContext context = new FacesContextMock();
+
+        Timeline timeline = new Timeline();
+        timeline.setId("timeline");
+        timeline.setVar("event");
+        timeline.setVarGroup("group");
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        requestMap.put("event", "the row of the outer table");
+        requestMap.put("group", "the group of the outer table");
+
+        new PrimeRendererWrapper(new TimelineRenderer()).decode(context, timeline);
+
+        assertEquals("the row of the outer table", requestMap.get("event"));
+        assertEquals("the group of the outer table", requestMap.get("group"));
     }
 }

--- a/primefaces/src/test/java/org/primefaces/component/tree/TreeRendererTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/tree/TreeRendererTest.java
@@ -23,11 +23,17 @@
  */
 package org.primefaces.component.tree;
 
+import org.primefaces.component.api.UITree;
 import org.primefaces.mock.CollectingResponseWriter;
 import org.primefaces.mock.FacesContextMock;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
+import org.primefaces.renderkit.PrimeRendererWrapper;
 
+import java.util.List;
+import java.util.Map;
+
+import jakarta.el.ValueExpression;
 import jakarta.faces.context.FacesContext;
 
 import org.junit.jupiter.api.Test;
@@ -35,6 +41,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class TreeRendererTest {
 
@@ -61,7 +69,44 @@ class TreeRendererTest {
         tree.setValue(root);
         tree.getChildren().add(treeNode);
 
-        new TreeRenderer().encodeEnd(context, tree);
+        new PrimeRendererWrapper(new TreeRenderer()).encodeEnd(context, tree);
+
+        assertNull(tree.getRowKey());
+        assertEquals(tree.getClientId(context), tree.getContainerClientId(context));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("node"));
+    }
+
+    /**
+     * The instant selection branch of decodeSelection stands the tree on the node which was checked, to collect the
+     * row keys below it, and does not reset it, unlike the branch above it. So the decode leaves the tree standing on
+     * no node either.
+     */
+    @Test
+    void decodeLeavesTheTreeStandingOnNoRow() {
+        FacesContext context = new FacesContextMock();
+
+        TreeNode<String> root = new DefaultTreeNode<>();
+        TreeNode<String> one = new DefaultTreeNode<>("one", root);
+        new DefaultTreeNode<>("one-one", one);
+        new DefaultTreeNode<>("two", root);
+
+        ValueExpression selectionVE = mock(ValueExpression.class);
+        when(selectionVE.getType(context.getELContext())).thenReturn((Class) List.class);
+
+        Tree tree = new Tree();
+        tree.setId("tree");
+        tree.setVar("node");
+        tree.setValue(root);
+        tree.setSelectionMode("checkbox");
+        tree.setDynamic(true);
+        tree.setPropagateSelectionDown(true);
+        tree.setValueExpression(UITree.PropertyKeys.selection.toString(), selectionVE);
+        tree.buildRowKeys(root);
+
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        params.put(tree.getClientId(context) + "_instantSelection", "0");
+
+        new PrimeRendererWrapper(new TreeRenderer()).decode(context, tree);
 
         assertNull(tree.getRowKey());
         assertEquals(tree.getClientId(context), tree.getContainerClientId(context));

--- a/primefaces/src/test/java/org/primefaces/component/treetable/TreeTableTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/TreeTableTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.treetable;
+
+import org.primefaces.component.api.UITree;
+import org.primefaces.component.columns.Columns;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.model.DefaultTreeNode;
+import org.primefaces.model.TreeNode;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TreeTableTest {
+
+    /**
+     * The row key the tree table stands on ends up in the client id of every descendant and puts the node in the
+     * request map under the tree table's var, and the same holds for the column a p:columns stands on. The expand,
+     * collapse, cell edit, row edit and page ajax requests never reach encodeTbody, which is the only place which
+     * used to reset the row key, so the reset has to happen after encodeEnd, for every request which encoded the
+     * tree table.
+     */
+    @Test
+    void cleanupIterationStateLeavesTheTreeTableStandingOnNoRowAndNoColumn() {
+        FacesContext context = new FacesContextMock();
+
+        TreeNode<String> root = new DefaultTreeNode<>();
+        new DefaultTreeNode<>("one", root);
+        new DefaultTreeNode<>("two", root);
+        root.setRowKey(UITree.ROOT_ROW_KEY);
+
+        Columns columns = new Columns();
+        columns.setId("cols");
+        columns.setVar("col");
+        columns.setValue(Arrays.asList("id", "name"));
+
+        TreeTable treeTable = new TreeTable();
+        treeTable.setId("treeTable");
+        treeTable.setVar("node");
+        treeTable.setValue(root);
+        treeTable.getChildren().add(columns);
+        treeTable.buildRowKeys(root);
+
+        treeTable.setRowKey(root, "1");
+        columns.setRowIndex(1);
+
+        Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        assertTrue(requestMap.containsKey("node"), "the tree table must stand on a node for this test to mean anything");
+        assertTrue(requestMap.containsKey("col"), "the columns must stand on a column for this test to mean anything");
+
+        treeTable.cleanupIterationState(context);
+
+        assertNull(treeTable.getRowKey());
+        assertEquals(-1, columns.getRowIndex());
+        assertEquals(treeTable.getClientId(context), treeTable.getContainerClientId(context));
+        assertFalse(requestMap.containsKey("node"));
+        assertFalse(requestMap.containsKey("col"));
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/component/treetable/TreeTableTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/treetable/TreeTableTest.java
@@ -24,12 +24,16 @@
 package org.primefaces.component.treetable;
 
 import org.primefaces.component.api.UITree;
+import org.primefaces.component.column.Column;
 import org.primefaces.component.columns.Columns;
+import org.primefaces.mock.CollectingResponseWriter;
 import org.primefaces.mock.FacesContextMock;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
+import org.primefaces.renderkit.PrimeRendererWrapper;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.faces.context.FacesContext;
@@ -85,5 +89,43 @@ class TreeTableTest {
         assertEquals(treeTable.getClientId(context), treeTable.getContainerClientId(context));
         assertFalse(requestMap.containsKey("node"));
         assertFalse(requestMap.containsKey("col"));
+    }
+
+    /**
+     * The expand, collapse, cell edit, row edit and page features never reach encodeTbody, which is the only place
+     * which used to reset the row key. They all dispatch from TreeTableRenderer#encodeEnd, so encoding the expand
+     * feature covers the shape of all five. There is no page level reproducer: these render one fragment and nothing
+     * renders after them.
+     */
+    @Test
+    void encodeEndOfTheExpandFeatureLeavesTheTreeTableStandingOnNoRow() throws Exception {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        TreeNode<String> root = new DefaultTreeNode<>();
+        TreeNode<String> one = new DefaultTreeNode<>("one", root);
+        new DefaultTreeNode<>("one-one", one);
+        root.setRowKey(UITree.ROOT_ROW_KEY);
+
+        Column column = new Column();
+        column.setId("col");
+
+        TreeTable treeTable = new TreeTable();
+        treeTable.setId("treeTable");
+        treeTable.setVar("node");
+        treeTable.setValue(root);
+        treeTable.getChildren().add(column);
+        treeTable.buildRowKeys(root);
+        // initFilterBy resolves the global filter through the search expression handler, which the mocks do not have
+        treeTable.setFilterByAsMap(new HashMap<>());
+
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        params.put(treeTable.getClientId(context) + "_encodeFeature", "true");
+        params.put(treeTable.getClientId(context) + "_expand", "0");
+
+        new PrimeRendererWrapper(new TreeTableRenderer()).encodeEnd(context, treeTable);
+
+        assertNull(treeTable.getRowKey());
+        assertEquals(treeTable.getClientId(context), treeTable.getContainerClientId(context));
+        assertFalse(context.getExternalContext().getRequestMap().containsKey("node"));
     }
 }

--- a/primefaces/src/test/java/org/primefaces/mock/FacesContextMock.java
+++ b/primefaces/src/test/java/org/primefaces/mock/FacesContextMock.java
@@ -52,6 +52,7 @@ public class FacesContextMock extends FacesContext {
     private ExternalContext externalContext = new ExternalContextMock();
     private Application application = new ApplicationMock();
     private PartialViewContext partialViewContext = new PartialViewContextMock();
+    private RenderKit renderKit = new RenderKitMock();
     private Map<String, List<FacesMessage>> messages = new HashMap<>();
 
     private Map<Object, Object> attributes;
@@ -143,7 +144,7 @@ public class FacesContextMock extends FacesContext {
 
     @Override
     public RenderKit getRenderKit() {
-        return new RenderKitMock();
+        return renderKit;
     }
 
     @Override

--- a/primefaces/src/test/java/org/primefaces/mock/RenderKitMock.java
+++ b/primefaces/src/test/java/org/primefaces/mock/RenderKitMock.java
@@ -25,6 +25,8 @@ package org.primefaces.mock;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.faces.context.ResponseStream;
 import jakarta.faces.context.ResponseWriter;
@@ -34,9 +36,15 @@ import jakarta.faces.render.ResponseStateManager;
 
 public class RenderKitMock extends RenderKit {
 
-    @Override
-    public void addRenderer(String arg0, String arg1, Renderer arg2) {
+    /**
+     * Renderers registered by a test, for the cases where a real one is needed. Anything not registered still gets a
+     * {@link RendererMock}.
+     */
+    private final Map<String, Renderer> renderers = new HashMap<>();
 
+    @Override
+    public void addRenderer(String family, String rendererType, Renderer renderer) {
+        renderers.put(family + '|' + rendererType, renderer);
     }
 
     @Override
@@ -51,8 +59,9 @@ public class RenderKitMock extends RenderKit {
     }
 
     @Override
-    public Renderer getRenderer(String arg0, String arg1) {
-        return new RendererMock();
+    public Renderer getRenderer(String family, String rendererType) {
+        Renderer renderer = renderers.get(family + '|' + rendererType);
+        return renderer != null ? renderer : new RendererMock();
     }
 
     @Override

--- a/primefaces/src/test/java/org/primefaces/renderkit/PrimeRenderKitTest.java
+++ b/primefaces/src/test/java/org/primefaces/renderkit/PrimeRenderKitTest.java
@@ -1,0 +1,135 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.renderkit;
+
+import org.primefaces.mock.RendererMock;
+
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.context.ResponseStream;
+import jakarta.faces.context.ResponseWriter;
+import jakarta.faces.render.RenderKit;
+import jakarta.faces.render.Renderer;
+import jakarta.faces.render.ResponseStateManager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PrimeRenderKitTest {
+
+    private static class RenderKitStub extends RenderKit {
+
+        private final Map<String, Renderer> renderers = new HashMap<>();
+
+        @Override
+        public void addRenderer(String family, String rendererType, Renderer renderer) {
+            renderers.put(family + rendererType, renderer);
+        }
+
+        @Override
+        public Renderer getRenderer(String family, String rendererType) {
+            return renderers.get(family + rendererType);
+        }
+
+        @Override
+        public ResponseStateManager getResponseStateManager() {
+            return null;
+        }
+
+        @Override
+        public ResponseWriter createResponseWriter(Writer writer, String contentTypeList, String characterEncoding) {
+            return null;
+        }
+
+        @Override
+        public ResponseStream createResponseStream(OutputStream out) {
+            return null;
+        }
+    }
+
+    @Test
+    void wrapsAPrimeFacesRenderer() {
+        RenderKitStub wrapped = new RenderKitStub();
+        Renderer renderer = new CoreRenderer<UIComponent>() { };
+        wrapped.addRenderer("family", "type", renderer);
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+
+        assertInstanceOf(PrimeRendererWrapper.class, renderKit.getRenderer("family", "type"));
+        assertSame(renderer, ((PrimeRendererWrapper) renderKit.getRenderer("family", "type")).getWrapped());
+    }
+
+    /**
+     * Renderers of the Faces implementation and of other component libraries are handed out untouched, so that code
+     * which casts them to their own type keeps working.
+     */
+    @Test
+    void handsOutAForeignRendererUntouched() {
+        RenderKitStub wrapped = new RenderKitStub();
+        Renderer renderer = new RendererMock();
+        wrapped.addRenderer("family", "type", renderer);
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+
+        assertSame(renderer, renderKit.getRenderer("family", "type"));
+    }
+
+    @Test
+    void handsOutTheSameWrapperEveryTime() {
+        RenderKitStub wrapped = new RenderKitStub();
+        wrapped.addRenderer("family", "type", new CoreRenderer<UIComponent>() { });
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+
+        assertSame(renderKit.getRenderer("family", "type"), renderKit.getRenderer("family", "type"));
+    }
+
+    @Test
+    void wrapsTheReplacementAfterAddRenderer() {
+        RenderKitStub wrapped = new RenderKitStub();
+        wrapped.addRenderer("family", "type", new CoreRenderer<UIComponent>() { });
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+        renderKit.getRenderer("family", "type");
+
+        Renderer replacement = new CoreRenderer<UIComponent>() { };
+        renderKit.addRenderer("family", "type", replacement);
+
+        assertSame(replacement, ((PrimeRendererWrapper) renderKit.getRenderer("family", "type")).getWrapped());
+    }
+
+    @Test
+    void handsOutNullForAnUnknownRenderer() {
+        PrimeRenderKit renderKit = new PrimeRenderKit(new RenderKitStub());
+
+        assertNull(renderKit.getRenderer("family", "type"));
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/renderkit/PrimeRenderKitTest.java
+++ b/primefaces/src/test/java/org/primefaces/renderkit/PrimeRenderKitTest.java
@@ -27,6 +27,7 @@ import org.primefaces.mock.RendererMock;
 
 import java.io.OutputStream;
 import java.io.Writer;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +40,7 @@ import jakarta.faces.render.ResponseStateManager;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -124,6 +126,49 @@ class PrimeRenderKitTest {
         renderKit.addRenderer("family", "type", replacement);
 
         assertSame(replacement, ((PrimeRendererWrapper) renderKit.getRenderer("family", "type")).getWrapped());
+    }
+
+    /**
+     * A {@link jakarta.faces.render.RenderKitWrapper} in the chain is free to build a new renderer per lookup, the way
+     * this class does itself. The cache has to stay bounded by the number of renderer types even then, because
+     * {@code UIComponentBase} looks a renderer up several times per component per request and the render kit lives as
+     * long as the application does.
+     */
+    @Test
+    void keepsTheCacheBoundedWhenTheDelegateHandsOutANewRendererEveryTime() throws Exception {
+        RenderKitStub wrapped = new RenderKitStub() {
+            @Override
+            public Renderer getRenderer(String family, String rendererType) {
+                return new CoreRenderer<UIComponent>() { };
+            }
+        };
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+        for (int i = 0; i < 100; i++) {
+            renderKit.getRenderer("family", "type");
+        }
+
+        Field wrappers = PrimeRenderKit.class.getDeclaredField("wrappers");
+        wrappers.setAccessible(true);
+
+        assertEquals(1, ((Map<?, ?>) wrappers.get(renderKit)).size());
+    }
+
+    /**
+     * Two renderer types of the same family are two different renderers, so they may not share a cache entry.
+     */
+    @Test
+    void keepsTheWrappersOfTwoRendererTypesApart() {
+        RenderKitStub wrapped = new RenderKitStub();
+        Renderer one = new CoreRenderer<UIComponent>() { };
+        Renderer two = new CoreRenderer<UIComponent>() { };
+        wrapped.addRenderer("family", "one", one);
+        wrapped.addRenderer("family", "two", two);
+
+        PrimeRenderKit renderKit = new PrimeRenderKit(wrapped);
+
+        assertSame(one, ((PrimeRendererWrapper) renderKit.getRenderer("family", "one")).getWrapped());
+        assertSame(two, ((PrimeRendererWrapper) renderKit.getRenderer("family", "two")).getWrapped());
     }
 
     @Test

--- a/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
+++ b/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
@@ -54,6 +54,18 @@ class PrimeRendererWrapperTest {
         }
     }
 
+    /**
+     * A component whose own cleanup blows up, the way a table's does when the value expression which already failed
+     * the render fails again while the cleanup walks its children.
+     */
+    private static class ThrowingCleanupComponent extends UIPanel implements IterationCleanupAware {
+
+        @Override
+        public void cleanupIterationState(FacesContext context) {
+            throw new IllegalStateException("cleanup blew up");
+        }
+    }
+
     private static class CountingRenderer extends CoreRenderer<UIComponent> {
 
         private int decodings;
@@ -139,6 +151,46 @@ class PrimeRendererWrapperTest {
 
         assertEquals("boom", thrown.getMessage());
         assertEquals(1, component.cleanups);
+    }
+
+    /**
+     * The render is the interesting one to debug, so its exception has to reach the user. A cleanup which fails in its
+     * own right rides along as a suppressed exception instead of replacing it.
+     */
+    @Test
+    void encodeEndKeepsTheRenderExceptionWhenTheCleanupBlowsUpToo() {
+        FacesContext context = new FacesContextMock();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ThrowingRenderer());
+        IOException thrown = assertThrows(IOException.class, () -> wrapper.encodeEnd(context, new ThrowingCleanupComponent()));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals("cleanup blew up", thrown.getSuppressed()[0].getMessage());
+    }
+
+    @Test
+    void encodeEndReportsTheCleanupFailureWhenTheRenderItselfWasFine() {
+        FacesContext context = new FacesContextMock();
+
+        Renderer wrapper = new PrimeRendererWrapper(new CountingRenderer());
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> wrapper.encodeEnd(context, new ThrowingCleanupComponent()));
+
+        assertEquals("cleanup blew up", thrown.getMessage());
+    }
+
+    @Test
+    void decodeKeepsTheDecodeExceptionWhenTheCleanupBlowsUpToo() {
+        FacesContext context = new FacesContextMock();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ThrowingRenderer());
+        IllegalStateException thrown =
+                assertThrows(IllegalStateException.class, () -> wrapper.decode(context, new ThrowingCleanupComponent()));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, thrown.getSuppressed().length);
+        assertEquals("cleanup blew up", thrown.getSuppressed()[0].getMessage());
     }
 
     @Test

--- a/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
+++ b/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
@@ -1,0 +1,154 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.renderkit;
+
+import org.primefaces.component.api.IterationCleanupAware;
+import org.primefaces.mock.FacesContextMock;
+
+import java.io.IOException;
+
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIOutput;
+import jakarta.faces.component.UIPanel;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.render.Renderer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PrimeRendererWrapperTest {
+
+    /**
+     * A component which counts how often it was cleaned up, so that a test can tell that it happened exactly once.
+     */
+    private static class CleanupAwareComponent extends UIPanel implements IterationCleanupAware {
+
+        private int cleanups;
+
+        @Override
+        public void cleanupIterationState(FacesContext context) {
+            cleanups++;
+        }
+    }
+
+    private static class CountingRenderer extends CoreRenderer<UIComponent> {
+
+        private int decodings;
+        private int encodings;
+
+        @Override
+        public void decode(FacesContext context, UIComponent component) {
+            decodings++;
+        }
+
+        @Override
+        public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+            encodings++;
+        }
+    }
+
+    private static class ThrowingRenderer extends CoreRenderer<UIComponent> {
+
+        @Override
+        public void decode(FacesContext context, UIComponent component) {
+            throw new IllegalStateException("boom");
+        }
+
+        @Override
+        public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+            throw new IOException("boom");
+        }
+    }
+
+    /**
+     * A decode can leave iteration state behind too. The instant selection branch of the Tree and TreeTable selection
+     * decode stands the component on the node which was checked and does not reset it.
+     */
+    @Test
+    void decodeDecodesAndThenCleansUp() {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+        CountingRenderer renderer = new CountingRenderer();
+
+        Renderer wrapper = new PrimeRendererWrapper(renderer);
+        wrapper.decode(context, component);
+
+        assertEquals(1, renderer.decodings);
+        assertEquals(1, component.cleanups);
+    }
+
+    @Test
+    void decodeCleansUpWhenTheRendererThrew() {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ThrowingRenderer());
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> wrapper.decode(context, component));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, component.cleanups);
+    }
+
+    @Test
+    void encodeEndEncodesAndThenCleansUp() throws Exception {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+        CountingRenderer renderer = new CountingRenderer();
+
+        Renderer wrapper = new PrimeRendererWrapper(renderer);
+        wrapper.encodeEnd(context, component);
+
+        assertEquals(1, renderer.encodings);
+        assertEquals(1, component.cleanups);
+    }
+
+    /**
+     * The state a renderer leaves behind is at its worst when the render blew up halfway, so the cleanup has to run
+     * even then, and the original exception has to survive it.
+     */
+    @Test
+    void encodeEndCleansUpWhenTheRendererThrew() {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ThrowingRenderer());
+        IOException thrown = assertThrows(IOException.class, () -> wrapper.encodeEnd(context, component));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, component.cleanups);
+    }
+
+    @Test
+    void encodeEndOfAComponentWhichNeedsNoCleanupJustDelegates() throws Exception {
+        FacesContext context = new FacesContextMock();
+        CountingRenderer renderer = new CountingRenderer();
+
+        Renderer wrapper = new PrimeRendererWrapper(renderer);
+        wrapper.encodeEnd(context, new UIOutput());
+
+        assertEquals(1, renderer.encodings);
+    }
+}

--- a/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
+++ b/primefaces/src/test/java/org/primefaces/renderkit/PrimeRendererWrapperTest.java
@@ -82,6 +82,17 @@ class PrimeRendererWrapperTest {
         }
     }
 
+    /**
+     * A component whose own cleanup fails with an {@link Error} rather than with an exception.
+     */
+    private static class ErrorThrowingCleanupComponent extends UIPanel implements IterationCleanupAware {
+
+        @Override
+        public void cleanupIterationState(FacesContext context) {
+            throw new StackOverflowError("cleanup blew up");
+        }
+    }
+
     private static class ThrowingRenderer extends CoreRenderer<UIComponent> {
 
         @Override
@@ -92,6 +103,22 @@ class PrimeRendererWrapperTest {
         @Override
         public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
             throw new IOException("boom");
+        }
+    }
+
+    /**
+     * A render which runs out of stack, the way a deeply nested or accidentally recursive component tree does.
+     */
+    private static class ErrorThrowingRenderer extends CoreRenderer<UIComponent> {
+
+        @Override
+        public void decode(FacesContext context, UIComponent component) {
+            throw new StackOverflowError("boom");
+        }
+
+        @Override
+        public void encodeEnd(FacesContext context, UIComponent component) throws IOException {
+            throw new StackOverflowError("boom");
         }
     }
 
@@ -191,6 +218,49 @@ class PrimeRendererWrapperTest {
         assertEquals("boom", thrown.getMessage());
         assertEquals(1, thrown.getSuppressed().length);
         assertEquals("cleanup blew up", thrown.getSuppressed()[0].getMessage());
+    }
+
+    /**
+     * A {@link StackOverflowError} out of a deeply nested render unwinds like any other throwable and the response is
+     * still turned into an error page, so the iteration state has to be cleaned up after it too.
+     */
+    @Test
+    void encodeEndCleansUpWhenTheRendererThrewAnError() {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ErrorThrowingRenderer());
+        StackOverflowError thrown = assertThrows(StackOverflowError.class, () -> wrapper.encodeEnd(context, component));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, component.cleanups);
+    }
+
+    @Test
+    void decodeCleansUpWhenTheRendererThrewAnError() {
+        FacesContext context = new FacesContextMock();
+        CleanupAwareComponent component = new CleanupAwareComponent();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ErrorThrowingRenderer());
+        StackOverflowError thrown = assertThrows(StackOverflowError.class, () -> wrapper.decode(context, component));
+
+        assertEquals("boom", thrown.getMessage());
+        assertEquals(1, component.cleanups);
+    }
+
+    /**
+     * An {@link Error} is not a lesser failure than what the render threw, so it wins rather than riding along as a
+     * suppressed exception.
+     */
+    @Test
+    void encodeEndLetsAnErrorFromTheCleanupWin() {
+        FacesContext context = new FacesContextMock();
+
+        Renderer wrapper = new PrimeRendererWrapper(new ThrowingRenderer());
+        StackOverflowError thrown =
+                assertThrows(StackOverflowError.class, () -> wrapper.encodeEnd(context, new ErrorThrowingCleanupComponent()));
+
+        assertEquals("cleanup blew up", thrown.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Fix #15164 
Fix #15165 
Fix #15166 
Fix #15167
Fix #15163

Five components set a row index, a row key or an iteration variable while rendering and returned without resetting it. The var then stayed in the request map, so whatever rendered after them resolved it to the last row, and where the component folds the row into the client id it hands its children, their state was saved under a client id which the next request does not rebuild.

Rather than fixing each renderer, give the components one place to clean up after themselves, as suggested in #15167:

- RenderCleanupAware is implemented by a component whose renderer leaves iteration state behind.
- PrimeRendererWrapper calls it right after encodeEnd, also when encodeEnd threw. PrimeRenderKit hands out every CoreRenderer inside that wrapper, and PrimeRenderKitFactory installs the render kit. Renderers of the Faces implementation and of other libraries are handed out untouched.

The implementations:

- PrimeUIData resets the row index, which covers the DataTable scroll, cell edit, row edit and add row ajax requests (#15164), none of which reach encodeTbody.
- SubTable resets the row index (#15165). It extends UIData directly, so it folds the row into its own client id as well.
- DataTable and TreeTable also reset every p:columns below them, since DynamicColumn#cleanModel had no call site at all (#15166).
- Timeline removes var and varGroup from the request map (#15167).
- UITree resets the row key, which moves the fix merged for #15161 off TreeRenderer and onto the interface, and covers TreeTable too.

Badge and OverlayPanel cast the result of RenderKit#getRenderer to their own renderer type, so they now go through ComponentUtils#getUnwrappedRenderer.