### PR TITLE
fix #15217: TextEditor must not copy normal spaces as non-breaking spaces

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.texteditor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class TextEditor005 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private String value;
+
+}

--- a/primefaces-integration-tests/src/main/webapp/texteditor/textEditor005.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/texteditor/textEditor005.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <!-- GitHub #15217: copying must not turn normal spaces into non-breaking spaces -->
+            <p:textEditor id="editor"
+                          widgetVar="wgtEditor"
+                          value="#{textEditor005.value}"
+                          secure="false"
+                          height="200"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/texteditor/TextEditor005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/texteditor/TextEditor005Test.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.texteditor;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.TextEditor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TextEditor005Test extends AbstractPrimePageTest {
+
+    /**
+     * Fires a real `copy` event at the editor and returns what the widget put onto the clipboard, so the
+     * whole Quill copy path (onCaptureCopy -> onCopy -> setData) is exercised without OS clipboard access.
+     */
+    private String copyToClipboard(String mimeType) {
+        return PrimeSelenium.executeScript(
+                    "var widget = PF('wgtEditor');"
+                                + "widget.editor.setSelection(0, widget.editor.getLength());"
+                                + "var data = new DataTransfer();"
+                                + "widget.editor.root.dispatchEvent("
+                                + "  new ClipboardEvent('copy', {clipboardData: data, bubbles: true, cancelable: true}));"
+                                + "return data.getData('" + mimeType + "');");
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("TextEditor: GitHub #15217 copying must keep normal spaces normal in text/html")
+    void copyKeepsNormalSpaces(Page page) {
+        // Arrange
+        page.textEditor.setValue("Lorem ipsum dolor sit amet");
+
+        // Act
+        String html = copyToClipboard("text/html");
+
+        // Assert
+        assertEquals("Lorem ipsum dolor sit amet", html);
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("TextEditor: GitHub #15217 copying keeps text/plain and the formatting intact")
+    void copyKeepsPlainTextAndFormatting(Page page) {
+        // Arrange - "ipsum" in bold
+        PrimeSelenium.executeScript("var q = PF('wgtEditor').editor;"
+                    + "q.setText('Lorem ipsum dolor');"
+                    + "q.formatText(6, 5, 'bold', true);");
+
+        // Act
+        String html = copyToClipboard("text/html");
+        String text = copyToClipboard("text/plain");
+
+        // Assert - spaces normalized, but the bold run survives
+        assertEquals("Lorem <strong>ipsum</strong> dolor", html);
+        assertEquals("Lorem ipsum dolor", text.strip());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("TextEditor: GitHub #15217 a deliberate non-breaking space must survive copying")
+    void copyKeepsDeliberateNonBreakingSpace(Page page) {
+        // Arrange - a real U+00A0 typed by the user, between "10" and "km"
+        PrimeSelenium.executeScript("PF('wgtEditor').editor.setText('10\u00A0km per hour');");
+
+        // Act
+        String html = copyToClipboard("text/html");
+
+        // Assert - only the spaces Quill invented are normalized, the deliberate one is kept
+        assertEquals("10\u00A0km per hour", html);
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:editor")
+        TextEditor textEditor;
+
+        @Override
+        public String getLocation() {
+            return "texteditor/textEditor005.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/texteditor/texteditor/src/texteditor.widget.js
+++ b/primefaces/src/main/frontend/packages/texteditor/texteditor/src/texteditor.widget.js
@@ -183,6 +183,20 @@ PrimeFaces.widget.TextEditor = class TextEditor extends PrimeFaces.widget.Deferr
 
             return delta;
         });
+
+        // #15217: QuillJS builds the text/html clipboard flavor with getSemanticHTML(), which replaces
+        // every normal space with an "&nbsp;" entity (see convertHTML in quill/core/editor.js). Other
+        // applications that prefer text/html therefore paste non-breaking spaces. Undo that here, right
+        // before the HTML is handed to the clipboard.
+        // Only the entity is replaced: a non-breaking space the user really typed is escaped as a raw
+        // U+00A0 character by QuillJS and so survives the copy.
+        var originalOnCopy = this.editor.clipboard.onCopy;
+        this.editor.clipboard.onCopy = function (range, isCut) {
+            var clipboardData = originalOnCopy.call(this, range, isCut);
+            clipboardData.html = clipboardData.html.replace(/&nbsp;/g, ' ');
+
+            return clipboardData;
+        };
     }
 
     /**


### PR DESCRIPTION
Fixes #15217.

You noted on the ticket that this is an upstream QuillJS bug — it is, so this patches it in the PF widget rather than waiting on Quill.

### Root cause (upstream, confirmed in Quill 2.0.3)

`quill/core/editor.js` → `convertHTML()`:

```js
if (blot instanceof TextBlot) {
    const escapedText = escapeText(blot.value().slice(index, index + length));
    return escapedText.replaceAll(' ', '&nbsp;');   // <-- every normal space
}
```

`getSemanticHTML()` goes through that, and `Clipboard#onCopy()` uses it for the `text/html` flavor, so the clipboard ends up with:

```
text/plain:  Lorem ipsum dolor sit amet
text/html:   <p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>
```

The #14843 matcher only normalizes the other direction (clipboard → editor).

### Fix

Wrap `clipboard.onCopy` — the documented hook returning the `{html, text}` pair that `onCaptureCopy` writes via `setData` — and normalize the HTML there. Cut uses the same hook, so `isCut` is passed through.

**Only the `&nbsp;` entity is replaced, not U+00A0.** Quill's `escapeText` escapes just `& < > " '`, so a non-breaking space the user *actually typed* stays a raw U+00A0 character in the output, while the ones Quill invents become the 6-character entity. That distinction is verifiable — the RED run below shows `10<U+00A0>km&nbsp;per&nbsp;hour` — so deliberate non-breaking spaces survive, which a blanket `/&nbsp;| /` replacement would have destroyed.

A user typing the literal text `&nbsp;` is also safe: `escapeText` turns it into `&amp;nbsp;`, which does not contain the `&nbsp;` substring.

The submitted value is unaffected — `getEditorValue()` reads the editor's `innerHTML`, not `getSemanticHTML()`.

### Tests

New triad `textEditor005`. The helper fires a real `copy` event at the editor root with a `DataTransfer` and reads back what the widget put on the clipboard, so the full `onCaptureCopy → onCopy → setData` path runs without needing OS clipboard access.

Written before the fix; the RED run reproduces the report verbatim:

```
expected: <Lorem ipsum dolor sit amet>        but was: <Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet>
expected: <Lorem <strong>ipsum</strong> dolor> but was: <Lorem&nbsp;<strong>ipsum</strong>&nbsp;dolor>
expected: <10 km per hour>                     but was: <10 km&nbsp;per&nbsp;hour>
[ERROR] Tests run: 3, Failures: 3
```

(the third expects a deliberate U+00A0 to be kept; note only the *invented* spaces are entities)

After the fix, plus the whole existing suite for regressions:

```
[INFO] Tests run: 3,  Failures: 0, Errors: 0   # TextEditor005Test
[INFO] Tests run: 11, Failures: 0, Errors: 0   # TextEditor*Test (all 5 classes)
```

Coverage: normal spaces normalized, bold/`<strong>` formatting preserved, `text/plain` unchanged, deliberate U+00A0 preserved. Checkstyle clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)