### PR TITLE
Fix #14295: allow summaryRow to define its own row group

### DIFF
--- a/docs/17_0_0/components/datatable.md
+++ b/docs/17_0_0/components/datatable.md
@@ -636,6 +636,27 @@ group. To enable this method, set groupRow to true on the grouping column.
     <p:column field="id" headerText="Id" />
 </p:dataTable>
 ```
+A `summaryRow` closes the group defined by the table, so on its own it needs to know what that group is. It picks
+up the group from a `headerRow`, a `groupRow="true"` column or the active sort; when there is none of those, define
+the group on the summary row itself with `field` (or `groupBy`). Note that the summary row only groups, it does not
+sort, so make sure the rows arrive grouped - via `headerRow`, a sorted column or a pre-sorted list.
+
+```xhtml
+<p:dataTable var="car" value="#{dtRowGroupView.cars}">
+    <p:column field="brand" headerText="Brand" sortBy="#{car.brand}" sortOrder="asc" />
+
+    <p:column field="year" headerText="Year" />
+
+    <p:summaryRow field="brand">
+        <p:column style="text-align:right">
+            <h:outputText value="Total:" />
+        </p:column>
+        <p:column>
+            <h:outputText value="#{dtRowGroupView.getTotal(car.brand)}" />
+        </p:column>
+    </p:summaryRow>
+</p:dataTable>
+```
 
 ## Scrolling
 Scrolling makes the header-footer of the table fixed and the body part scrollable. Scrolling is

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
@@ -21,36 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.component.summaryrow;
+package org.primefaces.integrationtests.datatable;
 
-import org.primefaces.cdk.api.FacesComponentBase;
-import org.primefaces.cdk.api.Property;
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
 
-import jakarta.faces.component.UIComponentBase;
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
-@FacesComponentBase
-public abstract class SummaryRowBase extends UIComponentBase {
+import lombok.Data;
 
-    public static final String COMPONENT_FAMILY = "org.primefaces.component";
+@Named
+@ViewScoped
+@Data
+public class DataTable052 implements Serializable {
 
-    public static final String DEFAULT_RENDERER = "org.primefaces.component.SummaryRowRenderer";
+    @Serial private static final long serialVersionUID = -3117401598325091316L;
 
-    public SummaryRowBase() {
-        setRendererType(DEFAULT_RENDERER);
+    private List<ProgrammingLanguage> progLanguages;
+
+    @Inject
+    private ProgrammingLanguageService service;
+
+    @PostConstruct
+    public void init() {
+        progLanguages = service.getLangs();
     }
 
-    @Override
-    public String getFamily() {
-        return COMPONENT_FAMILY;
+    public long getTotalCount(ProgrammingLanguage.ProgrammingLanguageType type) {
+        return progLanguages.stream().filter(lang -> lang.getType() == type).count();
     }
-
-    @Property(description = "Name of the field associated to bean \"var\".")
-    public abstract String getField();
-
-    @Property(description = "Property to be used for grouping.")
-    public abstract String getGroupBy();
-
-    @Property(description = "Method expression to execute before rendering summary row. (e.g. to calculate totals)")
-    public abstract jakarta.el.MethodExpression getListener();
-
 }

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:dataTable id="datatable" value="#{dataTable052.progLanguages}" var="lang">
+                <p:column field="id" headerText="ID"/>
+                <p:column field="name" headerText="Name"/>
+                <p:column field="firstAppeared" headerText="First appeared"/>
+                <p:column field="type" headerText="Type"/>
+
+                <!-- no headerRow, the summaryRow defines the group itself -->
+                <p:summaryRow field="type">
+                    <p:column colspan="3" style="text-align:right">
+                        <h:outputText value="Total programming languages:"/>
+                    </p:column>
+                    <p:column>
+                        <h:outputText value="#{dataTable052.getTotalCount(lang.type)}"/>
+                    </p:column>
+                </p:summaryRow>
+            </p:dataTable>
+
+            <p:commandButton id="button" value="Submit" update="@form"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.DataTable;
+import org.primefaces.selenium.component.model.datatable.Row;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Tag("DataTable-rowgroup")
+class DataTable052Test extends AbstractDataTableTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: RowGroup - summary row grouping by its own field, without a header row; see GitHub #14295")
+    void summaryRowWithoutHeaderRow(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        assertNotNull(dataTable);
+
+        // Assert
+        assertSummaryRows(dataTable);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: RowGroup - summary row survives an update, without a header row; see GitHub #14295")
+    void summaryRowWithoutHeaderRowAfterUpdate(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        assertNotNull(dataTable);
+
+        // Act
+        page.button.click();
+
+        // Assert
+        assertSummaryRows(dataTable);
+    }
+
+    private void assertSummaryRows(DataTable dataTable) {
+        List<Row> rows = dataTable.getRows();
+        assertNotNull(rows);
+        assertEquals(languages.size() + 2, rows.size()); //plus 2 summary-rows
+
+        //check summary-rows, one after each of the 2 groups (2 COMPILED, 3 INTERPRETED)
+        assertEquals("3", dataTable.getCell(2, 0).getWebElement().getAttribute("colspan"));
+        assertEquals("Total programming languages:", dataTable.getCell(2, 0).getText());
+        assertEquals("2", dataTable.getCell(2, 1).getText());
+        assertEquals("3", dataTable.getCell(6, 0).getWebElement().getAttribute("colspan"));
+        assertEquals("Total programming languages:", dataTable.getCell(6, 0).getText());
+        assertEquals("3", dataTable.getCell(6, 1).getText());
+
+        //remove summary-rows
+        rows.remove(6); //second summary-row
+        rows.remove(2); //first summary-row
+
+        assertRows(rows, languages);
+
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datatable")
+        DataTable dataTable;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable052.xhtml";
+        }
+    }
+}

--- a/primefaces-showcase/src/main/webapp/ui/data/datatable/rowGroup.xhtml
+++ b/primefaces-showcase/src/main/webapp/ui/data/datatable/rowGroup.xhtml
@@ -10,7 +10,7 @@
     </ui:define>
 
     <ui:define name="description">
-        Rows can be grouped in two ways, using rowGroup component or with groupRow attribute on a column.
+        Rows can be grouped using the headerRow and summaryRow components or with the groupRow attribute on a column.
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
@@ -22,7 +22,7 @@
         <div class="card">
             <h5 class="first">Header Row</h5>
             <h:form>
-                <p:dataTable var="customer" value="#{dtRowGroupView.customers}" sortBy="#{customer.representative.name}">
+                <p:dataTable var="customer" value="#{dtRowGroupView.customers}">
                     <p:headerRow field="representative.name"
                                  expandable="true" 
                                  expanded="#{customer.representative.name != 'Stephen Shaw'}">
@@ -64,6 +64,40 @@
 
                     <p:summaryRow>
                         <p:column colspan="5" style="text-align:right">
+                            <h:outputText value="Total Customers:"/>
+                        </p:column>
+                        <p:column>
+                            <h:outputText value="#{dtRowGroupView.getTotalCount(customer.representative.name)}"/>
+                        </p:column>
+                    </p:summaryRow>
+                </p:dataTable>
+            </h:form>
+        </div>
+
+        <div class="card">
+            <h5>Summary Row</h5>
+            <h:form>
+                <p:dataTable var="customer" value="#{dtRowGroupView.customers}">
+                    <p:column headerText="Representative" sortBy="#{customer.representative.name}" sortOrder="asc">
+                        <h:outputText value="#{customer.representative.name}" />
+                    </p:column>
+
+                    <p:column headerText="Name">
+                        <h:outputText value="#{customer.name}" />
+                    </p:column>
+
+                    <p:column headerText="Country">
+                        <span class="flag flag-#{customer.country.code}" style="width: 30px; height: 20px"/>
+                        <h:outputText style="vertical-align: middle; margin-left: .5rem" value="#{customer.country}"/>
+                    </p:column>
+
+                    <p:column headerText="Company">
+                        <h:outputText value="#{customer.company}" />
+                    </p:column>
+
+                    <!-- no headerRow, the summaryRow defines the group itself -->
+                    <p:summaryRow field="representative.name">
+                        <p:column colspan="3" style="text-align:right">
                             <h:outputText value="Total Customers:"/>
                         </p:column>
                         <p:column>

--- a/primefaces/src/main/java/org/primefaces/component/api/UITable.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITable.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -376,6 +377,39 @@ public interface UITable<T extends UITableState> extends ColumnAware, MultiViewS
                 .filter(SortMeta::isActive)
                 .min(Comparator.comparingInt(SortMeta::getPriority))
                 .orElse(null);
+    }
+
+    /**
+     * Returns the {@link SortMeta} defining the row group boundaries used by header and summary rows.
+     * Grouping is defined explicitly by a header row or by a column with <code>groupRow</code>; only when
+     * neither is present it falls back to the active sort, so the group does not depend on sort priority.
+     *
+     * @return the grouping {@link SortMeta} or <code>null</code> if rows are not grouped
+     */
+    default SortMeta getGroupByMeta() {
+        Map<String, SortMeta> sortBy = getSortByAsMap();
+
+        for (SortMeta meta : sortBy.values()) {
+            if (meta.isHeaderRow() && meta.isActive()) {
+                return meta;
+            }
+        }
+
+        AtomicReference<SortMeta> groupRowMeta = new AtomicReference<>();
+        forEachColumn(column -> {
+            if (column.isGroupRow()) {
+                SortMeta meta = sortBy.get(column.getColumnKey());
+                if (meta != null && meta.isActive()) {
+                    groupRowMeta.set(meta);
+                    return false;
+                }
+            }
+
+            return true;
+        });
+
+        SortMeta meta = groupRowMeta.get();
+        return meta != null ? meta : getHighestPriorityActiveSortMeta();
     }
 
     /**

--- a/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/DataTableRenderer.java
@@ -1126,9 +1126,18 @@ public class DataTableRenderer extends DataRenderer<DataTable> {
         List<SummaryRow> summaryRows = table.getSummaryRows();
         HeaderRow headerRow = table.getHeaderRow();
 
-        SortMeta sort = table.getHighestPriorityActiveSortMeta();
-        boolean encodeHeaderRow = headerRow != null && headerRow.isEnabled() && sort != null;
-        boolean encodeSummaryRow = (!summaryRows.isEmpty() && sort != null);
+        // resolving the group only makes sense when there is something to group
+        SortMeta sort = (headerRow != null || !summaryRows.isEmpty()) ? table.getGroupByMeta() : null;
+        ValueExpression groupBy = sort != null ? sort.getSortBy() : null;
+
+        // a summaryRow may define the group itself, which is the only way to group without a headerRow
+        ValueExpression summaryGroupBy = resolveSummaryGroupBy(context, table, summaryRows);
+        if (summaryGroupBy == null) {
+            summaryGroupBy = groupBy;
+        }
+
+        boolean encodeHeaderRow = headerRow != null && headerRow.isEnabled() && groupBy != null;
+        boolean encodeSummaryRow = (!summaryRows.isEmpty() && summaryGroupBy != null);
 
         for (int i = first; i < last; i++) {
             table.setRowIndex(i);
@@ -1136,16 +1145,32 @@ public class DataTableRenderer extends DataRenderer<DataTable> {
                 break;
             }
 
-            if (encodeHeaderRow && (i == first || !isInSameGroup(context, table, i, -1, sort.getSortBy(), false))) {
+            if (encodeHeaderRow && (i == first || !isInSameGroup(context, table, i, -1, groupBy, false))) {
                 encodeHeaderRow(context, table, headerRow);
             }
 
             encodeRow(context, table, i, columnStart, columnEnd);
 
-            if (encodeSummaryRow && !isInSameGroup(context, table, i, 1, sort.getSortBy(), i == last - 1)) {
-                encodeSummaryRow(context, summaryRows, sort);
+            if (encodeSummaryRow && !isInSameGroup(context, table, i, 1, summaryGroupBy, i == last - 1)) {
+                encodeSummaryRow(context, summaryRows, summaryGroupBy);
             }
         }
+    }
+
+    /**
+     * Resolves the group defined by the summary rows themselves, the first one declaring a group wins.
+     *
+     * @return the group by {@link ValueExpression} or <code>null</code> when no summary row defines a group
+     */
+    protected ValueExpression resolveSummaryGroupBy(FacesContext context, DataTable table, List<SummaryRow> summaryRows) {
+        for (int i = 0; i < summaryRows.size(); i++) {
+            ValueExpression groupBy = summaryRows.get(i).getGroupByValueExpression(context, table.getVar());
+            if (groupBy != null) {
+                return groupBy;
+            }
+        }
+
+        return null;
     }
 
     protected void encodeFrozenRows(FacesContext context, DataTable table, int columnStart, int columnEnd) throws IOException {
@@ -1168,11 +1193,15 @@ public class DataTableRenderer extends DataRenderer<DataTable> {
     }
 
     protected void encodeSummaryRow(FacesContext context, List<SummaryRow> summaryRows, SortMeta sort) throws IOException {
+        encodeSummaryRow(context, summaryRows, sort == null ? null : sort.getSortBy());
+    }
+
+    protected void encodeSummaryRow(FacesContext context, List<SummaryRow> summaryRows, ValueExpression groupBy) throws IOException {
         for (int i = 0; i < summaryRows.size(); i++) {
             SummaryRow summaryRow = summaryRows.get(i);
             MethodExpression me = summaryRow.getListener();
             if (me != null) {
-                me.invoke(context.getELContext(), new Object[]{sort.getSortBy()});
+                me.invoke(context.getELContext(), new Object[]{groupBy});
             }
 
             summaryRow.encodeAll(context);

--- a/primefaces/src/main/java/org/primefaces/component/summaryrow/SummaryRow.java
+++ b/primefaces/src/main/java/org/primefaces/component/summaryrow/SummaryRow.java
@@ -25,8 +25,12 @@ package org.primefaces.component.summaryrow;
 
 import org.primefaces.cdk.api.FacesComponentHandler;
 import org.primefaces.cdk.api.FacesComponentInfo;
+import org.primefaces.component.api.UIColumn;
+import org.primefaces.util.LangUtils;
 
+import jakarta.el.ValueExpression;
 import jakarta.faces.component.FacesComponent;
+import jakarta.faces.context.FacesContext;
 
 @FacesComponent(value = SummaryRow.COMPONENT_TYPE, namespace = SummaryRow.COMPONENT_FAMILY)
 @FacesComponentInfo(description = "SummaryRow is a helper component for data grouping.")
@@ -34,4 +38,22 @@ import jakarta.faces.component.FacesComponent;
 public class SummaryRow extends SummaryRowBaseImpl {
 
     public static final String COMPONENT_TYPE = "org.primefaces.component.SummaryRow";
+
+    /**
+     * Returns the expression this summary row groups by. When neither <code>groupBy</code> nor <code>field</code>
+     * is set, the group is defined by the table itself (header row, <code>groupRow</code> column or active sort).
+     *
+     * @param context the {@link FacesContext}
+     * @param var the name of the request-scoped variable of the enclosing table
+     * @return the group by {@link ValueExpression} or <code>null</code> if this summary row defines no group
+     */
+    public ValueExpression getGroupByValueExpression(FacesContext context, String var) {
+        ValueExpression groupByVE = getValueExpression(PropertyKeys.groupBy);
+        if (groupByVE != null) {
+            return groupByVE;
+        }
+
+        String field = getField();
+        return LangUtils.isBlank(field) ? null : UIColumn.createValueExpressionFromField(context, var, field);
+    }
 }


### PR DESCRIPTION
Fixes #14295

## Problem

Removing `<p:headerRow>` from a table also makes `<p:summaryRow>` disappear.

Since the `SortMeta` refactor in v10, `DataTableRenderer.encodeRows` derives the row group boundary solely from `getHighestPriorityActiveSortMeta()`:

```java
SortMeta sort = table.getHighestPriorityActiveSortMeta();
boolean encodeSummaryRow = (!summaryRows.isEmpty() && sort != null);
```

A header row is the only thing that reliably puts an *active* `SortMeta` into the map — `UITable.initSortBy()` synthesizes one from `<p:headerRow>` at `MAX_PRIORITY`. Without a header row, and unless a column happens to be actively sorted, `sort == null` and no summary rows are rendered. That is also why the reporter saw the summary rows reappear intermittently: clicking any sortable column header creates an active meta.

Before v10 the group expression came from the table's own `sortBy` attribute, independently of the header row (`7.0` `DataTableRenderer` lines 1206-1223), so `summaryRow` worked without one. There was no attribute left to supply the group.

## Fix

**`summaryRow` can define its own group**, mirroring `headerRow`:

- `SummaryRowBase` — new `field` and `groupBy` properties.
- `SummaryRow.getGroupByValueExpression(context, var)` — resolves `groupBy` (a VE) or builds one from `field`; `null` when neither is set.
- `DataTableRenderer.encodeRows` — the summary group is resolved independently of the header group; the summary row's own expression wins, otherwise it falls back to the table group exactly as before.

```xhtml
<p:dataTable var="customer" value="#{bean.customers}">
    <p:column headerText="Representative" sortBy="#{customer.representative.name}" sortOrder="asc" />
    <p:column headerText="Name" field="name" />

    <!-- no headerRow needed -->
    <p:summaryRow field="representative.name">
        ...
    </p:summaryRow>
