### PR TITLE
Fix #15211: correct InputNumber attribute descriptions

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberBase.java
@@ -45,29 +45,40 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
         return COMPONENT_FAMILY;
     }
 
-    @Property(description = "Currency symbol to display.")
+    @Property(description = "Desired symbol or unit to display, e.g. '$' or ' kg'.", implicitDefaultValue = "none")
     public abstract String getSymbol();
 
-    @Property(description = "Position of the sign. Options: 'p' for prefix, 's' for suffix.")
+    @Property(description = "Placement of the negative/positive sign relative to the symbolPosition option."
+            + " The sign is placed on either side of the symbolPosition, which can be placed on either side of the numbers."
+            + " Options: 'p' for prefix, 's' for suffix, 'l' for left, 'r' for right.")
     public abstract String getSignPosition();
 
-    @Property(description = "Position of the symbol. Options: 'p' for prefix, 's' for suffix.")
+    @Property(description = "Position of the symbol. Options: 'p' for prefix, 's' for suffix.", implicitDefaultValue = "p")
     public abstract String getSymbolPosition();
 
-    @Property(description = "Minimum value allowed.")
+    @Property(description = "Minimum value allowed. WARNING: if minValue is greater than 0, you effectively prevent your users from entirely"
+            + " deleting the content of their input.", implicitDefaultValue = "-10000000000000")
     public abstract String getMinValue();
 
-    @Property(description = "Maximum value allowed.")
+    @Property(description = "Maximum value allowed. WARNING: if maxValue is lower than 0, you effectively prevent your users from entirely"
+            + " deleting the content of their input.", implicitDefaultValue = "10000000000000")
     public abstract String getMaxValue();
 
