### PR TITLE
16.X Fix Chart Showcase failure caused by Jackson version mismatch 

### DIFF
--- a/primefaces-showcase/pom.xml
+++ b/primefaces-showcase/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                  <groupId>com.fasterxml.jackson</groupId>
                  <artifactId>jackson-bom</artifactId>
-                 <version>2.21.4</version>
+                 <version>2.22.1</version>
                  <scope>import</scope>
                  <type>pom</type>
             </dependency>   


### PR DESCRIPTION
cc @tandraschko 