### PR TITLE
Fix #15218: TabView key-based active tab state

### DIFF
--- a/docs/17_0_0/components/tabview.md
+++ b/docs/17_0_0/components/tabview.md
@@ -63,6 +63,24 @@ When the tabs to display are not static, use the built-in iteration feature simi
 </p:tabView>
 ```
 
+## Active Tab
+The active tab is defined with the _active_ attribute, which accepts either the 0-based index of the tab or the
+_key_ of a tab. Using keys is recommended whenever tabs are rendered conditionally or created dynamically, since
+indexes shift as soon as tabs are added or removed, whereas a key always refers to the same tab.
+
+```xhtml
+<p:tabView active="second">
+    <p:tab key="first" title="Tab One" rendered="#{bean.showFirstTab}">
+        <h:outputText value="Lorem" />
+    </p:tab>
+    <p:tab key="second" title="Tab Two">
+        <h:outputText value="Ipsum" />
+    </p:tab>
+</p:tabView>
+```
+
+The _activeIndex_ attribute is deprecated in favor of _active_ and will be removed in a future version.
+
 ## Orientations
 Four different orientations are available; _top(default)_ , _left_ , _right_ and _bottom_.
 

--- a/docs/migrationguide/16_0_0.md
+++ b/docs/migrationguide/16_0_0.md
@@ -199,6 +199,10 @@ To the following, so that any long dialog content is now scrollable by default:
 ### AccordionPanel
 * The attribute `activeIndex` has been renamed to `active`, it now supports keys defined with they `key` attribute in `p:tab` alongside indices to smoother handle dynamically rendered tabs. `activeIndex` is now deprecated and wil be removed in a future version.
 
+### TabView
+* The attribute `activeIndex` has been renamed to `active`, it now supports keys defined with the `key` attribute in `p:tab` alongside indices to smoother handle dynamically rendered tabs. `activeIndex` is now deprecated and will be removed in a future version.
+* The hidden state input has been renamed from `<clientId>_activeIndex` to `<clientId>_active`, in line with `p:accordionPanel`. It now holds the key of the active tab, if the tab defines one, and its index otherwise.
+
 ### SelectOneButton
 
 The accessibility of `p:selectOneButton` has been reworked to the same native-radio model used by `p:selectOneRadio`.

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tabview/TabView006.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tabview/TabView006.java
@@ -21,22 +21,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.component.tabview;
+package org.primefaces.integrationtests.tabview;
 
-import java.io.Serial;
 import java.io.Serializable;
 
-public class TabViewState implements Serializable {
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
 
-    @Serial private static final long serialVersionUID = 1L;
+import lombok.Data;
 
-    private String active;
-
-    public String getActive() {
-        return active;
-    }
-
-    public void setActive(String active) {
-        this.active = active;
-    }
+@Data
+@Named
+@ViewScoped
+public class TabView006 implements Serializable {
+    private boolean isFirstTabRendered;
 }

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tabview/TabView007.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/tabview/TabView007.java
@@ -21,22 +21,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.primefaces.component.tabview;
+package org.primefaces.integrationtests.tabview;
 
-import java.io.Serial;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
-public class TabViewState implements Serializable {
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
 
-    @Serial private static final long serialVersionUID = 1L;
+import lombok.Data;
 
-    private String active;
+@Data
+@Named
+@ViewScoped
+public class TabView007 implements Serializable {
+    private boolean isFirstTabRendered;
 
-    public String getActive() {
-        return active;
-    }
+    public List<String> getTabs() {
+        List<String> tabs = new ArrayList<>(3);
 
-    public void setActive(String active) {
-        this.active = active;
+        if (isFirstTabRendered) {
+            tabs.add("tab1");
+        }
+
+        tabs.add("tab2");
+        tabs.add("tab3");
+
+        return tabs;
     }
 }

--- a/primefaces-integration-tests/src/main/webapp/tabview/tabView006.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tabview/tabView006.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:selectBooleanCheckbox id="toggle" value="#{tabView006.firstTabRendered}">
+                <p:ajax process="@this" update="tabview"/>
+            </p:selectBooleanCheckbox>
+
+            <p:tabView id="tabview" multiViewState="true" active="tab2">
+                <p:tab key="tab1" title="Tab 1" rendered="#{tabView006.firstTabRendered}">
+                    Dummy-Content 1
+                </p:tab>
+                <p:tab key="tab2" title="Tab 2">
+                    Dummy-Content 2
+                </p:tab>
+                <p:tab key="tab3" title="Tab 3">
+                    Dummy-Content 3
+                </p:tab>
+            </p:tabView>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/tabview/tabView007.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/tabview/tabView007.xhtml
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:selectBooleanCheckbox id="toggle" value="#{tabView007.firstTabRendered}">
+                <p:ajax process="@this" update="tabview"/>
+            </p:selectBooleanCheckbox>
+
+            <p:tabView id="tabview" multiViewState="true" active="tab2"
+                       value="#{tabView007.tabs}" var="tab">
+                <p:tab key="#{tab}" title="#{tab}">
+                    Dummy-Content #{tab}
+                </p:tab>
+            </p:tabView>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView006Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView006Test.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tabview;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.SelectBooleanCheckbox;
+import org.primefaces.selenium.component.TabView;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TabView006Test extends AbstractPrimePageTest {
+
+    @Test
+    @DisplayName("TabView: the tab referenced by key in active is selected (static tabs)")
+    void activeTabByKey(Page page) {
+        // Assert
+        assertEquals("Tab 2", page.tabView.getSelectedTab().getTitle());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @DisplayName("TabView: the tab referenced by key stays selected when a preceding tab is added (static tabs)")
+    void activeTabByKeyStaysSelectedWhenTabsChange(Page page) {
+        // Act - render an additional tab in front of the active one
+        page.toggle.click();
+
+        // Assert - the tab identified by the key is still selected, although its index changed
+        assertEquals("Tab 2", page.tabView.getSelectedTab().getTitle());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:toggle")
+        SelectBooleanCheckbox toggle;
+
+        @FindBy(id = "form:tabview")
+        TabView tabView;
+
+        @Override
+        public String getLocation() {
+            return "tabview/tabView006.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView007Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/tabview/TabView007Test.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.tabview;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.SelectBooleanCheckbox;
+import org.primefaces.selenium.component.TabView;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TabView007Test extends AbstractPrimePageTest {
+
+    @Test
+    @DisplayName("TabView: the tab referenced by key in active is selected (dynamic tabs)")
+    void activeTabByKey(Page page) {
+        // Assert
+        assertEquals("tab2", page.tabView.getSelectedTab().getTitle());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @DisplayName("TabView: the tab referenced by key stays selected when a preceding tab is added (dynamic tabs)")
+    void activeTabByKeyStaysSelectedWhenTabsChange(Page page) {
+        // Act - render an additional tab in front of the active one
+        page.toggle.click();
+
+        // Assert - the tab identified by the key is still selected, although its index changed
+        assertEquals("tab2", page.tabView.getSelectedTab().getTitle());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:toggle")
+        SelectBooleanCheckbox toggle;
+
+        @FindBy(id = "form:tabview")
+        TabView tabView;
+
+        @Override
+        public String getLocation() {
+            return "tabview/tabView007.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/tabview/tabview.widget.js
@@ -73,8 +73,7 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
         super.init(cfg);
 
         this.panelContainer = this.jq.children('.ui-tabs-panels');
-        this.stateHolder = $(this.jqId + '_activeIndex');
-        this.cfg.selected = parseInt(this.stateHolder.val());
+        this.stateHolder = $(this.jqId + '_active');
         this.focusedTabHeader = null;
         this.tabindex = this.cfg.tabindex||0;
         this.cfg.focusOnError = this.cfg.focusOnError || false;
@@ -94,6 +93,8 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
         }
 
         this.headerContainer = this.navContainer.children('li.ui-tabs-header');
+
+        this.cfg.selected = this.resolveIndex(this.stateHolder.val());
 
         this.bindEvents();
 
@@ -506,6 +507,28 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
     }
 
     /**
+     * Resolves the 0-based index of the tab identified by the given key or index.
+     * @param {string | number | undefined} value Key or 0-based index of a tab.
+     * @return {number} The 0-based index of the tab, or `-1` when no tab matches.
+     */
+    resolveIndex(value) {
+        if (value === undefined || value === null || value === '') {
+            return -1;
+        }
+
+        var header = this.headerContainer.filter(function() {
+            return $(this).attr('data-key') === String(value);
+        });
+
+        if (header.length) {
+            return this.headerContainer.index(header.first());
+        }
+
+        var index = parseInt(value);
+        return isNaN(index) ? -1 : index;
+    }
+
+    /**
      * Selects the given tab, if it is not selected already.
      * @param {number} index 0-based index of the tab to select.
      * @param {boolean} [silent] Controls whether events are triggered.
@@ -523,7 +546,8 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
         shouldLoad = this.cfg.dynamic && !this.isLoaded(newPanel);
 
         //update state
-        this.stateHolder.val(newPanel.data('index'));
+        var key = newPanel.data('key');
+        this.stateHolder.val(key !== undefined && key !== null ? key : newPanel.data('index'));
         this.cfg.selected = index;
 
         if(shouldLoad) {
@@ -540,7 +564,7 @@ PrimeFaces.widget.TabView = class TabView extends PrimeFaces.widget.DeferredWidg
                     var options = {
                         source: this.id,
                         partialSubmit: true,
-                        partialSubmitFilter: PrimeFaces.escapeClientId(this.id + '_activeIndex'),
+                        partialSubmitFilter: PrimeFaces.escapeClientId(this.id + '_active'),
                         process: this.id,
                         ignoreAutoUpdate: true,
                         global: false,

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabView.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabView.java
@@ -31,6 +31,8 @@ import org.primefaces.event.TabCloseEvent;
 import org.primefaces.event.TabEvent;
 import org.primefaces.util.Callbacks;
 import org.primefaces.util.ComponentUtils;
+import org.primefaces.util.Constants;
+import org.primefaces.util.LangUtils;
 
 import java.util.Map;
 
@@ -129,7 +131,8 @@ public class TabView extends TabViewBaseImpl {
         }
     }
 
-    protected void resetActiveIndex() {
+    protected void resetActive() {
+        getStateHelper().remove(PropertyKeys.active);
         getStateHelper().remove(PropertyKeys.activeIndex);
     }
 
@@ -142,16 +145,108 @@ public class TabView extends TabViewBaseImpl {
         super.processUpdates(context);
 
         ELContext elContext = getFacesContext().getELContext();
-        ValueExpression expr = ValueExpressionAnalyzer.getExpression(elContext,
-                getValueExpression(PropertyKeys.activeIndex.toString()), true);
-        if (expr != null && !expr.isReadOnly(elContext)) {
-            expr.setValue(elContext, getActiveIndex());
-            resetActiveIndex();
+        ValueExpression activeExpr = ValueExpressionAnalyzer.getExpression(elContext,
+                getValueExpression(PropertyKeys.active.toString()), true);
+
+        if (activeExpr != null) {
+            if (!activeExpr.isReadOnly(elContext)) {
+                activeExpr.setValue(elContext, getActive());
+                resetActive();
+            }
+        }
+        else {
+            // Fallback to deprecated activeIndex
+            ValueExpression activeIndexExpr = ValueExpressionAnalyzer.getExpression(elContext,
+                    getValueExpression(PropertyKeys.activeIndex.toString()), true);
+            if (activeIndexExpr != null && !activeIndexExpr.isReadOnly(elContext)) {
+                activeIndexExpr.setValue(elContext, resolveActiveIndex());
+                resetActive();
+            }
         }
     }
 
+    /**
+     * Resolves the index of the active tab, either from the key or the index defined via <code>active</code>,
+     * falling back to the deprecated <code>activeIndex</code>.
+     *
+     * @return the 0-based index of the active tab
+     */
+    public int resolveActiveIndex() {
+        String active = getActive();
+
+        // Deprecated
+        if (active == null) {
+            return getActiveIndex();
+        }
+
+        if (LangUtils.isBlank(active)) {
+            return 0;
+        }
+
+        int index = findTabIndexByKey(active);
+        if (index != -1) {
+            return index;
+        }
+
+        try {
+            return Integer.parseInt(active.trim());
+        }
+        catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Resolves the key of the active tab, or its index if the tab does not define a key.
+     *
+     * @return the key or index of the active tab, or an empty string if there is no active tab
+     */
+    public String resolveActive() {
+        String[] resolved = new String[1];
+
+        forEachTab((tab, index, active) -> {
+            if (Boolean.TRUE.equals(active) && resolved[0] == null) {
+                resolved[0] = tab.getKey() != null ? tab.getKey() : Integer.toString(index);
+            }
+        });
+
+        return resolved[0] == null ? Constants.EMPTY_STRING : resolved[0];
+    }
+
+    protected int findTabIndexByKey(String key) {
+        if (isRepeating()) {
+            Tab tab = getDynamicTab();
+            try {
+                int dataCount = getRowCount();
+                for (int i = 0; i < dataCount; i++) {
+                    setIndex(i);
+                    if (tab.isRendered() && key.equals(tab.getKey())) {
+                        return i;
+                    }
+                }
+            }
+            finally {
+                setIndex(-1);
+            }
+        }
+        else {
+            int j = 0;
+            for (int i = 0; i < getChildCount(); i++) {
+                UIComponent child = getChildren().get(i);
+                if (child.isRendered() && child instanceof Tab tab) {
+                    if (key.equals(tab.getKey())) {
+                        return j;
+                    }
+                    j++;
+                }
+            }
+        }
+
+        return -1;
+    }
+
     public void forEachTab(Callbacks.TriConsumer<Tab, Integer, Boolean> callback) {
-        int activeIndex = getActiveIndex();
+        int activeIndex = resolveActiveIndex();
         boolean activeTabRendered = false;
 
         if (isRepeating()) {
@@ -215,7 +310,7 @@ public class TabView extends TabViewBaseImpl {
     public void restoreMultiViewState() {
         TabViewState ts = getMultiViewState(false);
         if (ts != null) {
-            setActiveIndex(ts.getActiveIndex());
+            setActive(ts.getActive());
         }
     }
 
@@ -230,6 +325,6 @@ public class TabView extends TabViewBaseImpl {
 
     @Override
     public void resetMultiViewState() {
-        setActiveIndex(0);
+        setActive(null);
     }
 }

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewBase.java
@@ -66,7 +66,10 @@ public abstract class TabViewBase extends UITabPanel implements Widget, RTLAware
     @Facet(description = "Allows to add custom action to the tab header.")
     public abstract UIComponent getActionsFacet();
 
-    @Property(defaultValue = "0", description = "Index of the active tab.")
+    @Property(description = "Index or key of the active tab.")
+    public abstract String getActive();
+
+    @Property(defaultValue = "0", description = "(Deprecated, use active instead!) Index of the active tab.")
     public abstract int getActiveIndex();
 
     @Property(description = "Animation effect to use when changing tabs.")

--- a/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
+++ b/primefaces/src/main/java/org/primefaces/component/tabview/TabViewRenderer.java
@@ -46,14 +46,14 @@ public class TabViewRenderer extends CoreRenderer<TabView> {
     @Override
     public void decode(FacesContext context, TabView component) {
         Map<String, String> params = context.getExternalContext().getRequestParameterMap();
-        String activeIndexValue = params.get(component.getClientId(context) + "_activeIndex");
+        String activeValue = params.get(component.getClientId(context) + "_active");
 
-        if (LangUtils.isNotBlank(activeIndexValue)) {
-            component.setActiveIndex(Integer.parseInt(activeIndexValue));
+        if (LangUtils.isNotBlank(activeValue)) {
+            component.setActive(activeValue);
 
             if (component.isMultiViewState()) {
                 TabViewState ts = component.getMultiViewState(true);
-                ts.setActiveIndex(component.getActiveIndex());
+                ts.setActive(component.getActive());
             }
         }
 
@@ -162,7 +162,7 @@ public class TabViewRenderer extends CoreRenderer<TabView> {
             encodeFooter(context, component);
         }
 
-        encodeStateHolder(context, component, clientId + "_activeIndex", String.valueOf(component.getActiveIndex()));
+        encodeStateHolder(context, component, clientId + "_active", component.resolveActive());
 
         if (component.isScrollable()) {
             String scrollParam = clientId + "_scrollState";
@@ -250,6 +250,9 @@ public class TabViewRenderer extends CoreRenderer<TabView> {
         writer.writeAttribute("class", styleClass, null);
         writer.writeAttribute("role", "presentation", null);
         writer.writeAttribute("data-index", index, null);
+        if (tab.getKey() != null) {
+            writer.writeAttribute("data-key", tab.getKey(), null);
+        }
         if (tab.getTitleStyle() != null) {
             writer.writeAttribute("style", tab.getTitleStyle(), null);
         }
@@ -338,6 +341,9 @@ public class TabViewRenderer extends CoreRenderer<TabView> {
         writer.writeAttribute(HTML.ARIA_HIDDEN, String.valueOf(!active), null);
         writer.writeAttribute(HTML.ARIA_LABELLEDBY, tabHeaderId, null);
         writer.writeAttribute("data-index", index, null);
+        if (tab.getKey() != null) {
+            writer.writeAttribute("data-key", tab.getKey(), null);
+        }
         writer.writeAttribute("tabindex", tabindex, null);
 
         if (dynamic) {


### PR DESCRIPTION
Adapts the key-based state of p:accordionPanel (#13890 / #13901) for p:tabView.

Fixes #15218

What changed

Java
- TabViewBase: new active attribute (String, accepts the key of a p:tab or a 0-based index). activeIndex (int) stays and is only marked deprecated.
- TabView: resolveActiveIndex() maps a key back to the current index and falls back to the deprecated activeIndex when active is not set; resolveActive() returns the key of the active tab, or its index when the tab defines no key. forEachTab(), processUpdates(), restoreMultiViewState() and resetMultiViewState() use them.
- TabViewState: int activeIndex → String active.
- TabViewRenderer: decodes _active, renders the state holder as _active, and writes data-key on the tab header and content elements.

Client side (tabview.widget.js)
- State holder is _active; new resolveIndex(keyOrIndex) resolves the stored value to the tab index, so cfg.selected stays a numeric index and the public widget API is unchanged.
- select() stores the tab key when the tab has one, its index otherwise; partialSubmitFilter for multi view state updated.

Docs
- New "Active Tab" section in docs/17_0_0/components/tabview.md.
- Migration notes in docs/migrationguide/16_0_0.md, next to the existing AccordionPanel entry.

Tests
- TabView006 — static tabs with keys, a preceding tab toggled via rendered.
- TabView007 — dynamic tabs via value/var, growing list.
- Both assert the tab addressed by key is selected initially and stays selected after the index shifts.

Backwards compatibility

activeIndex keeps working and is used whenever active is not set, including its value expression in processUpdates. Tabs without a key are still addressed by index, so mixed usage works.

One deliberate client-contract change: the hidden state input is renamed from <clientId>_activeIndex to <clientId>_active (the name p:accordionPanel already uses), since it now carries a key rather than an index. Documented in the migration guide.

Verification

- mvn install -pl primefaces (full build including the frontend bundle) — OK
- mvn test -pl primefaces — OK
- Checkstyle and license check — 0 violations
- mvn verify -f primefaces-integration-tests/pom.xml -Pintegration-tests,headless,chrome,mojarra-4.0 -Dit.test='TabView00*Test' — 9/9 pass
- Same for -Dit.test='AccordionPanel*Test' — 6/6 pass (no regression on the accordion counterpart)