-    @Property(description = "Rounding method. Options: 'S' for standard, 'A' for away from zero, 'C' for ceiling, 'F' for floor, 'D' for down, 'U' for up.",
+    @Property(description = "Controls the rounding method. Options: 'S' for round-half-up symmetric, 'A' for round-half-up asymmetric,"
+            + " 's' for round-half-down symmetric, 'a' for round-half-down asymmetric, 'B' for round-half-even (banker's rounding),"
+            + " 'U' for round up (away from zero), 'D' for round down (toward zero), 'C' for round to ceiling (toward positive infinity),"
+            + " 'F' for round to floor (toward negative infinity), 'N05' or 'CHF' for round to the nearest 0.05,"
+            + " 'U05' for round up to the next 0.05, 'D05' for round down to the next 0.05.",
         defaultValue = "S")
     public abstract String getRoundMethod();
 
-    @Property(description = "Number of decimal places to display.")
+    @Property(description = "Number of decimal places. If the value is a Byte/Short/Integer/Long/BigInteger it defaults to 0.",
+        implicitDefaultValue = "2")
     public abstract String getDecimalPlaces();
 
-    @Property(description = "Raw value for decimal places.")
+    @Property(description = "Specifies the number of decimal places to retain for the raw value, while decimalPlaces is used for the displayed"
+            + " value. If left as null, the decimalPlaces value is used. Note: setting this to fewer decimal places than those displayed may"
+            + " cause user confusion.")
     public abstract Integer getDecimalPlacesRawValue();
 
     @Property(description = "Decimal separator character. Defaults to locale-specific separator if not specified.")
@@ -76,33 +87,43 @@ public abstract class InputNumberBase extends AbstractPrimeHtmlInputText impleme
     @Property(description = "Thousand separator character. Defaults to locale-specific separator if not specified.")
     public abstract String getThousandSeparator();
 
-    @Property(description = "Empty value behavior. Options: 'focus', 'blur', 'always', 'never'.", defaultValue = "focus")
+    @Property(description = "Defines what to display when the input value is empty. Options: 'empty' (or null) to display nothing,"
+            + " 'focus' to display the symbol on focus, 'press' to display the symbol while a key is pressed, 'always' to always display"
+            + " the symbol, 'min' or 'max' to display the minValue/maxValue, 'zero' to display zero, or a string representing a number.",
+        defaultValue = "focus")
     public abstract String getEmptyValue();
 
-    @Property(description = "Inline style for the input element.")
+    @Property(description = "Inline style of the input element.")
     public abstract String getInputStyle();
 
-    @Property(description = "CSS class for the input element.")
+    @Property(description = "Style class of the input element.")
     public abstract String getInputStyleClass();
 
-    @Property(description = "Padding control. Options: 'true', 'false', 'floats'.", defaultValue = "true")
+    @Property(description = "Allow padding the decimal places with zeros. If set to 'true' it will always pad the decimal places with zeros,"
+            + " and never if set to 'false'. If set to 'floats', padding is only done when there are some decimals (up to the number of decimal"
+            + " places from the decimalPlaces attribute). If set to an integer greater than 0, padding will use that number for adding the"
+            + " zeros; 0 is not a valid value.",
+        defaultValue = "true")
     public abstract String getPadControl();
 
-    @Property(description = "Leading zero behavior. Options: 'allow', 'deny', 'keep'.", defaultValue = "allow")
+    @Property(description = "Controls leading zero behavior. Options: 'allow' to allow the leading zero while typing and remove it on focus"
+            + " out, 'deny' to prevent the leading zero from being entered, 'keep' to allow and keep the leading zero.",
+        defaultValue = "allow")
     public abstract String getLeadingZero();
 
-    @Property(description = "Alternative decimal separator character.")
+    @Property(description = "Allows declaring an alternative decimal separator which is automatically replaced by decimalSeparator when typed.")
     public abstract String getDecimalSeparatorAlternative();
 
-    @Property(description = "When enabled, mouse wheel modifies the value.", defaultValue = "true")
+    @Property(description = "Allows the user to increment or decrement the element value with the mouse wheel.", defaultValue = "true")
     public abstract boolean isModifyValueOnWheel();
 
-    @Property(description = "When enabled, up/down arrow keys modify the value.", defaultValue = "true")
+    @Property(description = "Allows the user to increment or decrement the element value with the up and down arrow keys.", defaultValue = "true")
     public abstract boolean isModifyValueOnUpDownArrow();
 
-    @Property(description = "When enabled, selects all text on focus.", defaultValue = "true")
+    @Property(description = "Defines if the element value should be selected on focus.", defaultValue = "true")
     public abstract boolean isSelectOnFocus();
 
-    @Property(description = "Caret position on focus. Options: 'start', 'end', 'min', 'max'.")
+    @Property(description = "Defines where the caret should be positioned on focus."
+            + " Options: 'start', 'end', 'decimalLeft', 'decimalRight'.")
     public abstract String getCaretPositionOnFocus();
 }

