### PR TITLE
Fix Chart Showcase failure caused by Jackson version mismatch

### DIFF
--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -40,7 +40,7 @@
             <dependency>
                  <groupId>com.fasterxml.jackson</groupId>
                  <artifactId>jackson-bom</artifactId>
-                 <version>2.21.4</version>
+                 <version>2.22.1</version>
                  <scope>import</scope>
                  <type>pom</type>
             </dependency>   


### PR DESCRIPTION
## Description

Updates the Jackson BOM used by the PrimeFaces Showcase from `2.21.4` to `2.22.1`.

The current Jackson version causes the Chart.js Showcase examples to fail during initialization with the following exception:

```text
java.lang.NoClassDefFoundError: com/fasterxml/jackson/annotation/JsonApplyView
```

The exception occurs while `software.xdev.chartjs` is creating the chart model and Jackson attempts to use `JsonApplyView`, which is not available with the currently resolved Jackson dependencies.

Updating the Jackson BOM to `2.22.1` aligns the Jackson dependencies and resolves the runtime error.

## Reproducer

### Showcase

Go to https://showcase.primefaces.org/ui/chart/bar

<img width="1106" height="773" alt="image" src="https://github.com/user-attachments/assets/2b8d2f6e-b25b-4593-8ec9-84d71346c916" />

### Local

1. Build and deploy the PrimeFaces Showcase.
2. Open a Chart.js Showcase example.
3. The `ChartView` bean fails during initialization.
4. The server log contains:

```text
Caused by: java.lang.NoClassDefFoundError:
com/fasterxml/jackson/annotation/JsonApplyView
```

The failure can be reproduced when deploying the Showcase on WildFly.

## Changes

* Update `com.fasterxml.jackson:jackson-bom` from `2.21.4` to `2.22.1` in `primefaces-showcase/pom.xml`.

## Result

After updating the Jackson BOM to `2.22.1`, the Chart.js Showcase initializes successfully and the charts are rendered without the `JsonApplyView` `NoClassDefFoundError`.

<img width="1134" height="745" alt="image" src="https://github.com/user-attachments/assets/4430055b-5330-4fd5-a459-908f541ffa72" />

