### PR TITLE
fix #15221 #15222: 16.X SelectOneMenu announce items with an empty label

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.selectonemenu;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class SelectOneMenu014 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private String option;
+    private String optionWithPlaceholder;
+
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014.java
@@ -23,7 +23,6 @@
  */
 package org.primefaces.integrationtests.selectonemenu;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import jakarta.faces.view.ViewScoped;
@@ -36,7 +35,7 @@ import lombok.Data;
 @Data
 public class SelectOneMenu014 implements Serializable {
 
-    @Serial private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private String option;
     private String optionWithPlaceholder;

--- a/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu014.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/selectonemenu/selectOneMenu014.xhtml
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="jakarta.faces.html" xmlns:f="jakarta.faces.core" xmlns:p="primefaces">
+    <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+        <h:head>
+
+    </h:head>
+        <h:body>
+            <h:form id="form">
+                <p:messages id="msgs" showDetail="true">
+                    <p:autoUpdate/>
+                </p:messages>
+
+                <!-- GitHub #15221 / #15222: an item with an empty label must still be announced by a screen reader -->
+                <p:selectOneMenu id="selectonemenu" value="#{selectOneMenu014.option}">
+                    <f:selectItem itemLabel="" itemValue=""/>
+                    <f:selectItem itemLabel="Ja" itemValue="true"/>
+                    <f:selectItem itemLabel="Nein" itemValue="false"/>
+                </p:selectOneMenu>
+
+                <!-- same, but with a placeholder: the placeholder is the visible and announced text -->
+                <p:selectOneMenu id="placeholder" value="#{selectOneMenu014.optionWithPlaceholder}" placeholder="Choose One">
+                    <f:selectItem itemLabel="" itemValue=""/>
+                    <f:selectItem itemLabel="Ja" itemValue="true"/>
+                    <f:selectItem itemLabel="Nein" itemValue="false"/>
+                </p:selectOneMenu>
+            </h:form>
+        </h:body>
+    </f:view>
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/selectonemenu/SelectOneMenu014Test.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.selectonemenu;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.SelectOneMenu;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SelectOneMenu014Test extends AbstractPrimePageTest {
+
+    /** The localized default of the {@code nullLabel} ARIA label. */
+    private static final String NULL_LABEL = "Not Selected";
+
+    @Test
+    @Order(1)
+    @DisplayName("SelectOneMenu: GitHub #15221 an item with an empty label is announced with the nullLabel ARIA label")
+    void emptyItemIsAnnounced(Page page) {
+        // Arrange
+        page.menu.show();
+
+        // Act
+        WebElement emptyItem = page.menu.getItems().findElement(By.id("form:selectonemenu_0"));
+        WebElement jaItem = page.menu.getItems().findElement(By.id("form:selectonemenu_1"));
+
+        // Assert - the blank item carries an accessible name, the labelled ones are announced by their text
+        assertEquals(NULL_LABEL, emptyItem.getDomAttribute("aria-label"));
+        assertNull(jaItem.getDomAttribute("aria-label"));
+        assertEquals("Ja", jaItem.getText());
+
+        page.menu.hide();
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("SelectOneMenu: GitHub #15222 selecting the empty item must not keep announcing the previous item")
+    void emptySelectionIsAnnounced(Page page) {
+        // Arrange
+        WebElement label = page.menu.getLabel();
+        page.menu.select("Ja");
+        assertEquals("Ja", label.getDomAttribute("aria-label"));
+
+        // Act - select the empty item the way a user does
+        page.menu.show();
+        page.menu.getItems().findElement(By.id("form:selectonemenu_0")).click();
+
+        // Assert - the stale "Ja" must be gone
+        assertEquals(NULL_LABEL, label.getDomAttribute("aria-label"));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("SelectOneMenu: GitHub #15222 with a placeholder the placeholder is announced for the empty item")
+    void emptySelectionAnnouncesPlaceholder(Page page) {
+        // Arrange
+        WebElement label = page.placeholder.getLabel();
+        page.placeholder.select("Nein");
+        assertEquals("Nein", label.getDomAttribute("aria-label"));
+
+        // Act
+        page.placeholder.show();
+        page.placeholder.getItems().findElement(By.id("form:placeholder_0")).click();
+
+        // Assert - the visible text is the placeholder, so that is what must be announced
+        assertEquals("Choose One", label.getText());
+        assertEquals("Choose One", label.getDomAttribute("aria-label"));
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:selectonemenu")
+        SelectOneMenu menu;
+
+        @FindBy(id = "form:placeholder")
+        SelectOneMenu placeholder;
+
+        @Override
+        public String getLocation() {
+            return "selectonemenu/selectOneMenu014.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/forms/forms.selectonemenu.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/forms/forms.selectonemenu.widget.js
@@ -1181,8 +1181,12 @@ PrimeFaces.widget.SelectOneMenu = class SelectOneMenu extends PrimeFaces.widget.
             if (valueEmpty) {
                 if (labelText != '&nbsp;') {
                     this.label.text(labelText);
+                    // the placeholder is the visible text, so that is what should be announced
+                    this.label.attr('aria-label', labelText);
                 } else {
                     this.label.html(labelText);
+                    // nothing is visible, so fall back to the localized "nothing selected" text
+                    this.label.attr('aria-label', this.getEmptyItemLabel());
                 }
             }
             else {
@@ -1670,6 +1674,10 @@ PrimeFaces.widget.SelectOneMenu = class SelectOneMenu extends PrimeFaces.widget.
         
         var dataLabel = escape ? label.replaceAll('"', '&quot;') : PrimeFaces.escapeHTML(label, true);
         label = label === "&amp;nbsp;" ? "&nbsp;" : label;
+        if (!isOptgroup && this.isBlankItemLabel(label)) {
+            // an item without a label has no accessible name, so give screen readers something to announce
+            content += ' aria-label="' + PrimeFaces.escapeHTML(this.getEmptyItemLabel(), true) + '"';
+        }
         content += ' data-label="' + dataLabel + '" data-value="' + PrimeFaces.escapeHTML($item.val(), true) + '">' + label + '</li>';
 
         if (isOptgroup) {
@@ -1677,6 +1685,31 @@ PrimeFaces.widget.SelectOneMenu = class SelectOneMenu extends PrimeFaces.widget.
         }
 
         return content;
+    }
+
+    /**
+     * Checks whether the given item label carries no text a screen reader could announce. An empty
+     * `itemLabel` is rendered as `&nbsp;` by the server, so a blank label is not necessarily an empty string.
+     * @private
+     * @param {string} label The label of a select item.
+     * @return {boolean} `true` if the label has no announceable text, or `false` otherwise.
+     */
+    isBlankItemLabel(label) {
+        if (label === null || label === undefined) {
+            return true;
+        }
+        return String(label).replaceAll('&amp;nbsp;', ' ').replaceAll('&nbsp;', ' ').replaceAll('\xa0', ' ').trim() === '';
+    }
+
+    /**
+     * Returns the text a screen reader should announce for an item without a label. Defaults to the localized
+     * `nullLabel` ARIA label ("Not Selected"), which can be overridden application-wide via the locale settings
+     * or per component via `cfg.labels.aria.nullLabel`.
+     * @private
+     * @return {string} The accessible text for an item without a label.
+     */
+    getEmptyItemLabel() {
+        return this.getAriaLabel('nullLabel');
     }
 
     /**


### PR DESCRIPTION
A `<f:selectItem itemLabel="" itemValue=""/>` produced no text for a screen reader, in two places:

* #15221 - the item is rendered as `<li role="option">&nbsp;</li>`, so its accessible name is empty and NVDA announces only "list item 1 of 3".
* #15222 - `setLabel` assigned `aria-label` on the closed menu only in its non-empty branch. Selecting the empty item left the previously selected item's label in place, so the screen reader kept announcing the old value.

Both now use the existing localized `nullLabel` ARIA label ("Not Selected"), the same key `p:triStateCheckbox` already uses for its "nothing selected" state. It can be changed application-wide through the locale settings or per component via `cfg.labels.aria.nullLabel`. When a `placeholder` is configured it is the visible text of the closed menu, so the placeholder is announced instead.

Optgroups are untouched: their `<li>` is `role="presentation"` and the group is named by `aria-labelledby`. Labels that only look blank after HTML escaping are detected via `&nbsp;`/`&amp;nbsp;`/`\xa0` normalization.