### PR TITLE
fix #15217: 16.X TextEditor must not copy normal spaces as non-breaki…

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.texteditor;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class TextEditor005 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private String value;
+
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/texteditor/TextEditor005.java
@@ -23,7 +23,6 @@
  */
 package org.primefaces.integrationtests.texteditor;
 
-import java.io.Serial;
 import java.io.Serializable;
 
 import jakarta.faces.view.ViewScoped;
@@ -36,7 +35,7 @@ import lombok.Data;
 @Data
 public class TextEditor005 implements Serializable {
 
-    @Serial private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private String value;
 

--- a/primefaces-integration-tests/src/main/webapp/texteditor/textEditor005.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/texteditor/textEditor005.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <!-- GitHub #15217: copying must not turn normal spaces into non-breaking spaces -->
+            <p:textEditor id="editor"
+                          widgetVar="wgtEditor"
+                          value="#{textEditor005.value}"
+                          secure="false"
+                          height="200"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/texteditor/TextEditor005Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/texteditor/TextEditor005Test.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.texteditor;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.TextEditor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TextEditor005Test extends AbstractPrimePageTest {
+
+    /**
+     * Fires a real `copy` event at the editor and returns what the widget put onto the clipboard, so the
+     * whole Quill copy path (onCaptureCopy -> onCopy -> setData) is exercised without OS clipboard access.
+     */
+    private String copyToClipboard(String mimeType) {
+        return PrimeSelenium.executeScript(
+                    "var widget = PF('wgtEditor');"
+                                + "widget.editor.setSelection(0, widget.editor.getLength());"
+                                + "var data = new DataTransfer();"
+                                + "widget.editor.root.dispatchEvent("
+                                + "  new ClipboardEvent('copy', {clipboardData: data, bubbles: true, cancelable: true}));"
+                                + "return data.getData('" + mimeType + "');");
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("TextEditor: GitHub #15217 copying must keep normal spaces normal in text/html")
+    void copyKeepsNormalSpaces(Page page) {
+        // Arrange
+        page.textEditor.setValue("Lorem ipsum dolor sit amet");
+
+        // Act
+        String html = copyToClipboard("text/html");
+
+        // Assert
+        assertEquals("Lorem ipsum dolor sit amet", html);
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("TextEditor: GitHub #15217 copying keeps text/plain and the formatting intact")
+    void copyKeepsPlainTextAndFormatting(Page page) {
+        // Arrange - "ipsum" in bold
+        PrimeSelenium.executeScript("var q = PF('wgtEditor').editor;"
+                    + "q.setText('Lorem ipsum dolor');"
+                    + "q.formatText(6, 5, 'bold', true);");
+
+        // Act
+        String html = copyToClipboard("text/html");
+        String text = copyToClipboard("text/plain");
+
+        // Assert - spaces normalized, but the bold run survives
+        assertEquals("Lorem <strong>ipsum</strong> dolor", html);
+        assertEquals("Lorem ipsum dolor", text.strip());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("TextEditor: GitHub #15217 a deliberate non-breaking space must survive copying")
+    void copyKeepsDeliberateNonBreakingSpace(Page page) {
+        // Arrange - a real U+00A0 typed by the user, between "10" and "km"
+        PrimeSelenium.executeScript("PF('wgtEditor').editor.setText('10\u00A0km per hour');");
+
+        // Act
+        String html = copyToClipboard("text/html");
+
+        // Assert - only the spaces Quill invented are normalized, the deliberate one is kept
+        assertEquals("10\u00A0km per hour", html);
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:editor")
+        TextEditor textEditor;
+
+        @Override
+        public String getLocation() {
+            return "texteditor/textEditor005.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/texteditor/texteditor/src/texteditor.widget.js
+++ b/primefaces/src/main/frontend/packages/texteditor/texteditor/src/texteditor.widget.js
@@ -183,6 +183,20 @@ PrimeFaces.widget.TextEditor = class TextEditor extends PrimeFaces.widget.Deferr
 
             return delta;
         });
+
+        // #15217: QuillJS builds the text/html clipboard flavor with getSemanticHTML(), which replaces
+        // every normal space with an "&nbsp;" entity (see convertHTML in quill/core/editor.js). Other
+        // applications that prefer text/html therefore paste non-breaking spaces. Undo that here, right
+        // before the HTML is handed to the clipboard.
+        // Only the entity is replaced: a non-breaking space the user really typed is escaped as a raw
+        // U+00A0 character by QuillJS and so survives the copy.
+        var originalOnCopy = this.editor.clipboard.onCopy;
+        this.editor.clipboard.onCopy = function (range, isCut) {
+            var clipboardData = originalOnCopy.call(this, range, isCut);
+            clipboardData.html = clipboardData.html.replace(/&nbsp;/g, ' ');
+
+            return clipboardData;
+        };
     }
 
     /**


### PR DESCRIPTION
…ng spaces

QuillJS assembles the text/html clipboard flavor with getSemanticHTML(), whose convertHTML() does `escapedText.replaceAll(' ', '&nbsp;')` for every TextBlot (quill/core/editor.js). Copying out of the editor therefore hands other applications non-breaking spaces:

    text/plain:  Lorem ipsum dolor sit amet
    text/html:   <p>Lorem&nbsp;ipsum&nbsp;dolor&nbsp;sit&nbsp;amet</p>

Applications that prefer text/html paste the latter. The #14843 matcher only normalizes the opposite direction (clipboard -> editor).

Wrap `clipboard.onCopy`, the documented hook that returns the `{html, text}` pair written to the clipboard, and normalize the HTML there. Cut goes through the same hook, so `isCut` is passed along.

Only the `&nbsp;` *entity* is replaced, not U+00A0. QuillJS escapes just `& < > " '`, so a non-breaking space the user really typed stays a raw U+00A0 character in the output while the ones QuillJS invents become the entity. That keeps deliberate non-breaking spaces intact - unlike a blanket replacement.

The submitted value is unaffected: getEditorValue() reads the editor's innerHTML, not getSemanticHTML().