### PR TITLE
fix #14798 #9925: TreeTable: checkbox selection propagates when it must not

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable010.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable010.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.model.CheckboxTreeNode;
+import org.primefaces.model.TreeNode;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class TreeTable010 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private TreeNode<Document> root;
+    private List<TreeNode<Document>> selectedNodes;
+
+    @PostConstruct
+    public void init() {
+        root = new CheckboxTreeNode<>(new Document("Files", "-", "Folder"), null);
+
+        TreeNode<Document> applications = new CheckboxTreeNode<>(new Document("Applications", "100kb", "Folder"), root);
+        applications.setExpanded(true);
+
+        TreeNode<Document> primefaces = new CheckboxTreeNode<>(new Document("Primefaces", "25kb", "Folder"), applications);
+        primefaces.setExpanded(true);
+
+        new CheckboxTreeNode<>("app", new Document("primefaces.app", "10kb", "Application"), primefaces);
+
+        // must never become selected, not even when its parent is selected
+        TreeNode<Document> nativeApp = new CheckboxTreeNode<>("app", new Document("native.app", "10kb", "Application"), primefaces);
+        nativeApp.setSelectable(false);
+
+        new CheckboxTreeNode<>("app", new Document("mobile.app", "5kb", "Application"), primefaces);
+    }
+
+    public void showSelectedNodes() {
+        String names = selectedNodes == null
+                ? ""
+                : selectedNodes.stream().map(n -> n.getData().getName()).collect(Collectors.joining(","));
+        TestUtils.addMessage("selected nodes", names);
+    }
+
+}

