### PR TITLE
Fix #13967: a tree visit must not drop another UIData's row var

### DIFF
--- a/primefaces/src/main/java/org/primefaces/component/patch/UIDataPatch.java
+++ b/primefaces/src/main/java/org/primefaces/component/patch/UIDataPatch.java
@@ -77,6 +77,8 @@ import jakarta.faces.render.Renderer;
  *   <li>Few methods are either copied or become abstract as they are tightly coupled with Mojarra.</li>
  *   <li>{@link UIDataPatch#getClientId(FacesContext)} and {@link UIDataPatch#getContainerClientId(FacesContext)} copied from MyFaces (see MYFACES-2744)</li>
  *   <li>Support of MyFaces view pooling in {@link UIDataPatch#saveState(FacesContext)}</li>
+ *   <li>{@link UIDataPatch#visitTree(VisitContext, VisitCallback)} restores the row var as well as the
+ *       row index, so that a tree visit cannot drop the var of another UIData sharing the var name (#13967)</li>
  * </ul>
  *
  * <p><strong class="changed_modified_2_0_rev_a
@@ -862,9 +864,23 @@ public abstract class UIDataPatch extends UIData {
 
         // Clear out the row index is one is set so that
         // we start from a clean slate.
+        // #13967 also remember the row var, because setRowIndex(-1) removes it from the request map
+        // unconditionally, even when it belongs to another UIData that shares the var name and is
+        // still rendering. A tree visit must leave the var exactly as it found it.
         int oldRowIndex = -1;
+        String var = null;
+        Object oldVarValue = null;
+        boolean hadVarValue = false;
         if (visitRows) {
             oldRowIndex = getRowIndex();
+
+            var = getVar();
+            if (var != null) {
+                Map<String, Object> requestMap = facesContext.getExternalContext().getRequestMap();
+                hadVarValue = requestMap.containsKey(var);
+                oldVarValue = requestMap.get(var);
+            }
+
             setRowIndex(-1);
         }
 
@@ -910,6 +926,18 @@ public abstract class UIDataPatch extends UIData {
             popComponentFromEL(facesContext);
             if (visitRows) {
                 setRowIndex(oldRowIndex);
+
+                // #13967 restore the var we found, which setRowIndex(oldRowIndex) only does when we
+                // were standing on a row of our own
+                if (var != null) {
+                    Map<String, Object> requestMap = facesContext.getExternalContext().getRequestMap();
+                    if (hadVarValue) {
+                        requestMap.put(var, oldVarValue);
+                    }
+                    else {
+                        requestMap.remove(var);
+                    }
+                }
             }
         }
 

--- a/primefaces/src/test/java/org/primefaces/component/datatable/DataTableVisitRowVarTest.java
+++ b/primefaces/src/test/java/org/primefaces/component/datatable/DataTableVisitRowVarTest.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.component.datatable;
+
+import org.primefaces.component.column.Column;
+import org.primefaces.mock.CollectingResponseWriter;
+import org.primefaces.mock.FacesContextMock;
+import org.primefaces.mock.TestVisitContext;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Map;
+
+import jakarta.faces.component.UIViewRoot;
+import jakarta.faces.component.visit.VisitHint;
+import jakarta.faces.component.visit.VisitResult;
+import jakarta.faces.context.FacesContext;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * #13967 A tree visit must not disturb the row var of a table that is still rendering.
+ *
+ * <p>Resolving a search expression such as {@code update="@root:@id(panel)"} on a command inside a
+ * column makes the Faces {@code @id} keyword resolver visit the whole view while the table is
+ * rendering a row. Every UIData reached by that visit iterates its rows, and on the way out calls
+ * {@code setRowIndex(-1)}, which removes the var from the request map unconditionally. When a second
+ * table shares the var name, that removal takes the rendering table's var with it and the remaining
+ * columns render empty.</p>
+ */
+class DataTableVisitRowVarTest {
+
+    private static DataTable table(String id, String var, Object... values) {
+        DataTable table = new DataTable();
+        table.setId(id);
+        table.setVar(var);
+        table.setValue(Arrays.asList(values));
+        table.getChildren().add(new Column());
+        return table;
+    }
+
+    private static Map<String, Object> requestMap(FacesContext context) {
+        return context.getExternalContext().getRequestMap();
+    }
+
+    /** The reported failure: a second table sharing the var name wipes it on the way out. */
+    @Test
+    void visitOfTableSharingTheVarNameKeepsTheRenderingVar() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        DataTable rendering = table("rendering", "row", "a", "b");
+        DataTable other = table("other", "row", "x", "y");
+
+        rendering.setRowIndex(0);
+        assertEquals("a", requestMap(context).get("row"), "precondition");
+
+        other.visitTree(new TestVisitContext(context), (ctx, target) -> VisitResult.ACCEPT);
+
+        assertEquals("a", requestMap(context).get("row"));
+    }
+
+    /** The reported shape: a whole-view visit, as @root:@id(...) performs. */
+    @Test
+    void wholeViewVisitKeepsTheRenderingVar() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        UIViewRoot root = new UIViewRoot();
+        DataTable rendering = table("rendering", "row", "a", "b");
+        root.getChildren().add(rendering);
+        root.getChildren().add(table("inDialog", "row", "x", "y"));
+
+        rendering.setRowIndex(0);
+
+        root.visitTree(new TestVisitContext(context), (ctx, target) -> VisitResult.ACCEPT);
+
+        assertEquals("a", requestMap(context).get("row"));
+    }
+
+    /** A table standing on a row of its own still exposes it after visiting itself. */
+    @Test
+    void visitOfTheRenderingTableItselfKeepsItsVar() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        DataTable rendering = table("rendering", "row", "a", "b");
+        rendering.setRowIndex(0);
+
+        rendering.visitTree(new TestVisitContext(context), (ctx, target) -> VisitResult.ACCEPT);
+
+        assertEquals("a", requestMap(context).get("row"));
+    }
+
+    /** A visit of an idle table must not leave a var behind either. */
+    @Test
+    void visitOfIdleTableLeavesNoVar() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        DataTable idle = table("idle", "row", "x", "y");
+
+        idle.visitTree(new TestVisitContext(context), (ctx, target) -> VisitResult.ACCEPT);
+
+        assertFalse(requestMap(context).containsKey("row"), "visit must not publish a var");
+    }
+
+    /** Unrelated var names were never affected, and must stay that way. */
+    @Test
+    void visitOfTableWithADifferentVarNameKeepsBoth() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        DataTable rendering = table("rendering", "row", "a", "b");
+        DataTable other = table("other", "otherRow", "x", "y");
+
+        rendering.setRowIndex(0);
+
+        other.visitTree(new TestVisitContext(context), (ctx, target) -> VisitResult.ACCEPT);
+
+        assertEquals("a", requestMap(context).get("row"));
+        assertFalse(requestMap(context).containsKey("otherRow"));
+    }
+
+    /** SKIP_ITERATION never triggered the row walk, so it was and stays safe. */
+    @Test
+    void visitWithSkipIterationKeepsTheRenderingVar() {
+        FacesContext context = new FacesContextMock(new CollectingResponseWriter());
+
+        DataTable rendering = table("rendering", "row", "a", "b");
+        DataTable other = table("other", "row", "x", "y");
+
+        rendering.setRowIndex(0);
+
+        other.visitTree(new TestVisitContext(context, EnumSet.of(VisitHint.SKIP_ITERATION)),
+                (ctx, target) -> VisitResult.ACCEPT);
+
+        assertEquals("a", requestMap(context).get("row"));
+    }
+}


