### PR TITLE
fix #13590: TreeTable Exporter: incorrect output in SelectionOnly and PageOnly

### DIFF
--- a/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/dataexporter/DataExporter004.java
+++ b/primefaces-integration-tests/src/main/java/org/primefaces/integrationtests/dataexporter/DataExporter004.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.dataexporter;
+
+import org.primefaces.component.export.DataExporters;
+import org.primefaces.component.export.ExportConfiguration;
+import org.primefaces.component.export.Exporter;
+import org.primefaces.component.treetable.TreeTable;
+import org.primefaces.integrationtests.treetable.Document;
+import org.primefaces.model.CheckboxTreeNode;
+import org.primefaces.model.TreeNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serial;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+
+import jakarta.annotation.PostConstruct;
+import jakarta.faces.FacesException;
+import jakarta.faces.context.FacesContext;
+import jakarta.faces.view.ViewScoped;
+import jakarta.inject.Named;
+
+import lombok.Data;
+
+/**
+ * Exports the TreeTable through the programmatic {@link Exporter} API into a String instead of a download, so the
+ * exported content can be asserted directly on the page.
+ */
+@Named
+@ViewScoped
+@Data
+public class DataExporter004 implements Serializable {
+
+    @Serial private static final long serialVersionUID = 1L;
+
+    private TreeNode<Document> root;
+    private TreeNode<Document>[] selectedNodes;
+    private String output;
+
+    @PostConstruct
+    public void init() {
+        root = new CheckboxTreeNode<>(new Document("Files", "-", "Folder"), null);
+
+        TreeNode<Document> applications = new CheckboxTreeNode<>(new Document("Applications", "100kb", "Folder"), root);
+        applications.setExpanded(true);
+
+        // collapsed, so "primefaces.app" is not displayed
+        TreeNode<Document> primefaces = new CheckboxTreeNode<>(new Document("Primefaces", "25kb", "Folder"), applications);
+        new CheckboxTreeNode<>("app", new Document("primefaces.app", "10kb", "Application"), primefaces);
+
+        new CheckboxTreeNode<>("app", new Document("editor.app", "25kb", "Application"), applications);
+
+        TreeNode<Document> cloud = new CheckboxTreeNode<>(new Document("Cloud", "20kb", "Folder"), root);
+        cloud.setExpanded(true);
+        new CheckboxTreeNode<>("document", new Document("backup-1.zip", "10kb", "Zip"), cloud);
+
+        // second page
+        TreeNode<Document> desktop = new CheckboxTreeNode<>(new Document("Desktop", "150kb", "Folder"), root);
+        new CheckboxTreeNode<>("document", new Document("note-todo.txt", "100kb", "Text"), desktop);
+    }
+
+    public void exportPageOnly() {
+        export(ExportConfiguration.builder().pageOnly(true));
+    }
+
+    public void exportSelectionOnly() {
+        export(ExportConfiguration.builder().selectionOnly(true));
+    }
+
+    public void exportAll() {
+        export(ExportConfiguration.builder());
+    }
+
+    private void export(ExportConfiguration.Builder builder) {
+        FacesContext context = FacesContext.getCurrentInstance();
+        TreeTable table = (TreeTable) context.getViewRoot().findComponent("form:treeTable");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        ExportConfiguration configuration = builder
+                .encodingType(StandardCharsets.UTF_8.name())
+                .exportHeader(true)
+                .visibleOnly(true)
+                .outputStream(out)
+                .build();
+
+        try {
+            Exporter<TreeTable> exporter = DataExporters.get(TreeTable.class, "csv");
+            exporter.export(context, Collections.singletonList(table), configuration);
+        }
+        catch (IOException e) {
+            throw new FacesException(e);
+        }
+
+        // drop the byte order mark, it is not part of what this test is about
+        output = out.toString(StandardCharsets.UTF_8).replace("\ufeff", "");
+    }
+
+}

