### PR TITLE
fix #14626: 16.X Diagram: action of a CommandLink inside the element facet is not executed

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/diagram/Diagram001.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/diagram/Diagram001.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.diagram;
+
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.model.diagram.DefaultDiagramModel;
+import org.primefaces.model.diagram.DiagramModel;
+import org.primefaces.model.diagram.Element;
+
+import java.io.Serializable;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class Diagram001 implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private DiagramModel model;
+
+    @PostConstruct
+    public void init() {
+        model = new DefaultDiagramModel();
+
+        model.addElement(createElement("A", "5em", "5em"));
+        model.addElement(createElement("B", "20em", "5em"));
+    }
+
+    public void select(String data) {
+        TestUtils.addMessage("Selected", data);
+    }
+
+    private Element createElement(String data, String x, String y) {
+        Element element = new Element(data, x, y);
+        element.setId(data);
+        // dragging would swallow the click in the browser
+        element.setDraggable(false);
+        return element;
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/diagram/diagram001.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/diagram/diagram001.xhtml
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+    <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+        <h:head>
+            <style>
+                .ui-diagram-element {
+                    width: 8em;
+                    height: 4em;
+                    text-align: center;
+                }
+            </style>
+        </h:head>
+
+        <h:body>
+            <h:form id="form">
+                <p:messages id="messages" showDetail="true"/>
+
+                <p:commandLink id="linkOutside" value="Outside"
+                               update="messages"
+                               action="#{diagram001.select('Outside')}"/>
+
+                <p:diagram id="diagram" value="#{diagram001.model}" var="el" style="height:400px">
+                    <f:facet name="element">
+                        <p:commandLink id="link" value="#{el.data}"
+                                       update=":form:messages"
+                                       action="#{diagram001.select(el.data)}"/>
+                    </f:facet>
+                </p:diagram>
+            </h:form>
+        </h:body>
+    </f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/diagram/Diagram001Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/diagram/Diagram001Test.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.diagram;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.component.CommandLink;
+import org.primefaces.selenium.component.Messages;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Diagram001Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("Diagram: GitHub #14626 action of a CommandLink inside the element facet must be executed")
+    void commandLinkInElementFacet(Page page) {
+        // Arrange
+        assertNoJavascriptErrors();
+
+        // Act
+        page.linkElementA.click();
+
+        // Assert
+        assertEquals(1, page.messages.getAllMessages().size());
+        assertEquals("Selected", page.messages.getMessage(0).getSummary());
+        assertEquals("A", page.messages.getMessage(0).getDetail());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Diagram: GitHub #14626 each element has its own CommandLink")
+    void commandLinkInElementFacetSecondElement(Page page) {
+        // Arrange
+        assertNoJavascriptErrors();
+
+        // Act
+        page.linkElementB.click();
+
+        // Assert
+        assertEquals(1, page.messages.getAllMessages().size());
+        assertEquals("Selected", page.messages.getMessage(0).getSummary());
+        assertEquals("B", page.messages.getMessage(0).getDetail());
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("Diagram: a CommandLink outside of the diagram is not affected")
+    void commandLinkOutside(Page page) {
+        // Arrange
+        assertNoJavascriptErrors();
+
+        // Act
+        page.linkOutside.click();
+
+        // Assert
+        assertEquals(1, page.messages.getAllMessages().size());
+        assertEquals("Outside", page.messages.getMessage(0).getDetail());
+        assertNoJavascriptErrors();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:diagram:0:link")
+        CommandLink linkElementA;
+
+        @FindBy(id = "form:diagram:1:link")
+        CommandLink linkElementB;
+
+        @FindBy(id = "form:linkOutside")
+        CommandLink linkOutside;
+
+        @FindBy(id = "form:messages")
+        Messages messages;
+
+        @Override
+        public String getLocation() {
+            return "diagram/diagram001.xhtml";
+        }
+    }
+
+}

--- a/primefaces/src/main/java/org/primefaces/component/diagram/Diagram.java
+++ b/primefaces/src/main/java/org/primefaces/component/diagram/Diagram.java
@@ -33,12 +33,17 @@ import org.primefaces.model.diagram.Element;
 import org.primefaces.model.diagram.endpoint.EndPoint;
 
 import java.util.Map;
+import java.util.function.IntPredicate;
 
 import jakarta.faces.application.ResourceDependency;
 import jakarta.faces.component.FacesComponent;
+import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.visit.VisitCallback;
+import jakarta.faces.component.visit.VisitContext;
 import jakarta.faces.context.FacesContext;
 import jakarta.faces.event.AjaxBehaviorEvent;
 import jakarta.faces.event.FacesEvent;
+import jakarta.faces.event.PhaseId;
 
 @FacesComponent(value = Diagram.COMPONENT_TYPE, namespace = Diagram.COMPONENT_FAMILY)
 @FacesComponentInfo(description = "Diagram is a component to create visual elements and connect them on a web page.")
@@ -137,5 +142,92 @@ public class Diagram extends DiagramBaseImpl {
         else {
             super.queueEvent(event);
         }
+    }
+
+    /**
+     * The <code>element</code> facet is rendered once per element, therefore it must not be processed a single time
+     * with a rowIndex of <code>-1</code>. Otherwise the client ids of its children would not match the ones generated
+     * while rendering and e.g. a nested <code>p:commandLink</code> would never be decoded.
+     */
+    @Override
+    protected void processFacets(FacesContext context, PhaseId phaseId) {
+        UIComponent elementFacet = getElementFacet();
+
+        if (getFacetCount() > 0) {
+            for (UIComponent facet : getFacets().values()) {
+                if (facet != elementFacet) {
+                    process(context, facet, phaseId);
+                }
+            }
+        }
+
+        if (elementFacet != null) {
+            forEachElement(i -> {
+                process(context, elementFacet, phaseId);
+                return false;
+            });
+        }
+    }
+
+    /**
+     * @see #processFacets(FacesContext, PhaseId)
+     */
+    @Override
+    protected boolean visitFacets(VisitContext context, VisitCallback callback, boolean visitRows) {
+        if (visitRows) {
+            setRowIndex(-1);
+        }
+
+        UIComponent elementFacet = getElementFacet();
+
+        if (getFacetCount() > 0) {
+            for (UIComponent facet : getFacets().values()) {
+                if (facet != elementFacet && facet.visitTree(context, callback)) {
+                    return true;
+                }
+            }
+        }
+
+        if (elementFacet == null) {
+            return false;
+        }
+
+        if (!visitRows) {
+            return elementFacet.visitTree(context, callback);
+        }
+
+        return forEachElement(i -> elementFacet.visitTree(context, callback));
+    }
+
+    /**
+     * Iterates over all elements of the model, exactly like the renderer does, and invokes the callback for each of
+     * them. The iteration stops as soon as the callback returns <code>true</code>.
+     *
+     * @param callback the callback to invoke for each element
+     * @return <code>true</code> if the callback returned <code>true</code> for one of the elements
+     */
+    private boolean forEachElement(IntPredicate callback) {
+        boolean result = false;
+
+        try {
+            int rowCount = getRowCount();
+            for (int i = 0; i < rowCount; i++) {
+                setRowIndex(i);
+
+                if (!isRowAvailable()) {
+                    break;
+                }
+
+                if (callback.test(i)) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        finally {
+            setRowIndex(-1);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
fix #14626

…

Since #11624 Diagram extends UIData, so the `element` facet is rendered once per element with a row index in the client id (`form:diagram:0:link`). Processing and visiting however still happened a single time with a row index of -1 (`form:diagram:link`), so the submitted client id never matched and actions/actionListeners of nested commands were never decoded.

Diagram now iterates the model when processing and visiting the `element` facet, exactly like the renderer does.