--- a/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/inputnumber/InputNumberRenderer.java
@@ -259,7 +259,7 @@ public class InputNumberRenderer extends InputRenderer<InputNumber> {
             .attr("maximumValue", getMaximum(context, isIntegral, component))
             .attr("emptyInputBehavior", emptyValue, "focus")
             .attr("leadingZero", component.getLeadingZero(), "deny")
-            .attr("allowDecimalPadding", component.getPadControl(), "true")
+            .attr("allowDecimalPadding", getPadControl(component), "true")
             .attr("modifyValueOnWheel", component.isModifyValueOnWheel(), true)
             .attr("modifyValueOnUpDownArrow", component.isModifyValueOnUpDownArrow(), true)
             .attr("roundingMethod", component.getRoundMethod(), "S")
@@ -392,6 +392,35 @@ public class InputNumberRenderer extends InputRenderer<InputNumber> {
             return "0";
         }
         return "2";
+    }
+
+    /**
+     * Validates the "padControl" property which maps to the AutoNumeric "allowDecimalPadding" option.
+     * AutoNumeric only accepts "true", "false", "floats" or an integer greater than 0, and throws a
+     * client side error for anything else, so fail early with a meaningful message instead.
+     * @param component the component
+     * @return the padControl value to use
+     */
+    protected String getPadControl(InputNumber component) {
+        String padControl = component.getPadControl();
+        if (LangUtils.isBlank(padControl)
+                || "true".equals(padControl)
+                || "false".equals(padControl)
+                || "floats".equals(padControl)) {
+            return padControl;
+        }
+
+        try {
+            if (Integer.parseInt(padControl) > 0) {
+                return padControl;
+            }
+        }
+        catch (NumberFormatException e) {
+            // handled below, along with any non positive integer
+        }
+
+        throw new FacesException("The padControl option of InputNumber is invalid; it should either be "
+                + "\"true\", \"false\", \"floats\" or an integer greater than 0, [" + padControl + "] given.");
     }
 
     private String determineMinimumFromType(FacesContext context, InputNumber component) {

--- a/primefaces/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/inputnumber/InputNumberTest.java
@@ -284,4 +284,40 @@ class InputNumberTest {
         assertFalse(renderer.isIntegral(context, inputNumber, null));
     }
 
+    @Test
+    void getPadControlAcceptsKeywordsAndPositiveIntegers() {
+        when(inputNumber.getPadControl()).thenReturn("true");
+        assertEquals("true", renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("false");
+        assertEquals("false", renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("floats");
+        assertEquals("floats", renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("1");
+        assertEquals("1", renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("15");
+        assertEquals("15", renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn(null);
+        assertNull(renderer.getPadControl(inputNumber));
+    }
+
+    /**
+     * GitHub #15211: AutoNumeric rejects 0, so fail server side with a meaningful message.
+     */
+    @Test
+    void getPadControlRejectsZero() {
+        when(inputNumber.getPadControl()).thenReturn("0");
+        FacesException thrown = assertThrows(FacesException.class, () -> renderer.getPadControl(inputNumber));
+        assertTrue(thrown.getMessage().contains("[0] given"), thrown.getMessage());
+    }
+
+    @Test
+    void getPadControlRejectsNegativeAndNonNumericValues() {
+        when(inputNumber.getPadControl()).thenReturn("-1");
+        assertThrows(FacesException.class, () -> renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("2.5");
+        assertThrows(FacesException.class, () -> renderer.getPadControl(inputNumber));
+        when(inputNumber.getPadControl()).thenReturn("yes");
+        assertThrows(FacesException.class, () -> renderer.getPadControl(inputNumber));
+    }
+
 }


### PR DESCRIPTION
AutoNumeric only accepts true, false, 'floats' or an integer greater than 0 for allowDecimalPadding, and throws "The decimal padding option 'allowDecimalPadding' is invalid" in the browser for anything else, which leaves the component silently broken with only a console error.

Validate padControl while rendering the widget configuration and throw a FacesException naming the offending value instead. Fix #15211: correct InputNumber attribute descriptions

The CDK refactoring replaced the hand-written primefaces.taglib.xml descriptions with shorter @Property descriptions, several of which were factually wrong. Restore accurate documentation, verified against the AutoNumeric option types:

- padControl: also accepts an integer greater than 0 (0 is rejected by AutoNumeric); document the 'true'/'false'/'floats'/integer semantics
- caretPositionOnFocus: 'decimalLeft'/'decimalRight', not 'min'/'max'
- emptyValue: 'empty'/'focus'/'press'/'always'/'min'/'max'/'zero'/number, not 'focus'/'blur'/'always'/'never'
- signPosition: also accepts 'l' (left) and 'r' (right)
- roundMethod: document all 13 AutoNumeric rounding methods
- decimalPlaces, decimalPlacesRawValue, decimalSeparatorAlternative, minValue, maxValue, symbol: restore the full descriptions and defaults