### PR DESCRIPTION
Closes #13967

This is option B from the [analysis on the ticket](https://github.com/primefaces/primefaces/issues/13967#issuecomment-5591202073).

## The bug

Resolving a search expression such as `update="@root:@id(panel)"` on a command inside a column makes the Faces `@id` keyword resolver visit the whole view **while the table is rendering a row**. Mojarra only avoids that visit when `SKIP_VIRTUAL_COMPONENTS` is set, which the `update` / `process` resolution in `AjaxRequestBuilder` does not set, so every `UIData` in the view iterates its rows mid-render.

`UIDataPatch#visitTree` saved and restored `rowIndex`, but not the row var:

```java
int oldRowIndex = -1;
if (visitRows) {
    oldRowIndex = getRowIndex();
    setRowIndex(-1);
}
...
finally {
    if (visitRows) {
        setRowIndex(oldRowIndex);
    }
}
```

For a table that was **not** standing on a row of its own, `oldRowIndex` is `-1`, so the restoring call is `setRowIndex(-1)`, and that removes the var from the request map unconditionally:

```java
if (rowIndex == -1) {
    oldVar = requestMap.remove(var);   // stashed in a field nothing reads again on this path
}
```

When a second table shares the var name -- `var="product"` on both tables in the reproducer -- that removal takes the *rendering* table's var with it. Every row re-renders column 0, which re-resolves `update`, which wipes the var again, so every column after the command renders empty for every row.

## The fix

Remember the request map entry alongside the row index and put it back exactly as it was found, so a tree visit is transparent for whoever started it. A table standing on a row of its own is unaffected: `setRowIndex(oldRowIndex)` already republished the same value, and writing it again is a no-op.

The deviation from stock Mojarra `UIData` is recorded in the class javadoc, as the file's convention requires.

## Why this beats the narrower fix

Passing `SKIP_VIRTUAL_COMPONENTS` from `AjaxRequestBuilder` (option A) would fix this one path and restore the pre-14.0 code path, but the trap stays armed for every other caller that starts a row-iterating visit mid-render -- `p:resolveClientId`, `@widgetVar`, application code. Fixing `visitTree` addresses the class of problem instead. Option A is still worth doing separately as a performance narrowing, since iterating rows is pointless work for client-side id resolution.

## Regression

Introduced in 14.0.0 by a7615bdcbd, which replaced PrimeFaces' own `IdExpressionResolver` with the Faces `SearchExpressionHandler`. The old resolver used `ComponentTraversalUtils.withId`, a plain recursive walk over children and facets that never called `setRowIndex`. That is why 13.0.10 was fine.

Note that stock `jakarta.faces.component.UIData#setRowIndex` contains the same unguarded removal, so `h:dataTable` is exposed to the same trap. This PR only fixes the PrimeFaces hierarchy.

## Tests

`DataTableVisitRowVarTest` covers six cases. Two of them fail on `master` and pass with the fix:

| Case | on master | with fix |
| --- | --- | --- |
| Visit of a table sharing the var name | **fails** (`null`) | passes |
| Whole-view visit, as `@root:@id(...)` performs | **fails** (`null`) | passes |
| Visit of the rendering table itself | passes | passes |
| Visit of an idle table publishes no var | passes | passes |
| Visit of a table with a different var name | passes | passes |
| Visit with `SKIP_ITERATION` | passes | passes |

The four already-passing cases are deliberate: they pin down what the fix must *not* change, and the "rendering table itself" case is the one that explains why the reproducer needed the `<p:dialog>` at all -- a table visiting only itself always restored correctly.

Verified:

- `mvn clean install -f primefaces/pom.xml` -- 0 Checkstyle violations, 486 tests / 0 failures, license check OK.
- 236 DataTable integration tests -- all pass, headless Chrome / Mojarra 4.0 / theme-aura.
- Full integration suite, same config -- 961 tests, 948 pass. 13 fail (`DataExporter001/002/003Test`, `Csv003Test`), and **the identical 13 fail on unmodified `master`** with the same messages, so nothing here is introduced by this change. They are local-environment issues: the DataExporter ones are all `Timeout ... waiting for File 'C:\Users\...\Temp\languages.csv' to be present`, i.e. the browser download never lands, and each of those tests asserts `dataTable.getRows().size()` *before* clicking and passes; the `Csv003Test` two are bean-validation message interpolation. `UIDataPatch` backs every iterating component, so the whole suite was run rather than the DataTable tests alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