--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable011.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/treetable/TreeTable011.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.integrationtests.general.utilities.TestUtils;
+import org.primefaces.model.CheckboxTreeNode;
+import org.primefaces.model.TreeNode;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+@Named
+@ViewScoped
+@Data
+public class TreeTable011 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private TreeNode<Document> root;
+    private List<TreeNode<Document>> selectedNodes;
+
+    @PostConstruct
+    public void init() {
+        root = new CheckboxTreeNode<>(new Document("Files", "-", "Folder"), null);
+
+        TreeNode<Document> applications = new CheckboxTreeNode<>(new Document("Applications", "100kb", "Folder"), root);
+        applications.setExpanded(true);
+
+        TreeNode<Document> primefaces = new CheckboxTreeNode<>(new Document("Primefaces", "25kb", "Folder"), applications);
+        primefaces.setExpanded(true);
+
+        new CheckboxTreeNode<>("app", new Document("primefaces.app", "10kb", "Application"), primefaces);
+        new CheckboxTreeNode<>("app", new Document("mobile.app", "5kb", "Application"), primefaces);
+
+        // a second child of "Applications", so selecting "Primefaces" leaves "Applications" partially selected
+        // and propagateSelectionUp does not add it to the selection - this test is only about downwards propagation
+        new CheckboxTreeNode<>("app", new Document("editor.app", "25kb", "Application"), applications);
+    }
+
+    public void showSelectedNodes() {
+        String names = selectedNodes == null
+                ? ""
+                : selectedNodes.stream().map(n -> n.getData().getName()).collect(Collectors.joining(","));
+        TestUtils.addMessage("selected nodes", names);
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/treetable/treeTable010.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/treetable/treeTable010.xhtml
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <p:treeTable id="treeTable" value="#{treeTable010.root}" var="document" widgetVar="ttWidget"
+                         selectionMode="checkbox" selection="#{treeTable010.selectedNodes}">
+                <f:facet name="header">
+                    File System
+                </f:facet>
+                <p:column headerText="Name">
+                    <h:outputText value="#{document.name}"/>
+                </p:column>
+                <p:column headerText="Type">
+                    <h:outputText value="#{document.type}"/>
+                </p:column>
+            </p:treeTable>
+
+            <p:commandButton id="showSelected" value="Show Selected" update="@form"
+                             action="#{treeTable010.showSelectedNodes}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/main/webapp/treetable/treeTable011.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/treetable/treeTable011.xhtml
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <p:treeTable id="treeTable" value="#{treeTable011.root}" var="document" widgetVar="ttWidget"
+                         selectionMode="checkbox" propagateSelectionDown="false"
+                         selection="#{treeTable011.selectedNodes}">
+                <f:facet name="header">
+                    File System
+                </f:facet>
+                <p:column headerText="Name">
+                    <h:outputText value="#{document.name}"/>
+                </p:column>
+                <p:column headerText="Type">
+                    <h:outputText value="#{document.type}"/>
+                </p:column>
+            </p:treeTable>
+
+            <p:commandButton id="showSelected" value="Show Selected" update="@form"
+                             action="#{treeTable011.showSelectedNodes}"/>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable010Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable010Test.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.TreeTable;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TreeTable010Test extends AbstractTreeTableTest {
+
+    /** rowKey of "Primefaces", the parent of the non-selectable node. */
+    private static final String PARENT = "0_0";
+    /** rowKey of "primefaces.app". */
+    private static final String SELECTABLE_CHILD = "0_0_0";
+    /** rowKey of "native.app", which is {@code setSelectable(false)}. */
+    private static final String UNSELECTABLE_CHILD = "0_0_1";
+
+    @Test
+    @Order(1)
+    @DisplayName("TreeTable: GitHub #14798 checkbox selection must not propagate to a non-selectable child node")
+    void checkboxSelectionDoesNotPropagateToUnselectableNode(Page page) {
+        // Arrange
+        assertFalse(isSelected(page, UNSELECTABLE_CHILD));
+
+        // Act - select the parent of the non-selectable node
+        selectCheckbox(page, PARENT);
+
+        // Assert - visually the non-selectable node must stay unselected, its selectable sibling must not
+        assertTrue(isSelected(page, PARENT));
+        assertTrue(isSelected(page, SELECTABLE_CHILD));
+        assertFalse(isSelected(page, UNSELECTABLE_CHILD));
+        assertFalse(isChecked(page, UNSELECTABLE_CHILD));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("TreeTable: GitHub #14798 a non-selectable child node must not be submitted as selected")
+    void unselectableNodeIsNotSubmitted(Page page) {
+        // Arrange
+        selectCheckbox(page, PARENT);
+
+        // Act
+        page.showSelected.click();
+
+        // Assert
+        String selected = page.messages.getMessage(0).getDetail();
+        assertFalse(selected.contains("native.app"), () -> "non-selectable node was submitted: " + selected);
+        assertTrue(selected.contains("primefaces.app"), () -> "selectable node is missing: " + selected);
+        assertTrue(selected.contains("mobile.app"), () -> "selectable node is missing: " + selected);
+        assertNoJavascriptErrors();
+    }
+
+    private void selectCheckbox(Page page, String rowKey) {
+        // checkbox selection always fires an AJAX request to resolve the descendants of the clicked node
+        PrimeSelenium.guardAjax(row(page, rowKey).findElement(By.cssSelector("div.ui-chkbox-box"))).click();
+    }
+
+    private boolean isSelected(Page page, String rowKey) {
+        return PrimeSelenium.hasCssClass(row(page, rowKey), "ui-state-highlight");
+    }
+
+    private boolean isChecked(Page page, String rowKey) {
+        return !row(page, rowKey).findElements(By.cssSelector("span.ui-chkbox-icon.ui-icon-check")).isEmpty();
+    }
+
+    private WebElement row(Page page, String rowKey) {
+        return page.getWebDriver().findElement(By.id("form:treeTable_node_" + rowKey));
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:treeTable")
+        TreeTable treeTable;
+
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:showSelected")
+        CommandButton showSelected;
+
+        @Override
+        public String getLocation() {
+            return "treetable/treeTable010.xhtml";
+        }
+    }
+}

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable011Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/treetable/TreeTable011Test.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.treetable;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.Messages;
+import org.primefaces.selenium.component.TreeTable;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TreeTable011Test extends AbstractTreeTableTest {
+
+    /** rowKey of "Primefaces", which has two children. */
+    private static final String PARENT = "0_0";
+    /** rowKey of "primefaces.app". */
+    private static final String CHILD = "0_0_0";
+
+    @Test
+    @Order(1)
+    @DisplayName("TreeTable: GitHub #9925 propagateSelectionDown=false must not select the child nodes")
+    void childIsNotSelectedVisually(Page page) {
+        // Act
+        selectCheckbox(page, PARENT);
+
+        // Assert
+        assertTrue(isSelected(page, PARENT));
+        assertFalse(isSelected(page, CHILD));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("TreeTable: GitHub #9925 propagateSelectionDown=false must not submit the child nodes either")
+    void childIsNotSubmitted(Page page) {
+        // Arrange
+        selectCheckbox(page, PARENT);
+
+        // Act
+        page.showSelected.click();
+
+        // Assert - only the clicked node, the children must not be propagated behind the scenes
+        assertEquals("Primefaces", page.messages.getMessage(0).getDetail());
+        assertNoJavascriptErrors();
+    }
+
+    private void selectCheckbox(Page page, String rowKey) {
+        // checkbox selection always fires an AJAX request to resolve the descendants of the clicked node
+        PrimeSelenium.guardAjax(row(page, rowKey).findElement(By.cssSelector("div.ui-chkbox-box"))).click();
+    }
+
+    private boolean isSelected(Page page, String rowKey) {
+        return PrimeSelenium.hasCssClass(row(page, rowKey), "ui-state-highlight");
+    }
+
+    private WebElement row(Page page, String rowKey) {
+        return page.getWebDriver().findElement(By.id("form:treeTable_node_" + rowKey));
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:treeTable")
+        TreeTable treeTable;
+
+        @FindBy(id = "form:msgs")
+        Messages messages;
+
+        @FindBy(id = "form:showSelected")
+        CommandButton showSelected;
+
+        @Override
+        public String getLocation() {
+            return "treetable/treeTable011.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/frontend/packages/components/src/treetable/treetable.widget.js
+++ b/primefaces/src/main/frontend/packages/components/src/treetable/treetable.widget.js
@@ -1265,9 +1265,26 @@ PrimeFaces.widget.TreeTable = class TreeTable extends PrimeFaces.widget.Deferred
 
         //propagate down
         if (this.cfg.propagateSelectionDown) {
-            var descendants = this.getDescendants(node);
+            var descendants = this.getDescendants(node),
+            skippedKey = null;
+
             for (var i = 0; i < descendants.length; i++) {
-                var descendant = descendants[i];
+                var descendant = descendants[i],
+                descendantKey = descendant.attr('data-rk');
+
+                // descendants are in depth-first order, so everything below a skipped node is still skipped
+                if (skippedKey && descendantKey.indexOf(skippedKey + '_') === 0) {
+                    continue;
+                }
+                skippedKey = null;
+
+                // a non-selectable node and its subtree must never be selected, just like
+                // CheckboxTreeNode#propagateSelectionDown does on the server side
+                if (!descendant.hasClass('ui-treetable-selectable-node')) {
+                    skippedKey = descendantKey;
+                    continue;
+                }
+
                 if (selected)
                     this.unselectNode(descendant, true);
                 else

--- a/primefaces/src/main/java/org/primefaces/component/api/UITree.java
+++ b/primefaces/src/main/java/org/primefaces/component/api/UITree.java
@@ -318,6 +318,14 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
         }
     }
 
+    /**
+     * Collects the rowKeys of all descendants of the given node, which the checkbox selection propagates down to.
+     * A non-selectable node and its whole subtree are skipped, just like {@link CheckboxTreeNode} does when the
+     * selection is propagated down on the model, see #14798.
+     *
+     * @param node the node to collect the descendants of
+     * @param keys the list to add the collected rowKeys to
+     */
     public void populateRowKeys(TreeNode<?> node, List<String> keys) {
         if (node == null) {
             return;
@@ -331,6 +339,9 @@ public abstract class UITree extends UIComponentBase implements NamingContainer 
         if (childCount > 0) {
             for (int i = 0; i < childCount; i++) {
                 TreeNode<?> childNode = node.getChildren().get(i);
+                if (!childNode.isSelectable()) {
+                    continue;
+                }
                 keys.add(childNode.getRowKey());
                 populateRowKeys(childNode, keys);
             }

--- a/primefaces/src/main/java/org/primefaces/component/treetable/feature/SelectionFeature.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/feature/SelectionFeature.java
@@ -90,7 +90,9 @@ public class SelectionFeature implements TreeTableFeature {
             table.setRowKey(root, null); //cleanup
         }
 
-        if (table.isCheckboxSelectionMode() && isSelectionRequest(context, clientId)) {
+        // the descendants are sent back to the client to be added to the selection, so they must only be collected
+        // when the selection actually propagates down - like TreeRenderer does for the Tree, see #9925
+        if (table.isCheckboxSelectionMode() && isSelectionRequest(context, clientId) && table.isPropagateSelectionDown()) {
             String selectedNodeRowKey = params.get(clientId + "_instantSelection");
             table.setRowKey(root, selectedNodeRowKey);
             TreeNode selectedNode = table.getRowNode();


### PR DESCRIPTION
Fixes #14798
Fixes #9925

Two bugs with the same shape: **the server tells the client to select descendants it must not select.** Both live in the `descendantRowKeys` round-trip, so they are fixed together.

## The shared mechanism

Checkbox selection propagates down over two paths:

1. **Client** — `TreeTable#toggleCheckboxNode` selects every *rendered* descendant row.
2. **Server** — `SelectionFeature#decode` answers every checkbox click with `UITree#populateRowKeys`, returned as the `descendantRowKeys` callback param; the widget feeds those straight into `addToSelection()`. This path exists for descendants that are *not* rendered (collapsed / lazy), so the client cannot filter it.

Path 2 is why both issues report the same "looks right on screen, wrong in the bean" symptom.

---

## #14798 — selection propagates to non-selectable nodes

`CheckboxTreeNode#propagateSelectionDown` already stops at a non-selectable node:

```java
protected void propagateSelectionDown(boolean selected) {
    if (!this.isSelectable()) {
        return;
    }
    ...
}
```

but neither propagation path consulted it, so the model rule never took effect.

Confirmed separately. With only the client fix applied, the non-selectable node stopped being highlighted but was still submitted — and it now arrived **last**, exactly where the `descendantRowKeys` callback appends it:

```
before any fix:     Primefaces,primefaces.app,native.app,mobile.app,Applications
client fix only:    Primefaces,primefaces.app,mobile.app,Applications,native.app
both fixes:         Primefaces,primefaces.app,mobile.app,Applications
```

**Fix:** both paths skip a non-selectable node **and its subtree**, matching `CheckboxTreeNode#propagateSelectionDown`, which stops the recursion there rather than only skipping the node itself. The client uses the `ui-treetable-selectable-node` row class the renderer already emits — the same marker the checkbox click handler binds to. Since `getDescendants()` returns rows depth-first, one skipped prefix covers the subtree.

`UITree#populateRowKeys` is shared with `p:tree`, whose `TreeRenderer` uses it for the same propagation, so `p:tree dynamic="true"` gets the same correction.

---

## #9925 — `propagateSelectionDown="false"` is ignored

The widget honours the flag (`if (this.cfg.propagateSelectionDown)`), so path 1 is correct and nothing looks wrong on screen. But path 2 ran unconditionally:

```java
if (table.isCheckboxSelectionMode() && isSelectionRequest(context, clientId)) {
```

`TreeRenderer` already guards the identical block with `isPropagateSelectionDown()` — `TreeTable`'s `SelectionFeature` never did. So the descendants came back from the server and were added to the selection anyway, which is precisely the reporter's *"on the surface there is no problem, but internally the leaf is selected"*.

```
before: Primefaces,primefaces.app,mobile.app
after:  Primefaces
```

**Fix:** add the same `isPropagateSelectionDown()` guard TreeTable was missing.

---

## Tests

Two new triads; neither scenario had coverage.

**`treeTable010`** (#14798) — a `CheckboxTreeNode` tree with one `setSelectable(false)` child, expanded, mirroring the reproducer:
* selecting the parent must not highlight or check the non-selectable child, while its selectable sibling is selected
* the non-selectable child must not appear in the selection submitted to the backing bean

**`treeTable011`** (#9925) — `propagateSelectionDown="false"`:
* the child must not be selected visually (passes on `master` — the widget already honours the flag)
* the child must not be submitted either (fails on `master`)

The tree is shaped so the clicked node's parent keeps a second, unselected child; that leaves the parent partially selected so `propagateSelectionUp` (still `true`) does not add it, keeping the assertion about downwards propagation only.

All four fail/pass as described on Mojarra 4.0 and MyFaces 4.0 + CSP.

Regression: all 38 `Tree*Test` / `TreeTable*Test` integration tests and the 483 `primefaces` unit tests pass; Checkstyle and license check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
