### PR TITLE
fix #14991: DataTable: draggable column order lost after live/virtual scroll

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/datatable/DataTable052.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class DataTable052 implements Serializable {
+
+    @Serial private static final long serialVersionUID = -7518459955779385835L;
+
+    protected ProgrammingLanguageLazyDataModel lazyDataModel;
+
+    @PostConstruct
+    public void init() {
+        lazyDataModel = new ProgrammingLanguageLazyDataModel();
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/datatable/dataTable052.xhtml
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <p:dataTable id="datatable" widgetVar="dtWidget" value="#{dataTable052.lazyDataModel}" var="lang"
+                         lazy="true" scrollable="true" liveScroll="true" scrollRows="5" scrollHeight="150"
+                         draggableColumns="true">
+
+                <p:column id="colId" field="id" headerText="ID"/>
+
+                <p:column id="colName" field="name" headerText="Name"/>
+
+                <p:column id="colFirstAppeared" field="firstAppeared" headerText="First Appeared"/>
+
+            </p:dataTable>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/datatable/DataTable052Test.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.datatable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.DataTable;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("DataTable-columnreorder")
+@Tag("DataTable-scrolling")
+@Tag("DataTable-lazy")
+class DataTable052Test extends AbstractPrimePageTest {
+
+    @Test
+    @Order(1)
+    @DisplayName("DataTable: GitHub #14991 column order must be retained by live scroll after a column was dragged")
+    void columnOrderRetainedAfterLiveScroll(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        assertEquals(List.of("1", "Language 1", "1991"), rowValues(dataTable, 0));
+
+        // Act - drag the "ID" column onto the "Name" column, then live scroll the next chunk in
+        dragColumnOnto(page, 0, 1);
+        assertEquals(List.of("Name", "ID", "First Appeared"), headerTexts(page));
+        assertEquals(List.of("Language 1", "1", "1991"), rowValues(dataTable, 0));
+
+        PrimeSelenium.executeScript(true, "PF('dtWidget').loadLiveRows()");
+
+        // Assert - the rows loaded by the scroll must follow the dragged column order, like the already visible ones
+        assertEquals(List.of("Language 1", "1", "1991"), rowValues(dataTable, 0));
+        assertEquals(List.of("Language 6", "6", "1996"), rowValues(dataTable, 5));
+        assertEquals(List.of("Language 10", "10", "1990"), rowValues(dataTable, 9));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: live scroll without any column reorder keeps the declared column order")
+    void declaredColumnOrderRetainedAfterLiveScroll(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        assertEquals(List.of("1", "Language 1", "1991"), rowValues(dataTable, 0));
+
+        // Act
+        PrimeSelenium.executeScript(true, "PF('dtWidget').loadLiveRows()");
+
+        // Assert
+        assertEquals(List.of("6", "Language 6", "1996"), rowValues(dataTable, 5));
+        assertNoJavascriptErrors();
+    }
+
+    private List<String> headerTexts(Page page) {
+        return page.dataTable.findElements(By.cssSelector(".ui-datatable-scrollable-header th")).stream().map(WebElement::getText).toList();
+    }
+
+    private List<String> rowValues(DataTable dataTable, int rowIndex) {
+        return dataTable.getRow(rowIndex).getWebElement().findElements(By.tagName("td"))
+                .stream()
+                .map(WebElement::getText)
+                .toList();
+    }
+
+    /**
+     * Drags the header of the column at {@code fromIndex} onto the header of the column at {@code toIndex}. jQuery UI draggable is driven by mouse
+     * events, so the drag has to be performed step by step: press, exceed the drag threshold, move over the target header and release there.
+     *
+     * @param page the page under test
+     * @param fromIndex index of the column to drag
+     * @param toIndex index of the column to drop it on
+     */
+    private void dragColumnOnto(Page page, int fromIndex, int toIndex) {
+        List<WebElement> headers = page.dataTable.findElements(By.cssSelector(".ui-datatable-scrollable-header th"));
+        WebElement source = headers.get(fromIndex);
+        WebElement target = headers.get(toIndex);
+
+        // grab the column title, not the header itself: the draggable cancels on ':input', which would be hit when the
+        // pointer lands in the center of a header carrying a filter input
+        new Actions(page.getWebDriver())
+                .moveToElement(source.findElement(By.cssSelector(".ui-column-title")))
+                .clickAndHold()
+                .moveByOffset(10, 0)
+                .moveToElement(target)
+                .moveByOffset((target.getSize().getWidth() / 2) - 1, 0)
+                .release()
+                .perform();
+    }
+
+    public static class Page extends AbstractPrimePage {
+        @FindBy(id = "form:datatable")
+        DataTable dataTable;
+
+        @Override
+        public String getLocation() {
+            return "datatable/dataTable052.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/ColumnAware.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 
 import jakarta.faces.FacesException;
 import jakarta.faces.component.UIComponent;
+import jakarta.faces.component.UIData;
 import jakarta.faces.component.visit.VisitContext;
 import jakarta.faces.component.visit.VisitResult;
 import jakarta.faces.context.FacesContext;
@@ -314,6 +315,10 @@ public interface ColumnAware {
 
         Map<String, ColumnMeta> columnMeta = getColumnMeta();
 
+        // features like live scroll or row editing encode single rows, so the table might still be positioned on a row
+        // when the columns are collected - the row index must not leak into the lookup, see #14991
+        int rowIndex = this instanceof UIData uiData ? uiData.getRowIndex() : -1;
+
         // sort by displayOrder
         columns.sort((c1, c2) -> {
             if (c1 instanceof DynamicColumn column1) {
@@ -321,7 +326,7 @@ public interface ColumnAware {
             }
 
             Integer dp1 = c1.getDisplayPriority();
-            ColumnMeta cm1 = columnMeta.get(c1.getColumnKey());
+            ColumnMeta cm1 = columnMeta.get(getColumnMetaKey(c1, rowIndex));
             if (cm1 != null && cm1.getDisplayPriority() != null) {
                 dp1 = cm1.getDisplayPriority();
             }
@@ -331,7 +336,7 @@ public interface ColumnAware {
             }
 
             Integer dp2 = c2.getDisplayPriority();
-            ColumnMeta cm2 = columnMeta.get(c2.getColumnKey());
+            ColumnMeta cm2 = columnMeta.get(getColumnMetaKey(c2, rowIndex));
             if (cm2 != null && cm2.getDisplayPriority() != null) {
                 dp2 = cm2.getDisplayPriority();
             }
@@ -340,6 +345,18 @@ public interface ColumnAware {
         });
 
         return columns;
+    }
+
+    /**
+     * The {@link ColumnMeta} is keyed by the row-less client id of the column, while {@link UIColumn#getColumnKey()} is
+     * the plain client id, which contains the row index as soon as the table is positioned on a row.
+     *
+     * @param column the column to resolve the key for
+     * @param rowIndex the row the table is currently positioned on, or <code>-1</code>
+     * @return the key to look up the {@link ColumnMeta} of the given column
+     */
+    private String getColumnMetaKey(UIColumn column, int rowIndex) {
+        return rowIndex == -1 ? column.getColumnKey() : column.getColumnKey((UIComponent) this, rowIndex);
     }
 
     default int getColumnsCount() {

--- a/primefaces/src/main/java/org/primefaces/component/datatable/feature/ScrollFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/datatable/feature/ScrollFeature.java
@@ -63,12 +63,17 @@ public class ScrollFeature implements DataTableFeature {
         int firstIndex = (isLazy && isVirtualScroll) ? 0 : scrollOffset;
         int lastIndex = (firstIndex + scrollRows);
 
+        // the columns must be resolved before the table is positioned on a row: a column key is the client id of the
+        // column, so it would contain the row index (e.g. form:table:5:colId) and would no longer match the ColumnMeta,
+        // which is keyed by the row-less client id - the reordered column display order would be lost, see #14991
+        int columnsCount = table.getColumns().size();
+
         for (int i = firstIndex; i < lastIndex; i++) {
             table.setRowIndex(i);
 
             if (table.isRowAvailable()) {
                 int rowIndex = (isLazy && isVirtualScroll) ? scrollOffset + i : i;
-                renderer.encodeRow(context, table, rowIndex);
+                renderer.encodeRow(context, table, rowIndex, 0, columnsCount);
             }
         }
     }


### PR DESCRIPTION
Fixes #14991

## Root cause

@tandraschko asked in the issue *"why the clientId comes with rowindex in that case, but not in others"* — here is the answer.

`UIColumn#getColumnKey()` is the **client id** of the column, and the client id of a column inside a `UIData` contains the current row index. The `ColumnMeta` map, on the other hand, is keyed by the **row-less** id, because the client sends the header ids (`saveColumnOrder()` collects `thead th` ids, which are rendered at row index `-1`).

On a normal render that never collides: the header is encoded first, so the first `getColumns()` call of the request happens at row index `-1` and the resulting list is cached for the request.

`ScrollFeature#encode` is different — it encodes **only rows**:

```java
for (int i = firstIndex; i < lastIndex; i++) {
    table.setRowIndex(i);          // <-- row index set first
    ...
    renderer.encodeRow(context, table, rowIndex);   // <-- first getColumns() of the request
}
```

so `collectColumns()` runs while the table sits on the first row of the chunk. Confirmed by instrumenting `collectColumns()` during the live-scroll request:

```
collectColumns rowIndex=-1  keys=[form:datatable:colId, ...]    metaKeys=[form:datatable:colName, form:datatable:colId, ...]   <- initial render
collectColumns rowIndex=5   keys=[form:datatable:5:colId, ...]  metaKeys=[form:datatable:colName, form:datatable:colId, ...]   <- live scroll
```

The lookup misses, `displayPriority` falls back to the declared value, and the dragged column order is lost. `AddRowFeature` and `RowEditFeature` set the row index before resolving the columns in the same way.

## Fix

Two layers:

1. **`ScrollFeature`** resolves the columns *before* positioning the table on a row, so the row index cannot leak into the column keys in the first place. This is the fix at the source.
2. **`ColumnAware#collectColumns`** strips the row index before looking up the `ColumnMeta`, using the existing `UIColumn#getColumnKey(parent, rowIndex)` — the same thing `DataTableRenderer#encodeCell` already does. This keeps any row-encoding feature (`AddRowFeature`, `RowEditFeature`, future ones) from breaking the lookup again.

Each layer was verified to fix the bug on its own.

## Tests

New triad `datatable/dataTable052.xhtml` + `DataTable052` + `DataTable052Test` — lazy + `liveScroll` + `draggableColumns`, which had no coverage before:

* drag the "ID" header onto "Name", live scroll the next chunk in, assert the newly loaded rows follow the dragged order
* live scroll without any reorder keeps the declared order (control)

Verified **failing** on `master` (`expected: <[Language 6, 6, 1996]> but was: <[6, Language 6, 1996]>` — exactly the reported symptom) and **passing** with the fix, on Mojarra 4.0 and MyFaces 4.0 + CSP.

Regression run of `DataTable*Test`, `TreeTable*Test`, `SubTable*Test` (257 tests) and the `primefaces` unit tests (483) — all green. (`DataExporter*Test` fails identically on clean `master` in my environment: headless-Chrome download timeouts, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