--- a/primefaces-integration-tests/src/main/webapp/dataexporter/dataExporter004.xhtml
+++ b/primefaces-integration-tests/src/main/webapp/dataexporter/dataExporter004.xhtml
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="jakarta.faces.html"
+      xmlns:f="jakarta.faces.core"
+      xmlns:p="primefaces">
+
+<f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
+    <h:head>
+
+    </h:head>
+
+    <h:body>
+
+        <h:form id="form">
+            <p:messages id="msgs" showDetail="true">
+                <p:autoUpdate/>
+            </p:messages>
+
+            <p:treeTable id="treeTable" value="#{dataExporter004.root}" var="document" widgetVar="ttWidget"
+                         paginator="true" rows="2" selectionMode="checkbox"
+                         selection="#{dataExporter004.selectedNodes}">
+                <p:column headerText="Name">
+                    <h:outputText value="#{document.name}"/>
+                </p:column>
+                <p:column headerText="Type">
+                    <h:outputText value="#{document.type}"/>
+                </p:column>
+            </p:treeTable>
+
+            <p:commandButton id="exportPageOnly" value="Export Page Only" update="output"
+                             action="#{dataExporter004.exportPageOnly}"/>
+            <p:commandButton id="exportSelectionOnly" value="Export Selection Only" update="output"
+                             action="#{dataExporter004.exportSelectionOnly}"/>
+            <p:commandButton id="exportAll" value="Export All" update="output"
+                             action="#{dataExporter004.exportAll}"/>
+
+            <h:panelGroup id="output" layout="block">
+                <pre><h:outputText id="csv" value="#{dataExporter004.output}"/></pre>
+            </h:panelGroup>
+        </h:form>
+
+    </h:body>
+</f:view>
+
+</html>

