### PR TITLE
fix #15225: AJAX connection errors must reach p:ajaxExceptionHandler

### DIFF
--- a/docs/17_0_0/core/errorhandling.md
+++ b/docs/17_0_0/core/errorhandling.md
@@ -40,10 +40,18 @@ For server-reported errors, the response contains:
 </partial-response>
 ```
 
+Connection errors have no server-reported error name, so they are reported with the dedicated error name
+`Ajax.ConnectionError` (available as `PrimeFaces.ajax.CONNECTION_ERROR`). A `p:ajaxExceptionHandler` can therefore be
+registered for exactly this kind of error:
+
+```xhtml
+<p:ajaxExceptionHandler type="Ajax.ConnectionError" onexception="alert('The server is not reachable: ' + errorMessage);" />
+```
+
 In both cases, PrimeFaces processes the error through the following chain:
 
 1. **Callbacks & Events** — `onerror` callbacks on `p:ajax` are triggered, as well as global listeners like `p:ajaxStatus` and the jQuery `pfAjaxError` event.
-2. **`p:ajaxExceptionHandler`** — If a specific or global `p:ajaxExceptionHandler` is defined, it is invoked with the error details.
+2. **`p:ajaxExceptionHandler`** — If a `p:ajaxExceptionHandler` for the error name is defined, it is invoked with the error details. Otherwise a global `p:ajaxExceptionHandler` (one without a `type`) is invoked.
 3. **Error Page Redirect** — If no `p:ajaxExceptionHandler` is found, PrimeFaces attempts to redirect to the matching `error-page` configured in `web.xml` / `web-fragment.xml`.
 4. **Console Log** — If neither a handler nor an error page is configured, the error is logged to the browser console.
 

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler001.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxexceptionhandler;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@RequestScoped
+@Data
+public class AjaxExceptionHandler001 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 6874262516024855417L;
+
+    /**
+     * Simulates a connection error: the AJAX response cannot be received at all, the client only sees the HTTP
+     * error status. This is the scenario of GitHub #15225 / #14779.
+     */
+    public void connectionError() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        context.getExternalContext().setResponseStatus(504);
+        context.responseComplete();
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/ajaxexceptionhandler/ajaxExceptionHandler001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxexceptionhandler/ajaxExceptionHandler001.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<!-- GitHub #15225: a connection error must be reported as 'Ajax.ConnectionError' -->
+		<p:ajaxExceptionHandler type="Ajax.ConnectionError"
+			onexception="$('#exceptionName').text(errorName); $('#exceptionMessage').text(errorMessage);" />
+
+		<div>Name: <span id="exceptionName"></span></div>
+		<div>Message: <span id="exceptionMessage"></span></div>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Simulate Connection Error"
+				action="#{ajaxExceptionHandler001.connectionError}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/ajaxexceptionhandler/ajaxExceptionHandler002.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/ajaxexceptionhandler/ajaxExceptionHandler002.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="jakarta.faces.html"
+	xmlns:f="jakarta.faces.core"
+	xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+	<h:head>
+
+	</h:head>
+
+	<h:body>
+
+		<!-- GitHub #15225: a connection error must reach the *global* p:ajaxExceptionHandler -->
+		<p:ajaxExceptionHandler
+			onexception="$('#exceptionName').text(errorName); $('#exceptionMessage').text(errorMessage);" />
+
+		<div>Name: <span id="exceptionName"></span></div>
+		<div>Message: <span id="exceptionMessage"></span></div>
+
+		<h:form id="form">
+			<p:commandButton id="button" value="Simulate Connection Error"
+				action="#{ajaxExceptionHandler001.connectionError}" />
+		</h:form>
+
+	</h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler001Test.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxexceptionhandler;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AjaxExceptionHandler001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxExceptionHandler: GitHub #15225 connection error triggers the handler registered for 'Ajax.ConnectionError'")
+    void connectionError(Page page) {
+        // Act - the response is never received, so the click cannot be guarded
+        page.button.clickUnguarded();
+
+        // Assert
+        PrimeSelenium.waitGui().until(ExpectedConditions.textToBePresentInElement(page.exceptionName, "Ajax.ConnectionError"));
+        assertTrue(page.exceptionMessage.getText().contains("504"),
+                    "Expected the HTTP status in the error message but was: " + page.exceptionMessage.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "exceptionName")
+        WebElement exceptionName;
+
+        @FindBy(id = "exceptionMessage")
+        WebElement exceptionMessage;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxexceptionhandler/ajaxExceptionHandler001.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler002Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/ajaxexceptionhandler/AjaxExceptionHandler002Test.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.ajaxexceptionhandler;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AjaxExceptionHandler002Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("AjaxExceptionHandler: GitHub #15225 connection error triggers the global handler")
+    void connectionError(Page page) {
+        // Act - the response is never received, so the click cannot be guarded
+        page.button.clickUnguarded();
+
+        // Assert
+        PrimeSelenium.waitGui().until(ExpectedConditions.textToBePresentInElement(page.exceptionName, "Ajax.ConnectionError"));
+        assertTrue(page.exceptionMessage.getText().contains("504"),
+                    "Expected the HTTP status in the error message but was: " + page.exceptionMessage.getText());
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "exceptionName")
+        WebElement exceptionName;
+
+        @FindBy(id = "exceptionMessage")
+        WebElement exceptionMessage;
+
+        @FindBy(id = "form:button")
+        CommandButton button;
+
+        @Override
+        public String getLocation() {
+            return "ajaxexceptionhandler/ajaxExceptionHandler002.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/core/src/core/core.ajax.ts
+++ b/primefaces/src/main/frontend/packages/core/src/core/core.ajax.ts
@@ -333,10 +333,11 @@ export class AjaxUtils {
      * @param errorMessage The error message.
      */
     handleError(errorName: string, errorMessage: string): void {
-        let exceptionHandlers: AjaxExceptionHandler[] = [];
+        // always resolve the handlers, otherwise the global AjaxExceptionHandler below can never be found
+        const exceptionHandlers = core.getWidgetsByType(AjaxExceptionHandler);
+
         if (errorName) {
             // try to invoke specific AjaxExceptionHandler
-            exceptionHandlers = core.getWidgetsByType(AjaxExceptionHandler);
             for (var exceptionHandler of exceptionHandlers) {
                 if (exceptionHandler.handles(errorName)) {
                     exceptionHandler.handle(errorName, errorMessage);
@@ -1677,6 +1678,15 @@ export class Ajax {
     RESOURCE = "jakarta.faces.Resource";
 
     /**
+     * Error name that is used when an AJAX response cannot be received at all, e.g. because of an HTTP error
+     * status, a timeout or a network failure. Register a `p:ajaxExceptionHandler` with this type to handle
+     * exactly these kind of errors.
+     * @type {string}
+     * @readonly
+     */
+    CONNECTION_ERROR = "Ajax.ConnectionError";
+
+    /**
      * Parameter shortcut mapping for the method {@link ab}.
      */
     CFG_SHORTCUTS: PrimeType.ajax.ShorthandToArticulateConfigurationMap = {
@@ -1800,7 +1810,15 @@ export function globalAjaxSetup(): void {
     });
 
     $(document).on('pfAjaxError', function(e, xhr, settings, error){
-        // this is very likely a connection error
-        ajax.Utils.handleError("", "AJAX failure");
+        // the response could not be received at all, e.g. HTTP error status, timeout or network failure;
+        // report a dedicated error name, so that a p:ajaxExceptionHandler can be registered for it
+        var errorMessage = 'AJAX failure';
+        if (xhr && xhr.status) {
+            errorMessage += ' with HTTP status ' + xhr.status;
+        }
+        if (error) {
+            errorMessage += ': ' + error;
+        }
+        ajax.Utils.handleError(ajax.CONNECTION_ERROR, errorMessage);
     });
 }


### PR DESCRIPTION
Fixes #15225 (follow-up of #14779, reported by @weissreto).

### Problem

#14779 made connection errors call `PrimeFaces.ajax.Utils.handleError`, but it passed an **empty** error name, so the fix never took effect:

1. `handleError` only resolved the `AjaxExceptionHandler` widgets *inside* the `if (errorName)` branch. With an empty name the list stayed empty, so the subsequent global-handler lookup (`exceptionHandlers.find(w => w.isGlobal())`) searched an empty array and the code always fell through to `No ajaxExceptionHandler or error page found for '' defined!`.
2. An empty error name also cannot be targeted by a specific `p:ajaxExceptionHandler type="..."`.

Net effect: on a 404/504/network failure the AJAX status indicator stayed visible forever and no handler ran.

### Fix

- Connection errors are now reported with a dedicated error name **`Ajax.ConnectionError`**, exposed as `PrimeFaces.ajax.CONNECTION_ERROR`, as suggested in the ticket. A handler can be registered for exactly this case:
  ```xhtml
  <p:ajaxExceptionHandler type="Ajax.ConnectionError" onexception="alert('Server not reachable: ' + errorMessage);" />
  ```
- `handleError` now resolves the handler widgets unconditionally, so the **global** `p:ajaxExceptionHandler` is found again.
- The error message carries the HTTP status, e.g. `AJAX failure with HTTP status 504`.

The error-page fallback is unchanged: `Ajax.ConnectionError` is not mapped in `web.xml`, so it still falls back to `java.lang.Throwable` and then to the default error page.

### Tests

New integration-test triads that reproduce the ticket (bean sets HTTP 504 + `responseComplete()`):

- `AjaxExceptionHandler001Test` — a `p:ajaxExceptionHandler type="Ajax.ConnectionError"` is invoked
- `AjaxExceptionHandler002Test` — a **global** `p:ajaxExceptionHandler` is invoked

Verified both fail on `master` and pass with this change:

```
# without the fix
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0

# with the fix
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Checkstyle (`mvn validate`) clean on both main and test sources.

Docs: `docs/17_0_0/core/errorhandling.md` documents the new error name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)