</p:dataTable>
```

**Secondary — the group no longer depends on sort priority.** `UITable.getGroupByMeta()` prefers the header-row meta, then a `groupRow` column, and only then the highest-priority active sort. This matters in multi-sort, where a `groupRow` column and a user-sorted column are both active at `MIN_PRIORITY` and `min()` resolved by declaration order. In single-sort nothing changes, because `SortFeature.decode()` deactivates every non-header-row meta on a sort click. Resolution is now also skipped entirely when the table has neither a header nor a summary row.

`encodeSummaryRow(…, SortMeta)` is kept as a delegating overload alongside the new `ValueExpression` one, so subclassed renderers still compile.

## Docs & showcase

- Removed the dead `sortBy="#{customer.representative.name}"` from the showcase Header Row demo — since v10 `sortBy` expects `SortMeta`, so this evaluates to `null` off-row and contributes nothing, while implying it drives the grouping.
- Added a **Summary Row** card to the showcase demonstrating the header-row-less pattern.
- Documented in `datatable.md` where a summary row takes its group from, and that it groups but does not sort.

## Verification

New IT triad `dataTable052` (`@Tag("DataTable-rowgroup")`) covering summary row grouping without a header row, on first render and after an AJAX update.

The test pins the reported bug — with `field="type"` removed from the page it fails with `expected: <7> but was: <5>`, i.e. zero summary rows.

```
DataTable-rowgroup + DataTable-sort:  Tests run: 115, Failures: 0, Errors: 0
primefaces unit tests:                Tests run: 480, Failures: 0, Errors: 0, Skipped: 1
checkstyle + license (both modules):  BUILD SUCCESS
```

Note this does not restore the pre-v10 `sortBy="#{var.field}"` string form on `dataTable` — that is gone by design with the `SortMeta` refactor, and reviving it would reintroduce a second, conflicting meaning for `sortBy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