--- a/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dataexporter/DataExporter004Test.java
+++ b/primefaces-integration-tests/src/test/java/org/primefaces/integrationtests/dataexporter/DataExporter004Test.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009-2026 PrimeFaces
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.primefaces.integrationtests.dataexporter;
+
+import org.primefaces.selenium.AbstractPrimePage;
+import org.primefaces.selenium.AbstractPrimePageTest;
+import org.primefaces.selenium.PrimeSelenium;
+import org.primefaces.selenium.component.CommandButton;
+import org.primefaces.selenium.component.TreeTable;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * TreeTable exporting, see GitHub #13590.
+ */
+class DataExporter004Test extends AbstractPrimePageTest {
+
+    private static final String HEADER = "\"Name\",\"Type\"";
+
+    @Test
+    @Order(1)
+    @DisplayName("TreeTable Exporter: GitHub #13590 pageOnly must export every row displayed on the current page")
+    void exportPageOnly(Page page) {
+        // Arrange - page 1 shows "Applications" and "Cloud" plus their expanded children;
+        // "Primefaces" is collapsed, so "primefaces.app" is not displayed
+        assertEquals(List.of("Applications", "Primefaces", "editor.app", "Cloud", "backup-1.zip"), displayedNames(page));
+
+        // Act
+        page.exportPageOnly.click();
+
+        // Assert
+        assertEquals(List.of(HEADER,
+                "\"Applications\",\"Folder\"",
+                "\"Primefaces\",\"Folder\"",
+                "\"editor.app\",\"Application\"",
+                "\"Cloud\",\"Folder\"",
+                "\"backup-1.zip\",\"Zip\""), csv(page));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("TreeTable Exporter: GitHub #13590 pageOnly must follow the paginator to the second page")
+    void exportPageOnlySecondPage(Page page) {
+        // Arrange - page 2 shows the collapsed "Desktop" only
+        page.treeTable.selectPage(2);
+        assertEquals(List.of("Desktop"), displayedNames(page));
+
+        // Act
+        page.exportPageOnly.click();
+
+        // Assert
+        assertEquals(List.of(HEADER, "\"Desktop\",\"Folder\""), csv(page));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("TreeTable Exporter: GitHub #13590 selectionOnly must export the selected nodes, not the root node")
+    void exportSelectionOnly(Page page) {
+        // Arrange - checking "Cloud" selects it and its child "backup-1.zip"
+        PrimeSelenium.guardAjax(row(page, "1").findElement(By.cssSelector("div.ui-chkbox-box"))).click();
+
+        // Act
+        page.exportSelectionOnly.click();
+
+        // Assert
+        assertEquals(List.of(HEADER,
+                "\"Cloud\",\"Folder\"",
+                "\"backup-1.zip\",\"Zip\""), csv(page));
+        assertNoJavascriptErrors();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("TreeTable Exporter: exporting everything is not restricted to the current page or to expanded nodes")
+    void exportAll(Page page) {
+        // Act
+        page.exportAll.click();
+
+        // Assert
+        assertEquals(List.of(HEADER,
+                "\"Applications\",\"Folder\"",
+                "\"Primefaces\",\"Folder\"",
+                "\"primefaces.app\",\"Application\"",
+                "\"editor.app\",\"Application\"",
+                "\"Cloud\",\"Folder\"",
+                "\"backup-1.zip\",\"Zip\"",
+                "\"Desktop\",\"Folder\"",
+                "\"note-todo.txt\",\"Text\""), csv(page));
+        assertNoJavascriptErrors();
+    }
+
+    private List<String> displayedNames(Page page) {
+        return page.treeTable.getRows().stream().map(r -> r.getCell(0).getText()).toList();
+    }
+
+    private List<String> csv(Page page) {
+        return page.csv.getText().lines().map(String::trim).filter(l -> !l.isEmpty()).toList();
+    }
+
+    private WebElement row(Page page, String rowKey) {
+        return page.getWebDriver().findElement(By.id("form:treeTable_node_" + rowKey));
+    }
+
+    public static class Page extends AbstractPrimePage {
+
+        @FindBy(id = "form:treeTable")
+        TreeTable treeTable;
+
+        @FindBy(id = "form:exportPageOnly")
+        CommandButton exportPageOnly;
+
+        @FindBy(id = "form:exportSelectionOnly")
+        CommandButton exportSelectionOnly;
+
+        @FindBy(id = "form:exportAll")
+        CommandButton exportAll;
+
+        @FindBy(id = "form:csv")
+        WebElement csv;
+
+        @Override
+        public String getLocation() {
+            return "dataexporter/dataExporter004.xhtml";
+        }
+    }
+}

--- a/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExporter.java
+++ b/primefaces/src/main/java/org/primefaces/component/treetable/export/TreeTableExporter.java
@@ -48,23 +48,38 @@ public abstract class TreeTableExporter<P, O extends ExporterOptions> extends Ta
 
     @Override
     protected void exportPageOnly(FacesContext context, TreeTable table) {
+        TreeNode<?> root = table.getValue();
+        if (root == null) {
+            return;
+        }
+
+        // a page of a TreeTable is a slice of the direct children of the root, each one rendered together with the
+        // descendants which are currently displayed - see TreeTableRenderer#encodeNodeChildren
         int first = table.getFirst();
-        int rows = table.getRows();
+        int last = Math.min(first + table.getRowsToRender(), root.getChildCount());
 
-        TreeNode root = table.getValue();
-        root.setExpanded(true);
-        int totalRows = getTreeRowCount(root) - 1;
-        if (rows == 0) {
-            rows = totalRows;
+        for (int i = first; i < last; i++) {
+            exportNode(context, table, root.getChildren().get(i), true);
+        }
+    }
+
+    /**
+     * Exports the given node followed by its descendants, in the same order the renderer displays them.
+     *
+     * @param context the {@link FacesContext}
+     * @param table the {@link TreeTable} being exported
+     * @param node the node to export
+     * @param displayedOnly whether to descend into collapsed nodes, which are not displayed
+     */
+    protected void exportNode(FacesContext context, TreeTable table, TreeNode<?> node, boolean displayedOnly) {
+        exportRow(context, table, node.getData());
+
+        if (displayedOnly && !node.isExpanded()) {
+            return;
         }
 
-        int rowsToExport = first + rows;
-        if (rowsToExport > totalRows) {
-            rowsToExport = totalRows;
-        }
-
-        for (int rowIndex = first; rowIndex < rowsToExport; rowIndex++) {
-            exportRow(context, table, rowIndex);
+        for (int i = 0; i < node.getChildCount(); i++) {
+            exportNode(context, table, node.getChildren().get(i), displayedOnly);
         }
     }
 
@@ -84,12 +99,21 @@ public abstract class TreeTableExporter<P, O extends ExporterOptions> extends Ta
     }
 
     protected void exportRow(FacesContext context, TreeTable table, int rowIndex) {
+        // rowIndex +1 because we are not interested in rootNode
+        exportRow(context, table, traverseTree(table.getValue(), rowIndex + 1));
+    }
+
+    /**
+     * Exports a single row for the given row data.
+     *
+     * @param context the {@link FacesContext}
+     * @param table the {@link TreeTable} being exported
+     * @param data the data of the node to export, which the columns are resolved against
+     */
+    protected void exportRow(FacesContext context, TreeTable table, Object data) {
         Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
 
         Object origVar = requestMap.get(table.getVar());
-
-        // rowIndex +1 because we are not interested in rootNode
-        Object data = traverseTree(table.getValue(), rowIndex + 1);
 
         requestMap.put(table.getVar(), data);
 
@@ -106,35 +130,29 @@ public abstract class TreeTableExporter<P, O extends ExporterOptions> extends Ta
     @Override
     protected void exportSelectionOnly(FacesContext context, TreeTable table) {
         Object selection = table.getSelection();
-        String var = table.getVar();
+        if (selection == null) {
+            return;
+        }
 
-        if (selection != null) {
-            Map<String, Object> requestMap = context.getExternalContext().getRequestMap();
+        if (selection.getClass().isArray()) {
+            int size = Array.getLength(selection);
 
-            if (selection.getClass().isArray()) {
-                int size = Array.getLength(selection);
-
-                for (int i = 0; i < size; i++) {
-                    requestMap.put(var, Array.get(selection, i));
-                    exportRow(context, table, -1);
-                }
-            }
-            else if (Collection.class.isAssignableFrom(selection.getClass())) {
-                for (Object obj : (Collection) selection) {
-                    if (obj instanceof TreeNode node) {
-                        requestMap.put(var, node.getData());
-                    }
-                    else {
-                        requestMap.put(var, obj);
-                    }
-                    exportRow(context, table, -1);
-                }
-            }
-            else {
-                requestMap.put(var, selection);
-                exportRow(context, table, -1);
+            for (int i = 0; i < size; i++) {
+                exportSelectedRow(context, table, Array.get(selection, i));
             }
         }
+        else if (selection instanceof Collection<?> collection) {
+            for (Object selected : collection) {
+                exportSelectedRow(context, table, selected);
+            }
+        }
+        else {
+            exportSelectedRow(context, table, selection);
+        }
+    }
+
+    protected void exportSelectedRow(FacesContext context, TreeTable table, Object selected) {
+        exportRow(context, table, selected instanceof TreeNode<?> node ? node.getData() : selected);
     }
 
     protected static int getTreeRowCount(TreeNode<?> node) {


### PR DESCRIPTION
Fixes #13590

@tandraschko — integration tests first, as requested. They are the first three commits' worth of the diff; the fix is ~40 lines.

## Root cause

### SelectionOnly — exports the root node instead of the selection

`exportSelectionOnly` put the selected node's data into the request map and then called `exportRow(context, table, -1)`:

```java
requestMap.put(var, node.getData());
exportRow(context, table, -1);
```

but `exportRow` immediately **overwrites** it:

```java
Object data = traverseTree(table.getValue(), rowIndex + 1);   // rowIndex -1 -> traverseTree(root, 0)
requestMap.put(table.getVar(), data);
```

`traverseTree(root, 0)` hits `if (index <= 0) return node.getData()` on the first call and returns the **root** node's data. So every selected row exported the root — exactly the `Files / Files / Files` output in @melloware's screenshot.

The array and single-selection branches were doubly broken: they put the `TreeNode` itself into the request map rather than its data.

### PageOnly — exports the wrong rows

`exportPageOnly` treated `first`/`rows` as indices into the depth-first flattening of the **whole** tree, collapsed nodes included:

```java
int totalRows = getTreeRowCount(root) - 1;   // every node in the tree
int rowsToExport = first + rows;             // rows = page size
```

But a TreeTable page is a slice of the **direct children of the root**, each rendered together with its *displayed* descendants (`TreeTableRenderer#encodeNodeChildren` slices `root.getChildren()[first, first+rows)`, and `encodeNode` recurses only into expanded nodes). `TreeTable#getRowCount()` likewise returns the number of root children.

The two never line up. On a page showing `Applications, Primefaces, editor.app, Cloud, backup-1.zip` (5 displayed rows, `rows="2"`), the export produced just `Applications, Primefaces` — the first 2 entries of the flattened tree. On page 2 it produced `primefaces.app, editor.app` (flattened indices 2–3) instead of the displayed `Desktop`.

## Fix

* Row export now takes the row **data** directly (`exportRow(context, table, Object data)`); `exportSelectionOnly` uses it and unwraps `TreeNode` uniformly across the array, collection and single-value branches.
* `exportPageOnly` walks `root.getChildren()[first, first + getRowsToRender())` and descends only into expanded nodes, mirroring the renderer.

`exportAll` is deliberately untouched — it still exports every node whether expanded or not, and its test passes unchanged before and after.

## Tests

TreeTable exporting had **no** coverage at all. New triad `dataexporter/dataExporter004.xhtml` + `DataExporter004` + `DataExporter004Test`.

The existing `DataExporter00{1,2,3}Test` assert against a real browser download. Rather than add a fourth download-based test, this one drives the exporter through its public `ExportConfiguration#outputStream` API from the backing bean and renders the CSV onto the page, so the test asserts the exporter's exact output with no download timing involved. Four cases:

| | on `master` | expected |
|---|---|---|
| pageOnly, page 1 | `Applications, Primefaces` | `Applications, Primefaces, editor.app, Cloud, backup-1.zip` |
| pageOnly, page 2 | `primefaces.app, editor.app` | `Desktop` |
| selectionOnly | `Files, Files` | `Cloud, backup-1.zip` |
| all | correct | correct (regression guard) |

The first three **fail** on `master` with exactly the output above and **pass** with the fix, on Mojarra 4.0 and MyFaces 4.0 + CSP. The selection case uses a `TreeNode[]` so it covers the array branch, which had both defects.

Regression: all `TreeTable*Test` integration tests and the 483 `primefaces` unit tests pass; Checkstyle and license check clean.

Note: `DataExporter00{1,2,3}Test` do not run in my environment — headless Chrome never writes the download — but they exercise `DataTableExporter` only, which this PR does not touch, and they fail identically on a clean `master` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
