### PR TITLE
Fix #14864: 15.X remove invalid role="alert" from Messages list items

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/messages/MessagesRenderer.java
@@ -160,7 +160,8 @@ public class MessagesRenderer extends UINotificationRenderer {
 
         writer.startElement("li", null);
 
-        writer.writeAttribute("role", "alert", null);
+        // role="alert" is not an allowed role for <li> (#14864), the enclosing ui-messages
+        // container is already an aria-live="polite" region which announces the message
         writer.writeAttribute(HTML.ARIA_ATOMIC, "true", null);
 
         String summary = message.getSummary() != null ? message.getSummary() : "";


### PR DESCRIPTION
Fix #14864: 15.X remove invalid role="alert" from Messages list items